### PR TITLE
feat: 添加 GitHub Copilot 支持

### DIFF
--- a/openclaw_mini/agent/llm.py
+++ b/openclaw_mini/agent/llm.py
@@ -13,7 +13,11 @@ logger = logging.getLogger(__name__)
 
 
 class LLMClient:
-    """Simple LLM client supporting OpenAI-compatible APIs."""
+    """Simple LLM client supporting OpenAI-compatible APIs and GitHub Copilot."""
+
+    # GitHub Copilot API configuration
+    COPILOT_API_BASE = "https://api.github.com/copilot"
+    COPILOT_SUFFIX = "/chat/completions"
 
     def __init__(self):
         self.provider = config.llm.get("provider", "openai")
@@ -24,6 +28,34 @@ class LLMClient:
         self.temperature = config.llm.get("temperature", 0.7)
         self.max_retries = config.llm.get("max_retries", 3)
         self.retry_delay = config.llm.get("retry_delay", 1)
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get headers for API request based on provider."""
+        if self.provider == "github_copilot":
+            return {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        else:
+            return {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            }
+
+    def _get_chat_endpoint(self) -> str:
+        """Get the chat completions endpoint URL."""
+        if self.provider == "github_copilot":
+            return f"{self.COPILOT_API_BASE}{self.COPILOT_SUFFIX}"
+        return f"{self.api_base}/chat/completions"
+
+    def _get_completions_endpoint(self) -> str:
+        """Get the completions endpoint URL."""
+        if self.provider == "github_copilot":
+            # GitHub Copilot uses chat completions primarily
+            return f"{self.COPILOT_API_BASE}{self.COPILOT_SUFFIX}"
+        return f"{self.api_base}/completions"
 
     async def chat(
         self,
@@ -45,17 +77,18 @@ class LLMClient:
             "temperature": self.temperature,
         }
 
+        # Add GitHub Copilot specific headers and parameters
+        headers = self._get_headers()
+        endpoint = self._get_chat_endpoint()
+
         # Make API request with retry
         last_error = None
         for attempt in range(self.max_retries):
             try:
                 async with httpx.AsyncClient(timeout=120.0) as client:
                     response = await client.post(
-                        f"{self.api_base}/chat/completions",
-                        headers={
-                            "Authorization": f"Bearer {self.api_key}",
-                            "Content-Type": "application/json",
-                        },
+                        endpoint,
+                        headers=headers,
                         json=payload,
                     )
                     response.raise_for_status()
@@ -90,17 +123,17 @@ class LLMClient:
             "temperature": self.temperature,
         }
 
+        headers = self._get_headers()
+        endpoint = self._get_completions_endpoint()
+
         # Make API request with retry
         last_error = None
         for attempt in range(self.max_retries):
             try:
                 async with httpx.AsyncClient(timeout=120.0) as client:
                     response = await client.post(
-                        f"{self.api_base}/completions",
-                        headers={
-                            "Authorization": f"Bearer {self.api_key}",
-                            "Content-Type": "application/json",
-                        },
+                        endpoint,
+                        headers=headers,
                         json=payload,
                     )
                     response.raise_for_status()
@@ -120,6 +153,10 @@ class LLMClient:
                     raise
 
         raise last_error
+
+    def is_github_copilot(self) -> bool:
+        """Check if current provider is GitHub Copilot."""
+        return self.provider == "github_copilot"
 
 
 # Global LLM client instance

--- a/openclaw_mini/config.yaml
+++ b/openclaw_mini/config.yaml
@@ -7,12 +7,23 @@ discord:
 
 # LLM Configuration
 llm:
-  provider: "openai"  # openai, anthropic, custom
+  provider: "openai"  # openai, anthropic, github_copilot, custom
   api_base: "https://api.openai.com/v1"
-  api_key: "YOUR_OPENAI_API_KEY"
+  api_key: "YOUR_API_KEY"
   model: "gpt-3.5-turbo"
   max_tokens: 1000
   temperature: 0.7
+  max_retries: 3  # Number of retry attempts for API failures
+  retry_delay: 1  # Base delay in seconds (exponential backoff)
+
+# GitHub Copilot Configuration Example:
+# llm:
+#   provider: "github_copilot"
+#   api_base: "https://api.github.com/copilot"
+#   api_key: "ghp_YOUR_GITHUB_TOKEN"
+#   model: "gpt-4"  # or "gpt-3.5-turbo"
+#   max_tokens: 1000
+#   temperature: 0.7
 
 # Session Configuration
 session:


### PR DESCRIPTION
## 概述

添加 GitHub Copilot 作为 LLM provider 支持。

## 主要变更

- 添加 GitHub Copilot API 端点支持
- 添加 GitHub 特定的请求头配置
- 添加配置示例

## 使用方式

```yaml
llm:
  provider: "github_copilot"
  api_base: "https://api.github.com/copilot"
  api_key: "ghp_你的GitHub_Token"
  model: "gpt-4"
```