### PR TITLE
fix: 修复 Bot 模式下 HTTP 服务器不启动的问题

### DIFF
--- a/openclaw_mini/gateway/server.py
+++ b/openclaw_mini/gateway/server.py
@@ -312,8 +312,12 @@ class Gateway:
     async def start(self) -> None:
         """Start the gateway server."""
         if self.mode == "bot":
-            # Bot API mode - start Discord bot and HTTP server for API endpoints
-            await discord_channel.start(message_callback=handle_discord_message)
+            # Bot API mode - start Discord bot and HTTP server in parallel
+            # Use create_task because discord_channel.start() blocks
+            bot_task = asyncio.create_task(discord_channel.start(message_callback=handle_discord_message))
+            
+            # Small delay to let bot start
+            await asyncio.sleep(2)
             
             # Start HTTP server for API endpoints (including test endpoint)
             self.runner = web.AppRunner(self.app)


### PR DESCRIPTION
修复 Discord Bot API 模式下 HTTP 服务器不启动的问题。

## 问题

在 Bot 模式下，`discord_channel.start()` 会阻塞主线程，导致 `gateway.start()` 中启动 HTTP 服务器的代码永远不会被执行。

## 解决方案

使用 `asyncio.create_task()` 并行启动 Discord bot 和 HTTP 服务器。