### PR TITLE
fix: handle None content from LLM responses

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -9,7 +9,7 @@ from agent.llm import llm_client
 from agent.memory import memory_system
 from session.manager import session_manager
 from skills.executor import (
-    skills_executor,
+    _get_executor,
     SkillResult,
     get_tools_schemas,
     execute_tool_by_name,
@@ -105,7 +105,7 @@ You have access to the following tools. When a user asks you to do something tha
         usage_data = {}
         
         # Check if message matches a skill first
-        skill_name = skills_executor.match_skill(message)
+        skill_name = _get_executor().match_skill(message)
         if skill_name:
             logger.info(f"Matched skill: {skill_name}")
             result = await self._execute_skill(skill_name, message, session_id)
@@ -131,7 +131,7 @@ You have access to the following tools. When a user asks you to do something tha
         if track_usage:
             usage_data = llm_result.get("usage", {})
         
-        content = llm_result.get("content", "").strip()
+        content = (llm_result.get("content") or "").strip()
         tool_calls = llm_result.get("tool_calls", [])
         
         # If no tool calls, return directly
@@ -185,7 +185,7 @@ You have access to the following tools. When a user asks you to do something tha
             tools=self.tools
         )
         
-        final_content = final_result.get("content", "").strip()
+        final_content = (final_result.get("content") or "").strip()
         
         # Track final usage and merge
         if track_usage:
@@ -214,7 +214,7 @@ You have access to the following tools. When a user asks you to do something tha
         try:
             # Note: session_id is used for tracking but not passed to skills
             # Skills don't accept session_id as a parameter
-            result = await skills_executor.execute_skill(
+            result = await _get_executor().execute_skill(
                 skill_name,
                 message=message,
             )

--- a/gateway/webchat.py
+++ b/gateway/webchat.py
@@ -110,7 +110,7 @@ async def api_chat(request: web.Request) -> web.Response:
     """
     try:
         data = await request.json()
-        message = data.get('message', '').strip()
+        message = (data.get('message') or '').strip()
         
         # Dynamic session_id with timestamp-based default for multi-session support
         session_id = data.get('session_id', f'webchat_{datetime.utcnow().strftime("%Y%m%d_%H%M%S")}')


### PR DESCRIPTION
## 问题描述

当 LLM 返回 tool_calls 时，`content` 字段为 `None`，导致调用 `.strip()` 时抛出 `AttributeError: 'NoneType' object has no attribute 'strip'`。

## 修复内容

### 1. agent/core.py

- **第 134 行**: 当 LLM 返回 tool_calls 时，`content` 可能为 `None`：
  ```python
  # 修复前
  content = llm_result.get("content", "").strip()
  # 修复后
  content = (llm_result.get("content") or "").strip()
  ```
- **第 188 行**: 同样处理 `final_result.get("content")` 可能为 `None` 的情况
- **第 11,107,216 行**: 使用 `_get_executor()` 延迟加载模式替代直接引用 `skills_executor`，避免循环导入问题

### 2. gateway/webchat.py

- **第 113 行**: 处理 API 请求中 `message` 字段为 `None` 的情况：
  ```python
  # 修复前
  message = data.get('message', '').strip()
  # 修复后
  message = (data.get('message') or '').strip()
  ```

## 测试验证

修复后 `curl -X POST http://192.168.8.235:8000/api/chat -d '{"message": "ls /"}'` 可以正常返回结果。

## 影响范围

- 修复了 tool_calls 场景下 LLM 响应处理的问题
- 提升了系统稳定性，避免 None 值导致的异常
