### PR TITLE
fix: remove _get_executor, use skills_executor directly

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -9,7 +9,7 @@ from agent.llm import llm_client
 from agent.memory import memory_system
 from session.manager import session_manager
 from skills.executor import (
-    _get_executor,
+    skills_executor,
     SkillResult,
     get_tools_schemas,
     execute_tool_by_name,
@@ -105,7 +105,7 @@ You have access to the following tools. When a user asks you to do something tha
         usage_data = {}
         
         # Check if message matches a skill first
-        skill_name = _get_executor().match_skill(message)
+        skill_name = skills_executor.match_skill(message)
         if skill_name:
             logger.info(f"Matched skill: {skill_name}")
             result = await self._execute_skill(skill_name, message, session_id)
@@ -214,7 +214,7 @@ You have access to the following tools. When a user asks you to do something tha
         try:
             # Note: session_id is used for tracking but not passed to skills
             # Skills don't accept session_id as a parameter
-            result = await _get_executor().execute_skill(
+            result = await skills_executor.execute_skill(
                 skill_name,
                 message=message,
             )


### PR DESCRIPTION
## Problem

After PR #38 unified the `skills_executor` initialization pattern, the `_get_executor()` lazy loading function was removed from `skills/executor/__init__.py`. However, `agent/core.py` still imports and uses `_get_executor`, causing an `ImportError`.

```
ImportError: cannot import name '_get_executor' from 'skills.executor'
```

## Solution

Replace all usages of `_get_executor()` with direct access to `skills_executor`:

1. Change import:
   ```python
   from skills.executor import (
       skills_executor,  # was: _get_executor
       ...
   )
   ```

2. Update function calls:
   ```python
   # Before
   skill_name = _get_executor().match_skill(message)
   result = await _get_executor().execute_skill(...)

   # After
   skill_name = skills_executor.match_skill(message)
   result = await skills_executor.execute_skill(...)
   ```

## Files Changed

- `agent/core.py` - 3 lines changed

## Verification

- VM-235 deployed and tested
- API responses working correctly
- Debug mode functional