### PR TITLE
fix: Add tools support to Ollama provider

### DIFF
--- a/agent/llm.py
+++ b/agent/llm.py
@@ -370,6 +370,23 @@ class OllamaProvider(BaseProvider):
             }
         }
         
+        # Add tools support for Ollama (format varies by model version)
+        if tools:
+            # Convert OpenAI-style tools to Ollama format if needed
+            # Note: Not all Ollama models support tools - check your model
+            ollama_tools = []
+            for tool in tools:
+                func = tool.get("function", {})
+                ollama_tools.append({
+                    "type": "function",
+                    "function": {
+                        "name": func.get("name", ""),
+                        "description": func.get("description", ""),
+                        "parameters": func.get("parameters", {}),
+                    }
+                })
+            payload["tools"] = ollama_tools
+        
         try:
             async with httpx.AsyncClient(timeout=120.0) as client:
                 response = await client.post(
@@ -391,9 +408,30 @@ class OllamaProvider(BaseProvider):
     def _parse_response(self, data: Dict) -> Dict[str, Any]:
         """Parse Ollama response."""
         message = data.get("message", {})
+        content = message.get("content", "")
+        
+        # Parse tool_calls from Ollama response
+        tool_calls = []
+        raw_tool_calls = message.get("tool_calls", [])
+        if not raw_tool_calls:
+            # Try alternative location
+            raw_tool_calls = data.get("message", {}).get("tool_calls", [])
+        
+        for tc in raw_tool_calls:
+            # Ollama format: {"function": {"name": "...", "arguments": "..."}}
+            func_data = tc.get("function", tc)
+            tool_calls.append({
+                "id": tc.get("id", f"call_{len(tool_calls)}"),
+                "type": "function",
+                "function": {
+                    "name": func_data.get("name", ""),
+                    "arguments": func_data.get("arguments", "{}")
+                }
+            })
+        
         return {
-            "content": message.get("content", ""),
-            "tool_calls": [],
+            "content": content,
+            "tool_calls": tool_calls,
             "usage": {
                 "prompt_tokens": data.get("prompt_eval_count", 0),
                 "completion_tokens": data.get("eval_count", 0),


### PR DESCRIPTION
## Problem

Ollama provider had the `tools` parameter in its signature but never used it:
- Tools were not added to the API payload
- `_parse_response()` always returned empty `tool_calls`

## Solution

1. Added tools to Ollama API payload (converted to Ollama format)
2. Updated `_parse_response()` to extract tool_calls from Ollama response
3. Ollama uses a different format for tool_calls - now handled

## Changes

### Before
```python
payload = {
    "model": model or self.default_model,
    "messages": full_messages,
    "stream": False,
    "options": {...}
}
# No tools added!

def _parse_response(self, data):
    return {"content": content, "tool_calls": [], ...}
```

### After
```python
payload = {
    "model": model or self.default_model,
    "messages": full_messages,
    "stream": False,
    "options": {...}
}

# Tools now added in Ollama format
if tools:
    payload["tools"] = ollama_tools

def _parse_response(self, data):
    # Tool calls are now parsed from response
    return {"content": content, "tool_calls": tool_calls, ...}
```

## Notes

- Not all Ollama models support tools/function calling
- Check your model documentation
- Requires Ollama version with tool support (ollama 0.1.40+)

## Testing

```yaml
llm:
  provider: "ollama"
  model: "llama3"  # or other model with tool support
```