### PR TITLE
fix: Separate is_configured() from is_enabled() for Jira channel

### DIFF
--- a/channel/jira.py
+++ b/channel/jira.py
@@ -93,8 +93,20 @@ class JiraChannel:
         return {}
     
     def is_configured(self) -> bool:
-        """Check if Jira is properly configured."""
-        return bool(self.base_url and self.username and self.api_token and self.enabled)
+        """Check if Jira is properly configured with required credentials.
+        
+        Note: This only checks if credentials are present, not if enabled.
+        Use is_enabled() to check if the channel should be active.
+        """
+        has_auth = bool(
+            (self.base_url) and
+            (self.bearer_token or (self.username and (self.api_token or self.password)))
+        )
+        return has_auth
+    
+    def is_enabled(self) -> bool:
+        """Check if Jira channel is enabled."""
+        return bool(self.enabled)
     
     async def _request(
         self,


### PR DESCRIPTION
## Problem

Original `is_configured()` required:
```python
return bool(self.base_url and self.username and self.api_token and self.enabled)
```

**Issues:**
1. Required both `username` AND `api_token` - but Bearer auth only needs `bearer_token`
2. Mixed `enabled` flag with credential check

## Solution

Separated concerns:
- `is_configured()`: Check if credentials are properly set (base_url + valid auth)
- `is_enabled()`: Check if channel is enabled

```python
def is_configured(self) -> bool:
    has_auth = bool(
        (self.base_url) and
        (self.bearer_token or (self.username and (self.api_token or self.password)))
    )
    return has_auth

def is_enabled(self) -> bool:
    return bool(self.enabled)
```

## Auth Types Supported

| Type | Required Fields |
|------|----------------|
| Bearer | base_url + bearer_token |
| Basic | base_url + username + (api_token OR password) |

## Files Changed

| File | Changes |
|------|---------|
| `channel/jira.py` | Split `is_configured()` and added `is_enabled()` |
