### PR TITLE
fix: Parse URL and path arguments in skill execution

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -303,6 +303,7 @@ You have access to the following tools. When a user asks you to do something tha
         try:
             # Parse command and arguments from message
             # Format: "git status" or "git log limit=5" or "git commit message='fix bug'"
+            #        or "git clone https://github.com/owner/repo.git"
             parts = message.split()
             if not parts:
                 return "Error: Empty message"
@@ -321,6 +322,12 @@ You have access to the following tools. When a user asks you to do something tha
                     if value.isdigit():
                         value = int(value)
                     args[key] = value
+                elif part.startswith('http://') or part.startswith('https://') or part.startswith('git@'):
+                    # Handle URL as path argument for clone operations
+                    args['path'] = part
+                elif part.startswith('/') or part.startswith('./') or part.startswith('../'):
+                    # Handle path arguments
+                    args['path'] = part
             
             result = await skills_executor.execute_skill(
                 skill_name,


### PR DESCRIPTION
## Overview

Allow passing URL/path as positional arguments in skill execution instead of requiring `key=value` format.

## Problem

When users said "git clone https://github.com/owner/repo.git", the URL was not parsed as the `path` argument because only `key=value` format was supported.

## Changes

### agent/core.py

Modified `_execute_skill()` to detect:
- URLs starting with `http://`, `https://`, or `git@`
- Paths starting with `/`, `./`, or `../`

These are now automatically passed as the `path` argument to skills.

## Example

Before (required format):
```
git clone path=https://github.com/owner/repo.git
```

After (now works):
```
git clone https://github.com/owner/repo.git
git clone git@github.com:owner/repo.git
```

## Related

Fixes SSH key setup not triggering for git clone operations.