### PR TITLE
feat: Add logging for subagent thinking level

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -184,6 +184,9 @@ You have access to the following tools. When a user asks you to do something tha
 
         # ===== REACT PATTERN =====
 
+        # Log thinking level for subagent tracking
+        logger.info(f"[{session_id}] think_level={self.think_level.value}, model={model or ''}")
+        
         # Step 1: Call LLM with tools
         logger.debug(f"Calling LLM with {len(self.tools)} tools")
         

--- a/tools/subagent.py
+++ b/tools/subagent.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional
 # Import Agent lazily to avoid circular imports
 _subagent_sessions: Dict[str, Dict[str, Any]] = {}
 
+logger = logging.getLogger(__name__)
+
 
 class SubAgent:
     """Represents a running sub-agent session."""
@@ -54,7 +56,8 @@ class SubAgent:
     async def _run(self):
         """Run the sub-agent task."""
         try:
-            logger.info(f"Sub-agent {self.session_key} started with task: {self.task[:100]}...")
+            logger.info(f"Sub-agent {self.session_key} started - think_level={self.thinking}, model={self.model}")
+            logger.debug(f"Task: {self.task[:200]}...")
             
             result = await self.agent.process(
                 message=self.task,
@@ -265,6 +268,9 @@ def sessions_spawn(
         "status": "started",
         "agent": subagent,
     }
+    
+    # Log subagent creation with thinking level
+    logger.info(f"Spawn subagent: session={session_key}, think_level={thinking}, model={model}")
     
     # Note: Actual async execution requires running event loop
     # The sub-agent will execute when process() is called


### PR DESCRIPTION
- tools/subagent.py: Add logger definition and log think_level when spawning subagent
- agent/core.py: Log think_level and model for each session processing

Log output examples:
- Spawn: "Spawn subagent: session=test, think_level=high, model=gpt-4"
- Process: "[test] think_level=high, model=gpt-4"