### PR TITLE
feat: Add debug logging for Claude and Ollama providers

### DIFF
--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -339,23 +339,32 @@ class GitHubCopilotProvider(BaseProvider):
             "X-GitHub-Api-Version": "2023-06-01",
             "Accept": "application/vnd.github.copilot-chat-preview+json",
         }
-        
+
         # Build messages - GitHub Copilot uses system differently
         all_messages = []
         if system_prompt:
             # GitHub Copilot: prepend system message to conversation
             all_messages.append({"role": "system", "content": system_prompt})
         all_messages.extend(messages)
-        
+
         payload = {
             "messages": all_messages,
             "model": model or self.default_model,
         }
-        
+
         # Add tools support (similar to OpenAI)
         if tools:
             payload["tools"] = tools
-        
+
+        # Debug: Log chat request details
+        if _is_debug_enabled():
+            logger.debug(f"=== [COPILOT] CHAT REQUEST ===")
+            logger.debug(f"Provider: {self.name}")
+            logger.debug(f"Model: {payload['model']}")
+            logger.debug(f"Messages count: {len(all_messages)}")
+            if system_prompt:
+                logger.debug(f"System prompt: {system_prompt[:200]}...")
+
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(
                 f"{self.api_base}/chat/completions",
@@ -364,6 +373,17 @@ class GitHubCopilotProvider(BaseProvider):
             )
             response.raise_for_status()
             data = response.json()
+
+        # Debug: Log response details
+        if _is_debug_enabled():
+            logger.debug(f"=== [COPILOT] CHAT RESPONSE ===")
+            message_data = data.get("choices", [{}])[0].get("message", {})
+            content = message_data.get("content", "")
+            logger.debug(f"Content length: {len(content)} chars")
+            if content:
+                logger.debug(f"Content preview: {content[:200]}...")
+            tool_calls = message_data.get("tool_calls", [])
+            logger.debug(f"Tool calls: {len(tool_calls)}")
         
         # Parse response - check for tool calls and reasoning
         message_data = data.get("choices", [{}])[0].get("message", {})
@@ -446,7 +466,18 @@ class ClaudeProvider(BaseProvider):
         
         if tools:
             payload["tools"] = self._convert_tools_to_claude(tools)
-        
+
+        # Debug: Log chat request details
+        if _is_debug_enabled():
+            logger.debug(f"=== [CLAUDE] CHAT REQUEST ===")
+            logger.debug(f"Provider: {self.name}")
+            logger.debug(f"Model: {payload['model']}")
+            logger.debug(f"Messages count: {len(all_messages)}")
+            if system_prompt:
+                logger.debug(f"System prompt: {system_prompt[:200]}...")
+            if tools:
+                logger.debug(f"Tools count: {len(tools)}")
+
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(
                 f"{self.api_base}/messages",
@@ -455,7 +486,20 @@ class ClaudeProvider(BaseProvider):
             )
             response.raise_for_status()
             data = response.json()
-        
+
+        # Debug: Log response details
+        if _is_debug_enabled():
+            logger.debug(f"=== [CLAUDE] CHAT RESPONSE ===")
+            content_blocks = data.get("content", [])
+            text_content = ""
+            for block in content_blocks:
+                if block.get("type") == "text":
+                    text_content = block.get("text", "")
+                    break
+            logger.debug(f"Content length: {len(text_content)} chars")
+            if text_content:
+                logger.debug(f"Content preview: {text_content[:200]}...")
+
         return self._parse_response(data)
     
     def _convert_tools_to_claude(self, tools: List[Dict]) -> List[Dict]:
@@ -574,7 +618,18 @@ class OllamaProvider(BaseProvider):
                     }
                 })
             payload["tools"] = ollama_tools
-        
+
+        # Debug: Log chat request details
+        if _is_debug_enabled():
+            logger.debug(f"=== [OLLAMA] CHAT REQUEST ===")
+            logger.debug(f"Provider: {self.name}")
+            logger.debug(f"Model: {payload['model']}")
+            logger.debug(f"Messages count: {len(full_messages)}")
+            if system_prompt:
+                logger.debug(f"System prompt: {system_prompt[:200]}...")
+            if tools:
+                logger.debug(f"Tools count: {len(tools)}")
+
         try:
             async with httpx.AsyncClient(timeout=120.0) as client:
                 response = await client.post(
@@ -590,7 +645,16 @@ class OllamaProvider(BaseProvider):
                 "error": "Ollama not running. Start with: ollama serve",
                 "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
             }
-        
+
+        # Debug: Log response details
+        if _is_debug_enabled():
+            logger.debug(f"=== [OLLAMA] CHAT RESPONSE ===")
+            message = data.get("message", {})
+            content = message.get("content", "")
+            logger.debug(f"Content length: {len(content)} chars")
+            if content:
+                logger.debug(f"Content preview: {content[:200]}...")
+
         return self._parse_response(data)
     
     def _parse_response(self, data: Dict) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
Add debug logging for Claude and Ollama providers.

## Changes
- **GitHubCopilotProvider**: Added `[COPILOT]` logging
- **ClaudeProvider**: Added `[CLAUDE]` logging  
- **OllamaProvider**: Added `[OLLAMA]` logging

All providers now log request details (model, messages, tools) and response details (content length, preview, tool calls) when DEBUG_LLM=true.

## Files
- `src/agents/llm.py` (+72 lines, -8 lines)

## Testing
- Tested locally with DEBUG_LLM=1