### PR TITLE
fix: Correct yaml.dump syntax in setup_gh_config

### DIFF
--- a/src/git/api.py
+++ b/src/git/api.py
@@ -168,7 +168,7 @@ async def setup_gh_config() -> bool:
         hosts_config = {"github.com": {"oauth_token": token, "user": ""}}
     
     with open(hosts_file, "w") as f:
-        yaml.dump({hosts_config, f)
+        yaml.dump(hosts_config, f)
     
     os.chmod(hosts_file, 0o600)
     return True


### PR DESCRIPTION
Fix syntax error where curly brace was used instead of parentheses. yaml.dump({hosts_config, f) -> yaml.dump(hosts_config, f)