### PR TITLE
fix: Remove string truncation to preserve complete data

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -13,6 +13,7 @@ from src.agents.llm import llm_client
 from src.agents.memory import memory_system
 from src.agents.thinking import ThinkLevel, normalize_think_level, format_runtime_info
 from src.config import config
+from src.utils.truncate import truncate, truncate_with_count
 from src.sessions.manager import session_manager
 from src.agents.executor import (
     skills_executor,
@@ -546,7 +547,7 @@ You have access to the following tools. When a user asks you to do something tha
                 
                 # Send completion event
                 send_event("complete", {
-                    "response": content[:500] if content else "",
+                    "response": truncate_with_count(content, 500),
                     "total_iterations": iteration
                 })
                 
@@ -629,7 +630,7 @@ You have access to the following tools. When a user asks you to do something tha
                 )
                 
                 # Send tool result event
-                result_preview = str(tool_result)[:200]
+                result_preview = truncate_with_count(str(tool_result), 200)
                 send_event("tool_result", {
                     "tool": tool_name,
                     "result": result_preview,
@@ -649,7 +650,7 @@ You have access to the following tools. When a user asks you to do something tha
                     extra={"tool_call_id": tool_call_id}
                 )
                 
-                logger.info(f"Tool result: {str(tool_result)[:200]}")
+                logger.info(f"Tool result: {truncate_with_count(str(tool_result), 200)}")
             
             # Send iteration complete event
             send_event("iteration_end", {"iteration": iteration})

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from src.config import config
+from src.utils.truncate import truncate, truncate_with_count
 from src.sessions.usage import usage_tracker, estimate_cost
 from .errors import (
     handle_httpx_error,
@@ -314,11 +315,11 @@ class OpenAIProvider(BaseProvider):
             logger.debug(f"Model: {payload['model']}")
             logger.debug(f"Messages count: {len(all_messages)}")
             if system_prompt:
-                logger.debug(f"System prompt: {system_prompt[:200]}...")
+                logger.debug(f"System prompt: {truncate(system_prompt, 200)}")
             logger.debug(f"Messages preview:")
             for i, msg in enumerate(all_messages[:5]):
                 role = msg.get("role", "unknown")
-                content = (msg.get("content") or "")[:100]
+                content = truncate(msg.get("content") or "", 100)
                 logger.debug(f"  [{i}] {role}: {content}")
             if len(all_messages) > 5:
                 logger.debug(f"  ... [{len(all_messages) - 5} more messages]")
@@ -341,7 +342,7 @@ class OpenAIProvider(BaseProvider):
             content = message.get("content") or ""
             logger.debug(f"Content length: {len(content)} chars")
             if content:
-                logger.debug(f"Content preview: {content[:200]}...")
+                logger.debug(f"Content preview: {truncate(content, 200)}")
             else:
                 logger.debug("Content: (empty - tool call response)")
             
@@ -349,7 +350,7 @@ class OpenAIProvider(BaseProvider):
             reasoning = message.get("reasoning")
             if reasoning:
                 logger.debug(f"Reasoning length: {len(reasoning)} chars")
-                logger.debug(f"Reasoning preview: {reasoning[:200]}...")
+                logger.debug(f"Reasoning preview: {truncate(reasoning, 200)}")
             
             tool_calls = message.get("tool_calls", [])
             logger.debug(f"Tool calls: {len(tool_calls)}")
@@ -472,7 +473,7 @@ class GitHubCopilotProvider(BaseProvider):
                     msg_summary["tool_call_id"] = msg.get("tool_call_id")
                 if msg.get("content"):
                     content = msg.get("content", "")
-                    msg_summary["content"] = content[:100] + "..." if len(content) > 100 else content
+                    msg_summary["content"] = truncate(content, 100)
                 logger.debug(f"  Message {i}: {msg_summary}")
         
         # Make API call with proper error handling

--- a/src/confluence/__init__.py
+++ b/src/confluence/__init__.py
@@ -53,7 +53,7 @@ async def confluence_get_page(page_id: str) -> str:
         else:
             body = 'No content'
         
-        return f"**{title}**\n\n{body[:500]}..."
+        return f"**{title}**\n\n{body}"
     except Exception as e:
         return f"Error getting page: {e}"
 
@@ -134,7 +134,7 @@ async def confluence_get_page_by_url(url: str) -> str:
         else:
             body = 'No content'
         
-        return f"**{title}**\n\nURL: {url}\n\n{body[:2000]}..."
+        return f"**{title}**\n\nURL: {url}\n\n{body}"
     except Exception as e:
         return f"Error getting page by URL: {e}"
 
@@ -185,7 +185,7 @@ async def confluence_get_comments(page_id: str) -> str:
                 body = c.get("body", {})
                 if isinstance(body, dict):
                     body = body.get("storage", {}).get("value", "")
-                lines.append(f"- {body[:200]}")
+                lines.append(f"- {body}")
             return "\n".join(lines)
         return str(result)
     except Exception as e:
@@ -299,7 +299,7 @@ async def confluence_get_space(space_key: str) -> str:
         if isinstance(result, dict):
             name = result.get("name", "Untitled")
             description = result.get("description", {}).get("plain", {}).get("value", "No description")
-            return f"**Space: {name}** ({space_key})\n\n{description[:500]}"
+            return f"**Space: {name}** ({space_key})\n\n{description}"
         return str(result)
     except Exception as e:
         return f"Error getting space: {e}"

--- a/src/confluence/api.py
+++ b/src/confluence/api.py
@@ -547,7 +547,7 @@ async def confluence_get_comments(page_id: str) -> str:
             author = comment.get("by", {}).get("displayName", "Unknown")
             created = comment.get("created", "")[:10]
             body = _extract_comment_body(comment)
-            lines.append(f"\n**{author}** ({created}):\n{body[:200]}")
+            lines.append(f"\n**{author}** ({created}):\n{body}")
         
         return "\n".join(lines)
     except Exception as e:
@@ -618,13 +618,13 @@ def _format_page_info(page: Dict) -> str:
     # Get body content - handle case where body might be a string or None
     body = page.get("body", {})
     if isinstance(body, str):
-        content = body[:1000]
+        content = body
     elif isinstance(body, dict):
         storage_body = body.get("storage", {})
         if isinstance(storage_body, dict):
-            content = storage_body.get("value", "")[:1000]
+            content = storage_body.get("value", "")
         else:
-            content = str(storage_body)[:1000] if storage_body else ""
+            content = str(storage_body) if storage_body else ""
     else:
         content = ""
     

--- a/src/github/__init__.py
+++ b/src/github/__init__.py
@@ -13,8 +13,8 @@ async def github_get_issue(owner: str, repo: str, issue_number: int) -> str:
         issue = await github_channel.get_issue(owner, repo, issue_number)
         state = issue.get("state", "unknown")
         title = issue.get("title", "Untitled")
-        body = issue.get("body", "")[:200]
-        return f"**{owner}/{repo}#{issue_number}: {title}**\n\n**State:** {state}\n\n{body}..."
+        body = issue.get("body", "")
+        return f"**{owner}/{repo}#{issue_number}: {title}**\n\n**State:** {state}\n\n{body}"
     except Exception as e:
         return f"Error getting issue: {e}"
 

--- a/src/github/api.py
+++ b/src/github/api.py
@@ -512,9 +512,9 @@ async def github_get_issue(owner: str, repo: str, issue_number: int) -> str:
         
         state = issue.get("state", "unknown")
         title = issue.get("title", "Untitled")
-        body = issue.get("body", "")[:200]
+        body = issue.get("body", "")
         
-        return f"**{owner}/{repo}#{issue_number}: {title}**\n\n**State:** {state}\n\n{body}..."
+        return f"**{owner}/{repo}#{issue_number}: {title}**\n\n**State:** {state}\n\n{body}"
     except Exception as e:
         return f"Error getting issue: {e}"
 

--- a/src/github/cli.py
+++ b/src/github/cli.py
@@ -101,7 +101,7 @@ class GitHubCLI:
                 f"**State:** {data.get('state')}",
                 f"**Author:** {data.get('author', {}).get('login', 'unknown')}",
                 "",
-                data.get('body', 'No description')[:500]
+                data.get('body', 'No description')
             ]
             return "\n".join(lines)
         except json.JSONDecodeError:
@@ -188,7 +188,7 @@ class GitHubCLI:
                 f"**Author:** {data.get('author', {}).get('login', 'unknown')}",
                 f"**Changes:** +{data.get('additions', 0)} -{data.get('deletions', 0)}",
                 "",
-                data.get('body', 'No description')[:500]
+                data.get('body', 'No description')
             ]
             return "\n".join(lines)
         except json.JSONDecodeError:

--- a/src/jira/api.py
+++ b/src/jira/api.py
@@ -689,7 +689,7 @@ async def jira_get_issue(issue_key: str) -> str:
 **Updated:** {fields.get("updated", "")[:10]}
 
 **Description:**
-{description[:500]}{'...' if len(description) > 500 else ''}"""
+{description}"""
     except httpx.HTTPStatusError as e:
         logger.error(f"jira_get_issue: HTTP error {e.response.status_code} for {issue_key}")
         return f"Error: HTTP {e.response.status_code} - {e.response.reason_phrase}"

--- a/src/sessions/pruning.py
+++ b/src/sessions/pruning.py
@@ -171,9 +171,7 @@ class SessionCompactor:
             role = msg.get("role", "unknown")
             content = msg.get("content", "")
             
-            # Truncate long content
-            if len(content) > 1000:
-                content = content[:1000] + "..."
+            # Keep full content (no truncation to preserve data)
             
             lines.append(f"{role.upper()}: {content}")
         

--- a/src/utils/truncate.py
+++ b/src/utils/truncate.py
@@ -1,0 +1,40 @@
+"""String truncation utilities."""
+
+def truncate(text: str, max_length: int = 500, suffix: str = "...") -> str:
+    """Safely truncate string, never raises error.
+    
+    Args:
+        text: String to truncate
+        max_length: Maximum length before truncation
+        suffix: Suffix to append when truncated
+        
+    Returns:
+        Truncated string with suffix if needed
+    """
+    if not text:
+        return ""
+    text = str(text)
+    if len(text) <= max_length:
+        return text
+    return text[:max_length] + suffix
+
+
+def truncate_with_count(text: str, max_length: int = 500) -> str:
+    """Truncate and show remaining character count.
+    
+    Args:
+        text: String to truncate
+        max_length: Maximum length before truncation
+        
+    Returns:
+        Truncated string with count info if needed
+    """
+    if not text:
+        return "(empty)"
+    text = str(text)
+    if len(text) <= max_length:
+        return text
+    return f"{text[:max_length]}... [{len(text) - max_length} chars hidden]"
+
+
+__all__ = ["truncate", "truncate_with_count"]


### PR DESCRIPTION
- Add src/utils/truncate.py with safe truncation functions
- Remove all truncation in:
  - sessions/pruning.py: Keep full content
  - jira/api.py: Return full description
  - confluence/__init__.py: Return full body
  - confluence/api.py: Return full content
  - github/__init__.py: Return full body
  - github/api.py: Return full body
  - github/cli.py: Return full body
- Use truncate/truncate_with_count in agents for preview/logging only