### PR TITLE
chore: Remove Reference issue URLs from docstrings

### DIFF
--- a/src/skills/__init__.py
+++ b/src/skills/__init__.py
@@ -1,7 +1,5 @@
 """Skills Framework - Modular skill processing engine.
 
-Reference: https://github.com/dvnuo/engineering-flow-platform/issues/169
-
 Architecture:
 - Skills are prompt-level abstractions (NOT executable code)
 - Tools are executable capabilities

--- a/src/skills/registry.py
+++ b/src/skills/registry.py
@@ -1,7 +1,5 @@
 """Skill Registry - Central storage and discovery of all available skills.
 
-Reference: https://github.com/dvnuo/engineering-flow-platform/issues/169
-
 Responsibilities:
 - Load skills at startup
 - Index trigger keywords

--- a/src/skills/tracer.py
+++ b/src/skills/tracer.py
@@ -1,7 +1,5 @@
 """Skill Execution Tracer - Audit and replay capability.
 
-Reference: https://github.com/dvnuo/engineering-flow-platform/issues/169
-
 Responsibilities:
 - FR-7: Execution Trace - Log matched skill, tool calls, input/output
 - FR-8: Replay Capability - Support replaying tool sequence for debugging


### PR DESCRIPTION
This pull request makes minor documentation updates to the skills framework. The main change is the removal of outdated reference links from the docstrings in several files.