### PR TITLE
Fix/GitHub enterprise description

### DIFF
--- a/src/bash_tools/api.py
+++ b/src/bash_tools/api.py
@@ -313,10 +313,9 @@ def get_tools_schemas() -> list:
 - git status, git add ., git commit -m "msg", git push
 - git log --oneline -10, git diff, git checkout -b branch
 
-**GitHub (gh):**
+**GitHub (gh):** (Enterprise only - uses config from ~/gh/hosts.yml)
 - gh repo view, gh issue list, gh pr list
 - gh pr view 123, gh pr checkout 123
-- **Supports GitHub Enterprise** - uses config from ~/gh/hosts.yml
 
 **Search:**
 - grep -r "pattern" ., rg "pattern" --type py

--- a/src/github/__init__.py
+++ b/src/github/__init__.py
@@ -10,7 +10,7 @@ __all__ = ["GitHubClient", "github_channel", "github_get_issue", "github_search_
 async def github_get_issue(owner: str, repo: str, issue_number: int) -> str:
     """Get GitHub issue or PR details.
     
-    Supports both public GitHub (github.com) and GitHub Enterprise.
+    Only supports GitHub Enterprise (internal).
     Uses base_url from config (defaults to api.github.com for public).
     """
     try:
@@ -26,7 +26,7 @@ async def github_get_issue(owner: str, repo: str, issue_number: int) -> str:
 async def github_search_issues(query: str, max_results: int = 10) -> str:
     """Search GitHub issues and PRs.
     
-    Supports both public GitHub (github.com) and GitHub Enterprise.
+    Only supports GitHub Enterprise (internal).
     """
     try:
         result = await github_channel.search_issues(query, max_results)
@@ -49,7 +49,7 @@ async def github_search_issues(query: str, max_results: int = 10) -> str:
 async def github_add_comment(owner: str, repo: str, issue_number: int, comment: str) -> str:
     """Add a comment to a GitHub issue or PR.
     
-    Supports both public GitHub (github.com) and GitHub Enterprise.
+    Only supports GitHub Enterprise (internal).
     """
     try:
         result = await github_channel.add_comment(owner, repo, issue_number, comment)
@@ -62,7 +62,7 @@ async def github_add_comment(owner: str, repo: str, issue_number: int, comment: 
 def get_tools_schemas() -> list:
     """Return GitHub tool schemas for OpenAI.
     
-    Supports both public GitHub (github.com) and GitHub Enterprise.
+    Only supports GitHub Enterprise (internal).
     For internal GitHub Enterprise, use gh CLI (exec tool) or configure base_url in config.
     """
     return [
@@ -70,7 +70,7 @@ def get_tools_schemas() -> list:
             "type": "function",
             "function": {
                 "name": "github_get_issue",
-                "description": "Get GitHub issue or PR details. Supports both public GitHub and GitHub Enterprise.",
+                "description": "Get GitHub issue or PR details. Only supports GitHub Enterprise (internal).",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -86,7 +86,7 @@ def get_tools_schemas() -> list:
             "type": "function",
             "function": {
                 "name": "github_search_issues",
-                "description": "Search GitHub issues and PRs. Supports both public GitHub and GitHub Enterprise.",
+                "description": "Search GitHub issues and PRs. Only supports GitHub Enterprise (internal).",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -101,7 +101,7 @@ def get_tools_schemas() -> list:
             "type": "function",
             "function": {
                 "name": "github_add_comment",
-                "description": "Add a comment to a GitHub issue or PR. Supports both public GitHub and GitHub Enterprise.",
+                "description": "Add a comment to a GitHub issue or PR. Only supports GitHub Enterprise (internal).",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/src/github/api.py
+++ b/src/github/api.py
@@ -69,12 +69,12 @@ class GitHubChannel:
     Configuration:
         github.api_token: API token for authentication
         github.enabled: Whether GitHub integration is enabled
-        github.base_url: Base URL for API (default: https://api.github.com)
+        github.base_url: Base URL for API (default: (enterprise only - must configure base_url))
         github.hostname: Hostname for gh CLI (defaults to base_url hostname)
     """
     
     def __init__(self):
-        self.base_url = config.get("github.base_url", "https://api.github.com")
+        self.base_url = config.get("github.base_url", "(enterprise only)")
         self.token = config.get("github.api_token", "")
         self.enabled = config.get("github.enabled", False)
         self.hostname = config.get("github.hostname", "")
@@ -95,7 +95,7 @@ class GitHubChannel:
         """Reinitialize GitHubChannel (called when config changes)."""
         logger.info("Reinitializing GitHubChannel...")
         github_config = config.github or {}
-        self.base_url = github_config.get("base_url", "https://api.github.com")
+        self.base_url = github_config.get("base_url", "(enterprise only)")
         self.token = github_config.get("api_token", "")
         self.enabled = github_config.get("enabled", False)
         self.hostname = github_config.get("hostname", "")


### PR DESCRIPTION
This pull request updates the GitHub integration to clarify that support is now limited to GitHub Enterprise (internal use only). It updates documentation, function docstrings, and configuration defaults to reflect this restriction, and adjusts user-facing descriptions to prevent confusion about public GitHub support.

**GitHub Enterprise-only clarification:**

* Updated all relevant function docstrings in `src/github/__init__.py` (`github_get_issue`, `github_search_issues`, `github_add_comment`, and `get_tools_schemas`) to explicitly state that only GitHub Enterprise is supported, and clarified configuration requirements. [[1]](diffhunk://#diff-d0c9567cebd2052e7d1eba8894216715d7d3e2e67e5ae281a9edca42c8e03936L11-R15) [[2]](diffhunk://#diff-d0c9567cebd2052e7d1eba8894216715d7d3e2e67e5ae281a9edca42c8e03936L23-R30) [[3]](diffhunk://#diff-d0c9567cebd2052e7d1eba8894216715d7d3e2e67e5ae281a9edca42c8e03936L43-R53) [[4]](diffhunk://#diff-d0c9567cebd2052e7d1eba8894216715d7d3e2e67e5ae281a9edca42c8e03936L53-R77)
* Updated tool schema descriptions and parameter documentation in `get_tools_schemas` to indicate GitHub Enterprise-only support and provide more specific guidance for internal usage. [[1]](diffhunk://#diff-d0c9567cebd2052e7d1eba8894216715d7d3e2e67e5ae281a9edca42c8e03936L53-R77) [[2]](diffhunk://#diff-d0c9567cebd2052e7d1eba8894216715d7d3e2e67e5ae281a9edca42c8e03936L75-R89) [[3]](diffhunk://#diff-d0c9567cebd2052e7d1eba8894216715d7d3e2e67e5ae281a9edca42c8e03936L90-R104)

**Configuration changes:**

* Changed the default value for `github.base_url` in `src/github/api.py` to indicate that it must be configured for enterprise use, both in the class initializer and in the `reinit` method. [[1]](diffhunk://#diff-529fd800eca3413f9b627150789cc1b8e884abd3eec3d0dc1f8b54ee526e12afL72-R77) [[2]](diffhunk://#diff-529fd800eca3413f9b627150789cc1b8e884abd3eec3d0dc1f8b54ee526e12afL98-R98)

**Documentation improvements:**

* Updated inline documentation and user-facing comments to clarify the distinction between public GitHub and GitHub Enterprise, and to direct users to configure their environment accordingly.