### PR TITLE
fix: Add session isolation to tracer events

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -557,7 +557,7 @@ You have access to the following tools. When a user asks you to do something tha
                 # Get events for UI
                 from src.skills import get_tracer
                 tracer_instance = get_tracer()
-                events = tracer_instance.get_events_for_ui(limit=10)
+                events = tracer_instance.get_events_for_ui(limit=10, session_id=session_id)
                 result["events"] = events
                 
                 return result
@@ -674,7 +674,7 @@ You have access to the following tools. When a user asks you to do something tha
         # Get events for UI
         from src.skills import get_tracer
         tracer_instance = get_tracer()
-        events = tracer_instance.get_events_for_ui(limit=10)
+        events = tracer_instance.get_events_for_ui(limit=10, session_id=session_id)
         
         return {"response": "Task completed (max iterations reached)", "usage": usage_data or {}, "events": events}
 

--- a/src/skills/tracer.py
+++ b/src/skills/tracer.py
@@ -196,13 +196,14 @@ class ExecutionTracer:
             for e in self.execution_history[-limit:]
         ]
     
-    def get_events_for_ui(self, limit: int = 10, event_types: List[str] = None) -> List[Dict]:
+    def get_events_for_ui(self, limit: int = 10, event_types: List[str] = None, session_id: str = None) -> List[Dict]:
         """Get events formatted for UI display.
         
         Args:
             limit: Maximum number of executions to include
             event_types: Optional list of event types to include (e.g., ['skill_matched', 'tool_call', 'tool_result', 'llm_thinking', 'complete'])
                        If None, all event types are included
+            session_id: Optional session ID to filter events (for session isolation)
         
         Returns:
             List of events with type, data, and display info
@@ -222,7 +223,14 @@ class ExecutionTracer:
         
         events = []
         
-        for execution in self.execution_history[-limit:]:
+        # Filter executions by session_id if provided (for session isolation)
+        filtered_executions = self.execution_history
+        if session_id:
+            filtered_executions = [e for e in self.execution_history if e.session_id == session_id]
+            # Take only the last 'limit' executions for this session
+            filtered_executions = filtered_executions[-limit:]
+        
+        for execution in filtered_executions:
             # Skill matched
             if 'skill_matched' in event_types and execution.matched_skill:
                 events.append({


### PR DESCRIPTION
- Add session_id parameter to get_events_for_ui() for filtering
- Update core.py to pass session_id when fetching events
- Each session now only sees its own thinking/process events