### PR TITLE
fix: Use list+join instead of bytearray for file upload

### DIFF
--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -1091,6 +1091,8 @@ async def api_files_upload(request: web.Request) -> web.Response:
         # Upload
         metadata = await upload_file(
             content=b"".join(content_chunks),
+            filename=filename,
+            session_id=session_id,
             max_size_mb=max_size_mb
         )
         


### PR DESCRIPTION
bytearray.extend() is incompatible with aiohttp's read() method

This pull request refactors the file upload handling in the `api_files_upload` endpoint to improve memory efficiency for large files. Instead of accumulating the entire file in a single `bytearray`, the code now collects file chunks in a list and joins them at the end, which can be more efficient for large uploads.

**File upload handling improvements:**

* Changed the file upload logic to collect file chunks in a `content_chunks` list and track the total size incrementally, instead of using a single `bytearray`. This makes the upload process more memory-efficient and scalable for large files.
* Updated the call to `upload_file` to join the collected chunks into a single bytes object before uploading, ensuring compatibility with the new chunked approach.