### PR TITLE
Set default model to gpt-5-mini and update UI options

### DIFF
--- a/docs/openai-responses-api.md
+++ b/docs/openai-responses-api.md
@@ -1,0 +1,19 @@
+# OpenAI GPT-5 Model Support
+
+## 目标
+
+将默认模型从 gpt-3.5-turbo 升级到 gpt-5-mini。
+
+## 改动范围
+
+### 1. 后端 (src/agents/llm.py)
+- 默认模型改为 gpt-5-mini
+
+### 2. 前端设置页面
+- 移除旧模型（GPT-4 及以下）
+- 显示新模型选项：GPT-5 Mini, GPT-5, GPT-4o
+
+## 注意
+
+- gpt-5-mini 和 gpt-5 可能需要 OpenAI API 许可才能使用
+- 如果模型不可用，API 会返回错误

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -255,7 +255,7 @@ class OpenAIProvider(BaseProvider):
             api_base=config.llm.get('api_base', 'https://api.openai.com/v1'),
             api_key_env='EFP_LLM_API_KEY'
         )
-        self.default_model = config.llm.get('model', 'gpt-3.5-turbo')
+        self.default_model = config.llm.get('model', 'gpt-5-mini')
     
     async def chat(
         self,
@@ -389,8 +389,8 @@ class OpenAIProvider(BaseProvider):
     
     def list_models(self) -> List[str]:
         return [
-            "gpt-3.5-turbo",
-            "gpt-3.5-turbo-16k",
+            "gpt-5-mini",
+            "gpt-5-mini-16k",
             "gpt-4",
             "gpt-4-turbo",
             "gpt-4o",

--- a/src/gateway/templates/settings/index.html
+++ b/src/gateway/templates/settings/index.html
@@ -30,9 +30,9 @@
             <div class="form-group">
                 <label for="model">Model</label>
                 <select id="model">
-                    <option value="gpt-4">GPT-4</option>
-                    <option value="gpt-4-turbo">GPT-4 Turbo</option>
-                    <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
+                    <option value="gpt-5-mini">GPT-5 Mini</option>
+                    <option value="gpt-5">GPT-5</option>
+                    <option value="gpt-4o">GPT-4o</option>
                 </select>
             </div>
 


### PR DESCRIPTION
This pull request updates the LLM model support in both backend and frontend, upgrading the default model to GPT-5 Mini and adjusting available model options throughout the application. The changes ensure that users can select newer models and remove outdated ones.

**Backend Model Updates:**
- Changed the default LLM model in `llm.py` from `gpt-3.5-turbo` to `gpt-5-mini`, so all new requests use the latest model by default.
- Updated the `list_models` method to include `gpt-5-mini` and its 16k variant, while removing older `gpt-3.5-turbo` entries.

**Frontend Model Selection:**
- Modified the settings page dropdown in `index.html` to remove GPT-4 and earlier models, and add options for `GPT-5 Mini`, `GPT-5`, and `GPT-4o`.

**Documentation:**
- Added a new documentation file outlining the scope and details of the GPT-5 model upgrade, including backend and frontend changes, and notes about API access requirements.