### PR TITLE
Add input_items parameter to GitHubCopilotProvider.responses

### DIFF
--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -839,7 +839,8 @@ class GitHubCopilotProvider(BaseProvider):
 
     async def responses(
         self,
-        messages: List[Dict],
+        messages: Optional[List[Dict]] = None,
+        input_items: Optional[List[Dict]] = None,
         system_prompt: Optional[str] = None,
         tools: Optional[List[Dict]] = None,
         model: Optional[str] = None,


### PR DESCRIPTION
This pull request makes a small update to the `responses` method in the `src/agents/llm.py` file, improving its flexibility by allowing the `messages` argument to be optional and introducing a new optional `input_items` parameter.