### PR TITLE
Optimize keydown handler for IME protection and cursor-based input

### DIFF
--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -901,7 +901,9 @@
                     const cursorPos = messageInput.selectionStart;
                     const atIndex = messageInput.value.lastIndexOf('@', cursorPos - 1);
                     if (atIndex !== -1) {
-                        messageInput.value = messageInput.value.slice(0, atIndex) + '@file_' + fileId.slice(0, 8) + ' ';
+                        const textBefore = messageInput.value.slice(0, atIndex);
+                        const textAfter = messageInput.value.slice(cursorPos);
+                        messageInput.value = textBefore + '@file_' + fileId.slice(0, 8) + ' ' + textAfter;
                     }
                     messageInput.focus();
                     hideFileSelector();


### PR DESCRIPTION
This pull request updates the `webchat.js` file to improve the behavior of the skill and file selectors in the chat input. The changes ensure selectors open and close more reliably based on user input, and enhance message sending logic to prevent issues with IME (Input Method Editor) composition. The most important changes are grouped below:

**Skill and File Selector Behavior Improvements:**

* The skill selector now opens when `/` is inserted at the start of the input, and the file selector opens when `@` is inserted at the start or after a space/newline. The code explicitly inserts these characters at the cursor position before opening the selector.
* The selectors are now closed automatically if their trigger character (`/` for skill selector, `@` for file selector) is deleted from the input, based on the current input value and cursor position. This logic has been moved from the keydown handler to the input event for more reliable detection.
* When inserting a file reference, the code now uses the cursor position to find the nearest `@` character, ensuring the correct replacement even if multiple `@` characters exist in the input.

**Message Sending Logic:**

* The message sending logic now includes protection against sending messages while IME composition is active, preventing accidental sends when users are typing in languages that use IME.…r-based replacement