### PR TITLE
feat: auto-switch to vision model when message contains images

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -731,7 +731,7 @@ You have access to the following tools. When a user asks you to do something tha
             if config_provider and isinstance(config_provider, str) and config_provider.strip():
                 provider = config_provider.lower()
             else:
-                provider = getattr(llm_client, "default_provider", "openai")
+                provider = (getattr(llm_client, "default_provider", None) or "openai").lower()
             
             # Check if messages contain images (handle both top-level and nested in content)
             has_images = False

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -718,11 +718,32 @@ You have access to the following tools. When a user asks you to do something tha
             
             logger.debug(f"[Tool Loop] Iteration {iteration}: Calling LLM with {len(input_items)} input_items")
             
+            # Check if any message contains images - if so, use vision model
+            from src.agents.llm import is_vision_model, get_vision_fallback_model
+            current_model = self.model or config.llm.get("model", "gpt-5-mini")
+            provider = config.llm.get("provider", "").lower()
+            
+            # Check if messages contain images
+            has_images = False
+            for item in input_items:
+                if item.get("type") == "input_image":
+                    has_images = True
+                    break
+            
+            # Switch to vision model if current model doesn't support images
+            effective_model = current_model
+            if has_images and not is_vision_model(provider, current_model):
+                fallback = get_vision_fallback_model(provider)
+                if fallback:
+                    logger.info(f"[Tool Loop] Message contains images, switching from {current_model} to {fallback}")
+                    effective_model = fallback
+            
             llm_result = await llm_client.responses(
                 input_items=input_items,
                 system_prompt=effective_system_prompt,
                 tools=self.tools,
                 reasoning_replay=enable_reasoning,
+                model=effective_model,  # Pass the effective model
             )
             
             # Check for LLM configuration error

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from src.agents.heartbeat import get_heartbeat, start_heartbeat, stop_heartbeat
 from src.agents.llm import (
+    _normalize_provider_key,
     llm_client,
     is_vision_model,
     get_vision_fallback_model,
@@ -779,7 +780,7 @@ You have access to the following tools. When a user asks you to do something tha
             
             # Pass provider to ensure correct LLM client routing
             if provider:
-                llm_kwargs["provider"] = provider
+                llm_kwargs["provider"] = _normalize_provider_key(provider)
             
             llm_result = await llm_client.responses(**llm_kwargs)
             # Check for LLM configuration error

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -10,7 +10,11 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
 from src.agents.heartbeat import get_heartbeat, start_heartbeat, stop_heartbeat
-from src.agents.llm import llm_client
+from src.agents.llm import (
+    llm_client,
+    is_vision_model,
+    get_vision_fallback_model,
+)
 from src.agents.memory import memory_system
 from src.memory.update_manager import MemoryUpdateManager
 from src.agents.thinking import ThinkLevel, normalize_think_level, format_runtime_info
@@ -719,33 +723,55 @@ You have access to the following tools. When a user asks you to do something tha
             logger.debug(f"[Tool Loop] Iteration {iteration}: Calling LLM with {len(input_items)} input_items")
             
             # Check if any message contains images - if so, use vision model
-            from src.agents.llm import is_vision_model, get_vision_fallback_model
-            current_model = self.model or config.llm.get("model", "gpt-5-mini")
+            # Use model explicitly set in agent, otherwise let provider decide
+            current_model = self.model or config.llm.get("model")
             provider = config.llm.get("provider", "").lower()
             
-            # Check if messages contain images
+            # Check if messages contain images (handle both top-level and nested in content)
             has_images = False
             for item in input_items:
+                # Handle top-level image items
                 if item.get("type") == "input_image":
                     has_images = True
                     break
+                # Handle images nested inside a message's content list
+                content = item.get("content")
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "input_image":
+                            has_images = True
+                            break
+                    if has_images:
+                        break
             
             # Switch to vision model if current model doesn't support images
             effective_model = current_model
-            if has_images and not is_vision_model(provider, current_model):
-                fallback = get_vision_fallback_model(provider)
-                if fallback:
-                    logger.info(f"[Tool Loop] Message contains images, switching from {current_model} to {fallback}")
-                    effective_model = fallback
+            if has_images:
+                if current_model:
+                    # Explicit model set but may not support vision
+                    if not is_vision_model(provider, current_model):
+                        fallback = get_vision_fallback_model(provider)
+                        if fallback:
+                            logger.info(f"[Tool Loop] Message contains images, switching from {current_model} to {fallback}")
+                            effective_model = fallback
+                else:
+                    # No explicit model, use provider's vision default
+                    fallback = get_vision_fallback_model(provider)
+                    if fallback:
+                        logger.info(f"[Tool Loop] Message contains images, using vision fallback {fallback}")
+                        effective_model = fallback
             
-            llm_result = await llm_client.responses(
+            # Only pass model if explicitly set
+            llm_kwargs = dict(
                 input_items=input_items,
                 system_prompt=effective_system_prompt,
                 tools=self.tools,
                 reasoning_replay=enable_reasoning,
-                model=effective_model,  # Pass the effective model
             )
+            if effective_model:
+                llm_kwargs["model"] = effective_model
             
+            llm_result = await llm_client.responses(**llm_kwargs)
             # Check for LLM configuration error
             if llm_result.get("error"):
                 error_info = llm_result["error"]

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -725,7 +725,13 @@ You have access to the following tools. When a user asks you to do something tha
             # Check if any message contains images - if so, use vision model
             # Use model explicitly set in agent, otherwise let provider decide
             current_model = self.model or config.llm.get("model")
-            provider = config.llm.get("provider", "").lower()
+            
+            # Resolve provider: use config if set, otherwise use llm_client's default
+            config_provider = config.llm.get("provider")
+            if config_provider and isinstance(config_provider, str) and config_provider.strip():
+                provider = config_provider.lower()
+            else:
+                provider = getattr(llm_client, "default_provider", "openai")
             
             # Check if messages contain images (handle both top-level and nested in content)
             has_images = False

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -777,6 +777,10 @@ You have access to the following tools. When a user asks you to do something tha
             if effective_model:
                 llm_kwargs["model"] = effective_model
             
+            # Pass provider to ensure correct LLM client routing
+            if provider:
+                llm_kwargs["provider"] = provider
+            
             llm_result = await llm_client.responses(**llm_kwargs)
             # Check for LLM configuration error
             if llm_result.get("error"):

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -1739,24 +1739,48 @@ service_reload_manager.register('llm', llm_client.reinit)
 USE_VISION_MODELS = {
     "openai": {"gpt-4o", "gpt-4o-mini", "gpt-5-mini", "gpt-5"},
     "github_copilot": {"gpt-4o", "gpt-5-mini", "gpt-5", "gemini-2.5-pro"},
-    "claude": {"claude-sonnet-4", "claude-haiku-4", "claude-opus-4"},
+    "claude": {"claude-sonnet", "claude-haiku", "claude-opus"},
+    "anthropic": {"claude-sonnet", "claude-haiku", "claude-opus"},  # Alias for claude
     "ollama": set(),  # Ollama vision support varies
 }
 
 
 def get_vision_fallback_model(provider: str) -> Optional[str]:
     """Get a fallback model that supports vision for a provider."""
+    # Normalize provider alias
+    if provider == "anthropic":
+        provider = "claude"
+    
     vision_fallbacks = {
         "openai": "gpt-5-mini",
         "github_copilot": "gpt-5-mini",
-        "claude": "claude-haiku-4",
+        "claude": "claude-haiku-4-20250514",
         "ollama": None,
     }
     return vision_fallbacks.get(provider)
 
 
 def is_vision_model(provider: str, model: str) -> bool:
-    """Check if a model supports vision/image input."""
+    """Check if a model supports vision/image input.
+    
+    Supports prefix matching for versioned model names (e.g., claude-sonnet-4-20250514).
+    """
+    # Normalize provider alias
+    if provider == "anthropic":
+        provider = "claude"
+    
     if provider not in USE_VISION_MODELS:
         return False
-    return model.lower() in USE_VISION_MODELS[provider]
+    
+    model_lower = model.lower()
+    
+    # Check exact match first
+    if model_lower in USE_VISION_MODELS[provider]:
+        return True
+    
+    # Check prefix match for versioned models
+    for base_name in USE_VISION_MODELS[provider]:
+        if model_lower.startswith(base_name.lower()):
+            return True
+    
+    return False

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -1734,3 +1734,29 @@ llm_client = LLMClient()
 # Register for config reload
 from src.config import service_reload_manager
 service_reload_manager.register('llm', llm_client.reinit)
+
+# Models that support vision/image input
+USE_VISION_MODELS = {
+    "openai": {"gpt-4o", "gpt-4o-mini", "gpt-5-mini", "gpt-5"},
+    "github_copilot": {"gpt-4o", "gpt-5-mini", "gpt-5", "gemini-2.5-pro"},
+    "claude": {"claude-sonnet-4", "claude-haiku-4", "claude-opus-4"},
+    "ollama": set(),  # Ollama vision support varies
+}
+
+
+def get_vision_fallback_model(provider: str) -> Optional[str]:
+    """Get a fallback model that supports vision for a provider."""
+    vision_fallbacks = {
+        "openai": "gpt-5-mini",
+        "github_copilot": "gpt-5-mini",
+        "claude": "claude-haiku-4",
+        "ollama": None,
+    }
+    return vision_fallbacks.get(provider)
+
+
+def is_vision_model(provider: str, model: str) -> bool:
+    """Check if a model supports vision/image input."""
+    if provider not in USE_VISION_MODELS:
+        return False
+    return model.lower() in USE_VISION_MODELS[provider]

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -1740,7 +1740,6 @@ USE_VISION_MODELS = {
     "openai": {"gpt-4o", "gpt-4o-mini", "gpt-5-mini", "gpt-5"},
     "github_copilot": {"gpt-4o", "gpt-5-mini", "gpt-5", "gemini-2.5-pro"},
     "claude": {"claude-sonnet", "claude-haiku", "claude-opus"},
-    "anthropic": {"claude-sonnet", "claude-haiku", "claude-opus"},  # Alias for claude
     "ollama": set(),  # Ollama vision support varies
 }
 
@@ -1748,7 +1747,6 @@ USE_VISION_MODELS = {
 def get_vision_fallback_model(provider: str) -> Optional[str]:
     """Get a fallback model that supports vision for a provider."""
     # Normalize provider alias
-    if provider == "anthropic":
         provider = "claude"
     
     vision_fallbacks = {
@@ -1766,7 +1764,6 @@ def is_vision_model(provider: str, model: str) -> bool:
     Supports prefix matching for versioned model names (e.g., claude-sonnet-4-20250514).
     """
     # Normalize provider alias
-    if provider == "anthropic":
         provider = "claude"
     
     if provider not in USE_VISION_MODELS:

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -1744,10 +1744,31 @@ USE_VISION_MODELS = {
 }
 
 
+def _normalize_provider_key(provider: Optional[str]) -> Optional[str]:
+    """Normalize provider name to internal key used in USE_VISION_MODELS."""
+    if provider is None:
+        return None
+    normalized = provider.strip().lower()
+    if not normalized:
+        return None
+    alias_map = {
+        "anthropic": "claude",
+        "claude": "claude",
+        "openai": "openai",
+        "github": "github_copilot",
+        "github-copilot": "github_copilot",
+        "copilot": "github_copilot",
+        "github_copilot": "github_copilot",
+        "ollama": "ollama",
+    }
+    return alias_map.get(normalized, normalized)
+
+
 def get_vision_fallback_model(provider: str) -> Optional[str]:
     """Get a fallback model that supports vision for a provider."""
-    # Normalize provider alias
-        provider = "claude"
+    normalized_provider = _normalize_provider_key(provider)
+    if not normalized_provider:
+        return None
     
     vision_fallbacks = {
         "openai": "gpt-5-mini",
@@ -1755,7 +1776,7 @@ def get_vision_fallback_model(provider: str) -> Optional[str]:
         "claude": "claude-haiku-4-20250514",
         "ollama": None,
     }
-    return vision_fallbacks.get(provider)
+    return vision_fallbacks.get(normalized_provider)
 
 
 def is_vision_model(provider: str, model: str) -> bool:
@@ -1763,20 +1784,18 @@ def is_vision_model(provider: str, model: str) -> bool:
     
     Supports prefix matching for versioned model names (e.g., claude-sonnet-4-20250514).
     """
-    # Normalize provider alias
-        provider = "claude"
-    
-    if provider not in USE_VISION_MODELS:
+    normalized_provider = _normalize_provider_key(provider)
+    if not normalized_provider or normalized_provider not in USE_VISION_MODELS:
         return False
     
     model_lower = model.lower()
     
     # Check exact match first
-    if model_lower in USE_VISION_MODELS[provider]:
+    if model_lower in USE_VISION_MODELS[normalized_provider]:
         return True
     
     # Check prefix match for versioned models
-    for base_name in USE_VISION_MODELS[provider]:
+    for base_name in USE_VISION_MODELS[normalized_provider]:
         if model_lower.startswith(base_name.lower()):
             return True
     

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -905,3 +905,107 @@ class TestOllamaProvider:
         # Should not have Authorization header for local Ollama
         assert "Authorization" not in headers
         assert "Content-Type" in headers
+
+
+class TestVisionModelSelection:
+    """Tests for vision model detection and fallback selection."""
+
+    def test_normalize_provider_key_anthropic(self):
+        """Test that anthropic is normalized to claude."""
+        from src.agents.llm import _normalize_provider_key
+        assert _normalize_provider_key("anthropic") == "claude"
+        assert _normalize_provider_key("Anthropic") == "claude"
+        assert _normalize_provider_key("ANTHROPIC") == "claude"
+
+    def test_normalize_provider_key_github(self):
+        """Test that github aliases are normalized."""
+        from src.agents.llm import _normalize_provider_key
+        assert _normalize_provider_key("github") == "github_copilot"
+        assert _normalize_provider_key("github-copilot") == "github_copilot"
+        assert _normalize_provider_key("copilot") == "github_copilot"
+        assert _normalize_provider_key("GitHub_Copilot") == "github_copilot"
+
+    def test_normalize_provider_key_openai(self):
+        """Test that openai is normalized correctly."""
+        from src.agents.llm import _normalize_provider_key
+        assert _normalize_provider_key("openai") == "openai"
+        assert _normalize_provider_key("OpenAI") == "openai"
+
+    def test_normalize_provider_key_none_empty(self):
+        """Test that None and empty strings return None."""
+        from src.agents.llm import _normalize_provider_key
+        assert _normalize_provider_key(None) is None
+        assert _normalize_provider_key("") is None
+        assert _normalize_provider_key("   ") is None
+
+    def test_is_vision_model_openai(self):
+        """Test vision model detection for OpenAI provider."""
+        from src.agents.llm import is_vision_model
+        # Vision models
+        assert is_vision_model("openai", "gpt-4o") is True
+        assert is_vision_model("openai", "gpt-4o-mini") is True
+        assert is_vision_model("openai", "gpt-5-mini") is True
+        assert is_vision_model("openai", "gpt-5") is True
+        # Non-vision models
+        assert is_vision_model("openai", "gpt-4.1") is False
+        assert is_vision_model("openai", "gpt-3.5-turbo") is False
+        assert is_vision_model("openai", "o1") is False
+
+    def test_is_vision_model_github_copilot(self):
+        """Test vision model detection for GitHub Copilot provider."""
+        from src.agents.llm import is_vision_model
+        # Vision models
+        assert is_vision_model("github_copilot", "gpt-4o") is True
+        assert is_vision_model("github_copilot", "gpt-5-mini") is True
+        assert is_vision_model("github_copilot", "gpt-5") is True
+        assert is_vision_model("github_copilot", "gemini-2.5-pro") is True
+        # Non-vision models
+        assert is_vision_model("github_copilot", "gpt-4.1") is False
+
+    def test_is_vision_model_claude_with_version_suffix(self):
+        """Test that versioned Claude models are detected as vision-capable."""
+        from src.agents.llm import is_vision_model
+        # Versioned Claude models should match via prefix
+        assert is_vision_model("claude", "claude-sonnet-4-20250514") is True
+        assert is_vision_model("claude", "claude-haiku-4-20250514") is True
+        assert is_vision_model("claude", "claude-opus-4-20250514") is True
+
+    def test_is_vision_model_claude_alias(self):
+        """Test that anthropic alias works for Claude models."""
+        from src.agents.llm import is_vision_model
+        assert is_vision_model("anthropic", "claude-sonnet-4-20250514") is True
+        assert is_vision_model("anthropic", "claude-haiku-4") is True
+
+    def test_is_vision_model_unknown_provider(self):
+        """Test that unknown providers return False."""
+        from src.agents.llm import is_vision_model
+        assert is_vision_model("unknown_provider", "gpt-4o") is False
+        assert is_vision_model(None, "gpt-4o") is False
+
+    def test_get_vision_fallback_model_openai(self):
+        """Test fallback model for OpenAI."""
+        from src.agents.llm import get_vision_fallback_model
+        assert get_vision_fallback_model("openai") == "gpt-5-mini"
+
+    def test_get_vision_fallback_model_github_copilot(self):
+        """Test fallback model for GitHub Copilot."""
+        from src.agents.llm import get_vision_fallback_model
+        assert get_vision_fallback_model("github_copilot") == "gpt-5-mini"
+        assert get_vision_fallback_model("github") == "gpt-5-mini"
+
+    def test_get_vision_fallback_model_claude(self):
+        """Test fallback model for Claude."""
+        from src.agents.llm import get_vision_fallback_model
+        assert get_vision_fallback_model("claude") == "claude-haiku-4-20250514"
+        assert get_vision_fallback_model("anthropic") == "claude-haiku-4-20250514"
+
+    def test_get_vision_fallback_model_ollama(self):
+        """Test fallback model for Ollama."""
+        from src.agents.llm import get_vision_fallback_model
+        assert get_vision_fallback_model("ollama") is None
+
+    def test_get_vision_fallback_model_unknown(self):
+        """Test fallback model for unknown provider."""
+        from src.agents.llm import get_vision_fallback_model
+        assert get_vision_fallback_model("unknown") is None
+        assert get_vision_fallback_model(None) is None


### PR DESCRIPTION
This pull request adds logic to automatically switch to a vision-capable language model when input messages contain images, ensuring compatibility and better user experience. The changes introduce utility functions to detect vision models and select appropriate fallbacks, and update the agent logic to use these when needed.

Vision model support and fallback logic:

* Introduced the `USE_VISION_MODELS` dictionary in `src/agents/llm.py` to track which models support vision/image input for each provider.
* Added `is_vision_model` and `get_vision_fallback_model` utility functions in `src/agents/llm.py` to check model vision support and retrieve fallback models, respectively.

Agent logic updates:

* Updated `_to_input_items` in `src/agents/core.py` to detect if any input message contains images and, if so, switch to a vision-capable model using the new utilities before calling the LLM.