### PR TITLE
feat(skills): add Claude Code-style lightweight skill session mode

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -9,7 +9,7 @@ import platform
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from src.agents.heartbeat import get_heartbeat, start_heartbeat, stop_heartbeat
 from src.agents.llm import (
@@ -238,7 +238,7 @@ You have access to the following tools. When a user asks you to do something tha
                     f"think_level={self.think_level.value}")
 
     @staticmethod
-    def _extract_skill_control(content: str) -> (str, str):
+    def _extract_skill_control(content: str) -> Tuple[str, str]:
         """Extract skill control tag and cleaned body from model response."""
         if not content:
             return "EXECUTE", ""
@@ -266,6 +266,57 @@ You have access to the following tools. When a user asks you to do something tha
 
         merged = f"{skill_session.memory_summary}\n{addition}"
         skill_session.memory_summary = merged[-2000:]
+
+    @staticmethod
+    def _parse_plan_text(plan_text: str) -> List[Dict[str, str]]:
+        """Parse model output into a lightweight plan list."""
+        steps: List[Dict[str, str]] = []
+        for line in plan_text.splitlines():
+            cleaned = line.strip()
+            if not cleaned:
+                continue
+            cleaned = re.sub(r"^\d+[.)]\s*", "", cleaned)
+            cleaned = re.sub(r"^[-*]\s*", "", cleaned)
+            cleaned = cleaned.strip()
+            if not cleaned:
+                continue
+            steps.append({"step": cleaned, "status": "pending"})
+            if len(steps) >= 6:
+                break
+        return steps
+
+    async def _generate_initial_skill_plan(self, skill: Any, user_request: str) -> List[Dict[str, str]]:
+        """Generate a lightweight skill plan via one LLM call."""
+        planning_system_prompt = (
+            f"You are planning for skill `{skill.name}`.\n"
+            f"Skill description: {skill.description}\n"
+            "Generate a concise execution plan as a numbered list (3-6 steps).\n"
+            "Rules:\n"
+            "- Keep each step short and actionable\n"
+            "- Do not use JSON\n"
+            "- Do not include [EXECUTE]/[ASK_USER]/[FINISH] tags\n"
+            "- Output only the plan list"
+        )
+        plan_input_items = [{
+            "role": "user",
+            "content": [{"type": "input_text", "text": f"User request: {user_request}"}],
+        }]
+
+        try:
+            plan_result = await llm_client.responses(
+                input_items=plan_input_items,
+                system_prompt=planning_system_prompt,
+                tools=[],
+                reasoning_replay=False,
+            )
+            plan_text = (plan_result.get("content") or "").strip()
+            plan = self._parse_plan_text(plan_text)
+            if plan:
+                return plan
+        except Exception as e:
+            logger.warning(f"[Skill] Failed to generate initial plan: {e}")
+
+        return [{"step": "Analyze request and execute skill workflow", "status": "pending"}]
 
     async def process(
         self,
@@ -391,6 +442,7 @@ You have access to the following tools. When a user asks you to do something tha
                     goal=message,
                     status="active",
                 )
+                active_skill_session.plan = await self._generate_initial_skill_plan(best_skill, message)
                 await session_manager.set_active_skill_session(session_id, active_skill_session.to_dict())
                 logger.info(f"[Skill] Started skill session: {best_skill.name}")
             
@@ -404,6 +456,8 @@ You have access to the following tools. When a user asks you to do something tha
                 best_skill,
                 original_request=active_skill_session.original_user_request if active_skill_session else message,
                 memory_summary=active_skill_session.memory_summary if active_skill_session else "",
+                plan=active_skill_session.plan if active_skill_session else None,
+                completed_steps=active_skill_session.completed_steps if active_skill_session else None,
             )
             skill_prompt = f"{skill_prompt}\n\n{skill_mode_prompt}"
             # Log matched skill
@@ -974,6 +1028,18 @@ You have access to the following tools. When a user asks you to do something tha
                     else:
                         active_skill_session.status = "active"
                         active_skill_session.pending_question = None
+
+                    # Lightweight plan progression: close the next pending step when progressing.
+                    if control_tag in {"EXECUTE", "FINISH"} and active_skill_session.plan:
+                        for step in active_skill_session.plan:
+                            if step.get("status") == "pending":
+                                step["status"] = "completed"
+                                active_skill_session.completed_steps.append({
+                                    "step": step.get("step", ""),
+                                    "evidence": response_content[:300],
+                                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                                })
+                                break
 
                     self._update_skill_memory_summary(active_skill_session, message, response_content)
                     if active_skill_session.status == "finished":

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -6,6 +6,8 @@ import json
 import logging
 import os
 import platform
+import re
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
@@ -54,6 +56,39 @@ def get_skill_workdir() -> Optional[str]:
 # When DEBUG, complete input/output is logged (no truncation)
 
 _DEBUG_ENABLED = None  # Lazy initialization
+
+SKILL_CONTROL_TAG_PATTERN = re.compile(r"^\s*(\[(?:EXECUTE|ASK_USER|FINISH)\])\s*$", re.IGNORECASE)
+
+
+@dataclass
+class SkillSession:
+    """Lightweight skill session state for long-running skill mode."""
+    skill_name: str
+    original_user_request: str
+    status: str = "active"  # active / waiting_user / finished
+    goal: str = ""
+    plan: List[Dict[str, str]] = field(default_factory=list)
+    completed_steps: List[Dict[str, Any]] = field(default_factory=list)
+    memory_summary: str = ""
+    pending_question: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SkillSession":
+        """Build a SkillSession from session metadata."""
+        return cls(
+            skill_name=data.get("skill_name", ""),
+            original_user_request=data.get("original_user_request", ""),
+            status=data.get("status", "active"),
+            goal=data.get("goal", ""),
+            plan=data.get("plan", []) or [],
+            completed_steps=data.get("completed_steps", []) or [],
+            memory_summary=data.get("memory_summary", "") or "",
+            pending_question=data.get("pending_question"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize SkillSession to JSON-compatible dict."""
+        return asdict(self)
 
 
 def _is_debug_enabled() -> bool:
@@ -202,6 +237,36 @@ You have access to the following tools. When a user asks you to do something tha
                     f"length={len(self.system_prompt)}, tools={len(self.tools)}, "
                     f"think_level={self.think_level.value}")
 
+    @staticmethod
+    def _extract_skill_control(content: str) -> (str, str):
+        """Extract skill control tag and cleaned body from model response."""
+        if not content:
+            return "EXECUTE", ""
+
+        lines = [line for line in content.splitlines()]
+        if not lines:
+            return "EXECUTE", ""
+
+        first_line = lines[0].strip()
+        match = SKILL_CONTROL_TAG_PATTERN.match(first_line)
+        if not match:
+            return "EXECUTE", content.strip()
+
+        tag = match.group(1).upper().strip("[]")
+        body = "\n".join(lines[1:]).strip()
+        return tag, body
+
+    @staticmethod
+    def _update_skill_memory_summary(skill_session: SkillSession, user_message: str, assistant_message: str) -> None:
+        """Keep a concise rolling summary for skill mode context."""
+        addition = f"U: {user_message.strip()}\nA: {assistant_message.strip()}"
+        if not skill_session.memory_summary:
+            skill_session.memory_summary = addition[:1200]
+            return
+
+        merged = f"{skill_session.memory_summary}\n{addition}"
+        skill_session.memory_summary = merged[-2000:]
+
     async def process(
         self,
         message: str,
@@ -274,15 +339,33 @@ You have access to the following tools. When a user asks you to do something tha
             return {"response": fastlane_response, "usage": usage_data, "user_message_id": user_message_id}
         # ===== END FAST LANE =====
 
-        # ===== SKILL MATCHING (FR-1, FR-2) =====
+        # ===== SKILL MATCHING + SKILL SESSION MODE =====
         from src.skills import skill_registry, get_tracer
         
         # Initialize skill registry if needed
         if not skill_registry._initialized:
             skill_registry.load_skills()
         
-        # Match user message against skill triggers
-        matched_skills = skill_registry.match_skill(message)
+        # Check if there is an active skill session first
+        active_skill_data = await session_manager.get_active_skill_session(session_id)
+        active_skill_session = SkillSession.from_dict(active_skill_data) if active_skill_data else None
+
+        matched_skills = []
+        if active_skill_session and active_skill_session.skill_name:
+            active_skill = skill_registry.get_skill(active_skill_session.skill_name)
+            if active_skill and active_skill_session.status != "finished":
+                matched_skills = [active_skill]
+                if active_skill_session.status == "waiting_user":
+                    active_skill_session.status = "active"
+                    active_skill_session.pending_question = None
+                    await session_manager.set_active_skill_session(session_id, active_skill_session.to_dict())
+            else:
+                await session_manager.clear_active_skill_session(session_id)
+                active_skill_session = None
+
+        # No active skill mode: try matching from current user input
+        if not matched_skills:
+            matched_skills = skill_registry.match_skill(message)
         
         # Start execution tracing
         tracer = get_tracer()
@@ -299,6 +382,17 @@ You have access to the following tools. When a user asks you to do something tha
             # Use the best match
             best_skill = matched_skills[0]
             logger.info(f"[Skill] Matched skill: {best_skill.name}")
+
+            # Initialize skill session mode if this is a new match
+            if not active_skill_session:
+                active_skill_session = SkillSession(
+                    skill_name=best_skill.name,
+                    original_user_request=message,
+                    goal=message,
+                    status="active",
+                )
+                await session_manager.set_active_skill_session(session_id, active_skill_session.to_dict())
+                logger.info(f"[Skill] Started skill session: {best_skill.name}")
             
             # Set skill workdir for exec tool (async-safe via contextvars)
             if best_skill.path:
@@ -306,13 +400,19 @@ You have access to the following tools. When a user asks you to do something tha
                 logger.info(f"[Skill] Workdir: {best_skill.path}")
             
             skill_prompt = skill_registry.get_skill_prompt(best_skill)
+            skill_mode_prompt = skill_registry.get_skill_mode_prompt(
+                best_skill,
+                original_request=active_skill_session.original_user_request if active_skill_session else message,
+                memory_summary=active_skill_session.memory_summary if active_skill_session else "",
+            )
+            skill_prompt = f"{skill_prompt}\n\n{skill_mode_prompt}"
             # Log matched skill
             tracer.log_tool_call(
                 tool_name="skill_matched",
                 arguments={"skill": best_skill.name},
                 result=f"Matched skill: {best_skill.name}",
             )
-        # ===== END SKILL MATCHING =====
+        # ===== END SKILL MATCHING + SKILL SESSION MODE =====
 
         # ===== MESSAGE COMPACTION =====
         # Check if messages need compaction to fit within token limits
@@ -858,8 +958,31 @@ You have access to the following tools. When a user asks you to do something tha
             
             # If no function calls, we're done - return the response
             if not tool_calls:
-                await session_manager.add_message(session_id, "assistant", content)
-                result = {"response": content, "usage": usage_data, "user_message_id": user_message_id}
+                response_content = content
+
+                # Skill mode: interpret lightweight control tags
+                if active_skill_session:
+                    control_tag, clean_body = self._extract_skill_control(content)
+                    response_content = clean_body or content
+
+                    if control_tag == "ASK_USER":
+                        active_skill_session.status = "waiting_user"
+                        active_skill_session.pending_question = response_content
+                    elif control_tag == "FINISH":
+                        active_skill_session.status = "finished"
+                        active_skill_session.pending_question = None
+                    else:
+                        active_skill_session.status = "active"
+                        active_skill_session.pending_question = None
+
+                    self._update_skill_memory_summary(active_skill_session, message, response_content)
+                    if active_skill_session.status == "finished":
+                        await session_manager.clear_active_skill_session(session_id)
+                    else:
+                        await session_manager.set_active_skill_session(session_id, active_skill_session.to_dict())
+
+                await session_manager.add_message(session_id, "assistant", response_content)
+                result = {"response": response_content, "usage": usage_data, "user_message_id": user_message_id}
                 if enable_reasoning:
                     reasoning_content = llm_result.get("reasoning", "")
                     result["reasoning"] = reasoning_content
@@ -894,12 +1017,12 @@ You have access to the following tools. When a user asks you to do something tha
                 
                 # Send completion event
                 send_event("complete", {
-                    "response": truncate_with_count(content, 500),
+                    "response": truncate_with_count(response_content, 500),
                     "total_iterations": iteration
                 })
                 
                 # Complete execution tracing
-                tracer.complete_execution(content)
+                tracer.complete_execution(response_content)
                 
                 # Get events for UI
                 from src.skills import get_tracer
@@ -914,14 +1037,14 @@ You have access to the following tools. When a user asks you to do something tha
                     result["_llm_debug"] = {
                         "llm_request": llm_result["_llm_debug"],
                         "thinking_events": all_events,
-                        "final_response": content,
+                        "final_response": response_content,
                     }
                 
                 # Trigger memory update (async, fire and forget)
                 # We need to get the last user message and assistant response
                 recent_messages = await session_manager.get_history(session_id)
                 user_text = ""
-                assistant_text = content
+                assistant_text = response_content
                 for msg in reversed(recent_messages):
                     if msg.get("role") == "user":
                         user_text = msg.get("content", "")

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -268,34 +268,65 @@ You have access to the following tools. When a user asks you to do something tha
         skill_session.memory_summary = merged[-2000:]
 
     @staticmethod
-    def _parse_plan_text(plan_text: str) -> List[Dict[str, str]]:
-        """Parse model output into a lightweight plan list."""
+    def _parse_plan_json(plan_text: str) -> Tuple[str, List[Dict[str, str]]]:
+        """Parse planner JSON into (goal, steps)."""
+        text = plan_text.strip()
+        if not text:
+            return "", []
+
+        # Best effort: tolerate fenced JSON
+        if text.startswith("```"):
+            text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
+            text = re.sub(r"\s*```$", "", text)
+
+        try:
+            data = json.loads(text)
+        except Exception:
+            return "", []
+
+        goal = str(data.get("goal", "")).strip()
+        raw_steps = data.get("steps", [])
+        if not isinstance(raw_steps, list):
+            return goal, []
+
         steps: List[Dict[str, str]] = []
-        for line in plan_text.splitlines():
-            cleaned = line.strip()
-            if not cleaned:
+        for idx, step in enumerate(raw_steps, start=1):
+            if not isinstance(step, dict):
                 continue
-            cleaned = re.sub(r"^\d+[.)]\s*", "", cleaned)
-            cleaned = re.sub(r"^[-*]\s*", "", cleaned)
-            cleaned = cleaned.strip()
-            if not cleaned:
+            step_id = str(step.get("id", f"step{idx}")).strip() or f"step{idx}"
+            step_type = str(step.get("type", "execute")).strip() or "execute"
+            title = str(step.get("title", "")).strip()
+            if not title:
                 continue
-            steps.append({"step": cleaned, "status": "pending"})
+            steps.append({
+                "id": step_id,
+                "type": step_type,
+                "title": title,
+                "status": "pending",
+            })
             if len(steps) >= 6:
                 break
-        return steps
+        return goal, steps
 
-    async def _generate_initial_skill_plan(self, skill: Any, user_request: str) -> List[Dict[str, str]]:
+    async def _generate_initial_skill_plan(self, skill: Any, user_request: str) -> Tuple[str, List[Dict[str, str]]]:
         """Generate a lightweight skill plan via one LLM call."""
         planning_system_prompt = (
             f"You are planning for skill `{skill.name}`.\n"
             f"Skill description: {skill.description}\n"
-            "Generate a concise execution plan as a numbered list (3-6 steps).\n"
+            "Generate a concise execution plan as strict JSON.\n"
+            "Output JSON format:\n"
+            "{\n"
+            '  "goal": "...",\n'
+            '  "steps": [\n'
+            '    {"id": "step1", "type": "execute", "title": "..."},\n'
+            '    {"id": "step2", "type": "user_input_if_needed", "title": "..."}\n'
+            "  ]\n"
+            "}\n"
             "Rules:\n"
-            "- Keep each step short and actionable\n"
-            "- Do not use JSON\n"
+            "- Keep 3-6 steps, short and actionable\n"
+            "- type must be execute or user_input_if_needed\n"
             "- Do not include [EXECUTE]/[ASK_USER]/[FINISH] tags\n"
-            "- Output only the plan list"
+            "- Output JSON only, no extra text"
         )
         plan_input_items = [{
             "role": "user",
@@ -310,13 +341,18 @@ You have access to the following tools. When a user asks you to do something tha
                 reasoning_replay=False,
             )
             plan_text = (plan_result.get("content") or "").strip()
-            plan = self._parse_plan_text(plan_text)
+            goal, plan = self._parse_plan_json(plan_text)
             if plan:
-                return plan
+                return goal, plan
         except Exception as e:
             logger.warning(f"[Skill] Failed to generate initial plan: {e}")
 
-        return [{"step": "Analyze request and execute skill workflow", "status": "pending"}]
+        return user_request, [{
+            "id": "step1",
+            "type": "execute",
+            "title": "Analyze request and execute skill workflow",
+            "status": "pending",
+        }]
 
     async def process(
         self,
@@ -442,7 +478,9 @@ You have access to the following tools. When a user asks you to do something tha
                     goal=message,
                     status="active",
                 )
-                active_skill_session.plan = await self._generate_initial_skill_plan(best_skill, message)
+                plan_goal, plan_steps = await self._generate_initial_skill_plan(best_skill, message)
+                active_skill_session.goal = plan_goal or message
+                active_skill_session.plan = plan_steps
                 await session_manager.set_active_skill_session(session_id, active_skill_session.to_dict())
                 logger.info(f"[Skill] Started skill session: {best_skill.name}")
             
@@ -1035,7 +1073,9 @@ You have access to the following tools. When a user asks you to do something tha
                             if step.get("status") == "pending":
                                 step["status"] = "completed"
                                 active_skill_session.completed_steps.append({
-                                    "step": step.get("step", ""),
+                                    "step": step.get("title", step.get("step", "")),
+                                    "id": step.get("id", ""),
+                                    "type": step.get("type", ""),
                                     "evidence": response_content[:300],
                                     "timestamp": datetime.utcnow().isoformat() + "Z",
                                 })

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -380,6 +380,47 @@ class SessionManager:
         """Get conversation history for a session."""
         session = await self.get_session(session_id)
         return session.get("history", [])
+
+    async def get_active_skill_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get active skill session data from session metadata."""
+        session = await self.get_session(session_id)
+        metadata = session.get("metadata", {})
+        return metadata.get("active_skill_session")
+
+    async def set_active_skill_session(self, session_id: str, skill_session: Dict[str, Any]) -> None:
+        """Set active skill session data in session metadata."""
+        session = await self.get_session(session_id)
+        metadata = session.setdefault("metadata", {})
+        metadata["active_skill_session"] = skill_session
+        session["updated_at"] = datetime.now().isoformat()
+
+        if self.auto_save and self.persistence_enabled:
+            asyncio.create_task(
+                session_persistence.save_session(
+                    session_id=session_id,
+                    channel=session.get("channel", ""),
+                    messages=session.get("history", []),
+                    metadata=metadata,
+                )
+            )
+
+    async def clear_active_skill_session(self, session_id: str) -> None:
+        """Clear active skill session data from session metadata."""
+        session = await self.get_session(session_id)
+        metadata = session.setdefault("metadata", {})
+        if "active_skill_session" in metadata:
+            del metadata["active_skill_session"]
+            session["updated_at"] = datetime.now().isoformat()
+
+            if self.auto_save and self.persistence_enabled:
+                asyncio.create_task(
+                    session_persistence.save_session(
+                        session_id=session_id,
+                        channel=session.get("channel", ""),
+                        messages=session.get("history", []),
+                        metadata=metadata,
+                    )
+                )
     
     async def clear_history(self, session_id: str) -> None:
         """Clear session history."""

--- a/src/skills/registry.py
+++ b/src/skills/registry.py
@@ -332,7 +332,14 @@ class SkillRegistry:
         
         return "\n".join(prompt_parts)
 
-    def get_skill_mode_prompt(self, skill: Skill, original_request: str, memory_summary: str = "") -> str:
+    def get_skill_mode_prompt(
+        self,
+        skill: Skill,
+        original_request: str,
+        memory_summary: str = "",
+        plan: Optional[List[Dict[str, str]]] = None,
+        completed_steps: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
         """Generate a lightweight, Claude Code-style skill-mode prompt.
 
         This prompt asks the model to drive the workflow using simple control tags
@@ -352,6 +359,23 @@ class SkillRegistry:
                 memory_summary,
             ])
 
+        if plan:
+            prompt_parts.extend([
+                "",
+                "Execution plan (follow this incrementally):",
+            ])
+            for idx, step in enumerate(plan, start=1):
+                status = step.get("status", "pending")
+                prompt_parts.append(f"{idx}. [{status}] {step.get('step', '')}")
+
+        if completed_steps:
+            prompt_parts.extend([
+                "",
+                "Already completed steps:",
+            ])
+            for item in completed_steps[-5:]:
+                prompt_parts.append(f"- {item.get('step', '')}")
+
         if skill.strategy:
             prompt_parts.extend([
                 "",
@@ -367,6 +391,7 @@ class SkillRegistry:
             "- [ASK_USER] : pause and ask user for missing information",
             "- [FINISH] : task is completed",
             "",
+            "Use the plan as your guide and advance one meaningful step at a time.",
             "After the first-line tag, provide concise natural language details.",
             "Do not output JSON workflow objects.",
         ])

--- a/src/skills/registry.py
+++ b/src/skills/registry.py
@@ -337,7 +337,7 @@ class SkillRegistry:
         skill: Skill,
         original_request: str,
         memory_summary: str = "",
-        plan: Optional[List[Dict[str, str]]] = None,
+        plan: Optional[List[Dict[str, Any]]] = None,
         completed_steps: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
         """Generate a lightweight, Claude Code-style skill-mode prompt.
@@ -360,13 +360,23 @@ class SkillRegistry:
             ])
 
         if plan:
+            focus_step = next((s for s in plan if s.get("status") == "pending"), None)
             prompt_parts.extend([
                 "",
                 "Execution plan (follow this incrementally):",
             ])
             for idx, step in enumerate(plan, start=1):
                 status = step.get("status", "pending")
-                prompt_parts.append(f"{idx}. [{status}] {step.get('step', '')}")
+                step_id = step.get("id", f"step{idx}")
+                step_type = step.get("type", "execute")
+                title = step.get("title", step.get("step", ""))
+                prompt_parts.append(f"{idx}. [{status}] ({step_id}, {step_type}) {title}")
+
+            if focus_step:
+                prompt_parts.extend([
+                    "",
+                    f"Current focus step: {focus_step.get('id', '')} - {focus_step.get('title', focus_step.get('step', ''))}",
+                ])
 
         if completed_steps:
             prompt_parts.extend([

--- a/src/skills/registry.py
+++ b/src/skills/registry.py
@@ -331,6 +331,47 @@ class SkillRegistry:
         ])
         
         return "\n".join(prompt_parts)
+
+    def get_skill_mode_prompt(self, skill: Skill, original_request: str, memory_summary: str = "") -> str:
+        """Generate a lightweight, Claude Code-style skill-mode prompt.
+
+        This prompt asks the model to drive the workflow using simple control tags
+        instead of complex JSON workflow objects.
+        """
+        prompt_parts = [
+            f"You are now in SKILL MODE for `{skill.name}`.",
+            f"Skill description: {skill.description}",
+            "",
+            f"Original user request: {original_request}",
+        ]
+
+        if memory_summary:
+            prompt_parts.extend([
+                "",
+                "Skill memory summary from previous turns:",
+                memory_summary,
+            ])
+
+        if skill.strategy:
+            prompt_parts.extend([
+                "",
+                "Preferred strategy:",
+            ])
+            for step in skill.strategy:
+                prompt_parts.append(f"- {step}")
+
+        prompt_parts.extend([
+            "",
+            "Control protocol (MUST put one tag on the first line):",
+            "- [EXECUTE] : continue execution, may call tools when needed",
+            "- [ASK_USER] : pause and ask user for missing information",
+            "- [FINISH] : task is completed",
+            "",
+            "After the first-line tag, provide concise natural language details.",
+            "Do not output JSON workflow objects.",
+        ])
+
+        return "\n".join(prompt_parts)
     
     def get_all_skill_summaries(self) -> List[Dict]:
         """Get summary of all skills for frontend/UI."""


### PR DESCRIPTION
### Motivation

- Add a lightweight, persistent skill session mode so skills can run as multi-turn, model-driven workflows without a complex server-side workflow engine. 
- Keep normal chat/tool behavior unchanged while enabling the model to control skill progress using a minimal protocol. 
- Provide a small, durable state (memory summary / pending question / status) so skill interactions can pause for user input and resume cleanly.

### Description

- Adds a `SkillSession` dataclass and helpers in `src/agents/core.py` to represent an active skill session (`skill_name`, `status`, `memory_summary`, `pending_question`, etc.).
- Extends `Agent.process()` to resume an active skill session from session metadata, initialize a new skill session on first match, inject a compact skill-mode prompt, and parse first-line control tags from model responses (`[EXECUTE]`, `[ASK_USER]`, `[FINISH]`) to update session state.
- Adds session persistence helpers to `src/sessions/manager.py`: `get_active_skill_session`, `set_active_skill_session`, and `clear_active_skill_session`, storing the skill session in the session `metadata` and reusing existing auto-save logic.
- Extends `src/skills/registry.py` with `get_skill_mode_prompt(...)` which emits a Claude Code-style instruction asking the LLM to drive the skill using the simple control-tag protocol and include the original request and a rolling memory summary.

### Testing

- Ran `python -m compileall src/agents/core.py src/skills/registry.py src/sessions/manager.py src/skills/__init__.py`, which succeeded.
- Ran `pytest -q`; test collection failed in this environment due to missing runtime setup (test runner could not locate `src` imports and `/root/.efp/config.yaml`), so failures occurred during collection and are environment-related rather than caused by these changes.
- Basic static validation performed: code compiles and new functions are implemented without altering the existing tool execution loop or message compaction flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7c6f89a4c832aa1ec2cef50e75de1)