### PR TITLE
Persist and restore active_skill_session across reloads

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -13,6 +13,8 @@ from src.agents.skill_mode import (
     SkillSession,
     _build_skill_mode_system_prompt,
     _build_skill_mode_user_prompt,
+    _extract_skill_artifacts,
+    _merge_skill_artifacts,
     _parse_skill_control_marker,
     _update_skill_memory_summary,
     generate_initial_skill_plan,
@@ -1356,6 +1358,7 @@ You have access to the following tools. When a user asks you to do something tha
             return {"response": final_text, "usage": usage_data, "user_message_id": user_message_id}
 
         # default: execute
+        was_waiting_user = skill_session.status == "waiting_user"
         result_text = body.strip() if body.strip() else raw_output
         if len(result_text) < 30:
             result_text = f"{result_text}\n\n(Continuing skill execution, will ask if more info is needed.)"
@@ -1368,6 +1371,16 @@ You have access to the following tools. When a user asks you to do something tha
                 "result": result_text,
             }
         )
+        try:
+            turn_artifacts = _extract_skill_artifacts(
+                skill_session=skill_session,
+                user_message=message,
+                latest_result=result_text,
+                was_waiting_user=was_waiting_user,
+            )
+            skill_session.artifacts = _merge_skill_artifacts(skill_session.artifacts, turn_artifacts)
+        except Exception as artifact_exc:
+            logger.warning(f"[SkillMode] Artifact extraction failed: {artifact_exc}")
         skill_session.memory_summary = _update_skill_memory_summary(skill_session, message, result_text)
 
         await session_manager.set_active_skill_session(session_id, skill_session.to_dict())

--- a/src/agents/skill_mode.py
+++ b/src/agents/skill_mode.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -88,6 +89,7 @@ def _build_skill_mode_system_prompt(skill: Skill, skill_session: SkillSession) -
 
     # Include skill strategy for ongoing sessions
     strategy_hint = "\n".join(f"- {s}" for s in skill.strategy) if skill.strategy else "(none)"
+    artifacts_summary = _build_artifacts_summary(skill_session)
 
     return (
         "You are running an active skill-mode session.\n"
@@ -96,6 +98,7 @@ def _build_skill_mode_system_prompt(skill: Skill, skill_session: SkillSession) -
         f"Plan:\n{plan}\n\n"
         f"Completed summary:\n{completed}\n\n"
         f"Memory summary:\n{skill_session.memory_summary or '(empty)'}\n\n"
+        f"Known artifacts:\n{artifacts_summary}\n\n"
         f"Strategy hints:\n{strategy_hint}\n\n"
         "Output rules (STRICT):\n"
         "1) First line MUST be exactly one marker: [EXECUTE] or [ASK_USER] or [FINISH]\n"
@@ -241,3 +244,133 @@ def _update_skill_memory_summary(skill_session: SkillSession, user_message: str,
     if len(merged) > max_chars:
         merged = merged[-max_chars:]
     return merged
+
+
+_FILE_PATH_PATTERN = re.compile(
+    r"(?<![\w/.-])([A-Za-z0-9_./-]+\.(?:feature|java|xml|json|ya?ml|md))(?![\w.-])",
+    re.IGNORECASE,
+)
+_ISSUE_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
+
+
+def _extract_skill_artifacts(
+    skill_session: SkillSession,
+    user_message: str,
+    latest_result: str,
+    was_waiting_user: bool = False,
+) -> Dict[str, Any]:
+    """Extract lightweight structured artifacts from current turn."""
+    artifacts: Dict[str, Any] = {}
+    full_text = f"{user_message}\n{latest_result}"
+    files_created: List[str] = []
+    files_updated: List[str] = []
+
+    for line in full_text.splitlines():
+        line_paths = [m.group(1) for m in _FILE_PATH_PATTERN.finditer(line)]
+        if not line_paths:
+            continue
+        lowered = line.lower()
+        if any(token in lowered for token in ("create", "created", "generate", "generated", "new file", "wrote")):
+            files_created.extend(line_paths)
+        elif any(token in lowered for token in ("update", "updated", "modify", "modified", "edit", "edited", "patch")):
+            files_updated.extend(line_paths)
+        else:
+            # Default to created for explicit file references in execution outputs.
+            files_created.extend(line_paths)
+
+    if files_created:
+        artifacts["files_created"] = files_created
+    if files_updated:
+        artifacts["files_updated"] = files_updated
+
+    issue_keys = sorted(set(_ISSUE_KEY_PATTERN.findall(full_text)))
+    if issue_keys:
+        artifacts["issue_keys"] = issue_keys
+
+    feature_match = re.search(r"\bfeature(?:_name)?\s*[:=]\s*['\"]?([^\n,'\"]+)", full_text, re.IGNORECASE)
+    if not feature_match:
+        feature_match = re.search(r"^\s*Feature:\s*(.+)$", full_text, re.IGNORECASE | re.MULTILINE)
+    if feature_match:
+        artifacts["feature_name"] = feature_match.group(1).strip()
+
+    scenario_match = re.search(r"^\s*Scenario:\s*(.+)$", full_text, re.IGNORECASE | re.MULTILINE)
+    if scenario_match:
+        artifacts["scenario_name"] = scenario_match.group(1).strip()
+
+    for field in ("api_name", "module_name"):
+        match = re.search(rf"\b{field}\s*[:=]\s*['\"]?([^\n,'\"]+)", full_text, re.IGNORECASE)
+        if match:
+            artifacts[field] = match.group(1).strip()
+
+    confirmed_facts: List[str] = []
+    normalized_user = user_message.strip()
+    if was_waiting_user and normalized_user:
+        confirmed_facts.append(normalized_user)
+    if "expected" in normalized_user.lower() or "should" in normalized_user.lower():
+        confirmed_facts.append(normalized_user)
+
+    if confirmed_facts:
+        artifacts["confirmed_facts"] = confirmed_facts
+
+    return artifacts
+
+
+def _merge_skill_artifacts(existing: Dict[str, Any], new_artifacts: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge artifacts conservatively without overriding existing key facts."""
+    merged: Dict[str, Any] = dict(existing or {})
+
+    for key, value in (new_artifacts or {}).items():
+        if value in (None, "", [], {}):
+            continue
+        if isinstance(value, list):
+            current = merged.get(key, [])
+            if not isinstance(current, list):
+                current = []
+            seen = {str(item) for item in current}
+            for item in value:
+                marker = str(item)
+                if marker not in seen:
+                    current.append(item)
+                    seen.add(marker)
+            merged[key] = current
+            continue
+        if isinstance(value, dict):
+            current = merged.get(key, {})
+            if not isinstance(current, dict):
+                current = {}
+            current.update({k: v for k, v in value.items() if v is not None})
+            merged[key] = current
+            continue
+        if key not in merged or not merged.get(key):
+            merged[key] = value
+
+    return merged
+
+
+def _build_artifacts_summary(skill_session: SkillSession, max_items: int = 3, max_chars: int = 400) -> str:
+    """Build a compact artifacts summary for prompt context."""
+    artifacts = skill_session.artifacts or {}
+    if not artifacts:
+        return "(none)"
+
+    lines: List[str] = []
+    for key in ("files_created", "files_updated", "issue_keys", "confirmed_facts"):
+        value = artifacts.get(key)
+        if not value:
+            continue
+        if isinstance(value, list):
+            preview = ", ".join(str(v) for v in value[:max_items])
+            if len(value) > max_items:
+                preview += ", ..."
+            lines.append(f"- {key}: {preview}")
+        else:
+            lines.append(f"- {key}: {value}")
+
+    for key in ("feature_name", "scenario_name", "api_name", "module_name"):
+        if key in artifacts and artifacts[key]:
+            lines.append(f"- {key}: {artifacts[key]}")
+
+    summary = "\n".join(lines) if lines else "(none)"
+    if len(summary) > max_chars:
+        summary = summary[: max_chars - 3] + "..."
+    return summary

--- a/src/agents/skill_mode.py
+++ b/src/agents/skill_mode.py
@@ -29,6 +29,7 @@ class SkillSession:
     plan: List[Dict[str, str]] = field(default_factory=list)
     completed_steps: List[Dict[str, Any]] = field(default_factory=list)
     memory_summary: str = ""
+    artifacts: Dict[str, Any] = field(default_factory=dict)
     pending_question: Optional[str] = None
 
     @classmethod
@@ -41,6 +42,7 @@ class SkillSession:
             plan=data.get("plan", []) or [],
             completed_steps=data.get("completed_steps", []) or [],
             memory_summary=data.get("memory_summary", ""),
+            artifacts=data.get("artifacts", {}) or {},
             pending_question=data.get("pending_question"),
         )
 

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -183,11 +183,25 @@ class SessionManager:
             del self._session_timestamps[oldest_key]
         
         logger.debug(f"Evicted oldest session: {oldest_key}")
+
+    @staticmethod
+    def _restore_active_skill_session_from_metadata(session: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Restore active skill session from metadata if needed."""
+        active = session.get("active_skill_session")
+        if active is not None:
+            return active
+
+        metadata = session.get("metadata", {})
+        active = metadata.get("active_skill_session")
+        if active is not None:
+            session["active_skill_session"] = active
+        return active
     
     async def get_session(self, session_id: str) -> Dict[str, Any]:
         """Get or create a session."""
         # Check if session exists and is valid
         if session_id in self.sessions and self._is_valid_session(session_id):
+            self._restore_active_skill_session_from_metadata(self.sessions[session_id])
             self._update_timestamp(session_id)
             return self.sessions[session_id]
         
@@ -205,6 +219,7 @@ class SessionManager:
                     "updated_at": persisted.get("updated_at", datetime.now().isoformat()),
                     "_persisted": True,
                 }
+                self._restore_active_skill_session_from_metadata(self.sessions[session_id])
                 self._session_timestamps[session_id] = datetime.now()
                 return self.sessions[session_id]
         
@@ -385,12 +400,22 @@ class SessionManager:
     async def get_active_skill_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Get active skill session state for a chat session."""
         session = await self.get_session(session_id)
-        return session.get("active_skill_session")
+        active = session.get("active_skill_session")
+        if active:
+            return active
+
+        metadata = session.get("metadata", {})
+        active = metadata.get("active_skill_session")
+        if active:
+            session["active_skill_session"] = active
+        return active
 
     async def set_active_skill_session(self, session_id: str, skill_session: Optional[Dict[str, Any]]) -> None:
         """Set or clear active skill session state for a chat session."""
         session = await self.get_session(session_id)
         session["active_skill_session"] = skill_session
+        metadata = session.setdefault("metadata", {})
+        metadata["active_skill_session"] = skill_session
         session["updated_at"] = datetime.now().isoformat()
 
         if self.auto_save and self.persistence_enabled:


### PR DESCRIPTION
### Motivation
- Skill-mode `active_skill_session` was only kept in memory (`session["active_skill_session"]`) while persistence only saved `messages` and `metadata`, causing skill sessions to be lost after process/POD restart. 
- The change aims to minimally persist the active skill state and restore it on session load so multi-turn skill conversations survive restarts without changing overall architecture.

### Description
- Updated `SessionManager.set_active_skill_session()` to write both `session["active_skill_session"]` and `session["metadata"]["active_skill_session"]` so existing `save_session(..., metadata=...)` persists the skill state. (modified `src/sessions/manager.py`)
- Added `_restore_active_skill_session_from_metadata()` and call sites in `get_session()` to rehydrate and cache `active_skill_session` from `metadata` after loading from persistence or on cache hits. (modified `src/sessions/manager.py`)
- Enhanced `get_active_skill_session()` to first return in-memory `session["active_skill_session"]`, and if absent fallback to `session["metadata"]["active_skill_session"]` while writing it back into memory for subsequent calls. (modified `src/sessions/manager.py`)
- Added a lightweight structured `artifacts: Dict[str, Any]` field to `SkillSession` with `from_dict` support so key outputs (e.g., `{"files_created": [...]}`) can be carried with the session without touching the persistence engine or memory_summary logic. (modified `src/agents/skill_mode.py`)

### Testing
- Compiled the modified modules with `python -m compileall src/sessions/manager.py src/agents/skill_mode.py` which succeeded. 
- Ran `pytest -q tests/test_session_manager.py tests/test_session_manager_fixed.py` which failed during test collection due to a missing environment config file (`/root/.efp/config.yaml`) in this execution environment; the failure is an environment bootstrapping issue and not related to the persistence logic changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c88487ac20832a827bda23cf598f7f)