### PR TITLE
Fix nullable Jira tool-argument defaults in execute_tool

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -196,12 +196,16 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
     # Jira tools
     elif name == "jira_get_issue":
         issue_key = kwargs.get("issue_key", "")
-        format = kwargs.get("format", "markdown")
+        format = kwargs.get("format")
+        format = "markdown" if format is None else format
         max_chars = kwargs.get("max_chars")
-        max_comments = kwargs.get("max_comments", 5)
-        include_comments = kwargs.get("include_comments", True)
+        max_comments = kwargs.get("max_comments")
+        max_comments = 5 if max_comments is None else max_comments
+        include_comments = kwargs.get("include_comments")
+        include_comments = True if include_comments is None else include_comments
         include_fields = kwargs.get("include_fields")
-        include_attachment_urls = kwargs.get("include_attachment_urls", False)
+        include_attachment_urls = kwargs.get("include_attachment_urls")
+        include_attachment_urls = False if include_attachment_urls is None else include_attachment_urls
         result = await jira_module.jira_get_issue(
             issue_key, format=format, max_chars=max_chars, max_comments=max_comments,
             include_comments=include_comments, include_fields=include_fields,
@@ -246,12 +250,16 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
     
     elif name == "jira_get_issue_by_url":
         url = kwargs.get("url", "")
-        format = kwargs.get("format", "markdown")
+        format = kwargs.get("format")
+        format = "markdown" if format is None else format
         max_chars = kwargs.get("max_chars")
-        max_comments = kwargs.get("max_comments", 5)
-        include_comments = kwargs.get("include_comments", True)
+        max_comments = kwargs.get("max_comments")
+        max_comments = 5 if max_comments is None else max_comments
+        include_comments = kwargs.get("include_comments")
+        include_comments = True if include_comments is None else include_comments
         include_fields = kwargs.get("include_fields")
-        include_attachment_urls = kwargs.get("include_attachment_urls", False)
+        include_attachment_urls = kwargs.get("include_attachment_urls")
+        include_attachment_urls = False if include_attachment_urls is None else include_attachment_urls
         result = await jira_module.jira_get_issue_by_url(
             url, format=format, max_chars=max_chars, max_comments=max_comments,
             include_comments=include_comments, include_fields=include_fields,

--- a/tests/test_jira_dispatch_none_defaults.py
+++ b/tests/test_jira_dispatch_none_defaults.py
@@ -1,0 +1,61 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_jira_get_issue_none_values_use_defaults(monkeypatch):
+    from src import execute_tool
+
+    captured = {}
+
+    async def fake_jira_get_issue(issue_key, **kwargs):
+        captured["issue_key"] = issue_key
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("src.jira.jira_get_issue", fake_jira_get_issue)
+
+    result = await execute_tool(
+        "jira_get_issue",
+        issue_key="EFP-123",
+        format=None,
+        max_comments=None,
+        include_comments=None,
+        include_attachment_urls=None,
+    )
+
+    assert result.success is True
+    assert captured["issue_key"] == "EFP-123"
+    assert captured["format"] == "markdown"
+    assert captured["max_comments"] == 5
+    assert captured["include_comments"] is True
+    assert captured["include_attachment_urls"] is False
+
+
+@pytest.mark.asyncio
+async def test_jira_get_issue_preserves_false_and_zero(monkeypatch):
+    from src import execute_tool
+
+    captured = {}
+
+    async def fake_jira_get_issue(issue_key, **kwargs):
+        captured["issue_key"] = issue_key
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("src.jira.jira_get_issue", fake_jira_get_issue)
+
+    result = await execute_tool(
+        "jira_get_issue",
+        issue_key="EFP-456",
+        include_comments=False,
+        include_attachment_urls=False,
+        max_comments=0,
+        format="",
+    )
+
+    assert result.success is True
+    assert captured["issue_key"] == "EFP-456"
+    assert captured["include_comments"] is False
+    assert captured["include_attachment_urls"] is False
+    assert captured["max_comments"] == 0
+    assert captured["format"] == ""


### PR DESCRIPTION
### Motivation
- Strict schema conversion permits explicit `null` for optional tool arguments which became `None` in Python and incorrectly overrode intended defaults when using `kwargs.get(key, default)`.
- The Jira read/detail dispatch paths must treat `None` as "not provided" so defaults are applied while preserving explicit falsy values like `False`, `0`, and `""`.

### Description
- Updated `src/__init__.py` Jira dispatch branches `jira_get_issue` and `jira_get_issue_by_url` to use explicit None-coalescing instead of `kwargs.get(key, default)` for `format`, `max_comments`, `include_comments`, and `include_attachment_urls` (e.g. `val = kwargs.get("x"); val = DEFAULT if val is None else val`).
- Preserved all existing behavior for non-`None` values so falsy explicit values remain unchanged.
- Added a focused test `tests/test_jira_dispatch_none_defaults.py` which verifies `include_comments=None` -> `True`, `max_comments=None` -> `5`, `include_attachment_urls=None` -> `False`, and that explicit falsy values are preserved.
- No changes were made to `src/agents/llm.py`, Jira passthrough logic, or schema-conversion behavior.

### Testing
- Created `tests/test_jira_dispatch_none_defaults.py` and ran `pytest -q tests/test_jira_dispatch_none_defaults.py` which passed (`2 passed`).
- Verified the change only affects local dispatch coalescing and does not modify strict schema conversion or other tool behavior.
- Confirmed commit containing the code and test changes was created and includes only `src/__init__.py` and the new test file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccce85db1c832a91ca46c5ae9db11d)