### PR TITLE
Fix nullable enum/const handling in strict tool schema normalization

### DIFF
--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -217,6 +217,11 @@ def _convert_tools_schema(tools: List[Dict]) -> List[Dict]:
         elif isinstance(prop_type, str):
             if prop_type != "null":
                 schema["type"] = [prop_type, "null"]
+        if isinstance(schema.get("enum"), list) and None not in schema["enum"]:
+            schema["enum"] = [*schema["enum"], None]
+        if "const" in schema:
+            schema["enum"] = [schema["const"], None]
+            schema.pop("const", None)
         return schema
 
     converted = []

--- a/tests/test_agent_jira_minimal_fixes.py
+++ b/tests/test_agent_jira_minimal_fixes.py
@@ -120,11 +120,60 @@ def test_convert_tools_schema_jira_get_issue_optional_fields_nullable():
     assert params["properties"]["issue_key"]["type"] == "string"
     assert params["properties"]["issue_key"]["type"] != ["string", "null"]
     assert params["properties"]["format"]["type"] == ["string", "null"]
+    assert params["properties"]["format"]["enum"] == ["markdown", "wiki", "raw", None]
     assert params["properties"]["max_chars"]["type"] == ["integer", "null"]
     assert params["properties"]["max_comments"]["type"] == ["integer", "null"]
     assert params["properties"]["include_fields"]["type"] == ["array", "null"]
     assert params["properties"]["include_comments"]["type"] == ["boolean", "null"]
     assert params["properties"]["include_attachment_urls"]["type"] == ["boolean", "null"]
+
+
+def test_convert_tools_schema_required_enum_field_is_not_widened():
+    from src.agents.llm import _convert_tools_schema
+
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "required_enum",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "format": {"type": "string", "enum": ["markdown", "raw"]},
+                    "value": {"type": "string"},
+                },
+                "required": ["format"],
+            },
+        },
+    }]
+
+    params = _convert_tools_schema(tools)[0]["parameters"]
+    assert params["required"] == ["format", "value"]
+    assert params["properties"]["format"]["type"] == "string"
+    assert params["properties"]["format"]["enum"] == ["markdown", "raw"]
+    assert params["properties"]["value"]["type"] == ["string", "null"]
+
+
+def test_convert_tools_schema_optional_const_field_becomes_nullable_enum():
+    from src.agents.llm import _convert_tools_schema
+
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "optional_const",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "mode": {"type": "string", "const": "raw"},
+                },
+            },
+        },
+    }]
+
+    params = _convert_tools_schema(tools)[0]["parameters"]
+    assert params["required"] == ["mode"]
+    assert params["properties"]["mode"]["type"] == ["string", "null"]
+    assert params["properties"]["mode"]["enum"] == ["raw", None]
+    assert "const" not in params["properties"]["mode"]
 
 
 def test_convert_tools_schema_no_optional_properties_no_type_widening():


### PR DESCRIPTION
### Motivation

- The strict normalization helper currently widens optional property `type` to include `"null"` but leaves `enum` and `const` unchanged, which prevents optional enum-constrained fields from accepting `null`.

### Description

- Update `_make_nullable_if_optional` in `src/agents/llm.py` to keep the existing `type` widening and also append `None` to `enum` when an optional field with an `enum` is normalized by adding `None` if missing.
- Convert an optional `const: X` to an equivalent nullable enum by replacing `const` with `enum: [X, None]` and removing the original `const` key, preserving other metadata.
- Keep all other normalization behavior unchanged, including not altering originally-required fields and not redesigning `anyOf`/`oneOf` handling.
- Add focused tests in `tests/test_agent_jira_minimal_fixes.py` that exercise the new behaviors without modifying unrelated tests or code paths.

### Testing

- Ran the focused test module with `pytest -q tests/test_agent_jira_minimal_fixes.py` after ensuring the test environment config path existed, and the test suite passed with `22 passed`.
- The new/updated tests are `test_convert_tools_schema_jira_get_issue_optional_fields_nullable` (now asserts `None` is appended to `enum`), `test_convert_tools_schema_required_enum_field_is_not_widened` (ensures required enum stays unchanged), and `test_convert_tools_schema_optional_const_field_becomes_nullable_enum` (ensures `const` is converted to `enum: [value, None]`).
- No other automated test files were modified and only `src/agents/llm.py` and `tests/test_agent_jira_minimal_fixes.py` were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd1e65e6c832a98417d10dbde86b1)