### PR TITLE
Normalize None-valued tool kwargs before dispatch

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -94,6 +94,11 @@ def get_tools_schema() -> List[Dict]:
     return get_all_tools()
 
 
+def _strip_none_values(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove keys explicitly set to None so Python defaults can apply."""
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
 async def execute_tool(name: str, **kwargs) -> ToolResult:
     """Execute a tool by name."""
     from . import bash_tools as bash_tools_module
@@ -101,6 +106,7 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
     from . import jira as jira_module
     from . import github as github_module
     from . import confluence as confluence_module
+    kwargs = _strip_none_values(kwargs)
     
     # Bash/Shell tools
     if name == "read":

--- a/tests/test_jira_dispatch_none_defaults.py
+++ b/tests/test_jira_dispatch_none_defaults.py
@@ -2,6 +2,31 @@ import pytest
 
 
 @pytest.mark.asyncio
+async def test_none_kwargs_are_stripped_before_dispatch(monkeypatch):
+    from src import execute_tool
+
+    captured = {}
+
+    async def fake_github_search_issues(query, max_results):
+        captured["query"] = query
+        captured["max_results"] = max_results
+        return "ok"
+
+    monkeypatch.setattr("src.github.github_search_issues", fake_github_search_issues)
+
+    result = await execute_tool(
+        "github_search_issues",
+        query="is:issue is:open label:bug",
+        max_results=None,
+    )
+
+    assert result.success is True
+    assert captured["query"] == "is:issue is:open label:bug"
+    # If None is not stripped first, dispatch passes None instead of the default.
+    assert captured["max_results"] == 10
+
+
+@pytest.mark.asyncio
 async def test_jira_get_issue_none_values_use_defaults(monkeypatch):
     from src import execute_tool
 


### PR DESCRIPTION
### Motivation
- Fix a global dispatch bug where JSON `null` becomes Python `None` and was incorrectly overriding per-tool defaults when dispatch code used `kwargs.get(key, default)`.
- Provide a small, centralized fix in the tool dispatch layer so individual tools and Jira logic do not need to be modified.
- Ensure only `None` is treated as “not provided” while preserving `False`, `0`, and `""` semantics.

### Description
- Add a helper `def _strip_none_values(kwargs: Dict[str, Any]) -> Dict[str, Any]` in `src/__init__.py` which returns `{k: v for k, v in kwargs.items() if v is not None}`. 
- Apply the normalization immediately at the start of `execute_tool` via `kwargs = _strip_none_values(kwargs)` so keys explicitly set to `None` are removed before any per-tool default logic runs. 
- No changes were made to `src/agents/llm.py`, Jira adapter code, or individual tool implementations, preserving the strict schema strategy and existing Jira passthrough behavior.

### Testing
- Added `test_none_kwargs_are_stripped_before_dispatch` in `tests/test_jira_dispatch_none_defaults.py` to verify `None` is stripped so default `max_results` is used for `github_search_issues`, and existing tests in that file were kept to validate Jira defaults and false/zero/empty preservation.
- Ran the focused test file with `pytest -q tests/test_jira_dispatch_none_defaults.py` (after creating the expected config dir); the test run passed: `3 passed, 1 warning`.
- The change only strips `None` values (`v is not None`) so `False`, `0`, and `""` remain unchanged, and strict schema conversion behavior was not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd53b8684832a9e2a18db27168b81)