### PR TITLE
Fix jira_get_issue_by_url return type annotation to Union[str, dict]

### DIFF
--- a/src/jira/__init__.py
+++ b/src/jira/__init__.py
@@ -112,7 +112,7 @@ async def jira_get_issue(
     include_fields: List[str] = None,
     include_comments: bool = True,
     include_attachment_urls: bool = False
-) -> Union[str, dict]:
+ ) -> Union[str, dict]:
     """Get a Jira issue by key.
     
     Args:
@@ -177,7 +177,7 @@ async def jira_get_issue_by_url(
     include_fields: List[str] = None,
     include_comments: bool = True,
     include_attachment_urls: bool = False
-) -> str:
+) -> Union[str, dict]:
     """Get a Jira issue by its URL.
     
     Args:
@@ -192,7 +192,7 @@ async def jira_get_issue_by_url(
             attachment filenames are shown without URLs.
         
     Returns:
-        Issue details in requested format
+        Issue details in requested format (markdown/wiki: str, raw: dict)
     """
     import re
     


### PR DESCRIPTION
### Motivation
- Fix the type-annotation and docstring mismatch where `jira_get_issue_by_url` was annotated as returning `str` but can return a `dict` when `format="raw"`, making the API contract inaccurate.

### Description
- Change the return type annotation of `jira_get_issue_by_url` from `str` to `Union[str, dict]` and update the `Returns` docstring to: `Issue details in requested format (markdown/wiki: str, raw: dict)` while keeping all runtime behavior unchanged.

### Testing
- Ran `python -m py_compile src/jira/__init__.py` which succeeded; no automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccdbf91ba8832aa3c24109a762d258)