### PR TITLE
Fix retrieval verb false positives and align jira_get_issue signature indentation

### DIFF
--- a/src/agents/tool_result_policy.py
+++ b/src/agents/tool_result_policy.py
@@ -46,7 +46,7 @@ def _message_has_jira_transform_intent(text: str) -> bool:
 def _message_has_jira_retrieval_intent(text: str, latest_user_message: str) -> bool:
     if _message_has_any_keyword(text, _JIRA_RETRIEVAL_HINTS):
         return True
-    has_retrieval_verb = any(word in text for word in ("get", "show", "read", "open", "fetch", "retrieve"))
+    has_retrieval_verb = bool(re.search(r"\b(get|show|read|open|fetch|retrieve)\b", text))
     has_issue_hint = ("jira" in text) or ("issue" in text) or bool(
         re.search(r"\b[A-Z][A-Z0-9_]*-\d+\b", latest_user_message or "")
     )

--- a/src/jira/__init__.py
+++ b/src/jira/__init__.py
@@ -112,7 +112,7 @@ async def jira_get_issue(
     include_fields: List[str] = None,
     include_comments: bool = True,
     include_attachment_urls: bool = False
- ) -> Union[str, dict]:
+) -> Union[str, dict]:
     """Get a Jira issue by key.
     
     Args:


### PR DESCRIPTION
### Motivation
- The Jira retrieval heuristic produced false positives because it used substring checks that matched inside words (e.g., `target` matching `get`).
- The `jira_get_issue` function signature had a closing parenthesis mis-indented which should match the style used by `jira_get_issue_by_url` for consistency.

### Description
- Replaced substring-based retrieval verb detection in `_message_has_jira_retrieval_intent` with a whole-word regex using `re.search(r"\b(get|show|read|open|fetch|retrieve)\b", text)` in `src/agents/tool_result_policy.py` to prevent false positives.
- Adjusted the closing parenthesis indentation for the `jira_get_issue` signature in `src/jira/__init__.py` to align with the project style without changing parameters, return type, or logic.
- Changes are minimal and localized to `src/agents/tool_result_policy.py` and `src/jira/__init__.py` only, with no other logic or helper functions added.

### Testing
- Ran `python -m compileall src/agents/tool_result_policy.py src/jira/__init__.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccdf6d4330832ab2097fc1cdd5c1d2)