### PR TITLE
Tighten multi-word keyword boundary matching in tool result policy

### DIFF
--- a/src/agents/tool_result_policy.py
+++ b/src/agents/tool_result_policy.py
@@ -25,11 +25,13 @@ _JIRA_SEQUENCE_WORDS = {"then", "after", "next"}
 def _message_has_any_keyword(text: str, keywords: set[str]) -> bool:
     normalized_text = text.lower()
     for keyword in keywords:
-        escaped_keyword = re.escape(keyword.lower())
-        if " " in keyword:
-            if re.search(escaped_keyword, normalized_text):
+        keyword_tokens = keyword.lower().split()
+        if len(keyword_tokens) > 1:
+            phrase_pattern = r"\b" + r"\s+".join(re.escape(token) for token in keyword_tokens) + r"\b"
+            if re.search(phrase_pattern, normalized_text):
                 return True
             continue
+        escaped_keyword = re.escape(keyword_tokens[0])
         if re.search(rf"\b{escaped_keyword}\b", normalized_text):
             return True
     return False

--- a/tests/test_agent_jira_minimal_fixes.py
+++ b/tests/test_agent_jira_minimal_fixes.py
@@ -256,3 +256,22 @@ def test_should_passthrough_tool_result_heuristic(user_message, expected):
         tool_calls_count=1,
     )
     assert actual is expected
+
+
+def test_message_has_any_keyword_multiword_avoids_embedded_substring_false_positive():
+    from src.agents.tool_result_policy import _message_has_any_keyword
+
+    assert _message_has_any_keyword("show me the budget issue details", {"get issue"}) is False
+
+
+@pytest.mark.parametrize(
+    "text,keywords",
+    [
+        ("get issue EFP-123", {"get issue"}),
+        ("move to in progress", {"in progress"}),
+    ],
+)
+def test_message_has_any_keyword_multiword_preserves_true_positives(text, keywords):
+    from src.agents.tool_result_policy import _message_has_any_keyword
+
+    assert _message_has_any_keyword(text, keywords) is True


### PR DESCRIPTION
### Motivation
- Fix false positives where multi-word keyword phrases were matched as raw substrings (e.g. "budget issue" matching keyword "get issue") without changing the overall passthrough heuristic.

### Description
- Update `_message_has_any_keyword` to split multi-word keywords into tokens and match them with a boundary-aware phrase regex built as `r"\b" + r"\s+".join(re.escape(token) for token in tokens) + r"\b"` so multi-word phrases require word boundaries and allow flexible inter-word whitespace. 
- Preserve single-word behavior by continuing to use whole-word regex matching with `\b{escaped_keyword}\b` for single-token keywords. 
- Only the phrase-matching logic in `src/agents/tool_result_policy.py` was tightened; no other passthrough or intent logic was changed.

### Testing
- Added tests in `tests/test_agent_jira_minimal_fixes.py`: `test_message_has_any_keyword_multiword_avoids_embedded_substring_false_positive` and `test_message_has_any_keyword_multiword_preserves_true_positives` to cover the false-positive and true-positive cases. 
- Ran focused automated tests `pytest -q tests/test_agent_jira_minimal_fixes.py -k "message_has_any_keyword_multiword"` and `pytest -q tests/test_agent_jira_minimal_fixes.py -k "should_passthrough_tool_result_heuristic"`, and the targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cce2aa52e8832aaf89baea0f89be6d)