### PR TITLE
Persist portal and agent author metadata in saved chat messages

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -404,7 +404,7 @@ You have access to the following tools. When a user asks you to do something tha
     ) -> Dict[str, Any]:
         return {
             "author_type": "human",
-            "author_id": portal_user_id or user_name or "unknown",
+            "author_id": portal_user_id or portal_user_name or user_name or "unknown",
             "author_name": portal_user_name or user_name or "User",
             "author_source": "portal" if (portal_user_id or portal_user_name) else "runtime",
         }

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -277,12 +277,16 @@ class Agent:
         think_level: Optional[str] = None,
         provider: Optional[str] = None,
         model: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        agent_name: Optional[str] = None,
     ):
         # Resolve thinking level
         self.think_level = normalize_think_level(think_level) or ThinkLevel.OFF
         
         # Store model for later use
         self.model = model
+        self.agent_id = agent_id
+        self.agent_name = agent_name
         
         # Initialize heartbeat if enabled
         self._heartbeat_enabled = config.heartbeat.get("enabled", False)
@@ -392,6 +396,27 @@ You have access to the following tools. When a user asks you to do something tha
                     f"length={len(self.system_prompt)}, tools={len(self.tools)}, "
                     f"think_level={self.think_level.value}")
 
+    def _build_user_author_extra(
+        self,
+        portal_user_id: Optional[str],
+        portal_user_name: Optional[str],
+        user_name: Optional[str],
+    ) -> Dict[str, str]:
+        return {
+            "author_type": "human",
+            "author_id": portal_user_id or user_name or "",
+            "author_name": portal_user_name or user_name or "User",
+            "author_source": "portal" if (portal_user_id or portal_user_name) else "runtime",
+        }
+
+    def _build_agent_author_extra(self) -> Dict[str, str]:
+        return {
+            "author_type": "agent",
+            "author_id": self.agent_id or "",
+            "author_name": self.agent_name or "Assistant",
+            "author_source": "runtime",
+        }
+
     async def process(
         self,
         message: str,
@@ -402,6 +427,8 @@ You have access to the following tools. When a user asks you to do something tha
         stream_callback: Optional[Callable[[str], None]] = None,
         attached_images: Optional[List[str]] = None,
         attachments: Optional[List[str]] = None,
+        portal_user_id: Optional[str] = None,
+        portal_user_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Process a user message with ReAct pattern.
         
@@ -422,12 +449,12 @@ You have access to the following tools. When a user asks you to do something tha
         usage_data = {}
         
         # Add user message to history (with attachments if any)
-        extra = {}
+        extra = self._build_user_author_extra(portal_user_id, portal_user_name, user_name)
         if attachments:
             extra["attachments"] = attachments  # Save file IDs, not base64
         user_message_id = await session_manager.add_message(
             session_id, "user", message,
-            extra=extra if extra else None
+            extra=extra
         )
 
         # Get conversation history
@@ -460,7 +487,7 @@ You have access to the following tools. When a user asks you to do something tha
         fastlane_response = await process_fastlane_command(message, self)
         if fastlane_response:
             # Fast lane command processed, return the response
-            await session_manager.add_message(session_id, "assistant", fastlane_response)
+            await session_manager.add_message(session_id, "assistant", fastlane_response, extra=self._build_agent_author_extra())
             return {"response": fastlane_response, "usage": usage_data, "user_message_id": user_message_id}
         # ===== END FAST LANE =====
 
@@ -1088,7 +1115,7 @@ You have access to the following tools. When a user asks you to do something tha
                     # If still empty, provide a default prompt
                     if not fallback_content.strip():
                         fallback_content = "Operation completed, but no detailed result was returned."
-                await session_manager.add_message(session_id, "assistant", fallback_content)
+                await session_manager.add_message(session_id, "assistant", fallback_content, extra=self._build_agent_author_extra())
                 result = {"response": fallback_content, "usage": usage_data, "user_message_id": user_message_id}
                 if enable_reasoning:
                     reasoning_content = llm_result.get("reasoning", "")
@@ -1458,7 +1485,7 @@ You have access to the following tools. When a user asks you to do something tha
                     tool_calls_count=len(function_calls),
                 ):
                     passthrough_content = str(single_tool_result.content)
-                    await session_manager.add_message(session_id, "assistant", passthrough_content)
+                    await session_manager.add_message(session_id, "assistant", passthrough_content, extra=self._build_agent_author_extra())
                     send_event("complete", {
                         "response": truncate_with_count(passthrough_content, 500),
                         "total_iterations": iteration
@@ -1482,7 +1509,7 @@ You have access to the following tools. When a user asks you to do something tha
         
         # Safety: max iterations reached
         logger.warning(f"[Tool Loop] Max iterations ({max_tool_iterations}) reached")
-        await session_manager.add_message(session_id, "assistant", "Task completed after maximum iterations.")
+        await session_manager.add_message(session_id, "assistant", "Task completed after maximum iterations.", extra=self._build_agent_author_extra())
         
         # Send completion event
         send_event("complete", {
@@ -1639,7 +1666,7 @@ You have access to the following tools. When a user asks you to do something tha
         if not skill:
             await session_manager.set_active_skill_session(session_id, None)
             fallback = "Skill session was cleared because the skill definition is unavailable."
-            await session_manager.add_message(session_id, "assistant", fallback)
+            await session_manager.add_message(session_id, "assistant", fallback, extra=self._build_agent_author_extra())
             events = tracer.get_events_for_ui(limit=10, session_id=session_id)
             return {"response": fallback, "usage": usage_data, "events": events, "user_message_id": user_message_id}
 
@@ -2018,7 +2045,7 @@ You have access to the following tools. When a user asks you to do something tha
             tracer.log_skill_mode_step("ASK_USER", "completed", f"Question: {question[:50]}...")
             send_skill_event("skill_step", {"step": "ASK_USER", "status": "completed", "detail": question[:200]})
             await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
-            await session_manager.add_message(session_id, "assistant", question)
+            await session_manager.add_message(session_id, "assistant", question, extra=self._build_agent_author_extra())
             # Get events for UI
             events = tracer.get_events_for_ui(limit=10, session_id=session_id)
             send_skill_event("skill_complete", {"reason": "ask_user", "question": question[:200]})
@@ -2068,11 +2095,13 @@ You have access to the following tools. When a user asks you to do something tha
             send_skill_event("skill_complete", {"reason": "finish", "result": final_text[:200]})
             await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
             await session_manager.set_active_skill_session(session_id, None)
+            finish_extra = self._build_agent_author_extra()
+            finish_extra["terminal_skill_session"] = terminal_snapshot
             await session_manager.add_message(
                 session_id,
                 "assistant",
                 final_text,
-                extra={"terminal_skill_session": terminal_snapshot},
+                extra=finish_extra,
             )
             # Get events for UI
             events = tracer.get_events_for_ui(limit=10, session_id=session_id)
@@ -2112,7 +2141,7 @@ You have access to the following tools. When a user asks you to do something tha
         skill_session.memory_summary = _update_skill_memory_summary(skill_session, message, result_text)
 
         await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
-        await session_manager.add_message(session_id, "assistant", result_text)
+        await session_manager.add_message(session_id, "assistant", result_text, extra=self._build_agent_author_extra())
         # Get events for UI
         events = tracer.get_events_for_ui(limit=10, session_id=session_id)
         return {"response": result_text, "usage": usage_data, "events": events, "user_message_id": user_message_id}

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -404,7 +404,7 @@ You have access to the following tools. When a user asks you to do something tha
     ) -> Dict[str, Any]:
         return {
             "author_type": "human",
-            "author_id": portal_user_id or user_name or "",
+            "author_id": portal_user_id or user_name or "unknown",
             "author_name": portal_user_name or user_name or "User",
             "author_source": "portal" if (portal_user_id or portal_user_name) else "runtime",
         }
@@ -439,6 +439,10 @@ You have access to the following tools. When a user asks you to do something tha
                 When enabled, includes model's thinking process in response.
                 Default: Uses config.llm.reasoning_replay setting.
             stream_callback: Optional callback for streaming events (tool calls, progress, etc.)
+            portal_user_id: Optional portal-originated user ID used for persisted user-message
+                author metadata. Falls back to runtime/user_name identity when absent.
+            portal_user_name: Optional portal-originated display name used for persisted
+                user-message author metadata. Falls back to runtime/user_name when absent.
         
         Returns:
             Dict with:

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -401,7 +401,7 @@ You have access to the following tools. When a user asks you to do something tha
         portal_user_id: Optional[str],
         portal_user_name: Optional[str],
         user_name: Optional[str],
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Any]:
         return {
             "author_type": "human",
             "author_id": portal_user_id or user_name or "",
@@ -409,7 +409,7 @@ You have access to the following tools. When a user asks you to do something tha
             "author_source": "portal" if (portal_user_id or portal_user_name) else "runtime",
         }
 
-    def _build_agent_author_extra(self) -> Dict[str, str]:
+    def _build_agent_author_extra(self) -> Dict[str, Any]:
         return {
             "author_type": "agent",
             "author_id": self.agent_id or "",

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -412,8 +412,8 @@ You have access to the following tools. When a user asks you to do something tha
     def _build_agent_author_extra(self) -> Dict[str, Any]:
         return {
             "author_type": "agent",
-            "author_id": self.agent_id or "",
-            "author_name": self.agent_name or "Assistant",
+            "author_id": getattr(self, "agent_id", None) or "",
+            "author_name": getattr(self, "agent_name", None) or "Assistant",
             "author_source": "runtime",
         }
 

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -410,12 +410,15 @@ You have access to the following tools. When a user asks you to do something tha
         }
 
     def _build_agent_author_extra(self) -> Dict[str, Any]:
-        return {
+        extra: Dict[str, Any] = {
             "author_type": "agent",
-            "author_id": getattr(self, "agent_id", None) or "",
             "author_name": getattr(self, "agent_name", None) or "Assistant",
             "author_source": "runtime",
         }
+        agent_id = getattr(self, "agent_id", None)
+        if agent_id:
+            extra["author_id"] = agent_id
+        return extra
 
     async def process(
         self,

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -10,7 +10,6 @@ import json
 import logging
 import os
 import re
-import socket
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -88,8 +87,6 @@ def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str]
         runtime_agent_id = (
             str(global_config.get("agent.id", "") or "").strip()
             or str(global_config.get("server.id", "") or "").strip()
-            or str(global_config.get("server.host", "") or "").strip()
-            or str(socket.gethostname() or "").strip()
             or None
         )
 
@@ -325,8 +322,8 @@ async def api_chat(request: web.Request) -> web.Response:
             message=message,
             session_id=session_id,
             user_name=effective_user_name,
-            portal_user_id=portal_user_id,
-            portal_user_name=portal_user_name or effective_user_name,
+            portal_user_id=portal_user_id or None,
+            portal_user_name=portal_user_name or None,
             track_usage=True,
             reasoning_replay=reasoning_replay,
             attached_images=attached_images if attached_images else None,
@@ -515,8 +512,8 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             message=message,
             session_id=session_id,
             user_name=effective_user_name,
-            portal_user_id=portal_user_id,
-            portal_user_name=portal_user_name or effective_user_name,
+            portal_user_id=portal_user_id or None,
+            portal_user_name=portal_user_name or None,
             track_usage=True,
             stream_callback=event_queue,
         )

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import socket
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -46,6 +47,56 @@ logger = logging.getLogger(__name__)
 # Get template and static paths
 TEMPLATE_DIR = Path(__file__).parent / "templates"
 STATIC_DIR = Path(__file__).parent / "static"
+
+
+def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str], Optional[str]]:
+    """Resolve runtime agent identity from server-side state/config, never from client body."""
+    runtime_agent_id: Optional[str] = None
+    runtime_agent_name: Optional[str] = None
+
+    app = request.app
+
+    raw_agent_id = app.get("agent_id") if hasattr(app, "get") else None
+    raw_agent_name = app.get("agent_name") if hasattr(app, "get") else None
+    if raw_agent_id:
+        runtime_agent_id = str(raw_agent_id).strip() or None
+    if raw_agent_name:
+        runtime_agent_name = str(raw_agent_name).strip() or None
+
+    raw_agent = app.get("agent") if hasattr(app, "get") else None
+    if raw_agent:
+        if isinstance(raw_agent, dict):
+            if not runtime_agent_id:
+                runtime_agent_id = str(raw_agent.get("id") or raw_agent.get("agent_id") or "").strip() or None
+            if not runtime_agent_name:
+                runtime_agent_name = str(raw_agent.get("name") or raw_agent.get("agent_name") or raw_agent.get("display_name") or "").strip() or None
+        else:
+            if not runtime_agent_id:
+                runtime_agent_id = str(getattr(raw_agent, "id", None) or getattr(raw_agent, "agent_id", None) or "").strip() or None
+            if not runtime_agent_name:
+                runtime_agent_name = str(getattr(raw_agent, "name", None) or getattr(raw_agent, "agent_name", None) or getattr(raw_agent, "display_name", None) or "").strip() or None
+
+    if not runtime_agent_name:
+        runtime_agent_name = (
+            str(global_config.get("agent.name", "") or "").strip()
+            or str(global_config.get("agent.display_name", "") or "").strip()
+            or str(global_config.get("server.name", "") or "").strip()
+            or None
+        )
+
+    if not runtime_agent_id:
+        runtime_agent_id = (
+            str(global_config.get("agent.id", "") or "").strip()
+            or str(global_config.get("server.id", "") or "").strip()
+            or str(global_config.get("server.host", "") or "").strip()
+            or str(socket.gethostname() or "").strip()
+            or None
+        )
+
+    if not runtime_agent_name:
+        runtime_agent_name = str(global_config.llm.get("model") or "").strip() or "Assistant"
+
+    return runtime_agent_id, runtime_agent_name
 
 
 def load_template(filename: str) -> str:
@@ -146,8 +197,6 @@ async def api_chat(request: web.Request) -> web.Response:
         portal_user_id = str(data.get("portal_user_id") or "").strip()
         portal_user_name = str(data.get("portal_user_name") or "").strip()
         effective_user_name = portal_user_name or "webchat-user"
-        agent_id = str(data.get("agent_id") or "").strip()
-        agent_name = str(data.get("agent_name") or "").strip()
         logger.info(f"[api_chat] DEBUG: full request data: {data}")
         
         if not message and not attachments:
@@ -265,11 +314,12 @@ async def api_chat(request: web.Request) -> web.Response:
         model = global_config.llm.get('model', 'gpt-5-mini')
         
         # Run agent (history is managed internally by session_manager)
+        runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
         agent = AgentCore(
             model=model,
             session_id=session_id,
-            agent_id=agent_id or None,
-            agent_name=agent_name or None,
+            agent_id=runtime_agent_id,
+            agent_name=runtime_agent_name,
         )
         result = await agent.process(
             message=message,
@@ -423,8 +473,6 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         portal_user_id = str(data.get("portal_user_id") or "").strip()
         portal_user_name = str(data.get("portal_user_name") or "").strip()
         effective_user_name = portal_user_name or "webchat-user"
-        agent_id = str(data.get("agent_id") or "").strip()
-        agent_name = str(data.get("agent_name") or "").strip()
         
         if not message:
             response = web.json_response({'error': 'Empty message'}, status=400)
@@ -454,11 +502,12 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         model = global_config.llm.get('model', 'gpt-5-mini')
         
         # Run agent and stream response
+        runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
         agent = AgentCore(
             model=model,
             session_id=session_id,
-            agent_id=agent_id or None,
-            agent_name=agent_name or None,
+            agent_id=runtime_agent_id,
+            agent_name=runtime_agent_name,
         )
         
         # Pass the queue to the agent for real-time events

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -91,7 +91,7 @@ def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str]
         )
 
     if not runtime_agent_name:
-        runtime_agent_name = str(global_config.llm.get("model") or "").strip() or "Assistant"
+        runtime_agent_name = "Assistant"
 
     return runtime_agent_id, runtime_agent_name
 

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -194,7 +194,13 @@ async def api_chat(request: web.Request) -> web.Response:
         portal_user_id = str(data.get("portal_user_id") or "").strip()
         portal_user_name = str(data.get("portal_user_name") or "").strip()
         effective_user_name = portal_user_name or "webchat-user"
-        logger.info(f"[api_chat] DEBUG: full request data: {data}")
+        logger.debug(
+            "[api_chat] Request summary: session_id=%s, has_message=%s, attachment_count=%d, portal_user_id_present=%s",
+            session_id,
+            bool(message),
+            len(attachments) if isinstance(attachments, list) else 0,
+            bool(portal_user_id),
+        )
         
         if not message and not attachments:
             return web.json_response({'error': 'Empty message'}, status=400)

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -55,6 +55,22 @@ def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str]
 
     app = request.app
 
+    try:
+        global_config.reload()
+    except Exception:
+        pass
+    config_data = getattr(global_config, "_config", {}) or {}
+
+    def _cfg(path: str) -> str:
+        value = config_data
+        for part in path.split("."):
+            if not isinstance(value, dict):
+                return ""
+            value = value.get(part)
+            if value is None:
+                return ""
+        return str(value).strip()
+
     raw_agent_id = app.get("agent_id") if hasattr(app, "get") else None
     raw_agent_name = app.get("agent_name") if hasattr(app, "get") else None
     if raw_agent_id:
@@ -77,16 +93,16 @@ def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str]
 
     if not runtime_agent_name:
         runtime_agent_name = (
-            str(global_config.get("agent.name", "") or "").strip()
-            or str(global_config.get("agent.display_name", "") or "").strip()
-            or str(global_config.get("server.name", "") or "").strip()
+            _cfg("agent.name")
+            or _cfg("agent.display_name")
+            or _cfg("server.name")
             or None
         )
 
     if not runtime_agent_id:
         runtime_agent_id = (
-            str(global_config.get("agent.id", "") or "").strip()
-            or str(global_config.get("server.id", "") or "").strip()
+            _cfg("agent.id")
+            or _cfg("server.id")
             or None
         )
 

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -143,6 +143,11 @@ async def api_chat(request: web.Request) -> web.Response:
         
         # Get attachments from new field
         attachments = data.get('attachments', [])
+        portal_user_id = str(data.get("portal_user_id") or "").strip()
+        portal_user_name = str(data.get("portal_user_name") or "").strip()
+        effective_user_name = portal_user_name or "webchat-user"
+        agent_id = str(data.get("agent_id") or "").strip()
+        agent_name = str(data.get("agent_name") or "").strip()
         logger.info(f"[api_chat] DEBUG: full request data: {data}")
         
         if not message and not attachments:
@@ -260,11 +265,18 @@ async def api_chat(request: web.Request) -> web.Response:
         model = global_config.llm.get('model', 'gpt-5-mini')
         
         # Run agent (history is managed internally by session_manager)
-        agent = AgentCore(model=model, session_id=session_id)
+        agent = AgentCore(
+            model=model,
+            session_id=session_id,
+            agent_id=agent_id or None,
+            agent_name=agent_name or None,
+        )
         result = await agent.process(
             message=message,
             session_id=session_id,
-            user_name="webchat-user",
+            user_name=effective_user_name,
+            portal_user_id=portal_user_id,
+            portal_user_name=portal_user_name or effective_user_name,
             track_usage=True,
             reasoning_replay=reasoning_replay,
             attached_images=attached_images if attached_images else None,
@@ -408,6 +420,11 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         data = await request.json()
         message = (data.get('message') or '').strip()
         session_id = data.get('session_id', f'webchat_{datetime.utcnow().strftime("%Y%m%d_%H%M%S")}')
+        portal_user_id = str(data.get("portal_user_id") or "").strip()
+        portal_user_name = str(data.get("portal_user_name") or "").strip()
+        effective_user_name = portal_user_name or "webchat-user"
+        agent_id = str(data.get("agent_id") or "").strip()
+        agent_name = str(data.get("agent_name") or "").strip()
         
         if not message:
             response = web.json_response({'error': 'Empty message'}, status=400)
@@ -437,13 +454,20 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         model = global_config.llm.get('model', 'gpt-5-mini')
         
         # Run agent and stream response
-        agent = AgentCore(model=model, session_id=session_id)
+        agent = AgentCore(
+            model=model,
+            session_id=session_id,
+            agent_id=agent_id or None,
+            agent_name=agent_name or None,
+        )
         
         # Pass the queue to the agent for real-time events
         result = await agent.process(
             message=message,
             session_id=session_id,
-            user_name="webchat-user",
+            user_name=effective_user_name,
+            portal_user_id=portal_user_id,
+            portal_user_name=portal_user_name or effective_user_name,
             track_usage=True,
             stream_callback=event_queue,
         )

--- a/tests/test_author_metadata_persistence.py
+++ b/tests/test_author_metadata_persistence.py
@@ -49,14 +49,14 @@ def _isolated_home(tmp_path, monkeypatch):
 def _mk_session_manager(calls):
     class FakeSessionManager:
         async def add_message(self, session_id, role, content, extra=None):
-            calls.append(
-                {
-                    "session_id": session_id,
-                    "role": role,
-                    "content": content,
-                    "extra": extra,
-                }
-            )
+            message = {
+                "session_id": session_id,
+                "role": role,
+                "content": content,
+            }
+            if extra:
+                message.update(extra)
+            calls.append(message)
             return f"m{len(calls)}"
 
         async def get_history(self, session_id):
@@ -98,16 +98,16 @@ async def test_process_normal_path_persists_user_and_assistant_author_metadata(m
     )
 
     user_call = next(c for c in calls if c["role"] == "user")
-    assert user_call["extra"]["author_type"] == "human"
-    assert user_call["extra"]["author_id"] == "Runtime User"
-    assert user_call["extra"]["author_name"] == "Runtime User"
-    assert user_call["extra"]["author_source"] == "runtime"
+    assert user_call["author_type"] == "human"
+    assert user_call["author_id"] == "Runtime User"
+    assert user_call["author_name"] == "Runtime User"
+    assert user_call["author_source"] == "runtime"
 
     assistant_call = next(c for c in calls if c["role"] == "assistant")
-    assert assistant_call["extra"]["author_type"] == "agent"
-    assert assistant_call["extra"]["author_id"] == "agent-123"
-    assert assistant_call["extra"]["author_name"] == "Helper Bot"
-    assert assistant_call["extra"]["author_source"] == "runtime"
+    assert assistant_call["author_type"] == "agent"
+    assert assistant_call["author_id"] == "agent-123"
+    assert assistant_call["author_name"] == "Helper Bot"
+    assert assistant_call["author_source"] == "runtime"
 
 
 @pytest.mark.asyncio
@@ -134,10 +134,10 @@ async def test_process_fastlane_path_persists_assistant_author_metadata(monkeypa
 
     assistant_call = next(c for c in calls if c["role"] == "assistant")
     assert assistant_call["content"] == "fastlane response"
-    assert assistant_call["extra"]["author_type"] == "agent"
-    assert assistant_call["extra"]["author_id"] == "agent-fast"
-    assert assistant_call["extra"]["author_name"] == "Fast Bot"
-    assert assistant_call["extra"]["author_source"] == "runtime"
+    assert assistant_call["author_type"] == "agent"
+    assert assistant_call["author_id"] == "agent-fast"
+    assert assistant_call["author_name"] == "Fast Bot"
+    assert assistant_call["author_source"] == "runtime"
 
 
 @pytest.mark.asyncio
@@ -180,11 +180,9 @@ async def test_skill_finish_merges_terminal_snapshot_with_author_metadata(monkey
     assistant_calls = [c for c in calls if c["role"] == "assistant"]
     assert assistant_calls, "expected assistant save call"
     finish_call = assistant_calls[-1]
-    extra = finish_call["extra"]
-
-    assert extra["author_type"] == "agent"
-    assert extra["author_id"] == "agent-skill"
-    assert extra["author_name"] == "Skill Bot"
-    assert extra["author_source"] == "runtime"
-    assert "terminal_skill_session" in extra
-    assert isinstance(extra["terminal_skill_session"], dict)
+    assert finish_call["author_type"] == "agent"
+    assert finish_call["author_id"] == "agent-skill"
+    assert finish_call["author_name"] == "Skill Bot"
+    assert finish_call["author_source"] == "runtime"
+    assert "terminal_skill_session" in finish_call
+    assert isinstance(finish_call["terminal_skill_session"], dict)

--- a/tests/test_author_metadata_persistence.py
+++ b/tests/test_author_metadata_persistence.py
@@ -1,0 +1,171 @@
+import os
+import pytest
+from types import SimpleNamespace
+
+os.makedirs(os.path.expanduser("~/.efp"), exist_ok=True)
+
+from src.agents.core import Agent
+
+
+class FakeTracer:
+    def start_execution(self, **kwargs):
+        return "exec-1"
+
+    def complete_execution(self, *args, **kwargs):
+        return None
+
+    def log_tool_call(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_action(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_step(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_complete(self, *args, **kwargs):
+        return None
+
+    def get_events_for_ui(self, **kwargs):
+        return []
+
+
+def _mk_session_manager(calls):
+    class FakeSessionManager:
+        async def add_message(self, session_id, role, content, extra=None):
+            calls.append(
+                {
+                    "session_id": session_id,
+                    "role": role,
+                    "content": content,
+                    "extra": extra,
+                }
+            )
+            return f"m{len(calls)}"
+
+        async def get_history(self, session_id):
+            return []
+
+        async def set_active_skill_session(self, session_id, state):
+            return None
+
+    return FakeSessionManager()
+
+
+@pytest.mark.asyncio
+async def test_process_normal_path_persists_user_and_assistant_author_metadata(monkeypatch):
+    from src.agents import core as core_mod
+
+    calls = []
+    monkeypatch.setattr(core_mod, "session_manager", _mk_session_manager(calls))
+
+    async def fake_fastlane(*args, **kwargs):
+        return None
+
+    async def fake_responses(**kwargs):
+        return {"content": "assistant reply", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.fastlane.process_fastlane_command", fake_fastlane)
+    monkeypatch.setattr(core_mod, "llm_client", SimpleNamespace(responses=fake_responses))
+    monkeypatch.setattr("src.skills.get_tracer", lambda: FakeTracer())
+    monkeypatch.setattr("src.skills.skill_registry._initialized", True)
+    monkeypatch.setattr("src.skills.skill_registry.match_skill", lambda message: [])
+
+    agent = Agent(agent_id="agent-123", agent_name="Helper Bot")
+    await agent.process(
+        message="hello",
+        session_id="s1",
+        user_name="Runtime User",
+        portal_user_id=None,
+        portal_user_name=None,
+    )
+
+    user_call = next(c for c in calls if c["role"] == "user")
+    assert user_call["extra"]["author_type"] == "human"
+    assert user_call["extra"]["author_id"] == "Runtime User"
+    assert user_call["extra"]["author_name"] == "Runtime User"
+    assert user_call["extra"]["author_source"] == "runtime"
+
+    assistant_call = next(c for c in calls if c["role"] == "assistant")
+    assert assistant_call["extra"]["author_type"] == "agent"
+    assert assistant_call["extra"]["author_id"] == "agent-123"
+    assert assistant_call["extra"]["author_name"] == "Helper Bot"
+    assert assistant_call["extra"]["author_source"] == "runtime"
+
+
+@pytest.mark.asyncio
+async def test_process_fastlane_path_persists_assistant_author_metadata(monkeypatch):
+    from src.agents import core as core_mod
+
+    calls = []
+    monkeypatch.setattr(core_mod, "session_manager", _mk_session_manager(calls))
+
+    async def fake_fastlane(*args, **kwargs):
+        return "fastlane response"
+
+    monkeypatch.setattr("src.agents.fastlane.process_fastlane_command", fake_fastlane)
+
+    agent = Agent(agent_id="agent-fast", agent_name="Fast Bot")
+    await agent.process(
+        message="/status",
+        session_id="s-fast",
+        user_name="Portal User",
+        portal_user_id="p-1",
+        portal_user_name="Portal User",
+    )
+
+    assistant_call = next(c for c in calls if c["role"] == "assistant")
+    assert assistant_call["content"] == "fastlane response"
+    assert assistant_call["extra"]["author_type"] == "agent"
+    assert assistant_call["extra"]["author_id"] == "agent-fast"
+    assert assistant_call["extra"]["author_name"] == "Fast Bot"
+    assert assistant_call["extra"]["author_source"] == "runtime"
+
+
+@pytest.mark.asyncio
+async def test_skill_finish_merges_terminal_snapshot_with_author_metadata(monkeypatch):
+    from src.agents import core as core_mod
+    from src.agents.skill_mode import SkillSession
+
+    calls = []
+    monkeypatch.setattr(core_mod, "session_manager", _mk_session_manager(calls))
+    monkeypatch.setattr("src.skills.get_tracer", lambda: FakeTracer())
+
+    resp_calls = {"n": 0}
+
+    async def fake_responses(**kwargs):
+        resp_calls["n"] += 1
+        if resp_calls["n"] == 1:
+            return {"content": "", "function_calls": [], "usage": {}}
+        return {"content": "[FINISH]\nDone", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr(core_mod, "llm_client", SimpleNamespace(responses=fake_responses))
+
+    agent = Agent.__new__(Agent)
+    agent.model = None
+    agent.agent_id = "agent-skill"
+    agent.agent_name = "Skill Bot"
+    agent.tools = [{"function": {"name": "search"}}]
+
+    skill = SimpleNamespace(name="lookup", description="lookup skill", path="", tools=[], strategy=[])
+    skill_session = SkillSession(skill_name="lookup", original_user_request="help")
+
+    await agent._continue_skill_mode(
+        message="help",
+        session_id="s-skill",
+        user_message_id="u1",
+        skill_state=skill_session.to_dict(),
+        skill=skill,
+    )
+
+    assistant_calls = [c for c in calls if c["role"] == "assistant"]
+    assert assistant_calls, "expected assistant save call"
+    finish_call = assistant_calls[-1]
+    extra = finish_call["extra"]
+
+    assert extra["author_type"] == "agent"
+    assert extra["author_id"] == "agent-skill"
+    assert extra["author_name"] == "Skill Bot"
+    assert extra["author_source"] == "runtime"
+    assert "terminal_skill_session" in extra
+    assert isinstance(extra["terminal_skill_session"], dict)

--- a/tests/test_author_metadata_persistence.py
+++ b/tests/test_author_metadata_persistence.py
@@ -38,9 +38,9 @@ def _isolated_home(tmp_path, monkeypatch):
 
     import src.config as config_mod
 
-    config_mod.config.config_path = config_file
-    config_mod.config._config = {}
-    config_mod.config._last_modified = 0
+    monkeypatch.setattr(config_mod.config, "config_path", config_file, raising=False)
+    monkeypatch.setattr(config_mod.config, "_config", {}, raising=False)
+    monkeypatch.setattr(config_mod.config, "_last_modified", 0, raising=False)
     config_mod.config.load()
 
     return efp_dir

--- a/tests/test_author_metadata_persistence.py
+++ b/tests/test_author_metadata_persistence.py
@@ -1,10 +1,6 @@
-import os
 import pytest
 from types import SimpleNamespace
 
-os.makedirs(os.path.expanduser("~/.efp"), exist_ok=True)
-
-from src.agents.core import Agent
 
 
 class FakeTracer:
@@ -28,6 +24,14 @@ class FakeTracer:
 
     def get_events_for_ui(self, **kwargs):
         return []
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    efp_dir = tmp_path / ".efp"
+    efp_dir.mkdir(exist_ok=True)
+    return efp_dir
 
 
 def _mk_session_manager(calls):
@@ -54,6 +58,7 @@ def _mk_session_manager(calls):
 
 @pytest.mark.asyncio
 async def test_process_normal_path_persists_user_and_assistant_author_metadata(monkeypatch):
+    from src.agents.core import Agent
     from src.agents import core as core_mod
 
     calls = []
@@ -95,6 +100,7 @@ async def test_process_normal_path_persists_user_and_assistant_author_metadata(m
 
 @pytest.mark.asyncio
 async def test_process_fastlane_path_persists_assistant_author_metadata(monkeypatch):
+    from src.agents.core import Agent
     from src.agents import core as core_mod
 
     calls = []
@@ -124,6 +130,7 @@ async def test_process_fastlane_path_persists_assistant_author_metadata(monkeypa
 
 @pytest.mark.asyncio
 async def test_skill_finish_merges_terminal_snapshot_with_author_metadata(monkeypatch):
+    from src.agents.core import Agent
     from src.agents import core as core_mod
     from src.agents.skill_mode import SkillSession
 

--- a/tests/test_author_metadata_persistence.py
+++ b/tests/test_author_metadata_persistence.py
@@ -31,6 +31,18 @@ def _isolated_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     efp_dir = tmp_path / ".efp"
     efp_dir.mkdir(exist_ok=True)
+
+    config_file = efp_dir / "config.yaml"
+    if not config_file.exists():
+        config_file.write_text("{}", encoding="utf-8")
+
+    import src.config as config_mod
+
+    config_mod.config.config_path = config_file
+    config_mod.config._config = {}
+    config_mod.config._last_modified = 0
+    config_mod.config.load()
+
     return efp_dir
 
 


### PR DESCRIPTION
### Motivation

- Avoid relabeling historic chat history when shared agents are used by multiple portal users by persisting the real author identity on each saved message.
- Keep changes minimal, backward-compatible with existing session storage, and reuse the existing per-message `extra` mechanism for persistence.

### Description

- Parse `portal_user_id` and `portal_user_name` (with fallback to `webchat-user`) in both `/api/chat` and `/api/chat/stream`, compute `effective_user_name`, and pass these into `AgentCore.process(...)` while preserving current request behavior (file attachments and session handling). (file: `src/gateway/webchat.py`)
- Extend `Agent` constructor to accept optional `agent_id` and `agent_name` and pass them from webchat when available. (file: `src/agents/core.py`)
- Add `Agent._build_user_author_extra(...)` and `Agent._build_agent_author_extra()` helpers and extend `Agent.process(...)` to accept `portal_user_id` and `portal_user_name`; persist user author metadata on the initial user-message `add_message(...)` and preserve attachments. (file: `src/agents/core.py`)
- Update every assistant message save point to include agent author metadata, merging into existing `extra` when present (e.g., `terminal_skill_session`), so all assistant-saved messages carry `author_type: agent` plus id/name/source. (file: `src/agents/core.py`)
- Did not change `src/sessions/manager.py` behavior or session storage format; author fields are optional extras and maintain backward compatibility with old sessions. (no migration required)

### Testing

- Compiled modified modules successfully with `python -m compileall src/gateway/webchat.py src/agents/core.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce1d03adac832ab5117948b68d5123)