### PR TITLE
Harden logging: add redaction utilities and apply redacting filter

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -1914,7 +1914,7 @@ You have access to the following tools. When a user asks you to do something tha
                 logger.info(f"[SkillMode] [TOOL_FEEDBACK] Added to input_items, output length={len(output_text)}, preview={safe_preview(output_text, 300)}")
                 
                 # Log tool call for skill mode
-                tracer.log_tool_call(tool_name, safe_preview(args_str, 500), safe_preview(output_text, 500))
+                tracer.log_tool_call(tool_name, redact_value(normalized_args), safe_preview(output_text, 500))
                 
                 if not output_text.startswith("Error:"):
                     readonly_markers = ("get", "list", "query", "search", "fetch", "read", "issue", "pr", "file")

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -35,6 +35,7 @@ from src.memory.update_manager import MemoryUpdateManager
 from src.agents.thinking import ThinkLevel, normalize_think_level, format_runtime_info
 from src.config import config
 from src.utils.truncate import truncate, truncate_with_count
+from src.utils.redaction import safe_preview, redact_value, sanitize_exception_message
 from src.sessions.manager import session_manager
 from src.sessions.persistence import session_persistence
 from src.agents.executor import (
@@ -955,7 +956,7 @@ You have access to the following tools. When a user asks you to do something tha
                             text = " ".join([c.get("text", str(c)) for c in content])
                         else:
                             text = str(content)
-                        context_info.append(f"User: {text[:200]}")
+                        context_info.append(f"User: {safe_preview(text, 200)}")
             if context_info:
                 send_event("llm_thinking", {"message": " | ".join(context_info), "iteration": iteration})
             else:
@@ -1130,7 +1131,7 @@ You have access to the following tools. When a user asks you to do something tha
                     # Send actual thinking content if reasoning is available
                     if reasoning_content:
                         send_event("llm_thinking", {
-                            "message": reasoning_content[:500],  # Truncate for display
+                            "message": safe_preview(reasoning_content, 500),  # Truncate for display
                             "thinking": reasoning_content,  # Full thinking for storage
                             "iteration": iteration
                         })
@@ -1146,7 +1147,7 @@ You have access to the following tools. When a user asks you to do something tha
                     user_msg = ""
                     for item in input_items:
                         if item.get("type") == "message" and item.get("role") == "user":
-                            user_msg = item.get("content", "")[:200]
+                            user_msg = safe_preview(item.get("content", ""), 200)
                             break
                     if user_msg:
                         send_event("llm_thinking", {
@@ -1329,14 +1330,14 @@ You have access to the following tools. When a user asks you to do something tha
                             {
                                 "tool": tool_name,
                                 "call_id": call_id,
-                                "result": str(deny_result),
+                                "result": safe_preview(deny_result, 500),
                                 "success": False,
                             },
                         )
                         tracer.log_tool_call(
                             tool_name=tool_name,
-                            arguments=args,
-                            result=str(deny_result),
+                            arguments=redact_value(args),
+                            result=safe_preview(deny_result, 500),
                             success=False,
                         )
                         loop_messages.append(
@@ -1352,7 +1353,7 @@ You have access to the following tools. When a user asks you to do something tha
                             stage="post_tool",
                             session_id=session_id,
                             tool_name=tool_name,
-                            payload={"denied": True, "result": str(deny_result)},
+                            payload={"denied": True, "result": safe_preview(deny_result, 500)},
                             event_callback=send_event,
                         )
                         continue
@@ -1369,11 +1370,11 @@ You have access to the following tools. When a user asks you to do something tha
                     args = {**args, **pre_hook_effects.modified_args}
                 if pre_hook_effects.short_circuit_result is not None:
                     short_result = pre_hook_effects.short_circuit_result
-                    short_result_preview = truncate_with_count(str(short_result), 200)
+                    short_result_preview = safe_preview(short_result, 200)
                     tracer.log_tool_call(
                         tool_name=tool_name,
-                        arguments=args,
-                        result=str(short_result),
+                        arguments=redact_value(args),
+                        result=safe_preview(short_result, 500),
                         success=short_result.success,
                     )
                     loop_messages.append(
@@ -1417,7 +1418,7 @@ You have access to the following tools. When a user asks you to do something tha
                     logger.info(f"[Confirmation] Auto-confirming write operation: {tool_name}")
                 
                 # Execute the tool (task-capable tools go through task manager boundary)
-                logger.info(f"Executing tool: {tool_name} with args: {args}")
+                logger.info(f"Executing tool: {tool_name} with args: {safe_preview(args, 300)}")
                 tool_result = await run_skill_tool_with_task_boundary(
                     runtime_config=active_skill_runtime,
                     session_id=session_id,
@@ -1425,7 +1426,7 @@ You have access to the following tools. When a user asks you to do something tha
                     execute_direct=lambda tn=tool_name, tool_args=args: execute_tool_by_name(tn, **tool_args),
                     event_callback=send_event,
                 )
-                result_preview = truncate_with_count(str(tool_result), 200)
+                result_preview = safe_preview(tool_result, 200)
                 post_hook_effects = apply_skill_hooks(
                     runtime_config=active_skill_runtime,
                     stage="post_tool",
@@ -1436,11 +1437,11 @@ You have access to the following tools. When a user asks you to do something tha
                 )
                 if post_hook_effects.result_override is not None:
                     tool_result = post_hook_effects.result_override
-                    result_preview = truncate_with_count(str(tool_result), 200)
+                    result_preview = safe_preview(tool_result, 200)
                 tracer.log_tool_call(
                     tool_name=tool_name,
-                    arguments=args,
-                    result=str(tool_result),
+                    arguments=redact_value(args),
+                    result=safe_preview(tool_result, 500),
                     success=tool_result.success,
                 )
                 # Send tool result event
@@ -1479,7 +1480,7 @@ You have access to the following tools. When a user asks you to do something tha
                 # Instead, tool results stay in loop_messages for the current request's
                 # execution context and are passed directly to subsequent LLM calls.
                 
-                logger.info(f"Tool result: {truncate_with_count(str(tool_result), 200)}")
+                logger.info(f"Tool result: {safe_preview(tool_result, 200)}")
                 executed_tool_results.append((tool_name, tool_result))
 
             # Narrow passthrough shortcut for direct Jira detail retrieval requests.
@@ -1548,7 +1549,7 @@ You have access to the following tools. When a user asks you to do something tha
         tracer = get_tracer()
         
         logger.debug(f"[SkillMode] ===== _start_skill_mode BEGIN =====")
-        logger.debug(f"[SkillMode] message='{message[:200]}...'")
+        logger.debug(f"[SkillMode] message={safe_preview(message, 200)}")
         logger.debug(f"[SkillMode] session_id={session_id}, skill={skill.name if skill else None}")
         
         usage_data: Dict[str, Any] = {}
@@ -1580,10 +1581,10 @@ You have access to the following tools. When a user asks you to do something tha
 
         # Log skill mode entry
         tracer.log_skill_mode_entry(skill.name, message, session_id)
-        send_skill_event("skill_mode_start", {"skill": skill.name, "message": message[:100]})
+        send_skill_event("skill_mode_start", {"skill": skill.name, "message": safe_preview(message, 100)})
 
         # Generate initial plan (always returns 3-tuple: goal, steps, usage)
-        tracer.log_skill_mode_step("GENERATE_PLAN", "started", f"Creating plan for: {message[:50]}...")
+        tracer.log_skill_mode_step("GENERATE_PLAN", "started", f"Creating plan for: {safe_preview(message, 50)}")
         send_skill_event("skill_step", {"step": "GENERATE_PLAN", "status": "started", "detail": f"Creating plan..."})
         
         goal, steps, plan_usage = await generate_initial_skill_plan(skill, message, model=self.model)
@@ -1638,7 +1639,7 @@ You have access to the following tools. When a user asks you to do something tha
         tracer = get_tracer()
         
         logger.debug(f"[SkillMode] ===== _continue_skill_mode BEGIN =====")
-        logger.debug(f"[SkillMode] message='{message[:200]}...'")
+        logger.debug(f"[SkillMode] message={safe_preview(message, 200)}")
         logger.debug(f"[SkillMode] session_id={session_id}, skill_state keys={list(skill_state.keys()) if skill_state else None}")
         
         usage_data = usage_data or {}
@@ -1647,7 +1648,7 @@ You have access to the following tools. When a user asks you to do something tha
             """Send skill event via stream_callback if available, and also emit to event_bus for WebSocket."""
             import json
             event = json.dumps({"type": event_type, "data": data})
-            logger.debug(f"[SkillMode] [EVENT] type={event_type}, data={json.dumps(data)[:200]}")
+            logger.debug(f"[SkillMode] [EVENT] type={event_type}, data={safe_preview(data, 200)}")
             
             # Send via stream_callback (for SSE)
             if stream_callback:
@@ -1844,14 +1845,14 @@ You have access to the following tools. When a user asks you to do something tha
             function_calls = llm_result.get("function_calls", []) or llm_result.get("tool_calls", []) or []
             turn_state.has_function_calls = bool(function_calls)
 
-            logger.debug(f"[SkillMode] raw_output='{raw_output[:300]}...'")
+            logger.debug(f"[SkillMode] raw_output={safe_preview(raw_output, 300)}")
             logger.debug(f"[SkillMode] function_calls count={len(function_calls)}")
             
             # Log full response if content is empty for debugging
             if not raw_output and not function_calls:
                 logger.warning(f"[SkillMode] WARNING: LLM returned empty content AND no function_calls!")
                 logger.warning(f"[SkillMode] Full llm_result keys: {llm_result.keys() if llm_result else None}")
-                logger.warning(f"[SkillMode] llm_result: {str(llm_result)[:500]}")
+                logger.warning(f"[SkillMode] llm_result: {safe_preview(llm_result, 500)}")
 
             if not function_calls:
                 should_finalize_without_tools = True
@@ -1873,7 +1874,7 @@ You have access to the following tools. When a user asks you to do something tha
                 args_raw = function_payload.get("arguments", {}) or call.get("arguments", {})
                 args_str = args_raw if isinstance(args_raw, str) else json.dumps(args_raw, ensure_ascii=False)
 
-                logger.debug(f"[SkillMode] [TOOL_CALL] tool={tool_name}, args_str='{args_str[:200]}...'")
+                logger.debug(f"[SkillMode] [TOOL_CALL] tool={tool_name}, args={safe_preview(args_str, 200)}")
 
                 input_items.append({
                     "type": "function_call",
@@ -1882,7 +1883,7 @@ You have access to the following tools. When a user asks you to do something tha
                     "arguments": args_str,
                 })
                 
-                round_tool_calls.append((tool_name, args_str[:100]))
+                round_tool_calls.append((tool_name, safe_preview(args_str, 100)))
 
                 normalized_args = _normalize_tool_args(args_str)
                 # ===== CONFIRMATION GATE (skill-mode) =====
@@ -1894,15 +1895,15 @@ You have access to the following tools. When a user asks you to do something tha
                     turn_state.has_write_call = True
                     logger.info(f"[Confirmation][SkillMode] Tool '{tool_name}' requires confirmation, auto-confirming")
                 
-                logger.debug(f"[SkillMode] [TOOL_EXEC] Executing tool={tool_name}, parsed_args={normalized_args}")
+                logger.debug(f"[SkillMode] [TOOL_EXEC] Executing tool={tool_name}, parsed_args={safe_preview(normalized_args, 200)}")
                 executed_any_tool_this_round = True
                 try:
                     tool_result: ToolResult = await execute_tool_by_name(tool_name, **normalized_args)
                     output_text = str(tool_result)
-                    logger.debug(f"[SkillMode] [TOOL_RESULT] tool={tool_name}, result length={len(output_text)}, preview='{output_text[:200]}...'")
+                    logger.debug(f"[SkillMode] [TOOL_RESULT] tool={tool_name}, result length={len(output_text)}, preview={safe_preview(output_text, 200)}")
                 except Exception as tool_exc:
                     output_text = f"Error: Tool '{tool_name}' failed with {tool_exc}"
-                    logger.error(f"[SkillMode] [TOOL_ERROR] tool={tool_name}, error={tool_exc}")
+                    logger.error(f"[SkillMode] [TOOL_ERROR] tool={tool_name}, error={sanitize_exception_message(tool_exc)}")
 
                 input_items.append({
                     "type": "function_call_output",
@@ -1910,10 +1911,10 @@ You have access to the following tools. When a user asks you to do something tha
                     "output": output_text,
                 })
                 
-                logger.info(f"[SkillMode] [TOOL_FEEDBACK] Added to input_items, output length={len(output_text)}, first 300 chars: '{output_text[:300]}'")
+                logger.info(f"[SkillMode] [TOOL_FEEDBACK] Added to input_items, output length={len(output_text)}, preview={safe_preview(output_text, 300)}")
                 
                 # Log tool call for skill mode
-                tracer.log_tool_call(tool_name, args_str, output_text)
+                tracer.log_tool_call(tool_name, safe_preview(args_str, 500), safe_preview(output_text, 500))
                 
                 if not output_text.startswith("Error:"):
                     readonly_markers = ("get", "list", "query", "search", "fetch", "read", "issue", "pr", "file")
@@ -2038,7 +2039,7 @@ You have access to the following tools. When a user asks you to do something tha
             await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
         
         # Log skill mode action with raw output for debugging
-        logger.info(f"[SkillMode] Parsed action={action}, body_preview='{body[:100] if body else ''}', raw_output_preview='{raw_output[:100] if raw_output else ''}'")
+        logger.info(f"[SkillMode] Parsed action={action}, body_preview={safe_preview(body or '', 100)}, raw_output_preview={safe_preview(raw_output or '', 100)}")
         tracer.log_skill_mode_action(action, body)
 
         if action == "ask_user":
@@ -2050,12 +2051,12 @@ You have access to the following tools. When a user asks you to do something tha
             skill_session.pending_question = question
             skill_session.memory_summary = _update_skill_memory_summary(skill_session, message, question)
             tracer.log_skill_mode_step("ASK_USER", "completed", f"Question: {question[:50]}...")
-            send_skill_event("skill_step", {"step": "ASK_USER", "status": "completed", "detail": question[:200]})
+            send_skill_event("skill_step", {"step": "ASK_USER", "status": "completed", "detail": safe_preview(question, 200)})
             await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
             await session_manager.add_message(session_id, "assistant", question, extra=self._build_agent_author_extra())
             # Get events for UI
             events = tracer.get_events_for_ui(limit=10, session_id=session_id)
-            send_skill_event("skill_complete", {"reason": "ask_user", "question": question[:200]})
+            send_skill_event("skill_complete", {"reason": "ask_user", "question": safe_preview(question, 200)})
             logger.info("[SkillMode][Terminate] reason=%s", skill_session.termination_reason)
             logger.debug(f"[SkillMode] ===== _continue_skill_mode END (ASK_USER) =====")
             return {"response": question, "usage": usage_data, "events": events, "user_message_id": user_message_id}
@@ -2098,8 +2099,8 @@ You have access to the following tools. When a user asks you to do something tha
             }
             tracer.log_skill_mode_step("FINISH", "completed", f"Result: {final_text[:50]}...")
             tracer.log_skill_mode_complete(final_text)
-            send_skill_event("skill_step", {"step": "FINISH", "status": "completed", "detail": final_text[:200]})
-            send_skill_event("skill_complete", {"reason": "finish", "result": final_text[:200]})
+            send_skill_event("skill_step", {"step": "FINISH", "status": "completed", "detail": safe_preview(final_text, 200)})
+            send_skill_event("skill_complete", {"reason": "finish", "result": safe_preview(final_text, 200)})
             await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
             await session_manager.set_active_skill_session(session_id, None)
             finish_extra = self._build_agent_author_extra()
@@ -2120,7 +2121,7 @@ You have access to the following tools. When a user asks you to do something tha
         was_waiting_user = skill_session.status == "waiting_user"
         result_text = body.strip() if body.strip() else raw_output
         tracer.log_skill_mode_step("EXECUTE", "completed", f"Result preview: {result_text[:50]}...")
-        send_skill_event("skill_step", {"step": "EXECUTE", "status": "completed", "detail": result_text[:200]})
+        send_skill_event("skill_step", {"step": "EXECUTE", "status": "completed", "detail": safe_preview(result_text, 200)})
         if len(result_text) < 30:
             result_text = f"{result_text}\n\n(Continuing skill execution, will ask if more info is needed.)"
 

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from src.config import config
-from src.utils.truncate import truncate, truncate_with_count
+from src.utils.redaction import redact_value, safe_preview, sanitize_exception_message
 from src.sessions.usage import usage_tracker, estimate_cost
 from .errors import (
     handle_httpx_error,
@@ -120,9 +120,9 @@ def _log_request(component: str, url: str, method: str = "POST", headers: Dict =
     logger.debug(f"Method: {method}")
     logger.debug(f"URL: {url}")
     if headers:
-        logger.debug(f"Headers: {json.dumps(_sanitize_headers(headers))}")
+        logger.debug(f"Headers: {safe_preview(redact_value(_sanitize_headers(headers)), 2000)}")
     if payload:
-        logger.debug(f"Payload: {json.dumps(payload, indent=2, default=str)}")
+        logger.debug(f"Payload: {safe_preview(payload, 4000)}")
 
 
 def _log_response(component: str, status: int, body: Any = None):
@@ -132,8 +132,7 @@ def _log_response(component: str, status: int, body: Any = None):
     logger.debug(f"=== [{component}] RESPONSE ===")
     logger.debug(f"Status: {status}")
     if body:
-        body_str = json.dumps(body, indent=2, default=str) if isinstance(body, (dict, list)) else str(body)
-        logger.debug(f"Body: {body_str}")
+        logger.debug(f"Body: {safe_preview(body, 4000)}")
 
 
 def _sanitize_headers(headers: Dict[str, str]) -> Dict[str, str]:
@@ -145,11 +144,6 @@ def _sanitize_headers(headers: Dict[str, str]) -> Dict[str, str]:
         else:
             sanitized[k] = v
     return sanitized
-
-
-def _truncate_text(text: str, max_length: int = 200) -> str:
-    """Truncate text for logging preview (wrapper for truncate_with_count)."""
-    return truncate_with_count(text, max_length)
 
 
 
@@ -370,7 +364,7 @@ class BaseProvider:
                     # Debug: Log response body (truncated)
                     if _is_debug_enabled():
                         result_str = json.dumps(result, indent=2, default=str)
-                        logger.debug(f"Body: {_truncate_text(result_str, 1000)}")
+                        logger.debug(f"Body: {safe_preview(result, 1000)}")
 
                     return result
 
@@ -379,16 +373,16 @@ class BaseProvider:
                 if _is_debug_enabled():
                     logger.debug(f"=== [LLM] ERROR ===")
                     logger.debug(f"Attempt: {attempt + 1}/{max_retries}")
-                    logger.debug(f"Error: {type(e).__name__}: {e}")
+                    logger.debug(f"Error: {type(e).__name__}: {sanitize_exception_message(e)}")
 
                 if attempt < max_retries - 1:
                     delay = retry_delay * (2 ** attempt)
-                    logger.warning(f"API error, retrying in {delay}s: {e}")
+                    logger.warning(f"API error, retrying in {delay}s: {sanitize_exception_message(e)}")
                     # Log error response body for debugging
                     if hasattr(e, 'response') and e.response is not None:
                         try:
                             error_body = e.response.text
-                            logger.warning(f"Error response: {error_body[:500]}")
+                            logger.warning(f"Error response: {safe_preview(error_body, 500)}")
                         except:
                             pass
                     await asyncio.sleep(delay)
@@ -472,11 +466,11 @@ class OpenAIProvider(BaseProvider):
             logger.debug(f"Model: {payload['model']}")
             logger.debug(f"Messages count: {len(all_messages)}")
             if system_prompt:
-                logger.debug(f"System prompt: {truncate(system_prompt, 200)}")
+                logger.debug(f"System prompt: {safe_preview(system_prompt, 200)}")
             logger.debug(f"Messages preview:")
             for i, msg in enumerate(all_messages[:5]):
                 role = msg.get("role", "unknown")
-                content = truncate(msg.get("content") or "", 100)
+                content = safe_preview(msg.get("content") or "", 100)
                 logger.debug(f"  [{i}] {role}: {content}")
             if len(all_messages) > 5:
                 logger.debug(f"  ... [{len(all_messages) - 5} more messages]")
@@ -499,7 +493,7 @@ class OpenAIProvider(BaseProvider):
             content = message.get("content") or ""
             logger.debug(f"Content length: {len(content)} chars")
             if content:
-                logger.debug(f"Content preview: {truncate(content, 200)}")
+                logger.debug(f"Content preview: {safe_preview(content, 200)}")
             else:
                 logger.debug("Content: (empty - tool call response)")
             
@@ -507,7 +501,7 @@ class OpenAIProvider(BaseProvider):
             reasoning = message.get("reasoning")
             if reasoning:
                 logger.debug(f"Reasoning length: {len(reasoning)} chars")
-                logger.debug(f"Reasoning preview: {truncate(reasoning, 200)}")
+                logger.debug(f"Reasoning preview: {safe_preview(reasoning, 200)}")
             
             tool_calls = message.get("tool_calls", [])
             logger.debug(f"Tool calls: {len(tool_calls)}")
@@ -602,12 +596,12 @@ class OpenAIProvider(BaseProvider):
             logger.debug(f"=== [LLM] RESPONSES API REQUEST ===")
             logger.debug(f"Provider: {self.name}")
             logger.debug(f"Model: {model_name}")
-            logger.debug(f"Instructions: {truncate(system_prompt or '', 200)}")
+            logger.debug(f"Instructions: {safe_preview(system_prompt or '', 200)}")
             logger.debug(f"Input items count: {len(input_items)}")
 
         # Defensive check: If input_items is empty, immediately return an error to avoid Copilot API 400.
         if not input_items or not any(i.get("content") for i in input_items if isinstance(i, dict)):
-            logger.error(f"[LLM] responses() called with empty input_items, aborting Copilot API call. Payload: {{'messages': {messages}, 'input_items': {input_items}}}")
+            logger.error("[LLM] responses() called with empty input_items, aborting Copilot API call. messages=%s input_items=%s", safe_preview(messages, 300), safe_preview(input_items, 300))
             return {"error": {"message": "Input field missing for Copilot API.", "type": "bad_request", "code": "input_missing"}}
 
         # Use _call_api for centralized retry/backoff behavior
@@ -699,7 +693,7 @@ class OpenAIProvider(BaseProvider):
                         "cost_usd": estimate_cost(model_name, prompt_tokens, completion_tokens)
                     }
                 }
-            logger.error(f"[LLM] Copilot API returned empty content. Payload: {json.dumps(payload, ensure_ascii=False)} Response: {json.dumps(data, ensure_ascii=False)}")
+            logger.error("[LLM] Copilot API returned empty content. payload=%s response=%s", safe_preview(payload, 600), safe_preview(data, 600))
             return {"error": {"message": "Copilot API returned empty message. Please try rephrasing your prompt or check your input.", "type": "empty_response", "code": "empty_message"}}
 
         # Calculate usage
@@ -851,11 +845,11 @@ class GitHubCopilotProvider(BaseProvider):
             logger.debug(f"Model: {payload['model']}")
             logger.debug(f"Messages count: {len(all_messages)}")
             if system_prompt:
-                logger.debug(f"System prompt: {truncate(system_prompt, 200)}")
+                logger.debug(f"System prompt: {safe_preview(system_prompt, 200)}")
             logger.debug(f"Messages preview:")
             for i, msg in enumerate(all_messages[:5]):
                 role = msg.get("role", "unknown")
-                content = truncate(msg.get("content") or "", 100)
+                content = safe_preview(msg.get("content") or "", 100)
                 logger.debug(f"  [{i}] {role}: {content}")
             if len(all_messages) > 5:
                 logger.debug(f"  ... [{len(all_messages) - 5} more messages]")
@@ -880,14 +874,14 @@ class GitHubCopilotProvider(BaseProvider):
             content = message.get("content") or ""
             logger.debug(f"Content length: {len(content)} chars")
             if content:
-                logger.debug(f"Content preview: {truncate(content, 200)}")
+                logger.debug(f"Content preview: {safe_preview(content, 200)}")
             else:
                 logger.debug("Content: (empty - tool call response)")
             # Log reasoning if present
             reasoning = message.get("reasoning")
             if reasoning:
                 logger.debug(f"Reasoning length: {len(reasoning)} chars")
-                logger.debug(f"Reasoning preview: {truncate(reasoning, 200)}")
+                logger.debug(f"Reasoning preview: {safe_preview(reasoning, 200)}")
             tool_calls = message.get("tool_calls", [])
             logger.debug(f"Tool calls: {len(tool_calls)}")
             for tc in tool_calls:
@@ -1003,20 +997,20 @@ class GitHubCopilotProvider(BaseProvider):
         if _is_debug_enabled():
             logger.debug(f"=== [GITHUB COPILOT] RESPONSES API REQUEST ===")
             logger.debug(f"Model: {model_name}")
-            logger.debug(f"Instructions: {truncate(system_prompt or '', 200)}")
+            logger.debug(f"Instructions: {safe_preview(system_prompt or '', 200)}")
             logger.debug(f"Input messages count: {len(input_items)}")
-            logger.debug(f"Input items detail: {json.dumps(input_items, ensure_ascii=False)}")
+            logger.debug(f"Input items detail: {safe_preview(input_items, 1200)}")
 
         # Defensive check: if input_items is empty, return error immediately to avoid Copilot API 400
         if not input_items or not any(i.get("content") for i in input_items if isinstance(i, dict)):
-            logger.error(f"[LLM] responses() called with empty input_items, aborting Copilot API call. Payload: {{'messages': {messages}, 'input_items': {input_items}}}")
+            logger.error("[LLM] responses() called with empty input_items, aborting Copilot API call. messages=%s input_items=%s", safe_preview(messages, 300), safe_preview(input_items, 300))
             return {"error": {"message": "Input field missing for Copilot API.", "type": "bad_request", "code": "input_missing"}}
 
         # Use _call_api for centralized retry/backoff behavior
         data = await self._call_api("/responses", payload)
         if _is_debug_enabled():
             logger.debug(f"=== [GITHUB COPILOT] RESPONSES API RAW RESPONSE ===")
-            logger.debug(json.dumps(data, ensure_ascii=False))
+            logger.debug(safe_preview(data, 2000))
         
         # Debug: Log response (response handled inside _call_api)
         
@@ -1098,7 +1092,7 @@ class GitHubCopilotProvider(BaseProvider):
                         "cost_usd": estimate_cost(model_name, prompt_tokens, completion_tokens)
                     }
                 }
-            logger.error(f"[LLM] Copilot API returned empty content. Payload: {json.dumps(payload, ensure_ascii=False)} Response: {json.dumps(data, ensure_ascii=False)}")
+            logger.error("[LLM] Copilot API returned empty content. payload=%s response=%s", safe_preview(payload, 600), safe_preview(data, 600))
             return {"error": {"message": "Copilot API returned empty message. Please try rephrasing your prompt or check your input.", "type": "empty_response", "code": "empty_message"}}
 
         # Calculate usage
@@ -1275,7 +1269,7 @@ class ClaudeProvider(BaseProvider):
             content = parsed.get("content", "")
             tool_calls = parsed.get("tool_calls", [])
             logger.debug(f"Content length: {len(content)} chars")
-            logger.debug(f"Content preview: {_truncate_text(content, 200)}")
+            logger.debug(f"Content preview: {safe_preview(content, 200)}")
             logger.debug(f"Tool calls: {len(tool_calls)}")
             for tc in tool_calls:
                 tc_name = tc.get("function", {}).get("name", "unknown")
@@ -1451,7 +1445,7 @@ class OllamaProvider(BaseProvider):
             content = result.get("content", "")
             tool_calls = result.get("tool_calls", [])
             logger.debug(f"Content length: {len(content)} chars")
-            logger.debug(f"Content preview: {_truncate_text(content, 200)}")
+            logger.debug(f"Content preview: {safe_preview(content, 200)}")
             logger.debug(f"Tool calls: {len(tool_calls)}")
             for tc in tool_calls:
                 tc_name = tc.get("function", {}).get("name", "unknown")

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -10,7 +10,8 @@ Providers:
 Debug Logging:
 - Enable with log_level: DEBUG in config.yaml
 - Logs: LLM requests, responses, reasoning, tool calls
-- Complete input/output when debug is enabled (no truncation)
+- Debug output uses sanitized previews (redacted + truncated as needed),
+  not full raw request/response bodies
 """
 
 import asyncio
@@ -53,7 +54,7 @@ _HTTPX_TRACE_ENABLED = None
 
 # Debug logging is enabled when logger.level is DEBUG
 # Set log_level: DEBUG in config.yaml or use --debug flag
-# When DEBUG, complete input/output is logged (no truncation)
+# When DEBUG, verbose diagnostics are logged with redacted/truncated previews.
 
 def _setup_httpx_logging():
     """Configure httpx logging based on debug settings."""

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -363,7 +363,6 @@ class BaseProvider:
 
                     # Debug: Log response body (truncated)
                     if _is_debug_enabled():
-                        result_str = json.dumps(result, indent=2, default=str)
                         logger.debug(f"Body: {safe_preview(result, 1000)}")
 
                     return result

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -20,7 +20,7 @@ from src.utils.file_parser.storage import init_storage, _file_metadata, StoredFi
 init_storage()
 from src.utils.file_parser import parse_file
 from src.utils.truncate import truncate
-from src.utils.redaction import safe_preview, sanitize_exception_message
+from src.utils.redaction import safe_preview, safe_log_field, sanitize_exception_message
 
 
 from ruamel.yaml import YAML
@@ -304,7 +304,7 @@ async def api_chat(request: web.Request) -> web.Response:
         
         # Inject file context if user has uploaded files
         original_msg_for_history = message if message.strip() else ("[image]" if attached_images else "")
-        logger.info("[api_chat] Message summary: session_id=%s attached_images=%d message_length=%d preview=%s", session_id, len(attached_images) if attached_images else 0, len(original_msg_for_history), safe_preview(original_msg_for_history, 120))
+        logger.info("[api_chat] Message summary: session_id=%s attached_images=%d message_length=%d preview=%s", safe_log_field(session_id, 120), len(attached_images) if attached_images else 0, len(original_msg_for_history), safe_preview(original_msg_for_history, 120))
         original_message = message
         try:
             enhanced_message, budget_status, citations = inject_context(

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -20,6 +20,7 @@ from src.utils.file_parser.storage import init_storage, _file_metadata, StoredFi
 init_storage()
 from src.utils.file_parser import parse_file
 from src.utils.truncate import truncate
+from src.utils.redaction import safe_preview, sanitize_exception_message
 
 
 from ruamel.yaml import YAML
@@ -263,7 +264,7 @@ async def api_chat(request: web.Request) -> web.Response:
             except StoredFileNotFoundError:
                 logger.warning(f"[api_chat] File {file_id} not found")
             except Exception as e:
-                logger.warning(f"[api_chat] Failed to process file {file_id}: {e}")
+                logger.warning(f"[api_chat] Failed to process file {safe_preview(file_id, 80)}: {sanitize_exception_message(e)}")
             return False
         
         # 1. Parse @file_ references from message (backward compatibility)
@@ -284,9 +285,9 @@ async def api_chat(request: web.Request) -> web.Response:
                         if fid:
                             await process_file(fid)
                     except ValueError as ve:
-                        logger.warning(f"[api_chat] Prefix lookup failed: {ve}")
+                        logger.warning(f"[api_chat] Prefix lookup failed: {sanitize_exception_message(ve)}")
         except Exception as e:
-            logger.warning(f"[api_chat] @file_ parse error: {e}")
+            logger.warning(f"[api_chat] @file_ parse error: {sanitize_exception_message(e)}")
         
         # 2. Process attachments from new attachments field
         if attachments and isinstance(attachments, list):
@@ -303,7 +304,7 @@ async def api_chat(request: web.Request) -> web.Response:
         
         # Inject file context if user has uploaded files
         original_msg_for_history = message if message.strip() else ("[image]" if attached_images else "")
-        logger.info(f"[api_chat] DEBUG: original_msg_for_history='{original_msg_for_history}', attached_images={len(attached_images) if attached_images else 0}")
+        logger.info("[api_chat] Message summary: session_id=%s attached_images=%d message_length=%d preview=%s", session_id, len(attached_images) if attached_images else 0, len(original_msg_for_history), safe_preview(original_msg_for_history, 120))
         original_message = message
         try:
             enhanced_message, budget_status, citations = inject_context(
@@ -318,7 +319,7 @@ async def api_chat(request: web.Request) -> web.Response:
                 # Attach citations to request for response
                 request['file_citations'] = citations
         except Exception as e:
-            logger.warning(f"[api_chat] File context injection failed: {e}")
+            logger.warning(f"[api_chat] File context injection failed: {sanitize_exception_message(e)}")
             # Continue without file context if injection fails
         
         # Initialize session manager if needed
@@ -445,8 +446,8 @@ async def api_chat(request: web.Request) -> web.Response:
         error_details = extract_error_details(e)
         
         # Log full error details
-        logger.error(f"Chat error: {e}")
-        logger.error(f"Error details: {json.dumps(error_details, indent=2)}")
+        logger.error(f"Chat error: {sanitize_exception_message(e)}")
+        logger.error(f"Error details: {safe_preview(error_details, 800)}")
         
         # Return user-friendly error message with optional details
         user_message = str(e)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -18,7 +18,7 @@ from typing import Optional, Dict, Any
 import json
 import traceback
 
-from src.utils.redaction import redact_text, redact_value, safe_preview
+from src.utils.redaction import redact_text, redact_value, safe_preview, safe_log_field
 
 
 # Custom log format with detailed info
@@ -118,7 +118,7 @@ class EnhancedLogger:
     def _format_message(self, message: str, **kwargs) -> str:
         """Format message with context."""
         if kwargs:
-            context = " | ".join(f"{k}={safe_preview(v, 120)}" for k, v in kwargs.items())
+            context = " | ".join(f"{k}={safe_log_field(v, 120)}" for k, v in kwargs.items())
             return f"{message} | {context}"
         return message
     

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -18,7 +18,7 @@ from typing import Optional, Dict, Any
 import json
 import traceback
 
-from src.utils.redaction import redact_text, redact_value, safe_preview, safe_log_field
+from src.utils.redaction import redact_text, redact_value, safe_preview, safe_log_field, sanitize_log_line
 
 
 # Custom log format with detailed info
@@ -47,12 +47,12 @@ class RedactingFilter(logging.Filter):
             record.msg = redact_value(record.msg)
         try:
             final_message = record.getMessage()
-            record.msg = redact_text(final_message)
+            record.msg = sanitize_log_line(final_message)
             record.args = ()
         except Exception:
-            fallback = redact_text(str(record.msg))
+            fallback = sanitize_log_line(record.msg)
             if sanitized_args:
-                fallback = f"{fallback} | args={redact_text(str(sanitized_args))}"
+                fallback = f"{fallback} | args={sanitize_log_line(sanitized_args)}"
             record.msg = fallback
             record.args = ()
         return True
@@ -85,8 +85,8 @@ class StructuredLogger:
         # Add exception info if available
         if extra and "exc_info" in extra and extra["exc_info"]:
             log_data["traceback"] = traceback.format_exc()
-        
-        self.logger.log(level, json.dumps(log_data))
+
+        self.logger.log(level, json.dumps(redact_value(log_data)))
     
     def debug(self, message: str, **extra) -> None:
         self._log_data(logging.DEBUG, message, extra)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -18,6 +18,8 @@ from typing import Optional, Dict, Any
 import json
 import traceback
 
+from src.utils.redaction import redact_text, redact_value, safe_preview
+
 
 # Custom log format with detailed info
 DEFAULT_FORMAT = "%(asctime)s | %(levelname)-8s | %(filename)s:%(lineno)d | %(funcName)s | %(message)s"
@@ -25,6 +27,26 @@ DEFAULT_FORMAT = "%(asctime)s | %(levelname)-8s | %(filename)s:%(lineno)d | %(fu
 # Structured log format (JSON)
 STRUCTURED_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(filename)s:%(lineno)d | %(funcName)s | %(message)s"
 
+
+
+
+class RedactingFilter(logging.Filter):
+    """Log filter that redacts sensitive values in messages and args."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = redact_text(record.msg)
+        else:
+            record.msg = redact_value(record.msg)
+
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = redact_value(record.args)
+            elif isinstance(record.args, tuple):
+                record.args = tuple(redact_value(arg) for arg in record.args)
+            else:
+                record.args = redact_value(record.args)
+        return True
 
 class StructuredLogger:
     """Structured logger that outputs JSON logs."""
@@ -79,7 +101,7 @@ class EnhancedLogger:
     def _format_message(self, message: str, **kwargs) -> str:
         """Format message with context."""
         if kwargs:
-            context = " | ".join(f"{k}={v}" for k, v in kwargs.items())
+            context = " | ".join(f"{k}={safe_preview(v, 120)}" for k, v in kwargs.items())
             return f"{message} | {context}"
         return message
     
@@ -112,18 +134,18 @@ class EnhancedLogger:
         """Log function call with arguments."""
         msg = f"FUNC_CALL: {func_name}"
         if args:
-            msg += f" | args={args}"
+            msg += f" | args={safe_preview(args, 200)}"
         if kwargs:
-            msg += f" | kwargs={kwargs}"
+            msg += f" | kwargs={safe_preview(kwargs, 200)}"
         self.info(msg)
     
     def log_result(self, func_name: str, result: Any = None, error: str = None):
         """Log function result."""
         msg = f"FUNC_RESULT: {func_name}"
         if result is not None:
-            msg += f" | result={result}"
+            msg += f" | result={safe_preview(result, 200)}"
         if error:
-            msg += f" | error={error}"
+            msg += f" | error={safe_preview(error, 200)}"
         if error:
             self.error(msg)
         else:
@@ -176,6 +198,7 @@ def setup_logging(
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setLevel(log_level)
         console_handler.setFormatter(formatter)
+        console_handler.addFilter(RedactingFilter())
         root_logger.addHandler(console_handler)
     
     # File handler with rotation
@@ -188,6 +211,7 @@ def setup_logging(
     )
     file_handler.setLevel(log_level)
     file_handler.setFormatter(formatter)
+    file_handler.addFilter(RedactingFilter())
     root_logger.addHandler(file_handler)
     
     # Error-only file handler (only ERROR and above)
@@ -200,6 +224,7 @@ def setup_logging(
     )
     error_handler.setLevel(logging.ERROR)
     error_handler.setFormatter(formatter)
+    error_handler.addFilter(RedactingFilter())
     root_logger.addHandler(error_handler)
     
     # Log startup info

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -34,19 +34,36 @@ class RedactingFilter(logging.Filter):
     """Log filter that redacts sensitive values in messages and args."""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if isinstance(record.msg, str):
-            record.msg = redact_text(record.msg)
-        else:
-            record.msg = redact_value(record.msg)
-
+        sanitized_args = ()
         if record.args:
             if isinstance(record.args, dict):
-                record.args = redact_value(record.args)
+                sanitized_args = redact_value(record.args)
             elif isinstance(record.args, tuple):
-                record.args = tuple(redact_value(arg) for arg in record.args)
+                sanitized_args = tuple(redact_value(arg) for arg in record.args)
             else:
-                record.args = redact_value(record.args)
+                sanitized_args = redact_value(record.args)
+            record.args = sanitized_args
+        if not isinstance(record.msg, str):
+            record.msg = redact_value(record.msg)
+        try:
+            final_message = record.getMessage()
+            record.msg = redact_text(final_message)
+            record.args = ()
+        except Exception:
+            fallback = redact_text(str(record.msg))
+            if sanitized_args:
+                fallback = f"{fallback} | args={redact_text(str(sanitized_args))}"
+            record.msg = fallback
+            record.args = ()
         return True
+
+
+class RedactingFormatter(logging.Formatter):
+    """Formatter that sanitizes exception tracebacks."""
+
+    def formatException(self, exc_info):
+        return redact_text(super().formatException(exc_info))
+
 
 class StructuredLogger:
     """Structured logger that outputs JSON logs."""
@@ -191,7 +208,7 @@ def setup_logging(
     
     # Format
     log_format = STRUCTURED_FORMAT if structured else DEFAULT_FORMAT
-    formatter = logging.Formatter(log_format)
+    formatter = RedactingFormatter(log_format)
     
     # Console handler
     if console:

--- a/src/utils/redaction.py
+++ b/src/utils/redaction.py
@@ -151,6 +151,13 @@ def safe_log_field(value: Any, limit: int = 120) -> str:
     return "".join(ch if ch.isprintable() else "?" for ch in text)
 
 
+def sanitize_log_line(value: Any) -> str:
+    """Sanitize a value for safe single-line log output."""
+    text = redact_text(str(value))
+    text = text.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
+    return "".join(ch if ch.isprintable() else "?" for ch in text)
+
+
 def sanitize_exception_message(value: Any) -> str:
     """Sanitize arbitrary exception values for safe logging."""
     return safe_preview(value, limit=500)

--- a/src/utils/redaction.py
+++ b/src/utils/redaction.py
@@ -1,0 +1,111 @@
+"""Utilities for redacting sensitive data from logs."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from src.utils.truncate import truncate_with_count
+
+REDACTED = "***REDACTED***"
+
+_SENSITIVE_KEYS = {
+    "password", "passwd", "pwd",
+    "token", "access_token", "refresh_token",
+    "api_key", "apitoken", "api_token",
+    "secret", "secret_key",
+    "private_key", "ssh_key", "ssh_private_key",
+    "authorization", "cookie", "session",
+    "github_token", "github_api_token",
+    "openai_api_key", "llm_api_key",
+    "proxy_password",
+}
+
+_PRIVATE_KEY_BLOCK_RE = re.compile(
+    r"-----BEGIN (?:PRIVATE KEY|RSA PRIVATE KEY|OPENSSH PRIVATE KEY)-----[\s\S]*?-----END (?:PRIVATE KEY|RSA PRIVATE KEY|OPENSSH PRIVATE KEY)-----",
+    re.IGNORECASE,
+)
+
+_TEXT_PATTERNS = [
+    (re.compile(r"(?i)(authorization\s*:\s*bearer\s+)([^\s,;]+)"), r"\1" + REDACTED),
+    (re.compile(r"(?i)(authorization\s*:\s*basic\s+)([^\s,;]+)"), r"\1" + REDACTED),
+    (re.compile(r"(?i)(cookie\s*:\s*)([^\n\r]+)"), r"\1" + REDACTED),
+    (re.compile(r"(?i)(\btoken\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
+    (re.compile(r"(?i)(\bpassword\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
+    (re.compile(r"(?i)(\bapi_key\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
+    (re.compile(r"(?i)(\bsecret\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
+    (re.compile(r"\bghp_[A-Za-z0-9_]+\b"), REDACTED),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]+\b"), REDACTED),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"), REDACTED),
+    (re.compile(r"\bxoxb-[A-Za-z0-9-]{8,}\b"), REDACTED),
+]
+
+_URL_CREDS_RE = re.compile(r"\bhttps?://[^\s/@:]+:[^\s/@]+@[^\s]+", re.IGNORECASE)
+
+
+def _sanitize_url_credentials(text: str) -> str:
+    def _replace(match: re.Match) -> str:
+        raw = match.group(0)
+        try:
+            parsed = urlsplit(raw)
+            if parsed.username is None or parsed.hostname is None:
+                return raw
+            netloc = f"{parsed.username}:{REDACTED}@{parsed.hostname}"
+            if parsed.port:
+                netloc += f":{parsed.port}"
+            return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+        except Exception:
+            return raw
+
+    return _URL_CREDS_RE.sub(_replace, text)
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    normalized = str(key or "").strip().lower()
+    return normalized in _SENSITIVE_KEYS
+
+
+def redact_text(text: str) -> str:
+    """Redact sensitive values embedded in free text."""
+    if text is None:
+        return ""
+    value = str(text)
+    value = _PRIVATE_KEY_BLOCK_RE.sub(REDACTED, value)
+    value = _sanitize_url_credentials(value)
+    for pattern, replacement in _TEXT_PATTERNS:
+        value = pattern.sub(replacement, value)
+    return value
+
+
+def redact_value(value: Any) -> Any:
+    """Recursively redact sensitive values for common container types."""
+    if isinstance(value, dict):
+        redacted: dict[Any, Any] = {}
+        for k, v in value.items():
+            if _is_sensitive_key(k):
+                redacted[k] = REDACTED
+            else:
+                redacted[k] = redact_value(v)
+        return redacted
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_value(item) for item in value)
+    if isinstance(value, set):
+        return {redact_value(item) for item in value}
+    if isinstance(value, str):
+        return redact_text(value)
+    return value
+
+
+def safe_preview(value: Any, limit: int = 200) -> str:
+    """Sanitize a value then produce a truncated preview string."""
+    sanitized = redact_value(value)
+    return truncate_with_count(str(sanitized), limit)
+
+
+def sanitize_exception_message(value: Any) -> str:
+    """Sanitize arbitrary exception values for safe logging."""
+    return safe_preview(value, limit=500)
+

--- a/src/utils/redaction.py
+++ b/src/utils/redaction.py
@@ -93,13 +93,17 @@ def redact_text(text: str) -> str:
     return value
 
 
+def _redact_binary_value(value: bytes | bytearray) -> str:
+    return f"[{type(value).__name__} len={len(value)}]"
+
+
 def _redact_value_internal(value: Any, *, seen: set[int], depth: int, max_depth: int) -> Any:
     if depth > max_depth:
         return REDACTED
     if isinstance(value, str):
         return redact_text(value)
     if isinstance(value, (bytes, bytearray)):
-        return value
+        return _redact_binary_value(value)
 
     is_container = isinstance(value, (Mapping, Sequence, AbstractSet)) and not isinstance(value, (str, bytes, bytearray))
     if is_container:

--- a/src/utils/redaction.py
+++ b/src/utils/redaction.py
@@ -21,6 +21,7 @@ _SENSITIVE_KEYS = {
     "openai_api_key", "llm_api_key",
     "proxy_password",
 }
+_COMPACT_SENSITIVE_KEYS = {key.replace("_", "") for key in _SENSITIVE_KEYS}
 
 _PRIVATE_KEY_BLOCK_RE = re.compile(
     r"-----BEGIN (?:PRIVATE KEY|RSA PRIVATE KEY|OPENSSH PRIVATE KEY)-----[\s\S]*?-----END (?:PRIVATE KEY|RSA PRIVATE KEY|OPENSSH PRIVATE KEY)-----",
@@ -35,6 +36,9 @@ _TEXT_PATTERNS = [
     (re.compile(r"(?i)(\bpassword\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
     (re.compile(r"(?i)(\bapi_key\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
     (re.compile(r"(?i)(\bsecret\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
+    (re.compile(r"(?i)(\baccess_token\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
+    (re.compile(r"(?i)(\brefresh_token\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
+    (re.compile(r"(?i)(\bsecret_key\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
     (re.compile(r"\bghp_[A-Za-z0-9_]+\b"), REDACTED),
     (re.compile(r"\bgithub_pat_[A-Za-z0-9_]+\b"), REDACTED),
     (re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"), REDACTED),
@@ -63,7 +67,10 @@ def _sanitize_url_credentials(text: str) -> str:
 
 def _is_sensitive_key(key: Any) -> bool:
     normalized = str(key or "").strip().lower()
-    return normalized in _SENSITIVE_KEYS
+    if normalized in _SENSITIVE_KEYS:
+        return True
+    compact = normalized.replace("_", "")
+    return compact in _COMPACT_SENSITIVE_KEYS
 
 
 def redact_text(text: str) -> str:
@@ -102,10 +109,11 @@ def redact_value(value: Any) -> Any:
 def safe_preview(value: Any, limit: int = 200) -> str:
     """Sanitize a value then produce a truncated preview string."""
     sanitized = redact_value(value)
-    return truncate_with_count(str(sanitized), limit)
+    text = str(sanitized)
+    text = redact_text(text)
+    return truncate_with_count(text, limit)
 
 
 def sanitize_exception_message(value: Any) -> str:
     """Sanitize arbitrary exception values for safe logging."""
     return safe_preview(value, limit=500)
-

--- a/src/utils/redaction.py
+++ b/src/utils/redaction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from collections.abc import Mapping, Sequence, Set as AbstractSet
 from urllib.parse import urlsplit, urlunsplit
 
 from src.utils.truncate import truncate_with_count
@@ -39,6 +40,13 @@ _TEXT_PATTERNS = [
     (re.compile(r"(?i)(\baccess_token\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
     (re.compile(r"(?i)(\brefresh_token\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
     (re.compile(r"(?i)(\bsecret_key\s*[=:]\s*)([^\s&\"',;]+)"), r"\1" + REDACTED),
+    (re.compile(r'(?i)(["\']password["\']\s*:\s*["\'])([^"\']*)(["\'])'), r"\1" + REDACTED + r"\3"),
+    (re.compile(r'(?i)(["\']token["\']\s*:\s*["\'])([^"\']*)(["\'])'), r"\1" + REDACTED + r"\3"),
+    (re.compile(r'(?i)(["\']access_token["\']\s*:\s*["\'])([^"\']*)(["\'])'), r"\1" + REDACTED + r"\3"),
+    (re.compile(r'(?i)(["\']refresh_token["\']\s*:\s*["\'])([^"\']*)(["\'])'), r"\1" + REDACTED + r"\3"),
+    (re.compile(r'(?i)(["\']api_key["\']\s*:\s*["\'])([^"\']*)(["\'])'), r"\1" + REDACTED + r"\3"),
+    (re.compile(r'(?i)(["\']secret["\']\s*:\s*["\'])([^"\']*)(["\'])'), r"\1" + REDACTED + r"\3"),
+    (re.compile(r'(?i)(["\']secret_key["\']\s*:\s*["\'])([^"\']*)(["\'])'), r"\1" + REDACTED + r"\3"),
     (re.compile(r"\bghp_[A-Za-z0-9_]+\b"), REDACTED),
     (re.compile(r"\bgithub_pat_[A-Za-z0-9_]+\b"), REDACTED),
     (re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"), REDACTED),
@@ -85,25 +93,43 @@ def redact_text(text: str) -> str:
     return value
 
 
-def redact_value(value: Any) -> Any:
-    """Recursively redact sensitive values for common container types."""
-    if isinstance(value, dict):
-        redacted: dict[Any, Any] = {}
-        for k, v in value.items():
-            if _is_sensitive_key(k):
-                redacted[k] = REDACTED
-            else:
-                redacted[k] = redact_value(v)
-        return redacted
-    if isinstance(value, list):
-        return [redact_value(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(redact_value(item) for item in value)
-    if isinstance(value, set):
-        return {redact_value(item) for item in value}
+def _redact_value_internal(value: Any, *, seen: set[int], depth: int, max_depth: int) -> Any:
+    if depth > max_depth:
+        return REDACTED
     if isinstance(value, str):
         return redact_text(value)
+    if isinstance(value, (bytes, bytearray)):
+        return value
+
+    is_container = isinstance(value, (Mapping, Sequence, AbstractSet)) and not isinstance(value, (str, bytes, bytearray))
+    if is_container:
+        obj_id = id(value)
+        if obj_id in seen:
+            return REDACTED
+        seen.add(obj_id)
+        try:
+            if isinstance(value, Mapping):
+                redacted: dict[Any, Any] = {}
+                for k, v in value.items():
+                    if _is_sensitive_key(k):
+                        redacted[k] = REDACTED
+                    else:
+                        redacted[k] = _redact_value_internal(v, seen=seen, depth=depth + 1, max_depth=max_depth)
+                return redacted
+            if isinstance(value, tuple):
+                return tuple(_redact_value_internal(item, seen=seen, depth=depth + 1, max_depth=max_depth) for item in value)
+            if isinstance(value, Sequence):
+                return [_redact_value_internal(item, seen=seen, depth=depth + 1, max_depth=max_depth) for item in value]
+            if isinstance(value, AbstractSet):
+                return {_redact_value_internal(item, seen=seen, depth=depth + 1, max_depth=max_depth) for item in value}
+        finally:
+            seen.discard(obj_id)
     return value
+
+
+def redact_value(value: Any) -> Any:
+    """Recursively redact sensitive values for common container types."""
+    return _redact_value_internal(value, seen=set(), depth=0, max_depth=20)
 
 
 def safe_preview(value: Any, limit: int = 200) -> str:

--- a/src/utils/redaction.py
+++ b/src/utils/redaction.py
@@ -144,6 +144,13 @@ def safe_preview(value: Any, limit: int = 200) -> str:
     return truncate_with_count(text, limit)
 
 
+def safe_log_field(value: Any, limit: int = 120) -> str:
+    """Sanitize a value for safe single-line log fields."""
+    text = safe_preview(value, limit)
+    text = text.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
+    return "".join(ch if ch.isprintable() else "?" for ch in text)
+
+
 def sanitize_exception_message(value: Any) -> str:
     """Sanitize arbitrary exception values for safe logging."""
     return safe_preview(value, limit=500)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -35,6 +35,7 @@ from src.utils.logger import (
     quick_setup,
     DEFAULT_FORMAT,
     STRUCTURED_FORMAT,
+    RedactingFilter,
 )
 
 
@@ -273,6 +274,28 @@ class TestSetupLogging:
         )
         assert logger.level == logging.WARNING
 
+
+
+
+    def test_setup_logging_attaches_redacting_filter(self, tmp_path):
+        """All handlers should have redaction filter attached."""
+        log_dir = tmp_path / "logs"
+        logger = setup_logging(level="INFO", log_dir=str(log_dir), log_file="test.log", console=False)
+        assert logger.handlers
+        assert all(any(isinstance(f, RedactingFilter) for f in h.filters) for h in logger.handlers)
+
+
+class TestRedactionIntegration:
+    def test_log_output_is_redacted(self, capsys, tmp_path):
+        setup_logging(level="INFO", log_dir=str(tmp_path / "logs"), log_file="test.log", console=True)
+        test_logger = logging.getLogger("redact_integration")
+        test_logger.info("Authorization: Bearer supersecret token=abc password=hunter2")
+
+        captured = capsys.readouterr()
+        out = captured.out
+        assert "supersecret" not in out
+        assert "hunter2" not in out
+        assert "***REDACTED***" in out
 
 class TestQuickSetup:
     """Tests for quick_setup function."""

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,7 @@
 """Tests for logger utilities."""
 
 import logging
+import io
 import pytest
 
 
@@ -36,6 +37,7 @@ from src.utils.logger import (
     DEFAULT_FORMAT,
     STRUCTURED_FORMAT,
     RedactingFilter,
+    RedactingFormatter,
 )
 
 
@@ -296,6 +298,65 @@ class TestRedactionIntegration:
         assert "supersecret" not in out
         assert "hunter2" not in out
         assert "***REDACTED***" in out
+
+    def test_exception_traceback_is_redacted(self):
+        stream = io.StringIO()
+        logger = logging.getLogger("redact_exception")
+        logger.handlers = []
+        logger.propagate = False
+        logger.setLevel(logging.ERROR)
+
+        handler = logging.StreamHandler(stream)
+        handler.addFilter(RedactingFilter())
+        handler.setFormatter(RedactingFormatter("%(levelname)s:%(message)s"))
+        logger.addHandler(handler)
+
+        try:
+            raise ValueError("password=secret access_token=abc123")
+        except ValueError:
+            logger.exception("operation failed")
+
+        output = stream.getvalue()
+        assert "secret" not in output
+        assert "abc123" not in output
+        assert "***REDACTED***" in output
+
+    def test_structured_log_args_are_redacted(self):
+        stream = io.StringIO()
+        logger = logging.getLogger("redact_structured_args")
+        logger.handlers = []
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+
+        handler = logging.StreamHandler(stream)
+        handler.addFilter(RedactingFilter())
+        handler.setFormatter(RedactingFormatter("%(message)s"))
+        logger.addHandler(handler)
+
+        logger.info("payload=%s", {"password": "secret", "nested": {"token": "abc123"}})
+        output = stream.getvalue()
+        assert "secret" not in output
+        assert "abc123" not in output
+        assert "***REDACTED***" in output
+
+    def test_malformed_formatting_fallback_is_safe(self):
+        stream = io.StringIO()
+        logger = logging.getLogger("redact_bad_format")
+        logger.handlers = []
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+
+        handler = logging.StreamHandler(stream)
+        handler.addFilter(RedactingFilter())
+        handler.setFormatter(RedactingFormatter("%(message)s"))
+        logger.addHandler(handler)
+
+        # Intentionally mismatched placeholders/args.
+        logger.info("payload=%s %s", {"password": "secret", "token": "abc123"})
+        output = stream.getvalue()
+        assert "secret" not in output
+        assert "abc123" not in output
+        assert "***REDACTED***" in output
 
 class TestQuickSetup:
     """Tests for quick_setup function."""

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -367,6 +367,51 @@ class TestRedactionIntegration:
         assert "secret" not in output
         assert "***REDACTED***" in output
 
+    def test_filter_neutralizes_control_characters(self):
+        stream = io.StringIO()
+        logger = logging.getLogger("redact_ctrl_chars")
+        logger.handlers = []
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+
+        handler = logging.StreamHandler(stream)
+        handler.addFilter(RedactingFilter())
+        handler.setFormatter(RedactingFormatter("%(message)s"))
+        logger.addHandler(handler)
+
+        logger.info("payload=%s", "line1\npassword=secret\tline2\r")
+        output = stream.getvalue()
+        assert "\n" not in output.rstrip("\n")
+        assert "\r" not in output
+        assert "\t" not in output
+        assert "\\n" in output
+        assert "\\r" in output
+        assert "\\t" in output
+        assert "secret" not in output
+        assert "***REDACTED***" in output
+
+    def test_structured_logger_redacts_before_json_stringify(self):
+        stream = io.StringIO()
+        logger = logging.getLogger("structured_redaction")
+        logger.handlers = []
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+
+        handler = logging.StreamHandler(stream)
+        handler.addFilter(RedactingFilter())
+        handler.setFormatter(RedactingFormatter("%(message)s"))
+        logger.addHandler(handler)
+
+        structured = StructuredLogger("structured_redaction", logger)
+        structured.info(
+            "event",
+            details={"openaiApiKey": "sk-secret", "nested": {"githubApiToken": "ghp_abc"}},
+        )
+        output = stream.getvalue()
+        assert "sk-secret" not in output
+        assert "ghp_abc" not in output
+        assert "***REDACTED***" in output
+
     def test_malformed_formatting_fallback_is_safe(self):
         stream = io.StringIO()
         logger = logging.getLogger("redact_bad_format")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -63,6 +63,17 @@ class TestEnhancedLogger:
         assert "user=test_user" in result
         assert "action=login" in result
 
+    def test_format_message_kwargs_control_characters_sanitized(self):
+        """Context values should be safe for single-line logs."""
+        logger = EnhancedLogger("test")
+        result = logger._format_message("hello", user="abc\nx\r\ty")
+        assert "\n" not in result
+        assert "\r" not in result
+        assert "\t" not in result
+        assert "\\n" in result
+        assert "\\r" in result
+        assert "\\t" in result
+
     def test_get_logger(self):
         """Test get_logger convenience function."""
         logger = get_logger("test_module")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -339,6 +339,23 @@ class TestRedactionIntegration:
         assert "abc123" not in output
         assert "***REDACTED***" in output
 
+    def test_json_string_argument_is_redacted(self):
+        stream = io.StringIO()
+        logger = logging.getLogger("redact_json_arg")
+        logger.handlers = []
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+
+        handler = logging.StreamHandler(stream)
+        handler.addFilter(RedactingFilter())
+        handler.setFormatter(RedactingFormatter("%(message)s"))
+        logger.addHandler(handler)
+
+        logger.info("%s", '{"password": "secret"}')
+        output = stream.getvalue()
+        assert "secret" not in output
+        assert "***REDACTED***" in output
+
     def test_malformed_formatting_fallback_is_safe(self):
         stream = io.StringIO()
         logger = logging.getLogger("redact_bad_format")

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,54 @@
+"""Tests for redaction utilities."""
+
+from src.utils.redaction import redact_text, redact_value, safe_preview
+
+
+def test_sensitive_dict_keys_are_redacted():
+    data = {"password": "p@ss", "token": "abc", "ok": "value"}
+    out = redact_value(data)
+    assert out["password"] == "***REDACTED***"
+    assert out["token"] == "***REDACTED***"
+    assert out["ok"] == "value"
+
+
+def test_nested_structures_are_redacted():
+    data = {
+        "nested": [{"api_key": "secret123"}, {"x": "Authorization: Bearer abc"}],
+        "tuple": ("token=abc", {"refresh_token": "zzz"}),
+    }
+    out = redact_value(data)
+    assert out["nested"][0]["api_key"] == "***REDACTED***"
+    assert "***REDACTED***" in out["nested"][1]["x"]
+    assert "***REDACTED***" in out["tuple"][0]
+    assert out["tuple"][1]["refresh_token"] == "***REDACTED***"
+
+
+def test_text_patterns_are_redacted():
+    text = "Authorization: Bearer abc Cookie: foo=bar password=xyz api_key=zzz secret=1"
+    out = redact_text(text)
+    assert "abc" not in out
+    assert "foo=bar" not in out
+    assert "xyz" not in out
+    assert "zzz" not in out
+
+
+def test_url_credentials_are_redacted():
+    text = "fetch https://alice:hunter2@example.com/path"
+    out = redact_text(text)
+    assert "hunter2" not in out
+    assert "***REDACTED***" in out
+
+
+def test_private_key_block_is_redacted():
+    text = """line\n-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\nend"""
+    out = redact_text(text)
+    assert "BEGIN PRIVATE KEY" not in out
+    assert "***REDACTED***" in out
+
+
+def test_safe_preview_redacts_before_truncating():
+    value = {"Authorization": "Bearer abcdef", "payload": "x" * 500}
+    out = safe_preview(value, limit=80)
+    assert "abcdef" not in out
+    assert "***REDACTED***" in out
+    assert "chars hidden" in out

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,5 +1,7 @@
 """Tests for redaction utilities."""
 
+from collections.abc import Mapping
+
 from src.utils.redaction import redact_text, redact_value, safe_preview
 
 
@@ -75,6 +77,15 @@ def test_assignment_style_patterns_are_redacted():
     assert out.count("***REDACTED***") >= 3
 
 
+def test_json_style_text_patterns_are_redacted():
+    text = '{"password": "secret", "access_token": "abc123", "secret_key": "qwe"}'
+    out = redact_text(text)
+    assert '"password": "secret"' not in out
+    assert '"access_token": "abc123"' not in out
+    assert '"secret_key": "qwe"' not in out
+    assert "***REDACTED***" in out
+
+
 class StringifiesToSecret:
     def __str__(self):
         return "access_token=abc123 password=secret"
@@ -85,3 +96,32 @@ def test_safe_preview_redacts_custom_object_stringification():
     assert "abc123" not in preview
     assert "secret" not in preview
     assert "***REDACTED***" in preview
+
+
+class MappingLike(Mapping):
+    def __init__(self, data):
+        self._data = data
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+
+def test_mapping_like_is_redacted():
+    value = MappingLike({"githubApiToken": "ghp_secret", "nested": {"password": "pw"}})
+    out = redact_value(value)
+    assert out["githubApiToken"] == "***REDACTED***"
+    assert out["nested"]["password"] == "***REDACTED***"
+
+
+def test_cycle_is_redacted_safely():
+    data = {"password": "pw"}
+    data["self"] = data
+    out = redact_value(data)
+    assert out["password"] == "***REDACTED***"
+    assert out["self"] == "***REDACTED***"

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -52,3 +52,36 @@ def test_safe_preview_redacts_before_truncating():
     assert "abcdef" not in out
     assert "***REDACTED***" in out
     assert "chars hidden" in out
+
+
+def test_camelcase_sensitive_keys_are_redacted():
+    data = {
+        "githubApiToken": "ghp_abc123",
+        "openaiApiKey": "sk-test-value",
+        "accessToken": "access-secret",
+    }
+    out = redact_value(data)
+    assert out["githubApiToken"] == "***REDACTED***"
+    assert out["openaiApiKey"] == "***REDACTED***"
+    assert out["accessToken"] == "***REDACTED***"
+
+
+def test_assignment_style_patterns_are_redacted():
+    text = "access_token=abc refresh_token=xyz secret_key=qwe"
+    out = redact_text(text)
+    assert "abc" not in out
+    assert "xyz" not in out
+    assert "qwe" not in out
+    assert out.count("***REDACTED***") >= 3
+
+
+class StringifiesToSecret:
+    def __str__(self):
+        return "access_token=abc123 password=secret"
+
+
+def test_safe_preview_redacts_custom_object_stringification():
+    preview = safe_preview(StringifiesToSecret(), limit=200)
+    assert "abc123" not in preview
+    assert "secret" not in preview
+    assert "***REDACTED***" in preview

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 
-from src.utils.redaction import redact_text, redact_value, safe_preview
+from src.utils.redaction import redact_text, redact_value, safe_preview, safe_log_field
 
 
 def test_sensitive_dict_keys_are_redacted():
@@ -138,3 +138,13 @@ def test_safe_preview_redacts_binary_values_without_exposing_contents():
     assert "secret" not in bytearray_preview
     assert "abc123" not in bytearray_preview
     assert "[bytearray len=" in bytearray_preview
+
+
+def test_safe_log_field_neutralizes_control_characters():
+    out = safe_log_field("abc\nforged\rline\tend", 120)
+    assert "\n" not in out
+    assert "\r" not in out
+    assert "\t" not in out
+    assert "\\n" in out
+    assert "\\r" in out
+    assert "\\t" in out

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 
-from src.utils.redaction import redact_text, redact_value, safe_preview, safe_log_field
+from src.utils.redaction import redact_text, redact_value, safe_preview, safe_log_field, sanitize_log_line
 
 
 def test_sensitive_dict_keys_are_redacted():
@@ -148,3 +148,15 @@ def test_safe_log_field_neutralizes_control_characters():
     assert "\\n" in out
     assert "\\r" in out
     assert "\\t" in out
+
+
+def test_sanitize_log_line_neutralizes_control_characters_and_redacts():
+    out = sanitize_log_line("line1\npassword=secret\tline2\r")
+    assert "\n" not in out
+    assert "\r" not in out
+    assert "\t" not in out
+    assert "\\n" in out
+    assert "\\r" in out
+    assert "\\t" in out
+    assert "secret" not in out
+    assert "***REDACTED***" in out

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -125,3 +125,16 @@ def test_cycle_is_redacted_safely():
     out = redact_value(data)
     assert out["password"] == "***REDACTED***"
     assert out["self"] == "***REDACTED***"
+
+
+def test_safe_preview_redacts_binary_values_without_exposing_contents():
+    bytes_preview = safe_preview(b"password=secret access_token=abc123", limit=200)
+    bytearray_preview = safe_preview(bytearray(b"password=secret access_token=abc123"), limit=200)
+
+    assert "secret" not in bytes_preview
+    assert "abc123" not in bytes_preview
+    assert "[bytes len=" in bytes_preview
+
+    assert "secret" not in bytearray_preview
+    assert "abc123" not in bytearray_preview
+    assert "[bytearray len=" in bytearray_preview


### PR DESCRIPTION
### Motivation
- Logs currently expose credentials and sensitive payloads (Authorization headers, API keys, tokens, passwords, PEM blocks, tool args/results, LLM payloads and raw user messages) which must be sanitized before output.
- Provide a minimal, reusable redaction primitive and a global safety net so existing logging behavior/format is preserved while preventing accidental secret leakage.

### Description
- Added a new redaction utility module `src/utils/redaction.py` implementing `redact_text()`, `redact_value()`, `safe_preview()` and `sanitize_exception_message()` with rules for Authorization/Cookie/token/password/api_key/secret patterns, token-like keys (`ghp_`, `github_pat_`, `sk-`, `xoxb-`), URL credentials, and PEM private key blocks.
- Added `RedactingFilter` to `src/utils/logger.py` that sanitizes `record.msg` and `record.args` prior to formatting, and attached this filter to all handlers created by `setup_logging()` while keeping existing formats and file-rotation behavior intact.
- Hardened EnhancedLogger helpers to use sanitized previews via `safe_preview()` for `log_call()` and `log_result()` so arguments/results are never logged raw.
- Updated LLM logging in `src/agents/llm.py` to use `redact_value()`, `safe_preview()` and `sanitize_exception_message()` for request/response, headers, error bodies, system prompt/messages/input_items previews, and the defensive empty-`input_items` error path (now logs sanitized previews instead of raw payloads).
- Hardened tool execution and skill-mode logging in `src/agents/core.py` to sanitize tool arguments/results, tracer calls and event payloads using `safe_preview()`/`redact_value()` without changing control flow or tracer interfaces.
- Replaced raw user message logging in `src/gateway/webchat.py` with a metadata summary (session id, attached image count, message length) and an optional sanitized preview; exception/error logs in that path now use `sanitize_exception_message()`/`safe_preview()`.
- Tests added/updated: new `tests/test_redaction.py` (unit coverage for patterns, nested structures, URL creds, PEM blocks, preview truncation) and extended `tests/test_logger.py` with a test asserting the `RedactingFilter` is attached and a focused regression test that verifies secrets are redacted from console output.
- Changes strictly limited to log-generation/sanitization; config, API contracts, chat/tool flow and provider retry/backoff logic were not altered.

### Testing
- Static checks: ran `python -m py_compile` on modified modules to verify syntax; compilation succeeded.
- Unit tests: `PYTHONPATH=. pytest -q tests/test_logger.py tests/test_redaction.py` completed successfully (tests passed), validating filter attachment and redaction rules.
- Extended validation: ran `PYTHONPATH=. pytest -q tests/test_webchat.py tests/test_llm_client.py || true` to exercise broader areas; some unrelated environment-dependent tests (web assets, proxy/LLM network behavior) failed in this environment and are unchanged by this PR.
- Where test assertions depended on former unsafe log text, assertions were updated to assert sanitized previews instead of raw secrets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf21e3a8dc832a98b003da134f42df)