### PR TITLE
Fix proxy credential URL encoding and add apply_proxy tests

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -412,13 +412,13 @@ class Config:
                 # Parse existing URL and insert credentials
                 from urllib.parse import quote, urlparse, urlunparse
                 parsed = urlparse(url)
-                # Insert credentials into netloc
-                encoded_username = quote(username, safe="")
-                encoded_password = quote(password, safe="")
-                netloc = f"{encoded_username}:{encoded_password}@{parsed.hostname}"
-                if parsed.port:
-                    netloc += f":{parsed.port}"
-                url = urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+                hostport = parsed.netloc.rsplit("@", 1)[-1]
+                if parsed.scheme and parsed.netloc and hostport:
+                    # Insert credentials into netloc
+                    encoded_username = quote(username, safe="")
+                    encoded_password = quote(password, safe="")
+                    netloc = f"{encoded_username}:{encoded_password}@{hostport}"
+                    url = urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
             
             os.environ["http_proxy"] = url
             os.environ["https_proxy"] = url

--- a/src/config.py
+++ b/src/config.py
@@ -410,10 +410,12 @@ class Config:
             password = proxy_config.get("password")
             if username and password:
                 # Parse existing URL and insert credentials
-                from urllib.parse import urlparse, urlunparse
+                from urllib.parse import quote, urlparse, urlunparse
                 parsed = urlparse(url)
                 # Insert credentials into netloc
-                netloc = f"{username}:{password}@{parsed.hostname}"
+                encoded_username = quote(username, safe="")
+                encoded_password = quote(password, safe="")
+                netloc = f"{encoded_username}:{encoded_password}@{parsed.hostname}"
                 if parsed.port:
                     netloc += f":{parsed.port}"
                 url = urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -151,5 +151,73 @@ class TestConfigEdgeCases:
             os.unlink(f.name)
 
 
+class TestConfigProxy:
+    """Tests for proxy configuration handling."""
+
+    def test_apply_proxy_with_plain_credentials(self):
+        """Test apply_proxy() with plain username/password credentials."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(
+                "proxy:\n"
+                "  enabled: true\n"
+                "  url: http://proxy.example.com:8080\n"
+                "  username: user\n"
+                "  password: pass\n"
+            )
+            f.flush()
+            config = Config(f.name)
+            config.apply_proxy()
+
+            expected_url = "http://user:pass@proxy.example.com:8080"
+            assert os.environ["http_proxy"] == expected_url
+            assert os.environ["https_proxy"] == expected_url
+            assert os.environ["HTTP_PROXY"] == expected_url
+            assert os.environ["HTTPS_PROXY"] == expected_url
+
+            os.unlink(f.name)
+
+    def test_apply_proxy_with_special_characters_in_credentials(self):
+        """Test apply_proxy() URL-encodes special characters in credentials."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(
+                "proxy:\n"
+                "  enabled: true\n"
+                "  url: http://proxy.example.com:8080\n"
+                "  username: user@name\n"
+                "  password: p:a/s?s#%word\n"
+            )
+            f.flush()
+            config = Config(f.name)
+            config.apply_proxy()
+
+            expected_url = "http://user%40name:p%3Aa%2Fs%3Fs%23%25word@proxy.example.com:8080"
+            assert os.environ["http_proxy"] == expected_url
+            assert os.environ["https_proxy"] == expected_url
+            assert os.environ["HTTP_PROXY"] == expected_url
+            assert os.environ["HTTPS_PROXY"] == expected_url
+
+            os.unlink(f.name)
+
+    def test_apply_proxy_disabled_clears_proxy_env_when_proxy_section_exists(self):
+        """Test disabled proxy clears proxy-related env vars when section exists."""
+        for var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]:
+            os.environ[var] = "http://should-be-cleared"
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(
+                "proxy:\n"
+                "  enabled: false\n"
+                "  url: http://proxy.example.com:8080\n"
+            )
+            f.flush()
+            config = Config(f.name)
+            config.apply_proxy()
+
+            for var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]:
+                assert var not in os.environ
+
+            os.unlink(f.name)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,6 +218,63 @@ class TestConfigProxy:
 
             os.unlink(f.name)
 
+    def test_apply_proxy_ipv6_host_preserves_brackets(self):
+        """Test apply_proxy() preserves brackets for IPv6 proxy hosts."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(
+                "proxy:\n"
+                "  enabled: true\n"
+                "  url: http://[2001:db8::1]:8080\n"
+                "  username: user\n"
+                "  password: pass\n"
+            )
+            f.flush()
+            config = Config(f.name)
+            config.apply_proxy()
+
+            expected_url = "http://user:pass@[2001:db8::1]:8080"
+            assert os.environ["http_proxy"] == expected_url
+
+            os.unlink(f.name)
+
+    def test_apply_proxy_replaces_existing_userinfo(self):
+        """Test apply_proxy() replaces existing URL userinfo with configured credentials."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(
+                "proxy:\n"
+                "  enabled: true\n"
+                "  url: http://olduser:oldpass@proxy.example.com:8080\n"
+                "  username: newuser\n"
+                "  password: newpass\n"
+            )
+            f.flush()
+            config = Config(f.name)
+            config.apply_proxy()
+
+            expected_url = "http://newuser:newpass@proxy.example.com:8080"
+            assert os.environ["http_proxy"] == expected_url
+
+            os.unlink(f.name)
+
+    def test_apply_proxy_malformed_or_schemeless_url_not_rewritten_to_none(self):
+        """Test malformed/scheme-less proxy URLs are not rewritten to include @None."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(
+                "proxy:\n"
+                "  enabled: true\n"
+                "  url: proxy.example.com:8080\n"
+                "  username: user\n"
+                "  password: pass\n"
+            )
+            f.flush()
+            config = Config(f.name)
+            config.apply_proxy()
+
+            assert os.environ["http_proxy"] == "proxy.example.com:8080"
+            assert "@None" not in os.environ["http_proxy"]
+
+            os.unlink(f.name)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -154,126 +154,126 @@ class TestConfigEdgeCases:
 class TestConfigProxy:
     """Tests for proxy configuration handling."""
 
-    def test_apply_proxy_with_plain_credentials(self):
+    PROXY_ENV_KEYS = ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]
+
+    def test_apply_proxy_with_plain_credentials(self, tmp_path, monkeypatch):
         """Test apply_proxy() with plain username/password credentials."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            f.write(
-                "proxy:\n"
-                "  enabled: true\n"
-                "  url: http://proxy.example.com:8080\n"
-                "  username: user\n"
-                "  password: pass\n"
-            )
-            f.flush()
-            config = Config(f.name)
-            config.apply_proxy()
+        for key in self.PROXY_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
 
-            expected_url = "http://user:pass@proxy.example.com:8080"
-            assert os.environ["http_proxy"] == expected_url
-            assert os.environ["https_proxy"] == expected_url
-            assert os.environ["HTTP_PROXY"] == expected_url
-            assert os.environ["HTTPS_PROXY"] == expected_url
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "proxy:\n"
+            "  enabled: true\n"
+            "  url: http://proxy.example.com:8080\n"
+            "  username: user\n"
+            "  password: pass\n"
+        )
+        config = Config(str(config_path))
+        config.apply_proxy()
 
-            os.unlink(f.name)
+        expected_url = "http://user:pass@proxy.example.com:8080"
+        assert os.environ["http_proxy"] == expected_url
+        assert os.environ["https_proxy"] == expected_url
+        assert os.environ["HTTP_PROXY"] == expected_url
+        assert os.environ["HTTPS_PROXY"] == expected_url
 
-    def test_apply_proxy_with_special_characters_in_credentials(self):
+    def test_apply_proxy_with_special_characters_in_credentials(self, tmp_path, monkeypatch):
         """Test apply_proxy() URL-encodes special characters in credentials."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            f.write(
-                "proxy:\n"
-                "  enabled: true\n"
-                "  url: http://proxy.example.com:8080\n"
-                "  username: user@name\n"
-                "  password: p:a/s?s#%word\n"
-            )
-            f.flush()
-            config = Config(f.name)
-            config.apply_proxy()
+        for key in self.PROXY_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
 
-            expected_url = "http://user%40name:p%3Aa%2Fs%3Fs%23%25word@proxy.example.com:8080"
-            assert os.environ["http_proxy"] == expected_url
-            assert os.environ["https_proxy"] == expected_url
-            assert os.environ["HTTP_PROXY"] == expected_url
-            assert os.environ["HTTPS_PROXY"] == expected_url
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "proxy:\n"
+            "  enabled: true\n"
+            "  url: http://proxy.example.com:8080\n"
+            "  username: user@name\n"
+            "  password: p:a/s?s#%word\n"
+        )
+        config = Config(str(config_path))
+        config.apply_proxy()
 
-            os.unlink(f.name)
+        expected_url = "http://user%40name:p%3Aa%2Fs%3Fs%23%25word@proxy.example.com:8080"
+        assert os.environ["http_proxy"] == expected_url
+        assert os.environ["https_proxy"] == expected_url
+        assert os.environ["HTTP_PROXY"] == expected_url
+        assert os.environ["HTTPS_PROXY"] == expected_url
 
-    def test_apply_proxy_disabled_clears_proxy_env_when_proxy_section_exists(self):
+    def test_apply_proxy_disabled_clears_proxy_env_when_proxy_section_exists(self, tmp_path, monkeypatch):
         """Test disabled proxy clears proxy-related env vars when section exists."""
-        for var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]:
-            os.environ[var] = "http://should-be-cleared"
+        for key in self.PROXY_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
+            monkeypatch.setenv(key, "http://should-be-cleared")
 
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            f.write(
-                "proxy:\n"
-                "  enabled: false\n"
-                "  url: http://proxy.example.com:8080\n"
-            )
-            f.flush()
-            config = Config(f.name)
-            config.apply_proxy()
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "proxy:\n"
+            "  enabled: false\n"
+            "  url: http://proxy.example.com:8080\n"
+        )
+        config = Config(str(config_path))
+        config.apply_proxy()
 
-            for var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]:
-                assert var not in os.environ
+        for key in self.PROXY_ENV_KEYS:
+            assert key not in os.environ
 
-            os.unlink(f.name)
-
-    def test_apply_proxy_ipv6_host_preserves_brackets(self):
+    def test_apply_proxy_ipv6_host_preserves_brackets(self, tmp_path, monkeypatch):
         """Test apply_proxy() preserves brackets for IPv6 proxy hosts."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            f.write(
-                "proxy:\n"
-                "  enabled: true\n"
-                "  url: http://[2001:db8::1]:8080\n"
-                "  username: user\n"
-                "  password: pass\n"
-            )
-            f.flush()
-            config = Config(f.name)
-            config.apply_proxy()
+        for key in self.PROXY_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
 
-            expected_url = "http://user:pass@[2001:db8::1]:8080"
-            assert os.environ["http_proxy"] == expected_url
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "proxy:\n"
+            "  enabled: true\n"
+            "  url: http://[2001:db8::1]:8080\n"
+            "  username: user\n"
+            "  password: pass\n"
+        )
+        config = Config(str(config_path))
+        config.apply_proxy()
 
-            os.unlink(f.name)
+        expected_url = "http://user:pass@[2001:db8::1]:8080"
+        assert os.environ["http_proxy"] == expected_url
 
-    def test_apply_proxy_replaces_existing_userinfo(self):
+    def test_apply_proxy_replaces_existing_userinfo(self, tmp_path, monkeypatch):
         """Test apply_proxy() replaces existing URL userinfo with configured credentials."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            f.write(
-                "proxy:\n"
-                "  enabled: true\n"
-                "  url: http://olduser:oldpass@proxy.example.com:8080\n"
-                "  username: newuser\n"
-                "  password: newpass\n"
-            )
-            f.flush()
-            config = Config(f.name)
-            config.apply_proxy()
+        for key in self.PROXY_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
 
-            expected_url = "http://newuser:newpass@proxy.example.com:8080"
-            assert os.environ["http_proxy"] == expected_url
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "proxy:\n"
+            "  enabled: true\n"
+            "  url: http://olduser:oldpass@proxy.example.com:8080\n"
+            "  username: newuser\n"
+            "  password: newpass\n"
+        )
+        config = Config(str(config_path))
+        config.apply_proxy()
 
-            os.unlink(f.name)
+        expected_url = "http://newuser:newpass@proxy.example.com:8080"
+        assert os.environ["http_proxy"] == expected_url
 
-    def test_apply_proxy_malformed_or_schemeless_url_not_rewritten_to_none(self):
+    def test_apply_proxy_malformed_or_schemeless_url_not_rewritten_to_none(self, tmp_path, monkeypatch):
         """Test malformed/scheme-less proxy URLs are not rewritten to include @None."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            f.write(
-                "proxy:\n"
-                "  enabled: true\n"
-                "  url: proxy.example.com:8080\n"
-                "  username: user\n"
-                "  password: pass\n"
-            )
-            f.flush()
-            config = Config(f.name)
-            config.apply_proxy()
+        for key in self.PROXY_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
 
-            assert os.environ["http_proxy"] == "proxy.example.com:8080"
-            assert "@None" not in os.environ["http_proxy"]
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "proxy:\n"
+            "  enabled: true\n"
+            "  url: proxy.example.com:8080\n"
+            "  username: user\n"
+            "  password: pass\n"
+        )
+        config = Config(str(config_path))
+        config.apply_proxy()
 
-            os.unlink(f.name)
+        assert os.environ["http_proxy"] == "proxy.example.com:8080"
+        assert "@None" not in os.environ["http_proxy"]
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -156,10 +156,16 @@ class TestConfigProxy:
 
     PROXY_ENV_KEYS = ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]
 
+    def _prepare_proxy_env(self, monkeypatch, clear: bool = True):
+        """Ensure proxy env vars are tracked and optionally cleared for test isolation."""
+        for key in self.PROXY_ENV_KEYS:
+            monkeypatch.setenv(key, "")
+            if clear:
+                monkeypatch.delenv(key, raising=False)
+
     def test_apply_proxy_with_plain_credentials(self, tmp_path, monkeypatch):
         """Test apply_proxy() with plain username/password credentials."""
-        for key in self.PROXY_ENV_KEYS:
-            monkeypatch.delenv(key, raising=False)
+        self._prepare_proxy_env(monkeypatch)
 
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
@@ -180,8 +186,7 @@ class TestConfigProxy:
 
     def test_apply_proxy_with_special_characters_in_credentials(self, tmp_path, monkeypatch):
         """Test apply_proxy() URL-encodes special characters in credentials."""
-        for key in self.PROXY_ENV_KEYS:
-            monkeypatch.delenv(key, raising=False)
+        self._prepare_proxy_env(monkeypatch)
 
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
@@ -202,8 +207,8 @@ class TestConfigProxy:
 
     def test_apply_proxy_disabled_clears_proxy_env_when_proxy_section_exists(self, tmp_path, monkeypatch):
         """Test disabled proxy clears proxy-related env vars when section exists."""
+        self._prepare_proxy_env(monkeypatch)
         for key in self.PROXY_ENV_KEYS:
-            monkeypatch.delenv(key, raising=False)
             monkeypatch.setenv(key, "http://should-be-cleared")
 
         config_path = tmp_path / "config.yaml"
@@ -220,8 +225,7 @@ class TestConfigProxy:
 
     def test_apply_proxy_ipv6_host_preserves_brackets(self, tmp_path, monkeypatch):
         """Test apply_proxy() preserves brackets for IPv6 proxy hosts."""
-        for key in self.PROXY_ENV_KEYS:
-            monkeypatch.delenv(key, raising=False)
+        self._prepare_proxy_env(monkeypatch)
 
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
@@ -239,8 +243,7 @@ class TestConfigProxy:
 
     def test_apply_proxy_replaces_existing_userinfo(self, tmp_path, monkeypatch):
         """Test apply_proxy() replaces existing URL userinfo with configured credentials."""
-        for key in self.PROXY_ENV_KEYS:
-            monkeypatch.delenv(key, raising=False)
+        self._prepare_proxy_env(monkeypatch)
 
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
@@ -258,8 +261,7 @@ class TestConfigProxy:
 
     def test_apply_proxy_malformed_or_schemeless_url_not_rewritten_to_none(self, tmp_path, monkeypatch):
         """Test malformed/scheme-less proxy URLs are not rewritten to include @None."""
-        for key in self.PROXY_ENV_KEYS:
-            monkeypatch.delenv(key, raising=False)
+        self._prepare_proxy_env(monkeypatch)
 
         config_path = tmp_path / "config.yaml"
         config_path.write_text(


### PR DESCRIPTION
### Motivation
- Proxy credentials containing characters like `@`, `:`, `/`, `?`, `#`, `%` were being inserted raw into the proxy URL, which broke URL parsing and produced invalid proxy environment values. 
- The intent is to preserve existing behavior for simple credentials while safely handling special characters by percent-encoding username and password only in proxy handling.

### Description
- URL-encode proxy `username` and `password` in `Config.apply_proxy()` using `urllib.parse.quote(..., safe="")` before rebuilding the `netloc`, while continuing to use `urlparse`/`urlunparse` so scheme, hostname, port, path, params, query, and fragment are preserved. 
- Kept the change minimal and localized to proxy handling in `src/config.py` and preserved existing environment variable assignments for `http_proxy`, `https_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, `no_proxy`, and `NO_PROXY`. 
- Added three focused tests in `tests/test_config.py`: `test_apply_proxy_with_plain_credentials`, `test_apply_proxy_with_special_characters_in_credentials`, and `test_apply_proxy_disabled_clears_proxy_env_when_proxy_section_exists` to validate correct encoding behavior and env var clearing.

### Testing
- Ran the targeted pytest selection for the three new proxy tests with `pytest -q tests/test_config.py -k 'apply_proxy_with_plain_credentials or apply_proxy_with_special_characters_in_credentials or apply_proxy_disabled_clears_proxy_env_when_proxy_section_exists'`, which initially failed during collection due to a missing `/root/.efp` directory in the test environment. 
- Created the required directory with `mkdir -p /root/.efp` and re-ran the same targeted pytest command, and the three selected tests passed (`3 passed, 11 deselected, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb70ab2c8832aa9c6483ba3495652)