### PR TITLE
Phase 4 capability surface: registry, governance, execution, and API closeout

### DIFF
--- a/src/agents/executor.py
+++ b/src/agents/executor.py
@@ -6,6 +6,7 @@ This module provides the ability to execute skills and tools based on user reque
 import asyncio
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -358,8 +359,18 @@ async def execute_skill(skill_name: str, **kwargs) -> SkillResult:
 
 
 async def run_skill_execution(skill_name: str, **kwargs) -> SkillResult:
-    """Direct skill execution helper used by ExecutionBus adapters."""
-    # TODO(phase1): route deeper internal skill helper calls through ExecutionBus after compatibility validation.
+    """Skill execution helper with ExecutionBus-first routing.
+
+    Compatibility mode:
+    - Set EFP_ALLOW_LEGACY_DIRECT_EXECUTION=true to bypass bus routing.
+    - ExecutionBus internals set `_via_execution_bus=True` to avoid recursion.
+    """
+    via_execution_bus = bool(kwargs.pop("_via_execution_bus", False))
+    allow_legacy_direct = os.getenv("EFP_ALLOW_LEGACY_DIRECT_EXECUTION", "").strip().lower() == "true"
+
+    if not via_execution_bus and not allow_legacy_direct:
+        return await execute_skill(skill_name, _use_execution_bus=True, **kwargs)
+
     # Filter runtime control/internal kwargs before forwarding to concrete skill implementations.
     filtered_kwargs = {
         k: v

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -853,7 +853,17 @@ async def api_capabilities(request: web.Request) -> web.Response:
     """
     try:
         registry = get_capability_registry()
-        catalog = registry.export_catalog()
+        snapshot = (
+            registry.export_catalog_snapshot()
+            if hasattr(registry, "export_catalog_snapshot")
+            else {
+                "capabilities": registry.export_catalog(),
+                "count": len(registry.export_catalog()),
+                "catalog_version": "legacy",
+                "generated_at": datetime.utcnow().isoformat() + "Z",
+            }
+        )
+        catalog = list(snapshot.get("capabilities") or [])
 
         capability_id = str(request.query.get("capability_id") or "").strip().lower()
         if capability_id:
@@ -867,7 +877,16 @@ async def api_capabilities(request: web.Request) -> web.Response:
         if enabled_filter is not None:
             catalog = [item for item in catalog if bool(item.get("enabled")) is enabled_filter]
 
-        return web.json_response({"capabilities": catalog, "count": len(catalog)})
+        return web.json_response(
+            {
+                "capabilities": catalog,
+                "count": len(catalog),
+                "catalog_version": snapshot.get("catalog_version"),
+                "generated_at": snapshot.get("generated_at"),
+                "supports_snapshot_contract": True,
+                "runtime_contract_version": "phase4-capability-surface-v1",
+            }
+        )
     except Exception as exc:
         logger.error("Capabilities API error: %s", sanitize_exception_message(exc), exc_info=True)
         return web.json_response({"error": "Internal server error"}, status=500)

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -40,6 +40,7 @@ from src.agents.errors import extract_error_details, LLMError
 from src.hooks.file_context import inject_context
 from src.config import config as global_config
 from src.runtime.chat_orchestration_adapter import execute_chat_orchestration, execute_runtime_task_request
+from src.runtime.capability_registry import get_capability_registry
 from src.sessions.manager import session_manager
 from src.sessions.persistence import session_persistence
 from src.sessions.usage import usage_tracker
@@ -831,6 +832,44 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
         return web.json_response({"error": str(exc)}, status=400)
     except Exception as exc:
         logger.error("Task execution API error: %s", sanitize_exception_message(exc), exc_info=True)
+        return web.json_response({"error": "Internal server error"}, status=500)
+
+
+def _parse_bool_query(value: Optional[str]) -> Optional[bool]:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes"}:
+        return True
+    if normalized in {"0", "false", "no"}:
+        return False
+    return None
+
+
+async def api_capabilities(request: web.Request) -> web.Response:
+    """List runtime capability catalog.
+
+    GET /api/capabilities?type=...&enabled=true|false&capability_id=...
+    """
+    try:
+        registry = get_capability_registry()
+        catalog = registry.export_catalog()
+
+        capability_id = str(request.query.get("capability_id") or "").strip().lower()
+        if capability_id:
+            catalog = [item for item in catalog if str(item.get("capability_id") or "").lower() == capability_id]
+
+        capability_type = str(request.query.get("type") or "").strip().lower()
+        if capability_type:
+            catalog = [item for item in catalog if str(item.get("type") or "").lower() == capability_type]
+
+        enabled_filter = _parse_bool_query(request.query.get("enabled"))
+        if enabled_filter is not None:
+            catalog = [item for item in catalog if bool(item.get("enabled")) is enabled_filter]
+
+        return web.json_response({"capabilities": catalog, "count": len(catalog)})
+    except Exception as exc:
+        logger.error("Capabilities API error: %s", sanitize_exception_message(exc), exc_info=True)
         return web.json_response({"error": "Internal server error"}, status=500)
 
 
@@ -2523,6 +2562,7 @@ def setup_webchat_routes(app: web.Application):
     app.router.add_post('/api/chat', api_chat)
     app.router.add_post('/api/chat/stream', api_chat_stream)
     app.router.add_post('/api/tasks/execute', api_tasks_execute)
+    app.router.add_get('/api/capabilities', api_capabilities)
     app.router.add_get('/api/sessions', api_sessions)
     app.router.add_get('/api/sessions/{session_id}', api_load_session)
     app.router.add_get('/api/sessions/{session_id}/chatlog', api_session_chatlog)

--- a/src/runtime/adapter_executor.py
+++ b/src/runtime/adapter_executor.py
@@ -37,6 +37,24 @@ def _result_success(value: Any) -> bool:
     )
 
 
+def _normalize_adapter_contract(
+    *,
+    outcome: Dict[str, Any],
+    system: str,
+    action_name: str,
+    runtime_events: list[Dict[str, Any]],
+) -> Dict[str, Any]:
+    return {
+        "success": bool(outcome.get("success")),
+        "error": outcome.get("error"),
+        "result": outcome.get("result"),
+        "system": outcome.get("system", system),
+        "action_name": outcome.get("action_name", action_name),
+        "action_id": outcome.get("action_id", action_name),
+        "runtime_events": list(runtime_events),
+    }
+
+
 async def execute_jira_workflow_action(action_name: str, kwargs: Dict[str, Any]) -> Dict[str, Any]:
     from src import jira as jira_module
 
@@ -206,13 +224,12 @@ async def execute_adapter_action(action_id: str, kwargs: Dict[str, Any]) -> Dict
                 {"action_id": normalized_action_id, "system": system, "error": "unsupported_adapter_action"},
             )
         )
-        return {
-            "success": False,
-            "error": f"Unsupported adapter action: {action_id}",
-            "action_id": normalized_action_id,
-            "system": system,
-            "runtime_events": runtime_events,
-        }
+        return _normalize_adapter_contract(
+            outcome={"success": False, "error": f"Unsupported adapter action: {action_id}", "result": None},
+            system=system,
+            action_name=normalized_action_id,
+            runtime_events=runtime_events,
+        )
 
     if jira_action is not None:
         outcome = await execute_jira_workflow_action(jira_action, payload)
@@ -232,14 +249,12 @@ async def execute_adapter_action(action_id: str, kwargs: Dict[str, Any]) -> Dict
             },
         )
     )
-    return {
-        "action_id": normalized_action_id,
-        "system": outcome.get("system", system),
-        "success": bool(outcome.get("success")),
-        "error": outcome.get("error"),
-        "result": outcome.get("result"),
-        "runtime_events": runtime_events,
-    }
+    return _normalize_adapter_contract(
+        outcome=outcome,
+        system=outcome.get("system", system),
+        action_name=normalized_action_id,
+        runtime_events=runtime_events,
+    )
 
 
 def _normalize_json_field(value: Any) -> Any:

--- a/src/runtime/adapter_executor.py
+++ b/src/runtime/adapter_executor.py
@@ -8,6 +8,11 @@ import os
 from aiohttp import ClientSession
 
 from src.runtime.events import build_runtime_event
+from src.runtime.capability_adapters import (
+    build_github_adapter_capabilities,
+    build_jira_adapter_capabilities,
+    build_portal_adapter_capabilities,
+)
 
 
 def _event(event_type: str, state: str, detail_payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -191,32 +196,8 @@ async def execute_adapter_action(action_id: str, kwargs: Dict[str, Any]) -> Dict
     )
     runtime_events = [_event("task.adapter_action.started", "started", {"action_id": normalized_action_id, "system": system})]
 
-    jira_action_map = {
-        "adapter:jira:read_issue": "read_issue",
-        "adapter:jira:update_issue": "update_issue",
-        "adapter:jira:assign_issue": "assign_issue",
-        "adapter:jira:transition_issue": "transition_issue",
-        "adapter:jira:add_comment": "add_comment",
-    }
-    github_action_map = {
-        "adapter:github:review_pull_request": "review_pull_request",
-        "adapter:github:add_comment": "add_comment",
-    }
-    portal_action_map = {
-        "adapter:portal:create_delegation": "create_delegation",
-        "adapter:portal:list_group_delegations": "list_group_delegations",
-        "adapter:portal:get_group_task_board": "get_group_task_board",
-        "adapter:portal:list_group_coordination_runs": "list_group_coordination_runs",
-        "adapter:portal:get_coordination_run": "get_coordination_run",
-        "adapter:portal:get_specialist_pool": "get_specialist_pool",
-        "adapter:portal:create_task_agent": "create_task_agent",
-        "adapter:portal:delete_task_agent": "delete_task_agent",
-    }
-
-    jira_action = jira_action_map.get(normalized_action_id)
-    github_action = github_action_map.get(normalized_action_id)
-    portal_action = portal_action_map.get(normalized_action_id)
-    if jira_action is None and github_action is None and portal_action is None:
+    executor = ACTION_ID_TO_EXECUTOR.get(normalized_action_id)
+    if executor is None:
         runtime_events.append(
             _event(
                 "task.adapter_action.failed",
@@ -231,12 +212,7 @@ async def execute_adapter_action(action_id: str, kwargs: Dict[str, Any]) -> Dict
             runtime_events=runtime_events,
         )
 
-    if jira_action is not None:
-        outcome = await execute_jira_workflow_action(jira_action, payload)
-    elif portal_action is not None:
-        outcome = await execute_portal_control_plane_action(portal_action, payload)
-    else:
-        outcome = await execute_github_workflow_action(github_action, payload)
+    outcome = await executor(payload)
     runtime_events.append(
         _event(
             "task.adapter_action.completed" if outcome.get("success") else "task.adapter_action.failed",
@@ -255,6 +231,51 @@ async def execute_adapter_action(action_id: str, kwargs: Dict[str, Any]) -> Dict
         action_name=normalized_action_id,
         runtime_events=runtime_events,
     )
+
+
+async def _exec_jira(action_name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return await execute_jira_workflow_action(action_name, payload)
+
+
+async def _exec_github(action_name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return await execute_github_workflow_action(action_name, payload)
+
+
+async def _exec_portal(action_name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return await execute_portal_control_plane_action(action_name, payload)
+
+
+ACTION_ID_TO_EXECUTOR = {
+    "adapter:jira:read_issue": lambda payload: _exec_jira("read_issue", payload),
+    "adapter:jira:update_issue": lambda payload: _exec_jira("update_issue", payload),
+    "adapter:jira:assign_issue": lambda payload: _exec_jira("assign_issue", payload),
+    "adapter:jira:transition_issue": lambda payload: _exec_jira("transition_issue", payload),
+    "adapter:jira:add_comment": lambda payload: _exec_jira("add_comment", payload),
+    "adapter:github:review_pull_request": lambda payload: _exec_github("review_pull_request", payload),
+    "adapter:github:add_comment": lambda payload: _exec_github("add_comment", payload),
+    "adapter:portal:create_delegation": lambda payload: _exec_portal("create_delegation", payload),
+    "adapter:portal:list_group_delegations": lambda payload: _exec_portal("list_group_delegations", payload),
+    "adapter:portal:get_group_task_board": lambda payload: _exec_portal("get_group_task_board", payload),
+    "adapter:portal:list_group_coordination_runs": lambda payload: _exec_portal("list_group_coordination_runs", payload),
+    "adapter:portal:get_coordination_run": lambda payload: _exec_portal("get_coordination_run", payload),
+    "adapter:portal:get_specialist_pool": lambda payload: _exec_portal("get_specialist_pool", payload),
+    "adapter:portal:create_task_agent": lambda payload: _exec_portal("create_task_agent", payload),
+    "adapter:portal:delete_task_agent": lambda payload: _exec_portal("delete_task_agent", payload),
+}
+
+
+def validate_enabled_adapter_actions_have_executors() -> list[str]:
+    descriptor_ids = {
+        descriptor.action_id
+        for descriptor in [
+            *build_github_adapter_capabilities(),
+            *build_jira_adapter_capabilities(),
+            *build_portal_adapter_capabilities(),
+        ]
+        if descriptor.enabled
+    }
+    registered = set(ACTION_ID_TO_EXECUTOR.keys())
+    return sorted(descriptor_ids - registered)
 
 
 def _normalize_json_field(value: Any) -> Any:

--- a/src/runtime/capability_adapters.py
+++ b/src/runtime/capability_adapters.py
@@ -21,7 +21,7 @@ class AdapterActionDescriptor:
 
 
 def build_github_adapter_capabilities() -> List[AdapterActionDescriptor]:
-    return [
+    return _with_adapter_metadata([
         AdapterActionDescriptor(
             action_id="adapter:github:review_pull_request",
             adapter="github",
@@ -50,11 +50,11 @@ def build_github_adapter_capabilities() -> List[AdapterActionDescriptor]:
             requires_identity_binding=True,
             source_ref="src.github",
         ),
-    ]
+    ])
 
 
 def build_jira_adapter_capabilities() -> List[AdapterActionDescriptor]:
-    return [
+    return _with_adapter_metadata([
         AdapterActionDescriptor(
             action_id="adapter:jira:read_issue",
             adapter="jira",
@@ -112,11 +112,11 @@ def build_jira_adapter_capabilities() -> List[AdapterActionDescriptor]:
             requires_identity_binding=True,
             source_ref="src.jira",
         ),
-    ]
+    ])
 
 
 def build_portal_adapter_capabilities() -> List[AdapterActionDescriptor]:
-    return [
+    return _with_adapter_metadata([
         AdapterActionDescriptor(
             action_id="adapter:portal:create_delegation",
             adapter="portal",
@@ -235,4 +235,14 @@ def build_portal_adapter_capabilities() -> List[AdapterActionDescriptor]:
             source_ref="src.runtime",
             metadata={"internal_portal_api": True},
         ),
-    ]
+    ])
+
+
+def _with_adapter_metadata(descriptors: List[AdapterActionDescriptor]) -> List[AdapterActionDescriptor]:
+    for descriptor in descriptors:
+        descriptor.metadata = {
+            "action_alias": descriptor.name,
+            "adapter_system": descriptor.adapter,
+            **dict(descriptor.metadata or {}),
+        }
+    return descriptors

--- a/src/runtime/capability_registry.py
+++ b/src/runtime/capability_registry.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+from datetime import datetime
+import hashlib
+import json
 import logging
 
 from src.runtime.capability_adapters import (
@@ -51,6 +54,9 @@ class CapabilityRegistry:
     def export_catalog(self) -> List[Dict[str, Any]]:
         raise NotImplementedError
 
+    def export_catalog_snapshot(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
 
 class DefaultCapabilityRegistry(CapabilityRegistry):
     def __init__(self):
@@ -94,8 +100,19 @@ class DefaultCapabilityRegistry(CapabilityRegistry):
         return _dedupe_capability_id(capability_id) in self._capabilities
 
     def export_catalog(self) -> List[Dict[str, Any]]:
+        return self.export_catalog_snapshot()["capabilities"]
+
+    def export_catalog_snapshot(self) -> Dict[str, Any]:
         items = sorted(self._capabilities.values(), key=lambda item: item.capability_id)
-        return [_descriptor_to_dict(item) for item in items]
+        capabilities = [_descriptor_to_dict(item) for item in items]
+        serialized = json.dumps(capabilities, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+        catalog_version = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+        return {
+            "capabilities": capabilities,
+            "count": len(capabilities),
+            "catalog_version": catalog_version,
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+        }
 
     def register_many(self, descriptors: List[CapabilityDescriptor]) -> None:
         for descriptor in descriptors:
@@ -274,17 +291,23 @@ def _looks_read_only_tool(tool_name: str) -> bool:
 
 
 def _descriptor_to_dict(descriptor: CapabilityDescriptor) -> Dict[str, Any]:
+    metadata = dict(descriptor.metadata or {})
+    adapter_system = metadata.get("adapter_system") or metadata.get("adapter")
+    action_alias = metadata.get("action_alias") or descriptor.name
     return {
         "capability_id": descriptor.capability_id,
         "type": descriptor.type,
         "name": descriptor.name,
+        "logical_name": descriptor.name,
+        "action_alias": action_alias if descriptor.type == "adapter_action" else None,
+        "adapter_system": adapter_system if descriptor.type == "adapter_action" else None,
         "input_schema": dict(descriptor.input_schema or {}),
         "output_schema": dict(descriptor.output_schema or {}),
         "policy_tags": list(descriptor.policy_tags or []),
         "requires_identity_binding": bool(descriptor.requires_identity_binding),
         "enabled": bool(descriptor.enabled),
         "source_ref": descriptor.source_ref,
-        "metadata": dict(descriptor.metadata or {}),
+        "metadata": metadata,
     }
 
 

--- a/src/runtime/capability_registry.py
+++ b/src/runtime/capability_registry.py
@@ -42,6 +42,15 @@ class CapabilityRegistry:
     def list_by_type(self, capability_type: str) -> List[CapabilityDescriptor]:
         raise NotImplementedError
 
+    def list_enabled(self) -> List[CapabilityDescriptor]:
+        raise NotImplementedError
+
+    def exists(self, capability_id: str) -> bool:
+        raise NotImplementedError
+
+    def export_catalog(self) -> List[Dict[str, Any]]:
+        raise NotImplementedError
+
 
 class DefaultCapabilityRegistry(CapabilityRegistry):
     def __init__(self):
@@ -54,7 +63,7 @@ class DefaultCapabilityRegistry(CapabilityRegistry):
             return
         normalized = CapabilityDescriptor(
             capability_id=capability_id,
-            type=str(descriptor.type or "").strip(),
+            type=_normalize_component(descriptor.type),
             name=str(descriptor.name or "").strip() or capability_id,
             input_schema=dict(descriptor.input_schema or {}),
             output_schema=dict(descriptor.output_schema or {}),
@@ -73,10 +82,20 @@ class DefaultCapabilityRegistry(CapabilityRegistry):
         return list(self._capabilities.values())
 
     def list_by_type(self, capability_type: str) -> List[CapabilityDescriptor]:
-        normalized_type = str(capability_type or "").strip()
+        normalized_type = _normalize_component(capability_type)
         if not normalized_type:
             return []
         return [item for item in self._capabilities.values() if item.type == normalized_type]
+
+    def list_enabled(self) -> List[CapabilityDescriptor]:
+        return [item for item in self._capabilities.values() if item.enabled]
+
+    def exists(self, capability_id: str) -> bool:
+        return _dedupe_capability_id(capability_id) in self._capabilities
+
+    def export_catalog(self) -> List[Dict[str, Any]]:
+        items = sorted(self._capabilities.values(), key=lambda item: item.capability_id)
+        return [_descriptor_to_dict(item) for item in items]
 
     def register_many(self, descriptors: List[CapabilityDescriptor]) -> None:
         for descriptor in descriptors:
@@ -91,6 +110,7 @@ class _CapabilityBuilder:
         self._register_skills()
         self._register_adapter_actions()
         self._register_channel_actions()
+        self._register_tools()
 
     def _register_skills(self) -> None:
         try:
@@ -101,7 +121,7 @@ class _CapabilityBuilder:
             skills = skill_registry.list_active_skills()
             for skill in skills:
                 descriptor = CapabilityDescriptor(
-                    capability_id=f"skill:{skill.name}",
+                    capability_id=_format_capability_id("skill", skill.name),
                     type="skill",
                     name=skill.name,
                     input_schema={"type": "object", "properties": {"session_id": {"type": "string"}, "input": {"type": "string"}}},
@@ -111,6 +131,7 @@ class _CapabilityBuilder:
                     enabled=not bool(skill.deprecated),
                     source_ref=skill.source_file or skill.path or None,
                     metadata={
+                        "skill_name": skill.name,
                         "version": skill.version,
                         "owner": skill.owner,
                         "triggers": list(skill.triggers or []),
@@ -125,7 +146,7 @@ class _CapabilityBuilder:
         if not self.registry.list_by_type("skill"):
             self.registry.register(
                 CapabilityDescriptor(
-                    capability_id="skill:default",
+                    capability_id=_format_capability_id("skill", "default"),
                     type="skill",
                     name="default",
                     policy_tags=["skill", "fallback"],
@@ -142,7 +163,7 @@ class _CapabilityBuilder:
         for adapter_descriptor in adapter_descriptors:
             self.registry.register(
                 CapabilityDescriptor(
-                    capability_id=adapter_descriptor.action_id,
+                    capability_id=_normalize_adapter_action_id(adapter_descriptor.action_id),
                     type="adapter_action",
                     name=adapter_descriptor.name,
                     input_schema=adapter_descriptor.input_schema,
@@ -167,7 +188,7 @@ class _CapabilityBuilder:
                     continue
                 self.registry.register(
                     CapabilityDescriptor(
-                        capability_id=f"channel_action:{item_name}",
+                        capability_id=_format_capability_id("channel_action", item_name),
                         type="channel_action",
                         name=item_name,
                         input_schema={"type": "object"},
@@ -181,10 +202,90 @@ class _CapabilityBuilder:
         except Exception:
             logger.debug("Failed to register channel capabilities", exc_info=True)
 
+    def _register_tools(self) -> None:
+        try:
+            from src import get_tools_schema
+
+            for tool_schema in list(get_tools_schema() or []):
+                if not isinstance(tool_schema, dict):
+                    continue
+                tool_name = _extract_tool_name(tool_schema)
+                if not tool_name:
+                    continue
+                self.registry.register(
+                    CapabilityDescriptor(
+                        capability_id=_format_capability_id("tool", tool_name),
+                        type="tool",
+                        name=tool_name,
+                        input_schema=dict(tool_schema.get("parameters") or {}),
+                        output_schema={"type": "object"},
+                        policy_tags=["tool", *(["read"] if _looks_read_only_tool(tool_name) else [])],
+                        source_ref="src.__init__.get_tools_schema",
+                        metadata={
+                            "tool_name": tool_name,
+                            "description": tool_schema.get("description"),
+                            "declaration_only": True,
+                        },
+                    )
+                )
+        except Exception:
+            logger.debug("Failed to register tool capabilities", exc_info=True)
+
 
 def _dedupe_capability_id(capability_id: str) -> str:
     normalized = str(capability_id or "").strip().lower()
-    return normalized or "capability:unknown"
+    parts = [_normalize_component(item) for item in normalized.split(":")]
+    parts = [part for part in parts if part]
+    if not parts:
+        return "capability:unknown"
+    if len(parts) == 1:
+        return f"capability:{parts[0]}"
+    return ":".join(parts)
+
+
+def _normalize_component(value: Any) -> str:
+    return "_".join(str(value or "").strip().lower().split())
+
+
+def _format_capability_id(prefix: str, name: str) -> str:
+    return f"{_normalize_component(prefix)}:{_normalize_component(name)}"
+
+
+def _normalize_adapter_action_id(action_id: str) -> str:
+    parts = [_normalize_component(item) for item in str(action_id or "").split(":")]
+    if len(parts) >= 3 and parts[0] == "adapter":
+        return f"adapter:{parts[1]}:{parts[2]}"
+    return _dedupe_capability_id(action_id)
+
+
+def _extract_tool_name(tool_schema: Dict[str, Any]) -> str:
+    if isinstance(tool_schema.get("name"), str) and tool_schema.get("name").strip():
+        return str(tool_schema.get("name")).strip()
+    function_obj = tool_schema.get("function")
+    if isinstance(function_obj, dict):
+        function_name = function_obj.get("name")
+        if isinstance(function_name, str) and function_name.strip():
+            return function_name.strip()
+    return ""
+
+
+def _looks_read_only_tool(tool_name: str) -> bool:
+    return any(token in tool_name.lower() for token in ("read", "get", "list"))
+
+
+def _descriptor_to_dict(descriptor: CapabilityDescriptor) -> Dict[str, Any]:
+    return {
+        "capability_id": descriptor.capability_id,
+        "type": descriptor.type,
+        "name": descriptor.name,
+        "input_schema": dict(descriptor.input_schema or {}),
+        "output_schema": dict(descriptor.output_schema or {}),
+        "policy_tags": list(descriptor.policy_tags or []),
+        "requires_identity_binding": bool(descriptor.requires_identity_binding),
+        "enabled": bool(descriptor.enabled),
+        "source_ref": descriptor.source_ref,
+        "metadata": dict(descriptor.metadata or {}),
+    }
 
 
 def build_default_capability_registry() -> CapabilityRegistry:

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -547,6 +547,11 @@ def _as_list_of_strings(value: Any) -> list[str]:
 
 
 def resolve_task_capability_plan(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Compatibility shim: delegate task capability planning to the canonical resolver.
+
+    Keep this function name for existing callers, but do not add mapping logic
+    here; `src.runtime.task_capability_contracts` owns the contract mapping.
+    """
     return resolve_task_capability_contract(task_type, payload)
 
 

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -457,6 +457,72 @@ def _coerce_task_tool_result(raw_result: Any) -> Dict[str, Any]:
     }
 
 
+def _normalize_capability_component(value: Any) -> str:
+    return "_".join(str(value or "").strip().lower().split())
+
+
+def _resolve_tool_capability(tool_name: str) -> Dict[str, Any]:
+    normalized_tool_name = _normalize_capability_component(tool_name)
+    capability_id = f"tool:{normalized_tool_name}" if normalized_tool_name else None
+    fallback = {
+        "capability_id": capability_id,
+        "capability_type": "tool",
+        "capability_name": tool_name,
+        "policy_tags": [],
+        "requires_identity_binding": False,
+        "capability_resolution": "unresolved",
+    }
+    if not capability_id:
+        return fallback
+    descriptor = get_capability_registry().get(capability_id)
+    if descriptor is None:
+        return fallback
+    return {
+        "capability_id": descriptor.capability_id,
+        "capability_type": descriptor.type or "tool",
+        "capability_name": tool_name,
+        "policy_tags": list(descriptor.policy_tags or []),
+        "requires_identity_binding": bool(descriptor.requires_identity_binding),
+        "capability_resolution": "resolved",
+    }
+
+
+def _normalize_tool_execution_outcome(
+    *,
+    tool_name: str,
+    raw_result: Any,
+    task_boundary: bool,
+    task_type: Optional[str] = None,
+) -> Dict[str, Any]:
+    normalized = _coerce_task_tool_result(raw_result)
+    capability = _resolve_tool_capability(tool_name)
+    payload: Dict[str, Any] = {
+        "tool_name": tool_name,
+        "success": bool(normalized["success"]),
+        "content": normalized["content"],
+        "error": normalized["error"],
+        "result": normalized["result"],
+        "capability_id": capability.get("capability_id"),
+        "capability_type": capability.get("capability_type"),
+        "capability_name": capability.get("capability_name"),
+        "policy_tags": capability.get("policy_tags"),
+        "requires_identity_binding": capability.get("requires_identity_binding"),
+        "capability_resolution": capability.get("capability_resolution"),
+    }
+    if task_boundary:
+        payload["task_type"] = task_type or "tool_task"
+        payload["task_boundary"] = True
+
+    return {
+        "success": bool(normalized["success"]),
+        "output_payload": payload,
+        "artifacts": normalized["artifacts"],
+        "runtime_events": normalized["runtime_events"],
+        "next_action_hint": normalized["next_action_hint"],
+        "audit_ref": normalized["audit_ref"],
+    }
+
+
 def _as_list_of_dicts(value: Any) -> list[dict]:
     if isinstance(value, list):
         return [item for item in value if isinstance(item, dict)]
@@ -893,12 +959,24 @@ def build_default_execution_bus(
         kwargs.setdefault("session_id", request.session_id)
         return await run_skill_execution(skill_name, _via_execution_bus=True, **kwargs)
 
-    async def tool_handler(request: ExecutionRequest) -> ToolResult:
-        # TODO(phase1): unify broader tool call sites through ExecutionBus when policy/hook coverage is verified.
-        # For now this adapter intentionally reuses the existing execution stack.
+    async def tool_handler(request: ExecutionRequest) -> ExecutionResult:
         tool_name = _get_required(request.input_payload, "tool_name")
         kwargs = dict(request.input_payload.get("kwargs") or {})
-        return await execute_tool_callable(tool_name, **kwargs)
+        raw_tool_result = await execute_tool_callable(tool_name, **kwargs)
+        normalized = _normalize_tool_execution_outcome(
+            tool_name=tool_name,
+            raw_result=raw_tool_result,
+            task_boundary=False,
+        )
+        return make_execution_result(
+            request_id=request.request_id,
+            status="success" if normalized["success"] else "error",
+            output_payload=normalized["output_payload"],
+            artifacts=normalized["artifacts"],
+            runtime_events=normalized["runtime_events"],
+            next_action_hint=normalized["next_action_hint"],
+            audit_ref=normalized["audit_ref"],
+        )
 
     async def subagent_handler(request: ExecutionRequest) -> Dict[str, Any]:
         return await run_subagent_execution(
@@ -1858,7 +1936,12 @@ def build_default_execution_bus(
             coro_factory=lambda: execute_tool_callable(tool_name, **kwargs),
             event_callback=event_callback if callable(event_callback) else None,
         )
-        normalized = _coerce_task_tool_result(raw_task_result)
+        normalized = _normalize_tool_execution_outcome(
+            tool_name=tool_name,
+            raw_result=raw_task_result,
+            task_boundary=True,
+            task_type="tool_task",
+        )
         runtime_events = list(normalized["runtime_events"]) if isinstance(normalized["runtime_events"], list) else []
         runtime_events = bus._attach_task_id_to_runtime_events(runtime_events, task_id)
         runtime_events.append(
@@ -1875,7 +1958,9 @@ def build_default_execution_bus(
                     "task_type": "tool_task",
                     "tool_name": tool_name,
                     "success": bool(normalized["success"]),
-                    "error": normalized["error"],
+                    "error": normalized["output_payload"].get("error"),
+                    "capability_id": normalized["output_payload"].get("capability_id"),
+                    "capability_type": normalized["output_payload"].get("capability_type"),
                 },
                 legacy_payload={"legacy_type": "task_tool"},
             )
@@ -1883,15 +1968,7 @@ def build_default_execution_bus(
         return make_execution_result(
             request_id=request.request_id,
             status="success" if normalized["success"] else "error",
-            output_payload={
-                "task_type": "tool_task",
-                "tool_name": tool_name,
-                "success": bool(normalized["success"]),
-                "content": normalized["content"],
-                "error": normalized["error"],
-                "task_boundary": True,
-                "result": normalized["result"],
-            },
+            output_payload=normalized["output_payload"],
             artifacts=normalized["artifacts"],
             runtime_events=runtime_events,
             next_action_hint=normalized["next_action_hint"],

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -2185,3 +2185,4 @@ def build_default_execution_bus(
     bus.register_handler("subagent", subagent_handler)
     bus.register_handler("event", event_handler)
     return bus
+

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -545,12 +545,14 @@ def _as_list_of_strings(value: Any) -> list[str]:
     return []
 
 
-def _resolve_task_capability(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+def resolve_task_capability_plan(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     normalized_task_type = str(task_type or "").strip().lower()
     registry = get_capability_registry()
     fallback: Dict[str, Any] = {
+        "primary_capability_id": None,
         "capability_id": None,
         "capability_type": None,
+        "involved_capability_ids": [],
         "policy_tags": [],
         "requires_identity_binding": False,
         "capability_resolution": "unresolved",
@@ -559,22 +561,32 @@ def _resolve_task_capability(task_type: str, payload: Dict[str, Any]) -> Dict[st
         action_id = str(payload.get("action_id") or "").strip().lower()
         descriptor = registry.get(action_id) if action_id else None
         if descriptor is None:
-            return {**fallback, "capability_id": action_id or None, "action_id": action_id or None}
-        return {
+            return {**fallback, "primary_capability_id": action_id or None, "capability_id": action_id or None, "action_id": action_id or None}
+        plan = {
+            **fallback,
+            "primary_capability_id": descriptor.capability_id,
             "capability_id": descriptor.capability_id,
             "capability_type": descriptor.type,
+            "involved_capability_ids": [descriptor.capability_id],
             "policy_tags": list(descriptor.policy_tags or []),
             "requires_identity_binding": bool(descriptor.requires_identity_binding),
             "capability_resolution": "resolved",
             "action_id": descriptor.capability_id,
         }
+        return plan
     if normalized_task_type == "jira_workflow_review_task":
         descriptor = registry.get("adapter:jira:read_issue")
         if descriptor is None:
-            return fallback
+            return {
+                **fallback,
+                "involved_capability_ids": _resolve_involved_capability_ids(task_type, payload),
+            }
         return {
+            **fallback,
+            "primary_capability_id": descriptor.capability_id,
             "capability_id": descriptor.capability_id,
             "capability_type": descriptor.type,
+            "involved_capability_ids": _resolve_involved_capability_ids(task_type, payload),
             "policy_tags": list(descriptor.policy_tags or []),
             "requires_identity_binding": bool(descriptor.requires_identity_binding),
             "capability_resolution": "resolved",
@@ -583,10 +595,16 @@ def _resolve_task_capability(task_type: str, payload: Dict[str, Any]) -> Dict[st
     if normalized_task_type == "github_review_task":
         descriptor = registry.get("adapter:github:review_pull_request")
         if descriptor is None:
-            return fallback
+            return {
+                **fallback,
+                "involved_capability_ids": _resolve_involved_capability_ids(task_type, payload),
+            }
         return {
+            **fallback,
+            "primary_capability_id": descriptor.capability_id,
             "capability_id": descriptor.capability_id,
             "capability_type": descriptor.type,
+            "involved_capability_ids": _resolve_involved_capability_ids(task_type, payload),
             "policy_tags": list(descriptor.policy_tags or []),
             "requires_identity_binding": bool(descriptor.requires_identity_binding),
             "capability_resolution": "resolved",
@@ -601,18 +619,27 @@ def _resolve_task_capability(task_type: str, payload: Dict[str, Any]) -> Dict[st
         if descriptor is None:
             return {
                 **fallback,
+                "primary_capability_id": capability_id,
                 "capability_id": capability_id,
                 "capability_type": "skill",
                 "capability_resolution": "unresolved",
+                "involved_capability_ids": [capability_id],
             }
         return {
+            **fallback,
+            "primary_capability_id": descriptor.capability_id,
             "capability_id": descriptor.capability_id,
             "capability_type": descriptor.type,
+            "involved_capability_ids": [descriptor.capability_id],
             "policy_tags": list(descriptor.policy_tags or []),
             "requires_identity_binding": bool(descriptor.requires_identity_binding),
             "capability_resolution": "resolved",
         }
     return fallback
+
+
+def _resolve_task_capability(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return resolve_task_capability_plan(task_type, payload)
 
 
 def _resolve_involved_capability_ids(task_type: str, payload: Dict[str, Any]) -> list[str]:
@@ -1567,8 +1594,8 @@ def build_default_execution_bus(
             )
 
         if task_type == "jira_workflow_review_task":
-            capability = _resolve_task_capability(task_type, request.input_payload)
-            involved_capability_ids = _resolve_involved_capability_ids(task_type, request.input_payload)
+            capability = resolve_task_capability_plan(task_type, request.input_payload)
+            involved_capability_ids = list(capability.get("involved_capability_ids") or [])
             involved_action_ids = list(involved_capability_ids)
             governed_secondary_action_ids = sorted([item for item in involved_action_ids if item != "adapter:jira:read_issue"])
             blocked_secondary_action_ids: list[str] = []
@@ -1741,8 +1768,8 @@ def build_default_execution_bus(
             )
 
         if task_type == "github_review_task":
-            capability = _resolve_task_capability(task_type, request.input_payload)
-            involved_capability_ids = _resolve_involved_capability_ids(task_type, request.input_payload)
+            capability = resolve_task_capability_plan(task_type, request.input_payload)
+            involved_capability_ids = list(capability.get("involved_capability_ids") or [])
             involved_action_ids = list(involved_capability_ids)
             owner = _get_required(request.input_payload, "owner")
             repo = _get_required(request.input_payload, "repo")

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -26,6 +26,7 @@ from src.runtime.governance_bus import (
     GovernanceBus,
     GovernanceDecision,
     build_default_governance_bus,
+    evaluate_capability_constraint_decision,
     governance_audit_runtime_event,
 )
 from src.runtime.jira_workflow_review import run_jira_workflow_review
@@ -538,6 +539,31 @@ def _resolve_task_capability(task_type: str, payload: Dict[str, Any]) -> Dict[st
             "capability_resolution": "resolved",
         }
     return fallback
+
+
+def _resolve_involved_capability_ids(task_type: str, payload: Dict[str, Any]) -> list[str]:
+    normalized_task_type = str(task_type or "").strip().lower()
+    if normalized_task_type == "jira_workflow_review_task":
+        involved = {"adapter:jira:read_issue"}
+        has_transition = any(payload.get(key) for key in ("transition", "success_transition", "failure_transition"))
+        has_assign = any(
+            payload.get(key)
+            for key in ("assignee", "success_reassign_to", "failure_reassign_to", "explicit_success_assignee", "explicit_failure_assignee")
+        )
+        has_comment = any(payload.get(key) for key in ("review_comment", "review_comment_template", "transition_comment"))
+        has_update = bool(payload.get("fields"))
+        if has_transition:
+            involved.add("adapter:jira:transition_issue")
+        if has_assign:
+            involved.add("adapter:jira:assign_issue")
+        if has_comment:
+            involved.add("adapter:jira:add_comment")
+        if has_update:
+            involved.add("adapter:jira:update_issue")
+        return sorted(involved)
+    if normalized_task_type == "github_review_task":
+        return ["adapter:github:add_comment", "adapter:github:review_pull_request"]
+    return []
 
 
 def _as_dict(value: Any) -> dict:
@@ -1317,6 +1343,8 @@ def build_default_execution_bus(
 
         if task_type == "jira_workflow_review_task":
             capability = _resolve_task_capability(task_type, request.input_payload)
+            involved_capability_ids = _resolve_involved_capability_ids(task_type, request.input_payload)
+            involved_action_ids = list(involved_capability_ids)
             workflow_payload = {
                 "issue_key": _get_required(request.input_payload, "issue_key"),
                 "skill_name": request.input_payload.get("skill_name"),
@@ -1358,6 +1386,8 @@ def build_default_execution_bus(
                         "policy_tags": capability.get("policy_tags"),
                         "requires_identity_binding": capability.get("requires_identity_binding"),
                         "capability_resolution": capability.get("capability_resolution"),
+                        "involved_capability_ids": involved_capability_ids,
+                        "involved_action_ids": involved_action_ids,
                         "issue_key": workflow_result.get("issue_key"),
                         "skill_name": workflow_result.get("skill_name") or workflow_payload.get("skill_name"),
                         "workflow_outcome": workflow_result.get("workflow_outcome"),
@@ -1384,6 +1414,8 @@ def build_default_execution_bus(
                     "policy_tags": capability.get("policy_tags"),
                     "requires_identity_binding": capability.get("requires_identity_binding"),
                     "capability_resolution": capability.get("capability_resolution"),
+                    "involved_capability_ids": involved_capability_ids,
+                    "involved_action_ids": involved_action_ids,
                     "resolved_skill_capability_id": f"skill:{str(workflow_payload.get('skill_name') or '').strip().lower()}" if workflow_payload.get("skill_name") else None,
                     "workflow_outcome": workflow_result.get("workflow_outcome"),
                     "actions_applied": workflow_result.get("actions_applied") or [],
@@ -1394,6 +1426,8 @@ def build_default_execution_bus(
 
         if task_type == "github_review_task":
             capability = _resolve_task_capability(task_type, request.input_payload)
+            involved_capability_ids = _resolve_involved_capability_ids(task_type, request.input_payload)
+            involved_action_ids = list(involved_capability_ids)
             owner = _get_required(request.input_payload, "owner")
             repo = _get_required(request.input_payload, "repo")
             pull_number = _get_required(request.input_payload, "pull_number")
@@ -1420,24 +1454,76 @@ def build_default_execution_bus(
                 review_summary = review_comment_input
             comment_written = False
             error_value = review_result.get("error")
+            secondary_action_id = "adapter:github:add_comment"
+            secondary_action_attempted = False
+            secondary_action_success = False
 
             if review_result.get("success"):
                 comment_body = review_summary if isinstance(review_summary, str) and review_summary.strip() else review_comment_input
                 if isinstance(comment_body, str) and comment_body.strip():
-                    add_comment_result = await execute_adapter_action(
-                        "adapter:github:add_comment",
-                        {
-                            "owner": owner,
-                            "repo": repo,
-                            "pull_number": pull_number,
-                            "comment": comment_body,
-                        },
+                    secondary_action_attempted = True
+                    secondary_gate = evaluate_capability_constraint_decision(
+                        metadata=request.metadata if isinstance(request.metadata, dict) else {},
+                        capability_id=secondary_action_id,
+                        capability_type="adapter_action",
+                        action_id=secondary_action_id,
                     )
-                    runtime_events.extend(add_comment_result.get("runtime_events") or [])
-                    runtime_events = bus._attach_task_id_to_runtime_events(runtime_events, task_id)
-                    comment_written = bool(add_comment_result.get("success"))
-                    if not comment_written:
-                        error_value = add_comment_result.get("error") or "Failed to write GitHub review comment"
+                    if secondary_gate is not None:
+                        error_value = "capability policy blocked for secondary action"
+                        runtime_events.append(
+                            build_runtime_event(
+                                event_type="task.github_review.secondary_action.blocked",
+                                execution_type=request.execution_type,
+                                state="blocked",
+                                session_id=request.session_id,
+                                request_id=request.request_id,
+                                agent_id=request.agent_id,
+                                summary="github review secondary action blocked",
+                                task_id=task_id,
+                                detail_payload={
+                                    "task_type": task_type,
+                                    "secondary_action_id": secondary_action_id,
+                                    "reason": secondary_gate.get("reason"),
+                                    "message": secondary_gate.get("message"),
+                                },
+                                legacy_payload={"legacy_type": "task_github_review_secondary_action"},
+                            )
+                        )
+                    else:
+                        add_comment_result = await execute_adapter_action(
+                            secondary_action_id,
+                            {
+                                "owner": owner,
+                                "repo": repo,
+                                "pull_number": pull_number,
+                                "comment": comment_body,
+                            },
+                        )
+                        runtime_events.extend(add_comment_result.get("runtime_events") or [])
+                        runtime_events = bus._attach_task_id_to_runtime_events(runtime_events, task_id)
+                        comment_written = bool(add_comment_result.get("success"))
+                        secondary_action_success = comment_written
+                        runtime_events.append(
+                            build_runtime_event(
+                                event_type="task.github_review.secondary_action.completed" if comment_written else "task.github_review.secondary_action.failed",
+                                execution_type=request.execution_type,
+                                state="completed" if comment_written else "failed",
+                                session_id=request.session_id,
+                                request_id=request.request_id,
+                                agent_id=request.agent_id,
+                                summary="github review secondary action",
+                                task_id=task_id,
+                                detail_payload={
+                                    "task_type": task_type,
+                                    "secondary_action_id": secondary_action_id,
+                                    "success": comment_written,
+                                    "error": add_comment_result.get("error"),
+                                },
+                                legacy_payload={"legacy_type": "task_github_review_secondary_action"},
+                            )
+                        )
+                        if not comment_written:
+                            error_value = add_comment_result.get("error") or "Failed to write GitHub review comment"
                 else:
                     error_value = "Review succeeded but no summary/comment text available for write-back"
 
@@ -1459,10 +1545,15 @@ def build_default_execution_bus(
                         "policy_tags": capability.get("policy_tags"),
                         "requires_identity_binding": capability.get("requires_identity_binding"),
                         "capability_resolution": capability.get("capability_resolution"),
+                        "involved_capability_ids": involved_capability_ids,
+                        "involved_action_ids": involved_action_ids,
                         "owner": owner,
                         "repo": repo,
                         "pull_number": pull_number,
                         "comment_written": comment_written,
+                        "secondary_action_attempted": secondary_action_attempted,
+                        "secondary_action_id": secondary_action_id,
+                        "secondary_action_success": secondary_action_success,
                         "success": success_value,
                         "error": error_value,
                     },
@@ -1487,6 +1578,11 @@ def build_default_execution_bus(
                     "policy_tags": capability.get("policy_tags"),
                     "requires_identity_binding": capability.get("requires_identity_binding"),
                     "capability_resolution": capability.get("capability_resolution"),
+                    "involved_capability_ids": involved_capability_ids,
+                    "involved_action_ids": involved_action_ids,
+                    "secondary_action_attempted": secondary_action_attempted,
+                    "secondary_action_id": secondary_action_id,
+                    "secondary_action_success": secondary_action_success,
                 },
                 runtime_events=runtime_events,
             )

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -640,6 +640,88 @@ def _resolve_involved_capability_ids(task_type: str, payload: Dict[str, Any]) ->
     return []
 
 
+async def _execute_adapter_action_task(
+    *,
+    bus: ExecutionBus,
+    request: ExecutionRequest,
+    task_id: Optional[str],
+    task_type: str,
+    action_id: str,
+    kwargs: Dict[str, Any],
+) -> ExecutionResult:
+    """Standardized adapter-action capability boundary for runtime tasks.
+
+    Notes:
+    - This task boundary is the canonical runtime contract for adapter actions.
+    - `adapter_executor.execute_adapter_action` remains a low-level implementation detail
+      invoked only within this bus-owned path.
+    """
+    capability = _resolve_task_capability(task_type, {"action_id": action_id})
+    descriptor = get_capability_registry().get(action_id)
+    if descriptor is None or descriptor.type != "adapter_action":
+        return make_execution_result(
+            request_id=request.request_id,
+            status="blocked",
+            output_payload={
+                "task_type": task_type,
+                "action_id": action_id,
+                "success": False,
+                "error": f"Unknown or non-adapter action_id: {action_id}",
+                "task_boundary": True,
+                "capability_id": capability.get("capability_id"),
+                "capability_type": capability.get("capability_type"),
+                "requires_identity_binding": bool(capability.get("requires_identity_binding")),
+                "capability_resolution": "unresolved",
+                "result": None,
+            },
+        )
+    adapter_result = await execute_adapter_action(action_id, kwargs)
+    runtime_events = list(adapter_result.get("runtime_events") or [])
+    runtime_events = bus._attach_task_id_to_runtime_events(runtime_events, task_id)
+    requires_identity_binding = bool(descriptor.requires_identity_binding)
+    runtime_events.append(
+        build_runtime_event(
+            event_type="task.adapter_action.completed" if adapter_result.get("success") else "task.adapter_action.failed",
+            execution_type=request.execution_type,
+            state="completed" if adapter_result.get("success") else "failed",
+            session_id=request.session_id,
+            request_id=request.request_id,
+            agent_id=request.agent_id,
+            summary=f"adapter action {action_id}",
+            task_id=task_id,
+            detail_payload={
+                "task_type": task_type,
+                "action_id": action_id,
+                "capability_id": capability.get("capability_id"),
+                "capability_type": capability.get("capability_type"),
+                "policy_tags": capability.get("policy_tags"),
+                "requires_identity_binding": requires_identity_binding,
+                "capability_resolution": capability.get("capability_resolution"),
+                "success": bool(adapter_result.get("success")),
+            },
+            legacy_payload={"legacy_type": "task_adapter_action"},
+        )
+    )
+    return make_execution_result(
+        request_id=request.request_id,
+        status="success" if adapter_result.get("success") else "error",
+        output_payload={
+            "task_type": task_type,
+            "action_id": action_id,
+            "success": bool(adapter_result.get("success")),
+            "error": adapter_result.get("error"),
+            "task_boundary": True,
+            "capability_id": capability.get("capability_id"),
+            "capability_type": capability.get("capability_type"),
+            "policy_tags": capability.get("policy_tags"),
+            "requires_identity_binding": requires_identity_binding,
+            "capability_resolution": capability.get("capability_resolution"),
+            "result": adapter_result.get("result"),
+        },
+        runtime_events=runtime_events,
+    )
+
+
 def _action_name_to_capability_id(system: str, action_name: str) -> str:
     return f"adapter:{system}:{str(action_name or '').strip().lower()}"
 
@@ -1475,67 +1557,13 @@ def build_default_execution_bus(
         if task_type == "adapter_action_task":
             action_id = _get_required(request.input_payload, "action_id")
             kwargs = dict(request.input_payload.get("kwargs") or {})
-            capability = _resolve_task_capability(task_type, {"action_id": action_id})
-            descriptor = get_capability_registry().get(action_id)
-            if descriptor is None or descriptor.type != "adapter_action":
-                return make_execution_result(
-                    request_id=request.request_id,
-                    status="blocked",
-                    output_payload={
-                        "task_type": task_type,
-                        "action_id": action_id,
-                        "success": False,
-                        "error": f"Unknown or non-adapter action_id: {action_id}",
-                        "task_boundary": True,
-                        "capability_id": capability.get("capability_id"),
-                        "capability_type": capability.get("capability_type"),
-                        "capability_resolution": "unresolved",
-                    },
-                )
-            adapter_result = await execute_adapter_action(action_id, kwargs)
-            runtime_events = list(adapter_result.get("runtime_events") or [])
-            runtime_events = bus._attach_task_id_to_runtime_events(runtime_events, task_id)
-            requires_identity_binding = bool(descriptor.requires_identity_binding)
-            runtime_events.append(
-                build_runtime_event(
-                    event_type="task.adapter_action.completed" if adapter_result.get("success") else "task.adapter_action.failed",
-                    execution_type=request.execution_type,
-                    state="completed" if adapter_result.get("success") else "failed",
-                    session_id=request.session_id,
-                    request_id=request.request_id,
-                    agent_id=request.agent_id,
-                    summary=f"adapter action {action_id}",
-                    task_id=task_id,
-                    detail_payload={
-                        "task_type": task_type,
-                        "action_id": action_id,
-                        "capability_id": capability.get("capability_id"),
-                        "capability_type": capability.get("capability_type"),
-                        "policy_tags": capability.get("policy_tags"),
-                        "requires_identity_binding": requires_identity_binding,
-                        "capability_resolution": capability.get("capability_resolution"),
-                        "success": bool(adapter_result.get("success")),
-                    },
-                    legacy_payload={"legacy_type": "task_adapter_action"},
-                )
-            )
-            return make_execution_result(
-                request_id=request.request_id,
-                status="success" if adapter_result.get("success") else "error",
-                output_payload={
-                    "task_type": task_type,
-                    "action_id": action_id,
-                    "success": bool(adapter_result.get("success")),
-                    "error": adapter_result.get("error"),
-                    "task_boundary": True,
-                    "capability_id": capability.get("capability_id"),
-                    "capability_type": capability.get("capability_type"),
-                    "policy_tags": capability.get("policy_tags"),
-                    "requires_identity_binding": requires_identity_binding,
-                    "capability_resolution": capability.get("capability_resolution"),
-                    "result": adapter_result.get("result"),
-                },
-                runtime_events=runtime_events,
+            return await _execute_adapter_action_task(
+                bus=bus,
+                request=request,
+                task_id=task_id,
+                task_type=task_type,
+                action_id=action_id,
+                kwargs=kwargs,
             )
 
         if task_type == "jira_workflow_review_task":
@@ -2185,4 +2213,3 @@ def build_default_execution_bus(
     bus.register_handler("subagent", subagent_handler)
     bus.register_handler("event", event_handler)
     return bus
-

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -179,6 +179,14 @@ class ExecutionBus:
             request_id=request.request_id,
             status="blocked",
             output_payload=payload,
+            artifacts={
+                "governance": {
+                    "blocked": True,
+                    "deny_reason": reason or "governance_blocked",
+                    "execution_type": request.execution_type,
+                    "capability_id": (request.input_payload or {}).get("action_id"),
+                }
+            },
             runtime_events=runtime_events,
             audit_ref=audit_ref,
         )
@@ -883,7 +891,7 @@ def build_default_execution_bus(
         skill_name = _get_required(request.input_payload, "skill_name")
         kwargs = dict(request.input_payload.get("kwargs") or {})
         kwargs.setdefault("session_id", request.session_id)
-        return await run_skill_execution(skill_name, **kwargs)
+        return await run_skill_execution(skill_name, _via_execution_bus=True, **kwargs)
 
     async def tool_handler(request: ExecutionRequest) -> ToolResult:
         # TODO(phase1): unify broader tool call sites through ExecutionBus when policy/hook coverage is verified.
@@ -1208,7 +1216,7 @@ def build_default_execution_bus(
                 }
                 skill_kwargs["delegation_context"] = delegation_context
                 skill_kwargs.setdefault("session_id", request.session_id)
-                skill_result = await run_skill_execution(skill_name.strip(), **skill_kwargs)
+                skill_result = await run_skill_execution(skill_name.strip(), _via_execution_bus=True, **skill_kwargs)
                 normalized_skill = bus._normalize_result(request, skill_result)
                 raw_skill_result = dict(normalized_skill.output_payload or {})
                 skill_success = normalized_skill.status not in {"error", "blocked"}

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -566,6 +566,49 @@ def _resolve_involved_capability_ids(task_type: str, payload: Dict[str, Any]) ->
     return []
 
 
+def _action_name_to_capability_id(system: str, action_name: str) -> str:
+    return f"adapter:{system}:{str(action_name or '').strip().lower()}"
+
+
+def _evaluate_secondary_action_gate(
+    *,
+    request: ExecutionRequest,
+    action_id: str,
+) -> Optional[Dict[str, str]]:
+    metadata = request.metadata if isinstance(request.metadata, dict) else {}
+    return evaluate_capability_constraint_decision(
+        metadata=metadata,
+        capability_id=action_id,
+        capability_type="adapter_action",
+        action_id=action_id,
+    )
+
+
+def _append_secondary_action_event(
+    *,
+    runtime_events: list[Dict[str, Any]],
+    request: ExecutionRequest,
+    task_id: Optional[str],
+    event_type: str,
+    state: str,
+    detail_payload: Dict[str, Any],
+) -> None:
+    runtime_events.append(
+        build_runtime_event(
+            event_type=event_type,
+            execution_type=request.execution_type,
+            state=state,
+            session_id=request.session_id,
+            request_id=request.request_id,
+            agent_id=request.agent_id,
+            summary="secondary action governance",
+            task_id=task_id,
+            detail_payload=detail_payload,
+            legacy_payload={"legacy_type": "task_secondary_action"},
+        )
+    )
+
+
 def _as_dict(value: Any) -> dict:
     return dict(value) if isinstance(value, dict) else {}
 
@@ -1345,6 +1388,9 @@ def build_default_execution_bus(
             capability = _resolve_task_capability(task_type, request.input_payload)
             involved_capability_ids = _resolve_involved_capability_ids(task_type, request.input_payload)
             involved_action_ids = list(involved_capability_ids)
+            governed_secondary_action_ids = sorted([item for item in involved_action_ids if item != "adapter:jira:read_issue"])
+            blocked_secondary_action_ids: list[str] = []
+            applied_secondary_action_ids: list[str] = []
             workflow_payload = {
                 "issue_key": _get_required(request.input_payload, "issue_key"),
                 "skill_name": request.input_payload.get("skill_name"),
@@ -1366,9 +1412,35 @@ def build_default_execution_bus(
                 "fields": request.input_payload.get("fields"),
                 "transition_comment": request.input_payload.get("transition_comment"),
             }
+            def _jira_action_gate(action_name: str, _kwargs: Dict[str, Any]) -> Dict[str, Any]:
+                action_id = _action_name_to_capability_id("jira", action_name)
+                decision = _evaluate_secondary_action_gate(request=request, action_id=action_id)
+                if decision is not None:
+                    blocked_secondary_action_ids.append(action_id)
+                    return {
+                        "blocked": True,
+                        "reason": decision.get("reason"),
+                        "error": f"capability policy blocked for secondary action: {action_id}",
+                    }
+                applied_secondary_action_ids.append(action_id)
+                return {"blocked": False}
+
+            workflow_payload["_action_gate"] = _jira_action_gate
             workflow_result = await run_jira_workflow_review(workflow_payload)
             runtime_events = list(workflow_result.get("runtime_events") or [])
             runtime_events = bus._attach_task_id_to_runtime_events(runtime_events, task_id)
+            for blocked_action_id in blocked_secondary_action_ids:
+                _append_secondary_action_event(
+                    runtime_events=runtime_events,
+                    request=request,
+                    task_id=task_id,
+                    event_type="task.jira_workflow_review.secondary_action.blocked",
+                    state="blocked",
+                    detail_payload={
+                        "task_type": task_type,
+                        "secondary_action_id": blocked_action_id,
+                    },
+                )
             runtime_events.append(
                 build_runtime_event(
                     event_type="task.jira_workflow_review.completed" if workflow_result.get("success") else "task.jira_workflow_review.failed",
@@ -1388,6 +1460,9 @@ def build_default_execution_bus(
                         "capability_resolution": capability.get("capability_resolution"),
                         "involved_capability_ids": involved_capability_ids,
                         "involved_action_ids": involved_action_ids,
+                        "governed_secondary_action_ids": governed_secondary_action_ids,
+                        "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
+                        "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
                         "issue_key": workflow_result.get("issue_key"),
                         "skill_name": workflow_result.get("skill_name") or workflow_payload.get("skill_name"),
                         "workflow_outcome": workflow_result.get("workflow_outcome"),
@@ -1416,6 +1491,9 @@ def build_default_execution_bus(
                     "capability_resolution": capability.get("capability_resolution"),
                     "involved_capability_ids": involved_capability_ids,
                     "involved_action_ids": involved_action_ids,
+                    "governed_secondary_action_ids": governed_secondary_action_ids,
+                    "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
+                    "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
                     "resolved_skill_capability_id": f"skill:{str(workflow_payload.get('skill_name') or '').strip().lower()}" if workflow_payload.get("skill_name") else None,
                     "workflow_outcome": workflow_result.get("workflow_outcome"),
                     "actions_applied": workflow_result.get("actions_applied") or [],
@@ -1457,39 +1535,33 @@ def build_default_execution_bus(
             secondary_action_id = "adapter:github:add_comment"
             secondary_action_attempted = False
             secondary_action_success = False
+            governed_secondary_action_ids = [secondary_action_id]
+            blocked_secondary_action_ids: list[str] = []
+            applied_secondary_action_ids: list[str] = []
 
             if review_result.get("success"):
                 comment_body = review_summary if isinstance(review_summary, str) and review_summary.strip() else review_comment_input
                 if isinstance(comment_body, str) and comment_body.strip():
                     secondary_action_attempted = True
-                    secondary_gate = evaluate_capability_constraint_decision(
-                        metadata=request.metadata if isinstance(request.metadata, dict) else {},
-                        capability_id=secondary_action_id,
-                        capability_type="adapter_action",
-                        action_id=secondary_action_id,
-                    )
+                    secondary_gate = _evaluate_secondary_action_gate(request=request, action_id=secondary_action_id)
                     if secondary_gate is not None:
+                        blocked_secondary_action_ids.append(secondary_action_id)
                         error_value = "capability policy blocked for secondary action"
-                        runtime_events.append(
-                            build_runtime_event(
-                                event_type="task.github_review.secondary_action.blocked",
-                                execution_type=request.execution_type,
-                                state="blocked",
-                                session_id=request.session_id,
-                                request_id=request.request_id,
-                                agent_id=request.agent_id,
-                                summary="github review secondary action blocked",
-                                task_id=task_id,
-                                detail_payload={
-                                    "task_type": task_type,
-                                    "secondary_action_id": secondary_action_id,
-                                    "reason": secondary_gate.get("reason"),
-                                    "message": secondary_gate.get("message"),
-                                },
-                                legacy_payload={"legacy_type": "task_github_review_secondary_action"},
-                            )
+                        _append_secondary_action_event(
+                            runtime_events=runtime_events,
+                            request=request,
+                            task_id=task_id,
+                            event_type="task.github_review.secondary_action.blocked",
+                            state="blocked",
+                            detail_payload={
+                                "task_type": task_type,
+                                "secondary_action_id": secondary_action_id,
+                                "reason": secondary_gate.get("reason"),
+                                "message": secondary_gate.get("message"),
+                            },
                         )
                     else:
+                        applied_secondary_action_ids.append(secondary_action_id)
                         add_comment_result = await execute_adapter_action(
                             secondary_action_id,
                             {
@@ -1503,24 +1575,18 @@ def build_default_execution_bus(
                         runtime_events = bus._attach_task_id_to_runtime_events(runtime_events, task_id)
                         comment_written = bool(add_comment_result.get("success"))
                         secondary_action_success = comment_written
-                        runtime_events.append(
-                            build_runtime_event(
-                                event_type="task.github_review.secondary_action.completed" if comment_written else "task.github_review.secondary_action.failed",
-                                execution_type=request.execution_type,
-                                state="completed" if comment_written else "failed",
-                                session_id=request.session_id,
-                                request_id=request.request_id,
-                                agent_id=request.agent_id,
-                                summary="github review secondary action",
-                                task_id=task_id,
-                                detail_payload={
-                                    "task_type": task_type,
-                                    "secondary_action_id": secondary_action_id,
-                                    "success": comment_written,
-                                    "error": add_comment_result.get("error"),
-                                },
-                                legacy_payload={"legacy_type": "task_github_review_secondary_action"},
-                            )
+                        _append_secondary_action_event(
+                            runtime_events=runtime_events,
+                            request=request,
+                            task_id=task_id,
+                            event_type="task.github_review.secondary_action.completed" if comment_written else "task.github_review.secondary_action.failed",
+                            state="completed" if comment_written else "failed",
+                            detail_payload={
+                                "task_type": task_type,
+                                "secondary_action_id": secondary_action_id,
+                                "success": comment_written,
+                                "error": add_comment_result.get("error"),
+                            },
                         )
                         if not comment_written:
                             error_value = add_comment_result.get("error") or "Failed to write GitHub review comment"
@@ -1547,6 +1613,9 @@ def build_default_execution_bus(
                         "capability_resolution": capability.get("capability_resolution"),
                         "involved_capability_ids": involved_capability_ids,
                         "involved_action_ids": involved_action_ids,
+                        "governed_secondary_action_ids": governed_secondary_action_ids,
+                        "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
+                        "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
                         "owner": owner,
                         "repo": repo,
                         "pull_number": pull_number,
@@ -1580,6 +1649,9 @@ def build_default_execution_bus(
                     "capability_resolution": capability.get("capability_resolution"),
                     "involved_capability_ids": involved_capability_ids,
                     "involved_action_ids": involved_action_ids,
+                    "governed_secondary_action_ids": governed_secondary_action_ids,
+                    "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
+                    "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
                     "secondary_action_attempted": secondary_action_attempted,
                     "secondary_action_id": secondary_action_id,
                     "secondary_action_success": secondary_action_success,

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -662,6 +662,21 @@ def _record_secondary_action_decision(
     )
 
 
+def _build_secondary_governance_summary(
+    *,
+    governed_secondary_action_ids: list[str],
+    blocked_secondary_action_ids: list[str],
+    applied_secondary_action_ids: list[str],
+    secondary_action_decisions: list[Dict[str, Any]],
+) -> Dict[str, Any]:
+    return {
+        "governed_secondary_action_ids": sorted(set(governed_secondary_action_ids)),
+        "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
+        "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
+        "secondary_action_decisions": list(secondary_action_decisions),
+    }
+
+
 def _as_dict(value: Any) -> dict:
     return dict(value) if isinstance(value, dict) else {}
 
@@ -1548,6 +1563,12 @@ def build_default_execution_bus(
                         reason="not_invoked",
                         success=False,
                     )
+            secondary_summary = _build_secondary_governance_summary(
+                governed_secondary_action_ids=governed_secondary_action_ids,
+                blocked_secondary_action_ids=blocked_secondary_action_ids,
+                applied_secondary_action_ids=applied_secondary_action_ids,
+                secondary_action_decisions=secondary_action_decisions,
+            )
             runtime_events.append(
                 build_runtime_event(
                     event_type="task.jira_workflow_review.completed" if workflow_result.get("success") else "task.jira_workflow_review.failed",
@@ -1567,10 +1588,7 @@ def build_default_execution_bus(
                         "capability_resolution": capability.get("capability_resolution"),
                         "involved_capability_ids": involved_capability_ids,
                         "involved_action_ids": involved_action_ids,
-                        "governed_secondary_action_ids": governed_secondary_action_ids,
-                        "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
-                        "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
-                        "secondary_action_decisions": secondary_action_decisions,
+                        **secondary_summary,
                         "issue_key": workflow_result.get("issue_key"),
                         "skill_name": workflow_result.get("skill_name") or workflow_payload.get("skill_name"),
                         "workflow_outcome": workflow_result.get("workflow_outcome"),
@@ -1599,10 +1617,7 @@ def build_default_execution_bus(
                     "capability_resolution": capability.get("capability_resolution"),
                     "involved_capability_ids": involved_capability_ids,
                     "involved_action_ids": involved_action_ids,
-                    "governed_secondary_action_ids": governed_secondary_action_ids,
-                    "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
-                    "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
-                    "secondary_action_decisions": secondary_action_decisions,
+                    **secondary_summary,
                     "resolved_skill_capability_id": f"skill:{str(workflow_payload.get('skill_name') or '').strip().lower()}" if workflow_payload.get("skill_name") else None,
                     "workflow_outcome": workflow_result.get("workflow_outcome"),
                     "actions_applied": workflow_result.get("actions_applied") or [],
@@ -1746,6 +1761,12 @@ def build_default_execution_bus(
                     reason="primary_action_failed",
                     success=False,
                 )
+            secondary_summary = _build_secondary_governance_summary(
+                governed_secondary_action_ids=governed_secondary_action_ids,
+                blocked_secondary_action_ids=blocked_secondary_action_ids,
+                applied_secondary_action_ids=applied_secondary_action_ids,
+                secondary_action_decisions=secondary_action_decisions,
+            )
 
             success_value = bool(review_result.get("success")) and comment_written and not error_value
             runtime_events.append(
@@ -1767,10 +1788,7 @@ def build_default_execution_bus(
                         "capability_resolution": capability.get("capability_resolution"),
                         "involved_capability_ids": involved_capability_ids,
                         "involved_action_ids": involved_action_ids,
-                        "governed_secondary_action_ids": governed_secondary_action_ids,
-                        "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
-                        "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
-                        "secondary_action_decisions": secondary_action_decisions,
+                        **secondary_summary,
                         "owner": owner,
                         "repo": repo,
                         "pull_number": pull_number,
@@ -1804,10 +1822,7 @@ def build_default_execution_bus(
                     "capability_resolution": capability.get("capability_resolution"),
                     "involved_capability_ids": involved_capability_ids,
                     "involved_action_ids": involved_action_ids,
-                    "governed_secondary_action_ids": governed_secondary_action_ids,
-                    "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
-                    "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
-                    "secondary_action_decisions": secondary_action_decisions,
+                    **secondary_summary,
                     "secondary_action_attempted": secondary_action_attempted,
                     "secondary_action_id": secondary_action_id,
                     "secondary_action_success": secondary_action_success,

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -470,6 +470,76 @@ def _as_list_of_strings(value: Any) -> list[str]:
     return []
 
 
+def _resolve_task_capability(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    normalized_task_type = str(task_type or "").strip().lower()
+    registry = get_capability_registry()
+    fallback: Dict[str, Any] = {
+        "capability_id": None,
+        "capability_type": None,
+        "policy_tags": [],
+        "requires_identity_binding": False,
+        "capability_resolution": "unresolved",
+    }
+    if normalized_task_type == "adapter_action_task":
+        action_id = str(payload.get("action_id") or "").strip().lower()
+        descriptor = registry.get(action_id) if action_id else None
+        if descriptor is None:
+            return {**fallback, "capability_id": action_id or None, "action_id": action_id or None}
+        return {
+            "capability_id": descriptor.capability_id,
+            "capability_type": descriptor.type,
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": bool(descriptor.requires_identity_binding),
+            "capability_resolution": "resolved",
+            "action_id": descriptor.capability_id,
+        }
+    if normalized_task_type == "jira_workflow_review_task":
+        descriptor = registry.get("adapter:jira:read_issue")
+        if descriptor is None:
+            return fallback
+        return {
+            "capability_id": descriptor.capability_id,
+            "capability_type": descriptor.type,
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": bool(descriptor.requires_identity_binding),
+            "capability_resolution": "resolved",
+            "action_id": descriptor.capability_id,
+        }
+    if normalized_task_type == "github_review_task":
+        descriptor = registry.get("adapter:github:review_pull_request")
+        if descriptor is None:
+            return fallback
+        return {
+            "capability_id": descriptor.capability_id,
+            "capability_type": descriptor.type,
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": bool(descriptor.requires_identity_binding),
+            "capability_resolution": "resolved",
+            "action_id": descriptor.capability_id,
+        }
+    if normalized_task_type == "delegation_task":
+        skill_name = _non_empty_string(payload.get("skill_name"))
+        if not skill_name:
+            return fallback
+        capability_id = f"skill:{skill_name.lower()}"
+        descriptor = registry.get(capability_id)
+        if descriptor is None:
+            return {
+                **fallback,
+                "capability_id": capability_id,
+                "capability_type": "skill",
+                "capability_resolution": "unresolved",
+            }
+        return {
+            "capability_id": descriptor.capability_id,
+            "capability_type": descriptor.type,
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": bool(descriptor.requires_identity_binding),
+            "capability_resolution": "resolved",
+        }
+    return fallback
+
+
 def _as_dict(value: Any) -> dict:
     return dict(value) if isinstance(value, dict) else {}
 
@@ -1182,8 +1252,8 @@ def build_default_execution_bus(
         if task_type == "adapter_action_task":
             action_id = _get_required(request.input_payload, "action_id")
             kwargs = dict(request.input_payload.get("kwargs") or {})
-            registry = get_capability_registry()
-            descriptor = registry.get(action_id)
+            capability = _resolve_task_capability(task_type, {"action_id": action_id})
+            descriptor = get_capability_registry().get(action_id)
             if descriptor is None or descriptor.type != "adapter_action":
                 return make_execution_result(
                     request_id=request.request_id,
@@ -1194,6 +1264,9 @@ def build_default_execution_bus(
                         "success": False,
                         "error": f"Unknown or non-adapter action_id: {action_id}",
                         "task_boundary": True,
+                        "capability_id": capability.get("capability_id"),
+                        "capability_type": capability.get("capability_type"),
+                        "capability_resolution": "unresolved",
                     },
                 )
             adapter_result = await execute_adapter_action(action_id, kwargs)
@@ -1213,8 +1286,11 @@ def build_default_execution_bus(
                     detail_payload={
                         "task_type": task_type,
                         "action_id": action_id,
+                        "capability_id": capability.get("capability_id"),
+                        "capability_type": capability.get("capability_type"),
+                        "policy_tags": capability.get("policy_tags"),
                         "requires_identity_binding": requires_identity_binding,
-                        "capability_policy_tags": descriptor.policy_tags,
+                        "capability_resolution": capability.get("capability_resolution"),
                         "success": bool(adapter_result.get("success")),
                     },
                     legacy_payload={"legacy_type": "task_adapter_action"},
@@ -1229,13 +1305,18 @@ def build_default_execution_bus(
                     "success": bool(adapter_result.get("success")),
                     "error": adapter_result.get("error"),
                     "task_boundary": True,
+                    "capability_id": capability.get("capability_id"),
+                    "capability_type": capability.get("capability_type"),
+                    "policy_tags": capability.get("policy_tags"),
                     "requires_identity_binding": requires_identity_binding,
+                    "capability_resolution": capability.get("capability_resolution"),
                     "result": adapter_result.get("result"),
                 },
                 runtime_events=runtime_events,
             )
 
         if task_type == "jira_workflow_review_task":
+            capability = _resolve_task_capability(task_type, request.input_payload)
             workflow_payload = {
                 "issue_key": _get_required(request.input_payload, "issue_key"),
                 "skill_name": request.input_payload.get("skill_name"),
@@ -1272,6 +1353,11 @@ def build_default_execution_bus(
                     task_id=task_id,
                     detail_payload={
                         "task_type": task_type,
+                        "capability_id": capability.get("capability_id"),
+                        "capability_type": capability.get("capability_type"),
+                        "policy_tags": capability.get("policy_tags"),
+                        "requires_identity_binding": capability.get("requires_identity_binding"),
+                        "capability_resolution": capability.get("capability_resolution"),
                         "issue_key": workflow_result.get("issue_key"),
                         "skill_name": workflow_result.get("skill_name") or workflow_payload.get("skill_name"),
                         "workflow_outcome": workflow_result.get("workflow_outcome"),
@@ -1293,6 +1379,12 @@ def build_default_execution_bus(
                     "success": bool(workflow_result.get("success")),
                     "error": workflow_result.get("error"),
                     "task_boundary": True,
+                    "capability_id": capability.get("capability_id"),
+                    "capability_type": capability.get("capability_type"),
+                    "policy_tags": capability.get("policy_tags"),
+                    "requires_identity_binding": capability.get("requires_identity_binding"),
+                    "capability_resolution": capability.get("capability_resolution"),
+                    "resolved_skill_capability_id": f"skill:{str(workflow_payload.get('skill_name') or '').strip().lower()}" if workflow_payload.get("skill_name") else None,
                     "workflow_outcome": workflow_result.get("workflow_outcome"),
                     "actions_applied": workflow_result.get("actions_applied") or [],
                     "result": workflow_result,
@@ -1301,6 +1393,7 @@ def build_default_execution_bus(
             )
 
         if task_type == "github_review_task":
+            capability = _resolve_task_capability(task_type, request.input_payload)
             owner = _get_required(request.input_payload, "owner")
             repo = _get_required(request.input_payload, "repo")
             pull_number = _get_required(request.input_payload, "pull_number")
@@ -1361,6 +1454,11 @@ def build_default_execution_bus(
                     task_id=task_id,
                     detail_payload={
                         "task_type": task_type,
+                        "capability_id": capability.get("capability_id"),
+                        "capability_type": capability.get("capability_type"),
+                        "policy_tags": capability.get("policy_tags"),
+                        "requires_identity_binding": capability.get("requires_identity_binding"),
+                        "capability_resolution": capability.get("capability_resolution"),
                         "owner": owner,
                         "repo": repo,
                         "pull_number": pull_number,
@@ -1384,6 +1482,11 @@ def build_default_execution_bus(
                     "success": success_value,
                     "error": error_value,
                     "task_boundary": True,
+                    "capability_id": capability.get("capability_id"),
+                    "capability_type": capability.get("capability_type"),
+                    "policy_tags": capability.get("policy_tags"),
+                    "requires_identity_binding": capability.get("requires_identity_binding"),
+                    "capability_resolution": capability.get("capability_resolution"),
                 },
                 runtime_events=runtime_events,
             )

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -592,7 +592,7 @@ def _append_secondary_action_event(
     event_type: str,
     state: str,
     detail_payload: Dict[str, Any],
-) -> None:
+    ) -> None:
     runtime_events.append(
         build_runtime_event(
             event_type=event_type,
@@ -606,6 +606,59 @@ def _append_secondary_action_event(
             detail_payload=detail_payload,
             legacy_payload={"legacy_type": "task_secondary_action"},
         )
+    )
+
+
+def _append_secondary_governance_audit_event(
+    *,
+    runtime_events: list[Dict[str, Any]],
+    request: ExecutionRequest,
+    task_type: str,
+    action_id: str,
+    deny_reason: Optional[str],
+) -> None:
+    metadata = request.metadata if isinstance(request.metadata, dict) else {}
+    policy_profile_id = request.policy_profile_id or metadata.get("policy_profile_id") or "default"
+    audit_record = GovernanceAuditRecord(
+        audit_ref=f"gov-{request.request_id}-secondary-{action_id.split(':')[-1]}",
+        stage="secondary_action",
+        message="Blocked secondary action by capability policy",
+        metadata={
+            "stage": "secondary_action",
+            "status": "blocked",
+            "rule": "capability_policy",
+            "capability_id": action_id,
+            "capability_type": "adapter_action",
+            "action_id": action_id,
+            "deny_reason": deny_reason or "capability_policy_blocked",
+            "task_type": task_type,
+            "policy_profile_id": policy_profile_id,
+        },
+    )
+    runtime_events.append(
+        governance_audit_runtime_event(
+            request=request,
+            status="blocked",
+            audit_record=audit_record,
+        )
+    )
+
+
+def _record_secondary_action_decision(
+    decisions: list[Dict[str, Any]],
+    *,
+    action_id: str,
+    decision: str,
+    reason: Optional[str],
+    success: bool,
+) -> None:
+    decisions.append(
+        {
+            "action_id": action_id,
+            "decision": decision,
+            "reason": reason,
+            "success": bool(success),
+        }
     )
 
 
@@ -1391,6 +1444,8 @@ def build_default_execution_bus(
             governed_secondary_action_ids = sorted([item for item in involved_action_ids if item != "adapter:jira:read_issue"])
             blocked_secondary_action_ids: list[str] = []
             applied_secondary_action_ids: list[str] = []
+            blocked_secondary_action_reasons: Dict[str, str] = {}
+            secondary_action_decisions: list[Dict[str, Any]] = []
             workflow_payload = {
                 "issue_key": _get_required(request.input_payload, "issue_key"),
                 "skill_name": request.input_payload.get("skill_name"),
@@ -1417,6 +1472,7 @@ def build_default_execution_bus(
                 decision = _evaluate_secondary_action_gate(request=request, action_id=action_id)
                 if decision is not None:
                     blocked_secondary_action_ids.append(action_id)
+                    blocked_secondary_action_reasons[action_id] = str(decision.get("reason") or "capability_policy_blocked")
                     return {
                         "blocked": True,
                         "reason": decision.get("reason"),
@@ -1441,6 +1497,57 @@ def build_default_execution_bus(
                         "secondary_action_id": blocked_action_id,
                     },
                 )
+                _append_secondary_governance_audit_event(
+                    runtime_events=runtime_events,
+                    request=request,
+                    task_type=task_type,
+                    action_id=blocked_action_id,
+                    deny_reason=blocked_secondary_action_reasons.get(blocked_action_id),
+                )
+            actions_applied = workflow_result.get("actions_applied") if isinstance(workflow_result.get("actions_applied"), list) else []
+            action_results_by_id: Dict[str, Dict[str, Any]] = {}
+            for action_item in actions_applied:
+                if not isinstance(action_item, dict):
+                    continue
+                action_name = str(action_item.get("action") or "").strip().lower()
+                if not action_name:
+                    continue
+                action_results_by_id[_action_name_to_capability_id("jira", action_name)] = action_item
+
+            for governed_action_id in governed_secondary_action_ids:
+                action_result = action_results_by_id.get(governed_action_id) or {}
+                if governed_action_id in blocked_secondary_action_ids or bool(action_result.get("blocked")):
+                    _record_secondary_action_decision(
+                        secondary_action_decisions,
+                        action_id=governed_action_id,
+                        decision="blocked",
+                        reason=str(action_result.get("error") or blocked_secondary_action_reasons.get(governed_action_id) or "capability_policy_blocked"),
+                        success=False,
+                    )
+                elif action_result.get("success") is True:
+                    _record_secondary_action_decision(
+                        secondary_action_decisions,
+                        action_id=governed_action_id,
+                        decision="applied",
+                        reason=None,
+                        success=True,
+                    )
+                elif action_result:
+                    _record_secondary_action_decision(
+                        secondary_action_decisions,
+                        action_id=governed_action_id,
+                        decision="failed",
+                        reason=str(action_result.get("error") or "action_failed"),
+                        success=False,
+                    )
+                else:
+                    _record_secondary_action_decision(
+                        secondary_action_decisions,
+                        action_id=governed_action_id,
+                        decision="allowed",
+                        reason="not_invoked",
+                        success=False,
+                    )
             runtime_events.append(
                 build_runtime_event(
                     event_type="task.jira_workflow_review.completed" if workflow_result.get("success") else "task.jira_workflow_review.failed",
@@ -1463,6 +1570,7 @@ def build_default_execution_bus(
                         "governed_secondary_action_ids": governed_secondary_action_ids,
                         "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
                         "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
+                        "secondary_action_decisions": secondary_action_decisions,
                         "issue_key": workflow_result.get("issue_key"),
                         "skill_name": workflow_result.get("skill_name") or workflow_payload.get("skill_name"),
                         "workflow_outcome": workflow_result.get("workflow_outcome"),
@@ -1494,6 +1602,7 @@ def build_default_execution_bus(
                     "governed_secondary_action_ids": governed_secondary_action_ids,
                     "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
                     "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
+                    "secondary_action_decisions": secondary_action_decisions,
                     "resolved_skill_capability_id": f"skill:{str(workflow_payload.get('skill_name') or '').strip().lower()}" if workflow_payload.get("skill_name") else None,
                     "workflow_outcome": workflow_result.get("workflow_outcome"),
                     "actions_applied": workflow_result.get("actions_applied") or [],
@@ -1538,6 +1647,7 @@ def build_default_execution_bus(
             governed_secondary_action_ids = [secondary_action_id]
             blocked_secondary_action_ids: list[str] = []
             applied_secondary_action_ids: list[str] = []
+            secondary_action_decisions: list[Dict[str, Any]] = []
 
             if review_result.get("success"):
                 comment_body = review_summary if isinstance(review_summary, str) and review_summary.strip() else review_comment_input
@@ -1559,6 +1669,20 @@ def build_default_execution_bus(
                                 "reason": secondary_gate.get("reason"),
                                 "message": secondary_gate.get("message"),
                             },
+                        )
+                        _append_secondary_governance_audit_event(
+                            runtime_events=runtime_events,
+                            request=request,
+                            task_type=task_type,
+                            action_id=secondary_action_id,
+                            deny_reason=str(secondary_gate.get("reason") or "capability_policy_blocked"),
+                        )
+                        _record_secondary_action_decision(
+                            secondary_action_decisions,
+                            action_id=secondary_action_id,
+                            decision="blocked",
+                            reason=str(secondary_gate.get("reason") or "capability_policy_blocked"),
+                            success=False,
                         )
                     else:
                         applied_secondary_action_ids.append(secondary_action_id)
@@ -1590,8 +1714,38 @@ def build_default_execution_bus(
                         )
                         if not comment_written:
                             error_value = add_comment_result.get("error") or "Failed to write GitHub review comment"
+                            _record_secondary_action_decision(
+                                secondary_action_decisions,
+                                action_id=secondary_action_id,
+                                decision="failed",
+                                reason=str(add_comment_result.get("error") or "action_failed"),
+                                success=False,
+                            )
+                        else:
+                            _record_secondary_action_decision(
+                                secondary_action_decisions,
+                                action_id=secondary_action_id,
+                                decision="applied",
+                                reason=None,
+                                success=True,
+                            )
                 else:
                     error_value = "Review succeeded but no summary/comment text available for write-back"
+                    _record_secondary_action_decision(
+                        secondary_action_decisions,
+                        action_id=secondary_action_id,
+                        decision="failed",
+                        reason="missing_comment_body",
+                        success=False,
+                    )
+            elif not secondary_action_decisions:
+                _record_secondary_action_decision(
+                    secondary_action_decisions,
+                    action_id=secondary_action_id,
+                    decision="allowed",
+                    reason="primary_action_failed",
+                    success=False,
+                )
 
             success_value = bool(review_result.get("success")) and comment_written and not error_value
             runtime_events.append(
@@ -1616,6 +1770,7 @@ def build_default_execution_bus(
                         "governed_secondary_action_ids": governed_secondary_action_ids,
                         "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
                         "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
+                        "secondary_action_decisions": secondary_action_decisions,
                         "owner": owner,
                         "repo": repo,
                         "pull_number": pull_number,
@@ -1652,6 +1807,7 @@ def build_default_execution_bus(
                     "governed_secondary_action_ids": governed_secondary_action_ids,
                     "blocked_secondary_action_ids": sorted(set(blocked_secondary_action_ids)),
                     "applied_secondary_action_ids": sorted(set(applied_secondary_action_ids)),
+                    "secondary_action_decisions": secondary_action_decisions,
                     "secondary_action_attempted": secondary_action_attempted,
                     "secondary_action_id": secondary_action_id,
                     "secondary_action_success": secondary_action_success,

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -19,6 +19,7 @@ from src.runtime.contracts import (
     make_execution_request,
     make_execution_result,
 )
+from src.runtime.task_capability_contracts import resolve_task_capability_contract
 from src.runtime.events import build_runtime_event
 from src.runtime.governance import GovernanceHooks, as_governance_bus
 from src.runtime.governance_bus import (
@@ -546,125 +547,11 @@ def _as_list_of_strings(value: Any) -> list[str]:
 
 
 def resolve_task_capability_plan(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-    normalized_task_type = str(task_type or "").strip().lower()
-    registry = get_capability_registry()
-    fallback: Dict[str, Any] = {
-        "primary_capability_id": None,
-        "capability_id": None,
-        "capability_type": None,
-        "involved_capability_ids": [],
-        "policy_tags": [],
-        "requires_identity_binding": False,
-        "capability_resolution": "unresolved",
-    }
-    if normalized_task_type == "adapter_action_task":
-        action_id = str(payload.get("action_id") or "").strip().lower()
-        descriptor = registry.get(action_id) if action_id else None
-        if descriptor is None:
-            return {**fallback, "primary_capability_id": action_id or None, "capability_id": action_id or None, "action_id": action_id or None}
-        plan = {
-            **fallback,
-            "primary_capability_id": descriptor.capability_id,
-            "capability_id": descriptor.capability_id,
-            "capability_type": descriptor.type,
-            "involved_capability_ids": [descriptor.capability_id],
-            "policy_tags": list(descriptor.policy_tags or []),
-            "requires_identity_binding": bool(descriptor.requires_identity_binding),
-            "capability_resolution": "resolved",
-            "action_id": descriptor.capability_id,
-        }
-        return plan
-    if normalized_task_type == "jira_workflow_review_task":
-        descriptor = registry.get("adapter:jira:read_issue")
-        if descriptor is None:
-            return {
-                **fallback,
-                "involved_capability_ids": _resolve_involved_capability_ids(task_type, payload),
-            }
-        return {
-            **fallback,
-            "primary_capability_id": descriptor.capability_id,
-            "capability_id": descriptor.capability_id,
-            "capability_type": descriptor.type,
-            "involved_capability_ids": _resolve_involved_capability_ids(task_type, payload),
-            "policy_tags": list(descriptor.policy_tags or []),
-            "requires_identity_binding": bool(descriptor.requires_identity_binding),
-            "capability_resolution": "resolved",
-            "action_id": descriptor.capability_id,
-        }
-    if normalized_task_type == "github_review_task":
-        descriptor = registry.get("adapter:github:review_pull_request")
-        if descriptor is None:
-            return {
-                **fallback,
-                "involved_capability_ids": _resolve_involved_capability_ids(task_type, payload),
-            }
-        return {
-            **fallback,
-            "primary_capability_id": descriptor.capability_id,
-            "capability_id": descriptor.capability_id,
-            "capability_type": descriptor.type,
-            "involved_capability_ids": _resolve_involved_capability_ids(task_type, payload),
-            "policy_tags": list(descriptor.policy_tags or []),
-            "requires_identity_binding": bool(descriptor.requires_identity_binding),
-            "capability_resolution": "resolved",
-            "action_id": descriptor.capability_id,
-        }
-    if normalized_task_type == "delegation_task":
-        skill_name = _non_empty_string(payload.get("skill_name"))
-        if not skill_name:
-            return fallback
-        capability_id = f"skill:{skill_name.lower()}"
-        descriptor = registry.get(capability_id)
-        if descriptor is None:
-            return {
-                **fallback,
-                "primary_capability_id": capability_id,
-                "capability_id": capability_id,
-                "capability_type": "skill",
-                "capability_resolution": "unresolved",
-                "involved_capability_ids": [capability_id],
-            }
-        return {
-            **fallback,
-            "primary_capability_id": descriptor.capability_id,
-            "capability_id": descriptor.capability_id,
-            "capability_type": descriptor.type,
-            "involved_capability_ids": [descriptor.capability_id],
-            "policy_tags": list(descriptor.policy_tags or []),
-            "requires_identity_binding": bool(descriptor.requires_identity_binding),
-            "capability_resolution": "resolved",
-        }
-    return fallback
+    return resolve_task_capability_contract(task_type, payload)
 
 
 def _resolve_task_capability(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     return resolve_task_capability_plan(task_type, payload)
-
-
-def _resolve_involved_capability_ids(task_type: str, payload: Dict[str, Any]) -> list[str]:
-    normalized_task_type = str(task_type or "").strip().lower()
-    if normalized_task_type == "jira_workflow_review_task":
-        involved = {"adapter:jira:read_issue"}
-        has_transition = any(payload.get(key) for key in ("transition", "success_transition", "failure_transition"))
-        has_assign = any(
-            payload.get(key)
-            for key in ("assignee", "success_reassign_to", "failure_reassign_to", "explicit_success_assignee", "explicit_failure_assignee")
-        )
-        has_comment = any(payload.get(key) for key in ("review_comment", "review_comment_template", "transition_comment"))
-        has_update = bool(payload.get("fields"))
-        if has_transition:
-            involved.add("adapter:jira:transition_issue")
-        if has_assign:
-            involved.add("adapter:jira:assign_issue")
-        if has_comment:
-            involved.add("adapter:jira:add_comment")
-        if has_update:
-            involved.add("adapter:jira:update_issue")
-        return sorted(involved)
-    if normalized_task_type == "github_review_task":
-        return ["adapter:github:add_comment", "adapter:github:review_pull_request"]
-    return []
 
 
 async def _execute_adapter_action_task(

--- a/src/runtime/governance_bus.py
+++ b/src/runtime/governance_bus.py
@@ -340,6 +340,8 @@ def _resolve_capability_context(request: ExecutionRequest) -> Dict[str, Optional
     action_id: Optional[str] = None
     if request.execution_type == "task":
         if task_type in {"adapter_action_task", "jira_workflow_review_task", "github_review_task", "delegation_task"}:
+            # Governance intentionally follows the same canonical wrapper-task
+            # contract used by execution to avoid split sources of truth.
             plan = resolve_task_capability_contract(task_type, payload)
             capability_id = str(plan.get("primary_capability_id") or plan.get("capability_id") or "").strip().lower() or None
             action_id = str(plan.get("action_id") or capability_id or "").strip().lower() or None

--- a/src/runtime/governance_bus.py
+++ b/src/runtime/governance_bus.py
@@ -364,29 +364,165 @@ def _evaluate_capability_constraints(
     capability_type: Optional[str],
     action_id: Optional[str],
 ) -> Optional[Dict[str, str]]:
-    denied_capability_ids = _as_lower_str_list(metadata.get("denied_capability_ids"))
-    allowed_capability_ids = _as_lower_str_list(metadata.get("allowed_capability_ids"))
-    denied_capability_types = _as_lower_str_list(metadata.get("denied_capability_types"))
-    allowed_capability_types = _as_lower_str_list(metadata.get("allowed_capability_types"))
-    denied_adapter_actions = _as_lower_str_list(metadata.get("denied_adapter_actions"))
-    allowed_adapter_actions = _as_lower_str_list(metadata.get("allowed_adapter_actions"))
+    denied_capability_ids = _normalize_constraint_capability_ids(
+        metadata.get("denied_capability_ids"),
+        capability_type=capability_type,
+        action_id=action_id,
+    )
+    allowed_capability_ids = _normalize_constraint_capability_ids(
+        metadata.get("allowed_capability_ids"),
+        capability_type=capability_type,
+        action_id=action_id,
+    )
+    denied_capability_types = _normalize_constraint_capability_types(metadata.get("denied_capability_types"))
+    allowed_capability_types = _normalize_constraint_capability_types(metadata.get("allowed_capability_types"))
+    denied_adapter_actions = _normalize_action_constraints(
+        metadata.get("denied_adapter_actions"),
+        metadata.get("denied_actions"),
+    )
+    allowed_adapter_actions = _normalize_action_constraints(
+        metadata.get("allowed_adapter_actions"),
+        metadata.get("allowed_actions"),
+    )
 
     normalized_capability_id = str(capability_id or "").strip().lower()
     normalized_capability_type = str(capability_type or "").strip().lower()
     normalized_action_id = str(action_id or "").strip().lower()
+    normalized_action_name = normalized_action_id.split(":")[-1] if normalized_action_id else ""
 
-    if denied_capability_ids and normalized_capability_id and normalized_capability_id in denied_capability_ids:
+    if _matches_capability_constraint(
+        constraints=denied_capability_ids,
+        capability_id=normalized_capability_id,
+        capability_type=normalized_capability_type,
+        action_name=normalized_action_name,
+    ):
         return {"reason": "denied_capability_ids", "message": f"Capability blocked: {normalized_capability_id}"}
     if denied_capability_types and normalized_capability_type and normalized_capability_type in denied_capability_types:
         return {"reason": "denied_capability_types", "message": f"Capability type blocked: {normalized_capability_type}"}
-    if denied_adapter_actions and normalized_action_id and normalized_action_id in denied_adapter_actions:
+    if _matches_action_constraint(
+        constraints=denied_adapter_actions,
+        action_id=normalized_action_id,
+        action_name=normalized_action_name,
+    ):
         return {"reason": "denied_adapter_actions", "message": f"Adapter action blocked: {normalized_action_id}"}
 
-    if allowed_capability_ids and (not normalized_capability_id or normalized_capability_id not in allowed_capability_ids):
+    if allowed_capability_ids and not _matches_capability_constraint(
+        constraints=allowed_capability_ids,
+        capability_id=normalized_capability_id,
+        capability_type=normalized_capability_type,
+        action_name=normalized_action_name,
+    ):
         return {"reason": "allowed_capability_ids", "message": "Capability not in allowlist"}
     if allowed_capability_types and (not normalized_capability_type or normalized_capability_type not in allowed_capability_types):
         return {"reason": "allowed_capability_types", "message": "Capability type not in allowlist"}
-    if allowed_adapter_actions and (not normalized_action_id or normalized_action_id not in allowed_adapter_actions):
+    if allowed_adapter_actions and not _matches_action_constraint(
+        constraints=allowed_adapter_actions,
+        action_id=normalized_action_id,
+        action_name=normalized_action_name,
+    ):
         return {"reason": "allowed_adapter_actions", "message": "Adapter action not in allowlist"}
 
     return None
+
+
+def evaluate_capability_constraint_decision(
+    *,
+    metadata: Dict[str, Any],
+    capability_id: Optional[str],
+    capability_type: Optional[str],
+    action_id: Optional[str],
+) -> Optional[Dict[str, str]]:
+    return _evaluate_capability_constraints(
+        metadata=metadata,
+        capability_id=capability_id,
+        capability_type=capability_type,
+        action_id=action_id,
+    )
+
+
+def _normalize_constraint_capability_ids(value: Any, *, capability_type: Optional[str], action_id: Optional[str]) -> list[str]:
+    entries = _as_lower_str_list(value)
+    normalized: list[str] = []
+    for entry in entries:
+        if ":" in entry:
+            normalized.append(entry)
+            continue
+        expanded = _expand_capability_name_candidates(
+            entry,
+            capability_type=capability_type,
+            action_id=action_id,
+        )
+        normalized.extend(expanded)
+    return sorted(set(normalized))
+
+
+def _normalize_constraint_capability_types(value: Any) -> list[str]:
+    alias_map = {
+        "action": "adapter_action",
+        "adapter": "adapter_action",
+        "channel": "channel_action",
+        "tool": "tool",
+        "skill": "skill",
+        "adapter_action": "adapter_action",
+        "channel_action": "channel_action",
+    }
+    normalized: list[str] = []
+    for item in _as_lower_str_list(value):
+        mapped = alias_map.get(item)
+        if mapped:
+            normalized.append(mapped)
+    return sorted(set(normalized))
+
+
+def _expand_capability_name_candidates(
+    name: str,
+    *,
+    capability_type: Optional[str],
+    action_id: Optional[str],
+) -> list[str]:
+    normalized_name = str(name or "").strip().lower()
+    normalized_type = str(capability_type or "").strip().lower()
+    if not normalized_name:
+        return []
+    if normalized_type == "tool":
+        return [f"tool:{normalized_name}"]
+    if normalized_type == "skill":
+        return [f"skill:{normalized_name}"]
+    if normalized_type == "channel_action":
+        return [f"channel_action:{normalized_name}"]
+    if normalized_type == "adapter_action":
+        return [f"adapter_action_name:{normalized_name}"]
+    if str(action_id or "").strip().lower():
+        return [f"adapter_action_name:{normalized_name}"]
+    return [normalized_name]
+
+
+def _normalize_action_constraints(*values: Any) -> list[str]:
+    normalized: list[str] = []
+    for value in values:
+        normalized.extend(_as_lower_str_list(value))
+    return sorted(set(normalized))
+
+
+def _matches_capability_constraint(
+    *,
+    constraints: list[str],
+    capability_id: str,
+    capability_type: str,
+    action_name: str,
+) -> bool:
+    if not constraints:
+        return False
+    for constraint in constraints:
+        if constraint == capability_id:
+            return True
+        if constraint.startswith("adapter_action_name:") and capability_type == "adapter_action":
+            if constraint.split(":", 1)[1] == action_name:
+                return True
+    return False
+
+
+def _matches_action_constraint(*, constraints: list[str], action_id: str, action_name: str) -> bool:
+    if not constraints:
+        return False
+    return action_id in constraints or action_name in constraints

--- a/src/runtime/governance_bus.py
+++ b/src/runtime/governance_bus.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 import uuid
 
 from src.agents.tool_result_policy import should_passthrough_tool_result
+from src.runtime.capability_registry import get_capability_registry
 from src.runtime.contracts import ExecutionRequest, ExecutionResult, make_execution_result
 from src.runtime.events import build_runtime_event
 from src.utils.redaction import safe_preview
@@ -105,6 +106,31 @@ class DefaultGovernanceBus(GovernanceBus):
     async def before_execute(self, request: ExecutionRequest) -> GovernanceDecision:
         metadata = request.metadata if isinstance(request.metadata, dict) else {}
         policy_profile = request.policy_profile_id or metadata.get("policy_profile_id") or "default"
+        capability_context = _resolve_capability_context(request)
+
+        capability_decision = _evaluate_capability_constraints(
+            metadata=metadata,
+            capability_id=capability_context.get("capability_id"),
+            capability_type=capability_context.get("capability_type"),
+            action_id=capability_context.get("action_id"),
+        )
+        if capability_decision is not None:
+            deny_reason = capability_decision.get("reason") or "capability_policy_blocked"
+            audit = make_governance_audit_record(
+                request=request,
+                stage="before_execute",
+                message=capability_decision.get("message") or "Blocked by capability allow/deny policy",
+                metadata={
+                    "policy_profile_id": policy_profile,
+                    "rule": "capability_policy",
+                    "execution_type": request.execution_type,
+                    "capability_id": capability_context.get("capability_id"),
+                    "capability_type": capability_context.get("capability_type"),
+                    "action_id": capability_context.get("action_id"),
+                    "deny_reason": deny_reason,
+                },
+            )
+            return GovernanceDecision(allowed=False, reason=deny_reason, audit_record=audit)
 
         if metadata.get("auto_run") is True and metadata.get("governance_require_explicit_allow") is True:
             if metadata.get("governance_allow_auto_run") is not True:
@@ -264,3 +290,103 @@ def build_default_governance_bus() -> GovernanceBus:
 
 class NoopGovernanceBus(GovernanceBus):
     """Explicit no-op governance implementation for compatibility paths."""
+
+
+def _as_lower_str_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    for item in value:
+        if item is None:
+            continue
+        text = str(item).strip().lower()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def _resolve_capability_context(request: ExecutionRequest) -> Dict[str, Optional[str]]:
+    payload = request.input_payload if isinstance(request.input_payload, dict) else {}
+    metadata = request.metadata if isinstance(request.metadata, dict) else {}
+    task_type = str(payload.get("task_type") or "").strip().lower()
+
+    capability_id: Optional[str] = None
+    action_id: Optional[str] = None
+    if request.execution_type == "task":
+        if task_type == "adapter_action_task":
+            action_id = str(payload.get("action_id") or "").strip().lower() or None
+            capability_id = action_id
+        elif task_type == "jira_workflow_review_task":
+            capability_id = "adapter:jira:read_issue"
+            action_id = capability_id
+        elif task_type == "github_review_task":
+            capability_id = "adapter:github:review_pull_request"
+            action_id = capability_id
+        elif task_type == "tool_task":
+            tool_name = str(payload.get("tool_name") or "").strip().lower()
+            capability_id = f"tool:{tool_name}" if tool_name else None
+        elif task_type == "delegation_task":
+            skill_name = str(payload.get("skill_name") or "").strip().lower()
+            capability_id = f"skill:{skill_name}" if skill_name else None
+    elif request.execution_type == "tool":
+        tool_name = str(payload.get("tool_name") or metadata.get("tool_name") or "").strip().lower()
+        capability_id = f"tool:{tool_name}" if tool_name else None
+    elif request.execution_type == "skill":
+        skill_name = str(payload.get("skill_name") or "").strip().lower()
+        capability_id = f"skill:{skill_name}" if skill_name else None
+
+    descriptor = get_capability_registry().get(capability_id) if capability_id else None
+    capability_type = descriptor.type if descriptor is not None else _infer_capability_type_from_id(capability_id)
+    return {
+        "capability_id": capability_id,
+        "capability_type": capability_type,
+        "action_id": action_id,
+    }
+
+
+def _infer_capability_type_from_id(capability_id: Optional[str]) -> Optional[str]:
+    text = str(capability_id or "").strip().lower()
+    if text.startswith("adapter:"):
+        return "adapter_action"
+    if text.startswith("tool:"):
+        return "tool"
+    if text.startswith("skill:"):
+        return "skill"
+    if text.startswith("channel_action:"):
+        return "channel_action"
+    return None
+
+
+def _evaluate_capability_constraints(
+    *,
+    metadata: Dict[str, Any],
+    capability_id: Optional[str],
+    capability_type: Optional[str],
+    action_id: Optional[str],
+) -> Optional[Dict[str, str]]:
+    denied_capability_ids = _as_lower_str_list(metadata.get("denied_capability_ids"))
+    allowed_capability_ids = _as_lower_str_list(metadata.get("allowed_capability_ids"))
+    denied_capability_types = _as_lower_str_list(metadata.get("denied_capability_types"))
+    allowed_capability_types = _as_lower_str_list(metadata.get("allowed_capability_types"))
+    denied_adapter_actions = _as_lower_str_list(metadata.get("denied_adapter_actions"))
+    allowed_adapter_actions = _as_lower_str_list(metadata.get("allowed_adapter_actions"))
+
+    normalized_capability_id = str(capability_id or "").strip().lower()
+    normalized_capability_type = str(capability_type or "").strip().lower()
+    normalized_action_id = str(action_id or "").strip().lower()
+
+    if denied_capability_ids and normalized_capability_id and normalized_capability_id in denied_capability_ids:
+        return {"reason": "denied_capability_ids", "message": f"Capability blocked: {normalized_capability_id}"}
+    if denied_capability_types and normalized_capability_type and normalized_capability_type in denied_capability_types:
+        return {"reason": "denied_capability_types", "message": f"Capability type blocked: {normalized_capability_type}"}
+    if denied_adapter_actions and normalized_action_id and normalized_action_id in denied_adapter_actions:
+        return {"reason": "denied_adapter_actions", "message": f"Adapter action blocked: {normalized_action_id}"}
+
+    if allowed_capability_ids and (not normalized_capability_id or normalized_capability_id not in allowed_capability_ids):
+        return {"reason": "allowed_capability_ids", "message": "Capability not in allowlist"}
+    if allowed_capability_types and (not normalized_capability_type or normalized_capability_type not in allowed_capability_types):
+        return {"reason": "allowed_capability_types", "message": "Capability type not in allowlist"}
+    if allowed_adapter_actions and (not normalized_action_id or normalized_action_id not in allowed_adapter_actions):
+        return {"reason": "allowed_adapter_actions", "message": "Adapter action not in allowlist"}
+
+    return None

--- a/src/runtime/governance_bus.py
+++ b/src/runtime/governance_bus.py
@@ -10,6 +10,7 @@ from src.agents.tool_result_policy import should_passthrough_tool_result
 from src.runtime.capability_registry import get_capability_registry
 from src.runtime.contracts import ExecutionRequest, ExecutionResult, make_execution_result
 from src.runtime.events import build_runtime_event
+from src.runtime.task_capability_contracts import resolve_task_capability_contract
 from src.utils.redaction import safe_preview
 
 _ALLOWED_RESULT_STATUSES = {"success", "error", "blocked", "queued", "started"}
@@ -339,9 +340,7 @@ def _resolve_capability_context(request: ExecutionRequest) -> Dict[str, Optional
     action_id: Optional[str] = None
     if request.execution_type == "task":
         if task_type in {"adapter_action_task", "jira_workflow_review_task", "github_review_task", "delegation_task"}:
-            from src.runtime.execution_bus import resolve_task_capability_plan
-
-            plan = resolve_task_capability_plan(task_type, payload)
+            plan = resolve_task_capability_contract(task_type, payload)
             capability_id = str(plan.get("primary_capability_id") or plan.get("capability_id") or "").strip().lower() or None
             action_id = str(plan.get("action_id") or capability_id or "").strip().lower() or None
         elif task_type == "tool_task":

--- a/src/runtime/governance_bus.py
+++ b/src/runtime/governance_bus.py
@@ -132,6 +132,31 @@ class DefaultGovernanceBus(GovernanceBus):
             )
             return GovernanceDecision(allowed=False, reason=deny_reason, audit_record=audit)
 
+        identity_decision = _evaluate_identity_binding_constraints(
+            request=request,
+            metadata=metadata,
+            capability_id=capability_context.get("capability_id"),
+            capability_type=capability_context.get("capability_type"),
+            requires_identity_binding=bool(capability_context.get("requires_identity_binding")),
+        )
+        if identity_decision is not None:
+            deny_reason = identity_decision.get("reason") or "missing_identity_binding"
+            audit = make_governance_audit_record(
+                request=request,
+                stage="before_execute",
+                message=identity_decision.get("message") or "Blocked by identity binding policy",
+                metadata={
+                    "policy_profile_id": policy_profile,
+                    "rule": "identity_binding",
+                    "execution_type": request.execution_type,
+                    "capability_id": capability_context.get("capability_id"),
+                    "capability_type": capability_context.get("capability_type"),
+                    "deny_reason": deny_reason,
+                    **(identity_decision.get("metadata") or {}),
+                },
+            )
+            return GovernanceDecision(allowed=False, reason=deny_reason, audit_record=audit)
+
         if metadata.get("auto_run") is True and metadata.get("governance_require_explicit_allow") is True:
             if metadata.get("governance_allow_auto_run") is not True:
                 audit = make_governance_audit_record(
@@ -341,6 +366,7 @@ def _resolve_capability_context(request: ExecutionRequest) -> Dict[str, Optional
         "capability_id": capability_id,
         "capability_type": capability_type,
         "action_id": action_id,
+        "requires_identity_binding": bool(descriptor.requires_identity_binding) if descriptor is not None else False,
     }
 
 
@@ -526,3 +552,81 @@ def _matches_action_constraint(*, constraints: list[str], action_id: str, action
     if not constraints:
         return False
     return action_id in constraints or action_name in constraints
+
+
+def _evaluate_identity_binding_constraints(
+    *,
+    request: ExecutionRequest,
+    metadata: Dict[str, Any],
+    capability_id: Optional[str],
+    capability_type: Optional[str],
+    requires_identity_binding: bool,
+) -> Optional[Dict[str, Any]]:
+    normalized_type = str(capability_type or "").strip().lower()
+    if not requires_identity_binding or normalized_type not in {"adapter_action", "channel_action"}:
+        return None
+    if not _is_external_or_task_like_request(request):
+        return None
+
+    binding = _extract_identity_binding(metadata)
+    if not binding:
+        return {"reason": "missing_identity_binding", "message": "Missing required identity binding metadata"}
+
+    expected_systems = _expected_identity_binding_systems(capability_id=capability_id, capability_type=normalized_type)
+    binding_system = str(binding.get("system_type") or "").strip().lower()
+    if expected_systems and binding_system and binding_system not in expected_systems:
+        return {
+            "reason": "identity_binding_system_mismatch",
+            "message": "Identity binding system does not match capability target",
+            "metadata": {"expected_system_type": sorted(expected_systems), "provided_system_type": binding_system},
+        }
+    return None
+
+
+def _is_external_or_task_like_request(request: ExecutionRequest) -> bool:
+    metadata = request.metadata if isinstance(request.metadata, dict) else {}
+    if request.execution_type in {"task", "event", "subagent"}:
+        return True
+    if request.source_type in {"github", "jira", "portal", "internal"}:
+        return True
+    return metadata.get("external_triggered") is True
+
+
+def _extract_identity_binding(metadata: Dict[str, Any]) -> Optional[Dict[str, str]]:
+    nested = metadata.get("identity_binding")
+    if isinstance(nested, dict):
+        system_type = str(nested.get("system_type") or "").strip().lower()
+        binding_id = str(nested.get("id") or nested.get("identity_binding_id") or "").strip()
+        external_account_id = str(nested.get("external_account_id") or "").strip()
+        if system_type and (binding_id or external_account_id):
+            return {
+                "id": binding_id,
+                "system_type": system_type,
+                "external_account_id": external_account_id,
+            }
+
+    system_type = str(metadata.get("identity_binding_system_type") or "").strip().lower()
+    binding_id = str(metadata.get("identity_binding_id") or "").strip()
+    external_account_id = str(metadata.get("identity_binding_external_account_id") or "").strip()
+    if system_type and (binding_id or external_account_id):
+        return {
+            "id": binding_id,
+            "system_type": system_type,
+            "external_account_id": external_account_id,
+        }
+    return None
+
+
+def _expected_identity_binding_systems(*, capability_id: Optional[str], capability_type: str) -> set[str]:
+    normalized_id = str(capability_id or "").strip().lower()
+    if capability_type == "adapter_action" and normalized_id.startswith("adapter:"):
+        parts = normalized_id.split(":")
+        if len(parts) > 1 and parts[1]:
+            return {parts[1]}
+    if capability_type == "channel_action" and normalized_id.startswith("channel_action:"):
+        name = normalized_id.split(":", 1)[1]
+        if name.startswith("jira_"):
+            return {"jira"}
+        if name.startswith("confluence_"):
+            return {"confluence"}
+    return set()

--- a/src/runtime/governance_bus.py
+++ b/src/runtime/governance_bus.py
@@ -338,21 +338,15 @@ def _resolve_capability_context(request: ExecutionRequest) -> Dict[str, Optional
     capability_id: Optional[str] = None
     action_id: Optional[str] = None
     if request.execution_type == "task":
-        if task_type == "adapter_action_task":
-            action_id = str(payload.get("action_id") or "").strip().lower() or None
-            capability_id = action_id
-        elif task_type == "jira_workflow_review_task":
-            capability_id = "adapter:jira:read_issue"
-            action_id = capability_id
-        elif task_type == "github_review_task":
-            capability_id = "adapter:github:review_pull_request"
-            action_id = capability_id
+        if task_type in {"adapter_action_task", "jira_workflow_review_task", "github_review_task", "delegation_task"}:
+            from src.runtime.execution_bus import resolve_task_capability_plan
+
+            plan = resolve_task_capability_plan(task_type, payload)
+            capability_id = str(plan.get("primary_capability_id") or plan.get("capability_id") or "").strip().lower() or None
+            action_id = str(plan.get("action_id") or capability_id or "").strip().lower() or None
         elif task_type == "tool_task":
             tool_name = str(payload.get("tool_name") or "").strip().lower()
             capability_id = f"tool:{tool_name}" if tool_name else None
-        elif task_type == "delegation_task":
-            skill_name = str(payload.get("skill_name") or "").strip().lower()
-            capability_id = f"skill:{skill_name}" if skill_name else None
     elif request.execution_type == "tool":
         tool_name = str(payload.get("tool_name") or metadata.get("tool_name") or "").strip().lower()
         capability_id = f"tool:{tool_name}" if tool_name else None
@@ -585,7 +579,7 @@ def _evaluate_identity_binding_constraints(
 
 def _is_external_or_task_like_request(request: ExecutionRequest) -> bool:
     metadata = request.metadata if isinstance(request.metadata, dict) else {}
-    if request.execution_type in {"task", "event", "subagent"}:
+    if request.execution_type in {"event", "subagent"}:
         return True
     if request.source_type in {"github", "jira", "portal", "internal"}:
         return True

--- a/src/runtime/jira_workflow_review.py
+++ b/src/runtime/jira_workflow_review.py
@@ -31,6 +31,7 @@ def _event(event_type: str, state: str, issue_key: str, detail_payload: Dict[str
 
 async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
     plan = normalize_workflow_review_payload(payload)
+    action_gate = payload.get("_action_gate") if callable(payload.get("_action_gate")) else None
     if not plan.issue_key:
         return _build_failure(
             issue_key=None,
@@ -85,8 +86,13 @@ async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
             actions_applied,
             "add_comment",
             {"issue_key": plan.issue_key, "comment": action_plan.get("comment")},
+            action_gate=action_gate,
         )
-        if not comment_outcome.get("success"):
+        if comment_outcome.get("blocked"):
+            runtime_events.append(
+                _event("task.jira_workflow_review.action.blocked", "blocked", plan.issue_key, {"action": "add_comment", "error": comment_outcome.get("error")})
+            )
+        elif not comment_outcome.get("success"):
             return _build_failure(
                 issue_key=plan.issue_key,
                 error=comment_outcome.get("error") or "comment_failed",
@@ -104,8 +110,13 @@ async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
             actions_applied,
             "update_issue",
             {"issue_key": plan.issue_key, "fields": action_plan.get("fields")},
+            action_gate=action_gate,
         )
-        if not update_outcome.get("success"):
+        if update_outcome.get("blocked"):
+            runtime_events.append(
+                _event("task.jira_workflow_review.action.blocked", "blocked", plan.issue_key, {"action": "update_issue", "error": update_outcome.get("error")})
+            )
+        elif not update_outcome.get("success"):
             return _build_failure(
                 issue_key=plan.issue_key,
                 error=update_outcome.get("error") or "update_failed",
@@ -127,6 +138,7 @@ async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
                 "transition": action_plan.get("transition"),
                 "comment": action_plan.get("transition_comment"),
             },
+            action_gate=action_gate,
         )
         if not transition_outcome.get("success"):
             return _build_failure(
@@ -146,6 +158,7 @@ async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
             actions_applied,
             "assign_issue",
             {"issue_key": plan.issue_key, "assignee": action_plan.get("assignee")},
+            action_gate=action_gate,
         )
         if not assign_outcome.get("success"):
             return _build_failure(
@@ -234,13 +247,38 @@ async def _resolve_review_outcome(plan, issue_snapshot: Any) -> JiraWorkflowRevi
     return normalize_skill_review_outcome(skill_result)
 
 
-async def _apply_action(actions_applied: List[Dict[str, Any]], action_name: str, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+async def _apply_action(
+    actions_applied: List[Dict[str, Any]],
+    action_name: str,
+    kwargs: Dict[str, Any],
+    *,
+    action_gate: Any = None,
+) -> Dict[str, Any]:
+    if callable(action_gate):
+        gate_outcome = action_gate(action_name, kwargs)
+        if isinstance(gate_outcome, dict) and gate_outcome.get("blocked"):
+            outcome = {
+                "success": False,
+                "error": gate_outcome.get("error") or f"action_blocked:{action_name}",
+                "blocked": True,
+                "blocked_reason": gate_outcome.get("reason"),
+            }
+            actions_applied.append(
+                {
+                    "action": action_name,
+                    "success": False,
+                    "error": outcome.get("error"),
+                    "blocked": True,
+                }
+            )
+            return outcome
     outcome = await execute_jira_workflow_action(action_name, kwargs)
     actions_applied.append(
         {
             "action": action_name,
             "success": bool(outcome.get("success")),
             "error": outcome.get("error"),
+            "blocked": bool(outcome.get("blocked")),
         }
     )
     return outcome

--- a/src/runtime/jira_workflow_review.py
+++ b/src/runtime/jira_workflow_review.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from src.agents.executor import execute_skill
-from src.runtime.adapter_executor import execute_jira_workflow_action
+from src.runtime.runtime_adapter_execution import execute_adapter_action_via_bus
 from src.runtime.jira_workflow_contract import (
     JiraWorkflowReviewOutcome,
     derive_workflow_actions_from_outcome,
@@ -13,6 +13,17 @@ from src.runtime.jira_workflow_contract import (
     normalize_workflow_review_payload,
 )
 from src.runtime.events import build_runtime_event
+
+
+async def execute_jira_workflow_action(action_name: str, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute Jira workflow actions through the standardized runtime bus path."""
+    action_id = f"adapter:jira:{str(action_name or '').strip().lower()}"
+    return await execute_adapter_action_via_bus(
+        action_id,
+        kwargs,
+        source_type="runtime",
+        source_ref="jira_workflow_review",
+    )
 
 
 def _event(event_type: str, state: str, issue_key: str, detail_payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/runtime/jira_workflow_review.py
+++ b/src/runtime/jira_workflow_review.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from src.agents.executor import run_skill_execution
+from src.agents.executor import execute_skill
 from src.runtime.adapter_executor import execute_jira_workflow_action
 from src.runtime.jira_workflow_contract import (
     JiraWorkflowReviewOutcome,
@@ -235,7 +235,7 @@ async def _resolve_review_outcome(plan, issue_snapshot: Any) -> JiraWorkflowRevi
         "issue_snapshot": issue_snapshot,
         "workflow_context": dict(plan.workflow_context or {}),
     }
-    skill_result = await run_skill_execution(plan.skill_name, **skill_kwargs)
+    skill_result = await execute_skill(plan.skill_name, _use_execution_bus=True, **skill_kwargs)
     if not getattr(skill_result, "success", False):
         return JiraWorkflowReviewOutcome(
             approved=False,

--- a/src/runtime/leader_delegation_adapter.py
+++ b/src/runtime/leader_delegation_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-from src.runtime.adapter_executor import execute_adapter_action
+from src.runtime.runtime_adapter_execution import execute_adapter_action_via_bus
 
 
 REQUIRED_DELEGATION_FIELDS = ("group_id", "leader_agent_id", "assignee_agent_id", "objective")
@@ -29,6 +29,16 @@ TASK_COORDINATION_FIELDS = (
     "scope_label",
     "name",
 )
+
+
+async def execute_adapter_action(action_id: str, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Runtime adapter execution routed through ExecutionBus/GovernanceBus."""
+    return await execute_adapter_action_via_bus(
+        action_id,
+        kwargs,
+        source_type="runtime",
+        source_ref="leader_delegation_adapter",
+    )
 
 
 def normalize_leader_delegation_request(payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/runtime/leader_orchestration.py
+++ b/src/runtime/leader_orchestration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from src.runtime.adapter_executor import execute_adapter_action
+from src.runtime.runtime_adapter_execution import execute_adapter_action_via_bus
 from src.runtime.leader_delegation_adapter import (
     create_task_agent_for_group,
     create_specialist_delegation,
@@ -14,6 +14,16 @@ from src.runtime.leader_delegation_adapter import (
 )
 
 ACTIVE_TASK_STATUSES = {"queued", "running", "blocked"}
+
+
+async def execute_adapter_action(action_id: str, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Runtime adapter execution routed through ExecutionBus/GovernanceBus."""
+    return await execute_adapter_action_via_bus(
+        action_id,
+        kwargs,
+        source_type="runtime",
+        source_ref="leader_orchestration",
+    )
 
 
 def _extract_deleted_task_agent_ids(payload: Any) -> List[str]:

--- a/src/runtime/runtime_adapter_execution.py
+++ b/src/runtime/runtime_adapter_execution.py
@@ -1,0 +1,47 @@
+"""Helpers for routing runtime-internal adapter actions through ExecutionBus."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from src.runtime.chat_orchestration_adapter import execute_runtime_task_request
+
+
+async def execute_adapter_action_via_bus(
+    action_id: str,
+    kwargs: Dict[str, Any],
+    *,
+    source_type: str = "runtime",
+    source_ref: str = "runtime.adapter_action_via_bus",
+    session_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    policy_profile_id: Optional[str] = None,
+    context_ref: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    result = await execute_runtime_task_request(
+        request_id=f"runtime-{action_id}",
+        source_type=source_type,
+        source_ref=source_ref,
+        session_id=session_id,
+        execution_type="task",
+        context_ref=context_ref,
+        input_payload={
+            "task_type": "adapter_action_task",
+            "action_id": action_id,
+            "kwargs": dict(kwargs or {}),
+        },
+        metadata={"policy_profile_id": policy_profile_id, **dict(metadata or {})} if policy_profile_id else dict(metadata or {}),
+    )
+    output = result.output_payload if isinstance(result.output_payload, dict) else {}
+    return {
+        "success": result.status == "success" and bool(output.get("success", True)),
+        "error": output.get("error") or output.get("reason"),
+        "result": output.get("result"),
+        "action_id": output.get("action_id") or action_id,
+        "capability_id": output.get("capability_id") or action_id,
+        "capability_type": output.get("capability_type") or "adapter_action",
+        "runtime_events": list(result.runtime_events or []),
+        "status": result.status,
+        "reason": output.get("reason"),
+    }

--- a/src/runtime/task_capability_contracts.py
+++ b/src/runtime/task_capability_contracts.py
@@ -1,0 +1,123 @@
+"""Canonical task-wrapper capability contract resolution."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from src.runtime.capability_registry import get_capability_registry
+
+
+def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    normalized_task_type = str(task_type or "").strip().lower()
+    normalized_payload = dict(payload or {})
+    registry = get_capability_registry()
+
+    fallback: Dict[str, Any] = {
+        "primary_capability_id": None,
+        "capability_id": None,
+        "capability_type": None,
+        "action_id": None,
+        "involved_capability_ids": [],
+        "policy_tags": [],
+        "requires_identity_binding": False,
+        "capability_resolution": "unresolved",
+    }
+
+    if normalized_task_type == "adapter_action_task":
+        action_id = str(normalized_payload.get("action_id") or "").strip().lower()
+        descriptor = registry.get(action_id) if action_id else None
+        if descriptor is None:
+            return {**fallback, "primary_capability_id": action_id or None, "capability_id": action_id or None, "action_id": action_id or None}
+        return {
+            **fallback,
+            "primary_capability_id": descriptor.capability_id,
+            "capability_id": descriptor.capability_id,
+            "capability_type": descriptor.type,
+            "action_id": descriptor.capability_id,
+            "involved_capability_ids": [descriptor.capability_id],
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": bool(descriptor.requires_identity_binding),
+            "capability_resolution": "resolved",
+        }
+
+    if normalized_task_type == "jira_workflow_review_task":
+        primary_capability_id = "adapter:jira:read_issue"
+        descriptor = registry.get(primary_capability_id)
+        involved = _resolve_involved_capability_ids_for_task(normalized_task_type, normalized_payload)
+        if descriptor is None:
+            return {**fallback, "primary_capability_id": primary_capability_id, "capability_id": primary_capability_id, "action_id": primary_capability_id, "involved_capability_ids": involved}
+        return {
+            **fallback,
+            "primary_capability_id": descriptor.capability_id,
+            "capability_id": descriptor.capability_id,
+            "capability_type": descriptor.type,
+            "action_id": descriptor.capability_id,
+            "involved_capability_ids": involved,
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": bool(descriptor.requires_identity_binding),
+            "capability_resolution": "resolved",
+        }
+
+    if normalized_task_type == "github_review_task":
+        primary_capability_id = "adapter:github:review_pull_request"
+        descriptor = registry.get(primary_capability_id)
+        involved = _resolve_involved_capability_ids_for_task(normalized_task_type, normalized_payload)
+        if descriptor is None:
+            return {**fallback, "primary_capability_id": primary_capability_id, "capability_id": primary_capability_id, "action_id": primary_capability_id, "involved_capability_ids": involved}
+        return {
+            **fallback,
+            "primary_capability_id": descriptor.capability_id,
+            "capability_id": descriptor.capability_id,
+            "capability_type": descriptor.type,
+            "action_id": descriptor.capability_id,
+            "involved_capability_ids": involved,
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": bool(descriptor.requires_identity_binding),
+            "capability_resolution": "resolved",
+        }
+
+    if normalized_task_type == "delegation_task":
+        skill_name = str(normalized_payload.get("skill_name") or "").strip().lower()
+        if not skill_name:
+            return fallback
+        capability_id = f"skill:{skill_name}"
+        descriptor = registry.get(capability_id)
+        if descriptor is None:
+            return {**fallback, "primary_capability_id": capability_id, "capability_id": capability_id, "involved_capability_ids": [capability_id], "capability_type": "skill"}
+        return {
+            **fallback,
+            "primary_capability_id": descriptor.capability_id,
+            "capability_id": descriptor.capability_id,
+            "capability_type": descriptor.type,
+            "involved_capability_ids": [descriptor.capability_id],
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": bool(descriptor.requires_identity_binding),
+            "capability_resolution": "resolved",
+        }
+
+    return fallback
+
+
+def _resolve_involved_capability_ids_for_task(task_type: str, payload: Dict[str, Any]) -> list[str]:
+    normalized_task_type = str(task_type or "").strip().lower()
+    if normalized_task_type == "jira_workflow_review_task":
+        involved = {"adapter:jira:read_issue"}
+        has_transition = any(payload.get(key) for key in ("transition", "success_transition", "failure_transition"))
+        has_assign = any(
+            payload.get(key)
+            for key in ("assignee", "success_reassign_to", "failure_reassign_to", "explicit_success_assignee", "explicit_failure_assignee")
+        )
+        has_comment = any(payload.get(key) for key in ("review_comment", "review_comment_template", "transition_comment"))
+        has_update = bool(payload.get("fields"))
+        if has_transition:
+            involved.add("adapter:jira:transition_issue")
+        if has_assign:
+            involved.add("adapter:jira:assign_issue")
+        if has_comment:
+            involved.add("adapter:jira:add_comment")
+        if has_update:
+            involved.add("adapter:jira:update_issue")
+        return sorted(involved)
+    if normalized_task_type == "github_review_task":
+        return ["adapter:github:add_comment", "adapter:github:review_pull_request"]
+    return []

--- a/src/runtime/task_capability_contracts.py
+++ b/src/runtime/task_capability_contracts.py
@@ -1,4 +1,14 @@
-"""Canonical task-wrapper capability contract resolution."""
+"""Canonical wrapper-task capability contract resolution.
+
+This module is the single source of truth for wrapper-task -> capability
+mapping in the runtime capability surface. Execution and governance must both
+consume this resolver instead of maintaining parallel task-branch mapping
+logic in their own modules.
+
+The returned adapter action ids and involved capability ids are part of the
+runtime capability-surface contract and are intentionally centralized here so
+policy, auditing, and capability metadata remain consistent across call paths.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_adapter_boundaries.py
+++ b/tests/test_adapter_boundaries.py
@@ -169,3 +169,16 @@ def test_entrypoints_do_not_reintroduce_direct_bus_construction():
     for name, source in sources.items():
         for token in forbidden:
             assert token not in source, f"{name} unexpectedly contains {token}"
+
+
+def test_runtime_helper_modules_do_not_import_adapter_executor_directly():
+    from src.runtime import jira_workflow_review, leader_delegation_adapter, leader_orchestration
+
+    sources = {
+        "leader_delegation_adapter": inspect.getsource(leader_delegation_adapter),
+        "leader_orchestration": inspect.getsource(leader_orchestration),
+        "jira_workflow_review": inspect.getsource(jira_workflow_review),
+    }
+    forbidden = "from src.runtime.adapter_executor import execute_adapter_action"
+    for name, source in sources.items():
+        assert forbidden not in source, f"{name} unexpectedly imports low-level adapter executor"

--- a/tests/test_adapter_boundaries.py
+++ b/tests/test_adapter_boundaries.py
@@ -179,6 +179,6 @@ def test_runtime_helper_modules_do_not_import_adapter_executor_directly():
         "leader_orchestration": inspect.getsource(leader_orchestration),
         "jira_workflow_review": inspect.getsource(jira_workflow_review),
     }
-    forbidden = "from src.runtime.adapter_executor import execute_adapter_action"
+    forbidden = "from src.runtime.adapter_executor import"
     for name, source in sources.items():
         assert forbidden not in source, f"{name} unexpectedly imports low-level adapter executor"

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -291,3 +291,48 @@ async def test_create_portal_delegation_from_runtime_missing_fields_error():
     assert result["success"] is False
     assert result["delegation_id"] is None
     assert "Missing required fields" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_portal_delegation_from_runtime_routes_through_bus_helper(monkeypatch):
+    calls = []
+
+    async def _fake_bus_helper(action_id, kwargs, **_meta):
+        calls.append((action_id, dict(kwargs)))
+        return {"success": True, "result": {"delegation_id": "d-bus"}, "error": None}
+
+    async def _fail_direct(*_args, **_kwargs):
+        raise AssertionError("direct adapter executor path should not be used")
+
+    monkeypatch.setattr("src.runtime.leader_delegation_adapter.execute_adapter_action_via_bus", _fake_bus_helper)
+    monkeypatch.setattr("src.runtime.adapter_executor.execute_adapter_action", _fail_direct)
+    result = await create_portal_delegation_from_runtime(
+        {
+            "group_id": "g-1",
+            "leader_agent_id": "l-1",
+            "assignee_agent_id": "a-1",
+            "objective": "Review",
+        }
+    )
+    assert result["success"] is True
+    assert result["delegation_id"] == "d-bus"
+    assert calls and calls[0][0] == "adapter:portal:create_delegation"
+
+
+@pytest.mark.asyncio
+async def test_create_portal_delegation_from_runtime_preserves_block_reason(monkeypatch):
+    async def _fake_bus_helper(action_id, kwargs, **_meta):
+        return {"success": False, "result": None, "error": "denied_adapter_actions", "reason": "denied_adapter_actions"}
+
+    monkeypatch.setattr("src.runtime.leader_delegation_adapter.execute_adapter_action_via_bus", _fake_bus_helper)
+    result = await create_portal_delegation_from_runtime(
+        {
+            "group_id": "g-1",
+            "leader_agent_id": "l-1",
+            "assignee_agent_id": "a-1",
+            "objective": "Review",
+        }
+    )
+    assert result["success"] is False
+    assert result["delegation_id"] is None
+    assert result["error"] == "denied_adapter_actions"

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -1,6 +1,11 @@
 import pytest
 
-from src.runtime.adapter_executor import execute_adapter_action, execute_jira_workflow_action
+from src.runtime.adapter_executor import (
+    ACTION_ID_TO_EXECUTOR,
+    execute_adapter_action,
+    execute_jira_workflow_action,
+    validate_enabled_adapter_actions_have_executors,
+)
 from src.runtime.leader_delegation_adapter import create_portal_delegation_from_runtime
 
 
@@ -317,6 +322,17 @@ async def test_create_portal_delegation_from_runtime_routes_through_bus_helper(m
     assert result["success"] is True
     assert result["delegation_id"] == "d-bus"
     assert calls and calls[0][0] == "adapter:portal:create_delegation"
+
+
+def test_enabled_adapter_actions_have_registered_executors():
+    missing = validate_enabled_adapter_actions_have_executors()
+    assert missing == []
+
+
+def test_validate_enabled_adapter_actions_missing_executor(monkeypatch):
+    monkeypatch.delitem(ACTION_ID_TO_EXECUTOR, "adapter:jira:read_issue", raising=False)
+    missing = validate_enabled_adapter_actions_have_executors()
+    assert "adapter:jira:read_issue" in missing
 
 
 @pytest.mark.asyncio

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -88,3 +88,38 @@ def test_descriptor_fields_preserved():
     assert fetched.enabled is False
     assert fetched.policy_tags == ["secure", "write"]
     assert fetched.metadata == {"x": 1}
+
+
+def test_registry_export_catalog_and_filters():
+    registry = build_default_capability_registry()
+
+    catalog = registry.export_catalog()
+    assert isinstance(catalog, list)
+    assert catalog
+    first = catalog[0]
+    assert set(first.keys()) == {
+        "capability_id",
+        "type",
+        "name",
+        "input_schema",
+        "output_schema",
+        "policy_tags",
+        "requires_identity_binding",
+        "enabled",
+        "source_ref",
+        "metadata",
+    }
+    assert registry.exists(first["capability_id"]) is True
+    assert registry.list_enabled()
+    assert registry.list_by_type("adapter_action")
+    assert registry.list_by_type("skill")
+    assert registry.list_by_type("tool")
+
+
+def test_registry_collects_adapter_channel_tool_skill_types():
+    registry = build_default_capability_registry()
+    types = {item.type for item in registry.list_all()}
+    assert "adapter_action" in types
+    assert "skill" in types
+    assert "tool" in types
+    assert "channel_action" in types

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -97,10 +97,13 @@ def test_registry_export_catalog_and_filters():
     assert isinstance(catalog, list)
     assert catalog
     first = catalog[0]
-    assert set(first.keys()) == {
+    assert {
         "capability_id",
         "type",
         "name",
+        "logical_name",
+        "action_alias",
+        "adapter_system",
         "input_schema",
         "output_schema",
         "policy_tags",
@@ -108,7 +111,7 @@ def test_registry_export_catalog_and_filters():
         "enabled",
         "source_ref",
         "metadata",
-    }
+    }.issubset(set(first.keys()))
     assert registry.exists(first["capability_id"]) is True
     assert registry.list_enabled()
     assert registry.list_by_type("adapter_action")
@@ -123,3 +126,19 @@ def test_registry_collects_adapter_channel_tool_skill_types():
     assert "skill" in types
     assert "tool" in types
     assert "channel_action" in types
+
+
+def test_registry_export_catalog_snapshot_has_deterministic_version():
+    registry = build_default_capability_registry()
+    snapshot_a = registry.export_catalog_snapshot()
+    snapshot_b = registry.export_catalog_snapshot()
+    assert snapshot_a["catalog_version"] == snapshot_b["catalog_version"]
+    assert snapshot_a["count"] == len(snapshot_a["capabilities"])
+    assert isinstance(snapshot_a["generated_at"], str) and snapshot_a["generated_at"].endswith("Z")
+
+
+def test_registry_adapter_action_entries_include_alias_and_system():
+    registry = build_default_capability_registry()
+    adapter_entry = next(item for item in registry.export_catalog() if item["type"] == "adapter_action")
+    assert adapter_entry["action_alias"]
+    assert adapter_entry["adapter_system"] in {"github", "jira", "portal"}

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -2858,3 +2858,70 @@ async def test_jira_workflow_review_task_comment_denied_has_governance_audit_eve
     result = await bus.execute(req)
     assert result.status == "success"
     assert any(evt.get("event_type") == "governance.audit" for evt in result.runtime_events)
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_portal_style_metadata_with_explainability_fields(monkeypatch):
+    async def _fake_execute_adapter_action(action_id, _kwargs):
+        if action_id == "adapter:github:review_pull_request":
+            return {"success": True, "result": {"summary": "ok"}, "error": None, "runtime_events": []}
+        return {"success": True, "result": {"id": "c2"}, "error": None, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.execution_bus.execute_adapter_action", _fake_execute_adapter_action)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "github_review_task", "owner": "acme", "repo": "demo", "pull_number": 10},
+        metadata={
+            "capability_profile_id": "cap-1",
+            "policy_profile_id": "policy-1",
+            "allowed_capability_ids": ["adapter:github:review_pull_request", "adapter:github:add_comment"],
+            "allowed_capability_types": ["action"],
+            "allowed_actions": ["review_pull_request", "add_comment"],
+            "allowed_adapter_actions": ["adapter:github:review_pull_request", "adapter:github:add_comment"],
+            "unresolved_actions": ["foo_action"],
+            "resolved_action_mappings": {"foo_action": "adapter:github:add_comment"},
+        },
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    assert result.output_payload["secondary_action_decisions"][0]["decision"] == "applied"
+
+
+@pytest.mark.asyncio
+async def test_jira_workflow_review_task_portal_style_metadata_deny_transition(monkeypatch):
+    async def _fake_run_review(payload):
+        gate = payload["_action_gate"]
+        gate_result = gate("transition_issue", {"issue_key": payload["issue_key"], "transition": "Done"})
+        return {
+            "success": True,
+            "issue_key": payload["issue_key"],
+            "workflow_outcome": "approved",
+            "approved": True,
+            "actions_applied": [{"action": "transition_issue", "success": False, "blocked": True, "error": gate_result.get("error")}],
+            "runtime_events": [],
+            "error": None,
+        }
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_jira_workflow_review", _fake_run_review)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "jira_workflow_review_task", "issue_key": "ENG-53", "success_transition": "Done"},
+        metadata={
+            "capability_profile_id": "cap-jira",
+            "policy_profile_id": "policy-jira",
+            "allowed_capability_ids": ["adapter:jira:read_issue"],
+            "allowed_capability_types": ["action"],
+            "denied_actions": ["transition_issue"],
+            "unresolved_actions": ["old_transition"],
+            "resolved_action_mappings": {"old_transition": "adapter:jira:transition_issue"},
+        },
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    assert "adapter:jira:transition_issue" in result.output_payload["blocked_secondary_action_ids"]
+    assert any(item.get("decision") == "blocked" for item in result.output_payload["secondary_action_decisions"])
+    assert any(evt.get("event_type") == "governance.audit" for evt in result.runtime_events)

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -2631,10 +2631,19 @@ async def test_execution_bus_adapter_action_task_includes_capability_metadata(mo
         source_type="task",
         execution_type="task",
         input_payload={"task_type": "adapter_action_task", "action_id": "adapter:jira:read_issue", "kwargs": {"issue_key": "ENG-1"}},
+        metadata={"identity_binding_system_type": "jira", "identity_binding_external_account_id": "acct-1"},
     )
     result = await bus.execute(req)
     assert result.status == "success"
+    assert result.output_payload["task_type"] == "adapter_action_task"
+    assert result.output_payload["action_id"] == "adapter:jira:read_issue"
+    assert result.output_payload["success"] is True
+    assert result.output_payload["error"] is None
+    assert result.output_payload["result"] == {"ok": True}
     assert result.output_payload["capability_id"] == "adapter:jira:read_issue"
+    assert result.output_payload["capability_type"] == "adapter_action"
+    assert result.output_payload["requires_identity_binding"] is True
+    assert result.output_payload["capability_resolution"] == "resolved"
     assert result.output_payload["policy_tags"] == ["jira", "read"]
 
 

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -2653,6 +2653,8 @@ async def test_github_review_task_includes_involved_capability_ids(monkeypatch):
     assert result.output_payload["governed_secondary_action_ids"] == ["adapter:github:add_comment"]
     assert result.output_payload["blocked_secondary_action_ids"] == []
     assert result.output_payload["applied_secondary_action_ids"] == ["adapter:github:add_comment"]
+    decisions = result.output_payload["secondary_action_decisions"]
+    assert decisions and decisions[0]["decision"] == "applied"
 
 
 @pytest.mark.asyncio
@@ -2707,7 +2709,9 @@ async def test_github_review_task_secondary_action_denied_by_capability_policy(m
     assert result.output_payload["governed_secondary_action_ids"] == ["adapter:github:add_comment"]
     assert result.output_payload["blocked_secondary_action_ids"] == ["adapter:github:add_comment"]
     assert result.output_payload["applied_secondary_action_ids"] == []
+    assert result.output_payload["secondary_action_decisions"][0]["decision"] == "blocked"
     assert any(evt.get("event_type") == "task.github_review.secondary_action.blocked" for evt in result.runtime_events)
+    assert any(evt.get("event_type") == "governance.audit" for evt in result.runtime_events)
     assert calls == ["adapter:github:review_pull_request"]
 
 
@@ -2741,7 +2745,9 @@ async def test_jira_workflow_review_task_transition_denied_adds_blocked_secondar
     assert result.status == "success"
     assert "adapter:jira:transition_issue" in result.output_payload["blocked_secondary_action_ids"]
     assert result.output_payload["applied_secondary_action_ids"] == []
+    assert any(item.get("decision") == "blocked" for item in result.output_payload["secondary_action_decisions"])
     assert any(evt.get("event_type") == "task.jira_workflow_review.secondary_action.blocked" for evt in result.runtime_events)
+    assert any(evt.get("event_type") == "governance.audit" for evt in result.runtime_events)
 
 
 @pytest.mark.asyncio
@@ -2781,3 +2787,74 @@ async def test_jira_workflow_review_task_comment_and_assign_denied(monkeypatch):
     assert result.status == "error"
     blocked = set(result.output_payload["blocked_secondary_action_ids"])
     assert {"adapter:jira:add_comment", "adapter:jira:assign_issue"}.issubset(blocked)
+    decision_actions = {item.get("action_id"): item.get("decision") for item in result.output_payload["secondary_action_decisions"]}
+    assert decision_actions.get("adapter:jira:add_comment") == "blocked"
+    assert decision_actions.get("adapter:jira:assign_issue") == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_secondary_action_allowed_by_allowed_adapter_actions(monkeypatch):
+    async def _fake_execute_adapter_action(action_id, _kwargs):
+        if action_id == "adapter:github:review_pull_request":
+            return {"success": True, "result": {"summary": "ok"}, "error": None, "runtime_events": []}
+        return {"success": True, "result": {"id": "c1"}, "error": None, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.execution_bus.execute_adapter_action", _fake_execute_adapter_action)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "github_review_task", "owner": "acme", "repo": "demo", "pull_number": 8},
+        metadata={"allowed_adapter_actions": ["adapter:github:review_pull_request", "adapter:github:add_comment"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    assert result.output_payload["secondary_action_decisions"][0]["decision"] == "applied"
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_secondary_action_allowed_by_allowed_actions_alias(monkeypatch):
+    async def _fake_execute_adapter_action(action_id, _kwargs):
+        if action_id == "adapter:github:review_pull_request":
+            return {"success": True, "result": {"summary": "ok"}, "error": None, "runtime_events": []}
+        return {"success": True, "result": {"id": "c1"}, "error": None, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.execution_bus.execute_adapter_action", _fake_execute_adapter_action)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "github_review_task", "owner": "acme", "repo": "demo", "pull_number": 9},
+        metadata={"allowed_actions": ["review_pull_request", "add_comment"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    assert result.output_payload["secondary_action_decisions"][0]["decision"] == "applied"
+
+
+@pytest.mark.asyncio
+async def test_jira_workflow_review_task_comment_denied_has_governance_audit_event(monkeypatch):
+    async def _fake_run_review(payload):
+        gate = payload["_action_gate"]
+        gate_result = gate("add_comment", {"issue_key": payload["issue_key"], "comment": "hi"})
+        return {
+            "success": True,
+            "issue_key": payload["issue_key"],
+            "workflow_outcome": "approved",
+            "approved": True,
+            "actions_applied": [{"action": "add_comment", "success": False, "blocked": True, "error": gate_result.get("error")}],
+            "runtime_events": [],
+            "error": None,
+        }
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_jira_workflow_review", _fake_run_review)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "jira_workflow_review_task", "issue_key": "ENG-52", "review_comment": "x"},
+        metadata={"denied_actions": ["add_comment"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    assert any(evt.get("event_type") == "governance.audit" for evt in result.runtime_events)

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -56,7 +56,11 @@ async def test_execution_bus_tool_handler_preserves_tool_result_shape(monkeypatc
 
     result = await bus.execute(req)
     assert result.status in {"success", "error"}
-    assert set(result.output_payload.keys()) == {"success", "content", "error"}
+    assert result.output_payload["success"] is True
+    assert result.output_payload["content"] == "ok"
+    assert result.output_payload["capability_id"] == "tool:run_command"
+    assert result.output_payload["capability_type"] == "tool"
+    assert result.output_payload["tool_name"] == "run_command"
 
 
 @pytest.mark.asyncio
@@ -521,7 +525,29 @@ async def test_execution_bus_task_handler_tool_task(monkeypatch):
     assert result.output_payload["tool_name"] == "demo_tool"
     assert result.output_payload["task_boundary"] is True
     assert result.output_payload["success"] is True
+    assert result.output_payload["capability_id"] == "tool:demo_tool"
+    assert result.output_payload["capability_type"] == "tool"
     assert captured["session_id"] == "s-task"
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_tool_handler_failure_preserves_normalized_capability_metadata(monkeypatch):
+    async def _fake_execute_tool_by_name(_name, **_kwargs):
+        return ToolResult(success=False, content=None, error="tool failed")
+
+    monkeypatch.setattr("src.runtime.execution_bus.execute_tool_by_name", _fake_execute_tool_by_name)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="system",
+        execution_type="tool",
+        input_payload={"tool_name": "run_command", "kwargs": {"cmd": "false"}},
+    )
+
+    result = await bus.execute(req)
+    assert result.status == "error"
+    assert result.output_payload["error"] == "tool failed"
+    assert result.output_payload["capability_id"] == "tool:run_command"
+    assert result.output_payload["capability_type"] == "tool"
 
 
 @pytest.mark.asyncio
@@ -587,6 +613,8 @@ async def test_execution_bus_task_handler_dict_status_error_maps_to_failure(monk
     assert result.status == "error"
     assert result.output_payload["success"] is False
     assert result.output_payload["error"] is not None
+    assert result.output_payload["capability_id"] == "tool:demo_tool"
+    assert result.output_payload["capability_type"] == "tool"
 
 
 @pytest.mark.asyncio

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -2630,3 +2630,76 @@ async def test_execution_bus_task_capability_unresolved_fallback_for_non_adapter
     result = await bus.execute(req)
     assert result.status == "success"
     assert result.output_payload["capability_resolution"] == "unresolved"
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_includes_involved_capability_ids(monkeypatch):
+    async def _fake_execute_adapter_action(action_id, _kwargs):
+        if action_id == "adapter:github:review_pull_request":
+            return {"success": True, "result": {"summary": "ok"}, "error": None, "runtime_events": []}
+        return {"success": True, "result": {"comment_id": "c1"}, "error": None, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.execution_bus.execute_adapter_action", _fake_execute_adapter_action)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "github_review_task", "owner": "acme", "repo": "demo", "pull_number": 7},
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    assert "adapter:github:review_pull_request" in result.output_payload["involved_capability_ids"]
+    assert "adapter:github:add_comment" in result.output_payload["involved_capability_ids"]
+
+
+@pytest.mark.asyncio
+async def test_jira_workflow_review_task_includes_involved_capability_ids(monkeypatch):
+    async def _fake_run_review(_payload):
+        return {"success": True, "workflow_outcome": "approved", "actions_applied": [], "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_jira_workflow_review", _fake_run_review)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "jira_workflow_review_task",
+            "issue_key": "ENG-3",
+            "success_transition": "Done",
+            "explicit_success_assignee": "u1",
+            "review_comment": "LGTM",
+            "fields": {"summary": "x"},
+        },
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    involved = set(result.output_payload["involved_capability_ids"])
+    assert {"adapter:jira:read_issue", "adapter:jira:transition_issue", "adapter:jira:assign_issue", "adapter:jira:add_comment", "adapter:jira:update_issue"}.issubset(involved)
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_secondary_action_denied_by_capability_policy(monkeypatch):
+    calls = []
+
+    async def _fake_execute_adapter_action(action_id, _kwargs):
+        calls.append(action_id)
+        if action_id == "adapter:github:review_pull_request":
+            return {"success": True, "result": {"summary": "ok"}, "error": None, "runtime_events": []}
+        raise AssertionError("secondary action should be blocked before execution")
+
+    monkeypatch.setattr("src.runtime.execution_bus.execute_adapter_action", _fake_execute_adapter_action)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "github_review_task", "owner": "acme", "repo": "demo", "pull_number": 7},
+        metadata={"denied_actions": ["add_comment"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "error"
+    assert result.output_payload["secondary_action_attempted"] is True
+    assert result.output_payload["secondary_action_success"] is False
+    assert result.output_payload["secondary_action_id"] == "adapter:github:add_comment"
+    assert "capability policy blocked for secondary action" in str(result.output_payload["error"])
+    assert any(evt.get("event_type") == "task.github_review.secondary_action.blocked" for evt in result.runtime_events)
+    assert calls == ["adapter:github:review_pull_request"]

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -2577,3 +2577,56 @@ def test_execution_bus_copies_handlers_mapping():
     bus = ExecutionBus(handlers=provided)
     provided.clear()
     assert "chat" in bus._handlers
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_adapter_action_task_includes_capability_metadata(monkeypatch):
+    class _Registry:
+        def get(self, action_id):
+            return CapabilityDescriptor(
+                capability_id=action_id,
+                type="adapter_action",
+                name="read_issue",
+                policy_tags=["jira", "read"],
+                requires_identity_binding=True,
+            )
+
+    async def _fake_execute_adapter_action(_action_id, _kwargs):
+        return {"success": True, "error": None, "result": {"ok": True}, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.execution_bus.get_capability_registry", lambda: _Registry())
+    monkeypatch.setattr("src.runtime.execution_bus.execute_adapter_action", _fake_execute_adapter_action)
+
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:jira:read_issue", "kwargs": {"issue_key": "ENG-1"}},
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    assert result.output_payload["capability_id"] == "adapter:jira:read_issue"
+    assert result.output_payload["policy_tags"] == ["jira", "read"]
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_task_capability_unresolved_fallback_for_non_adapter_task(monkeypatch):
+    async def _fake_review(_payload):
+        return {"success": True, "runtime_events": [], "workflow_outcome": "approved", "actions_applied": []}
+
+    class _Registry:
+        def get(self, _capability_id):
+            return None
+
+    monkeypatch.setattr("src.runtime.execution_bus.get_capability_registry", lambda: _Registry())
+    monkeypatch.setattr("src.runtime.execution_bus.run_jira_workflow_review", _fake_review)
+
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "jira_workflow_review_task", "issue_key": "ENG-9"},
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    assert result.output_payload["capability_resolution"] == "unresolved"

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -2650,6 +2650,9 @@ async def test_github_review_task_includes_involved_capability_ids(monkeypatch):
     assert result.status == "success"
     assert "adapter:github:review_pull_request" in result.output_payload["involved_capability_ids"]
     assert "adapter:github:add_comment" in result.output_payload["involved_capability_ids"]
+    assert result.output_payload["governed_secondary_action_ids"] == ["adapter:github:add_comment"]
+    assert result.output_payload["blocked_secondary_action_ids"] == []
+    assert result.output_payload["applied_secondary_action_ids"] == ["adapter:github:add_comment"]
 
 
 @pytest.mark.asyncio
@@ -2701,5 +2704,80 @@ async def test_github_review_task_secondary_action_denied_by_capability_policy(m
     assert result.output_payload["secondary_action_success"] is False
     assert result.output_payload["secondary_action_id"] == "adapter:github:add_comment"
     assert "capability policy blocked for secondary action" in str(result.output_payload["error"])
+    assert result.output_payload["governed_secondary_action_ids"] == ["adapter:github:add_comment"]
+    assert result.output_payload["blocked_secondary_action_ids"] == ["adapter:github:add_comment"]
+    assert result.output_payload["applied_secondary_action_ids"] == []
     assert any(evt.get("event_type") == "task.github_review.secondary_action.blocked" for evt in result.runtime_events)
     assert calls == ["adapter:github:review_pull_request"]
+
+
+@pytest.mark.asyncio
+async def test_jira_workflow_review_task_transition_denied_adds_blocked_secondary_fields(monkeypatch):
+    async def _fake_run_review(payload):
+        gate = payload["_action_gate"]
+        gate_result = gate("transition_issue", {"issue_key": payload["issue_key"], "transition": "Done"})
+        return {
+            "success": True,
+            "issue_key": payload["issue_key"],
+            "workflow_outcome": "approved",
+            "approved": True,
+            "reassignment_target": None,
+            "actions_applied": [
+                {"action": "transition_issue", "success": False, "blocked": True, "error": gate_result.get("error")},
+            ],
+            "runtime_events": [],
+            "error": None,
+        }
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_jira_workflow_review", _fake_run_review)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "jira_workflow_review_task", "issue_key": "ENG-50", "success_transition": "Done"},
+        metadata={"denied_actions": ["transition_issue"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "success"
+    assert "adapter:jira:transition_issue" in result.output_payload["blocked_secondary_action_ids"]
+    assert result.output_payload["applied_secondary_action_ids"] == []
+    assert any(evt.get("event_type") == "task.jira_workflow_review.secondary_action.blocked" for evt in result.runtime_events)
+
+
+@pytest.mark.asyncio
+async def test_jira_workflow_review_task_comment_and_assign_denied(monkeypatch):
+    async def _fake_run_review(payload):
+        gate = payload["_action_gate"]
+        comment_gate = gate("add_comment", {"issue_key": payload["issue_key"], "comment": "hi"})
+        assign_gate = gate("assign_issue", {"issue_key": payload["issue_key"], "assignee": "u1"})
+        return {
+            "success": False,
+            "issue_key": payload["issue_key"],
+            "workflow_outcome": "rejected",
+            "approved": False,
+            "reassignment_target": "u1",
+            "actions_applied": [
+                {"action": "add_comment", "success": False, "blocked": True, "error": comment_gate.get("error")},
+                {"action": "assign_issue", "success": False, "blocked": True, "error": assign_gate.get("error")},
+            ],
+            "runtime_events": [],
+            "error": "assignment_failed",
+        }
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_jira_workflow_review", _fake_run_review)
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "jira_workflow_review_task",
+            "issue_key": "ENG-51",
+            "review_comment": "need change",
+            "explicit_success_assignee": "u1",
+        },
+        metadata={"denied_actions": ["add_comment", "assign_issue"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "error"
+    blocked = set(result.output_payload["blocked_secondary_action_ids"])
+    assert {"adapter:jira:add_comment", "adapter:jira:assign_issue"}.issubset(blocked)

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src import ToolResult
+from src.agents.executor import SkillResult, run_skill_execution
 from src.agents.errors import LLMError
 from src.runtime.contracts import ExecutionResult, make_execution_request, make_execution_result
 from src.runtime.execution_bus import ExecutionBus, build_default_execution_bus
@@ -2925,3 +2926,42 @@ async def test_jira_workflow_review_task_portal_style_metadata_deny_transition(m
     assert "adapter:jira:transition_issue" in result.output_payload["blocked_secondary_action_ids"]
     assert any(item.get("decision") == "blocked" for item in result.output_payload["secondary_action_decisions"])
     assert any(evt.get("event_type") == "governance.audit" for evt in result.runtime_events)
+
+
+@pytest.mark.asyncio
+async def test_run_skill_execution_routes_through_execution_bus_by_default(monkeypatch):
+    async def _fake_orchestration(**_kwargs):
+        return make_execution_result(
+            request_id="req-bus",
+            status="success",
+            output_payload={"output": "bus-path", "data": {"source": "bus"}},
+        )
+
+    async def _should_not_be_called(*_args, **_kwargs):
+        raise AssertionError("legacy direct execution should not be used by default")
+
+    monkeypatch.setattr("src.runtime.chat_orchestration_adapter.execute_skill_orchestration", _fake_orchestration)
+    monkeypatch.setattr("src.agents.executor.skills_executor.execute_skill", _should_not_be_called)
+    monkeypatch.delenv("EFP_ALLOW_LEGACY_DIRECT_EXECUTION", raising=False)
+
+    result = await run_skill_execution("demo_skill", input="hello")
+    assert result.success is True
+    assert result.output == "bus-path"
+    assert result.data.get("source") == "bus"
+
+
+@pytest.mark.asyncio
+async def test_run_skill_execution_legacy_direct_opt_in(monkeypatch):
+    async def _fake_direct(skill_name, **_kwargs):
+        return SkillResult(success=True, output=f"legacy:{skill_name}")
+
+    async def _should_not_be_called(**_kwargs):
+        raise AssertionError("execution bus path should not be used in legacy direct opt-in mode")
+
+    monkeypatch.setattr("src.agents.executor.skills_executor.execute_skill", _fake_direct)
+    monkeypatch.setattr("src.runtime.chat_orchestration_adapter.execute_skill_orchestration", _should_not_be_called)
+    monkeypatch.setenv("EFP_ALLOW_LEGACY_DIRECT_EXECUTION", "true")
+
+    result = await run_skill_execution("demo_skill", input="hello")
+    assert result.success is True
+    assert result.output == "legacy:demo_skill"

--- a/tests/test_governance_bus.py
+++ b/tests/test_governance_bus.py
@@ -469,3 +469,23 @@ async def test_default_governance_portal_style_metadata_combo_blocks_when_action
     result = await bus.execute(req)
     assert result.status == "blocked"
     assert result.output_payload["reason"] == "allowed_adapter_actions"
+
+
+@pytest.mark.asyncio
+async def test_default_governance_portal_style_metadata_ignores_explainability_fields():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:github:add_comment", "kwargs": {"owner": "acme", "repo": "demo", "pull_number": 1, "comment": "ok"}},
+        metadata={
+            "capability_profile_id": "cap-2",
+            "policy_profile_id": "policy-2",
+            "allowed_capability_types": ["action"],
+            "allowed_actions": ["add_comment"],
+            "unresolved_actions": ["legacy_comment_action"],
+            "resolved_action_mappings": {"legacy_comment_action": "adapter:github:add_comment"},
+        },
+    )
+    result = await bus.execute(req)
+    assert result.status in {"success", "error"}

--- a/tests/test_governance_bus.py
+++ b/tests/test_governance_bus.py
@@ -489,3 +489,52 @@ async def test_default_governance_portal_style_metadata_ignores_explainability_f
     )
     result = await bus.execute(req)
     assert result.status in {"success", "error"}
+
+
+@pytest.mark.asyncio
+async def test_default_governance_requires_identity_binding_for_external_adapter_action():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:github:add_comment", "kwargs": {"owner": "acme"}},
+        metadata={"external_triggered": True},
+    )
+    result = await bus.execute(req)
+    assert result.status == "blocked"
+    assert result.output_payload["reason"] == "missing_identity_binding"
+
+
+@pytest.mark.asyncio
+async def test_default_governance_blocks_identity_binding_system_mismatch():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:github:add_comment", "kwargs": {"owner": "acme"}},
+        metadata={
+            "external_triggered": True,
+            "identity_binding_system_type": "jira",
+            "identity_binding_external_account_id": "acct-1",
+        },
+    )
+    result = await bus.execute(req)
+    assert result.status == "blocked"
+    assert result.output_payload["reason"] == "identity_binding_system_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_default_governance_allows_matching_identity_binding_for_external_adapter_action():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:github:add_comment", "kwargs": {"owner": "acme"}},
+        metadata={
+            "external_triggered": True,
+            "identity_binding_system_type": "github",
+            "identity_binding_external_account_id": "acct-1",
+        },
+    )
+    result = await bus.execute(req)
+    assert result.status in {"success", "error"}

--- a/tests/test_governance_bus.py
+++ b/tests/test_governance_bus.py
@@ -367,3 +367,70 @@ async def test_default_governance_malformed_capability_lists_do_not_crash():
     )
     result = await bus.execute(req)
     assert result.status in {"success", "error", "blocked"}
+
+
+@pytest.mark.asyncio
+async def test_default_governance_allows_bare_tool_capability_name():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "tool_task", "tool_name": "shell", "kwargs": {"cmd": "echo hi"}},
+        metadata={"allowed_capability_ids": ["shell"]},
+    )
+    result = await bus.execute(req)
+    assert result.status in {"success", "error"}
+
+
+@pytest.mark.asyncio
+async def test_default_governance_allows_capability_type_alias_action():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:jira:read_issue", "kwargs": {"issue_key": "ENG-1"}},
+        metadata={"allowed_capability_types": ["action"]},
+    )
+    result = await bus.execute(req)
+    assert result.status in {"success", "error"}
+
+
+@pytest.mark.asyncio
+async def test_default_governance_allows_capability_type_alias_channel():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:jira:read_issue", "kwargs": {"issue_key": "ENG-1"}},
+        metadata={"allowed_capability_types": ["channel"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "blocked"
+    assert result.output_payload["reason"] == "allowed_capability_types"
+
+
+@pytest.mark.asyncio
+async def test_default_governance_allowed_actions_alias_supports_action_name():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:github:add_comment", "kwargs": {"owner": "acme", "repo": "demo", "pull_number": 1, "comment": "ok"}},
+        metadata={"allowed_actions": ["add_comment"]},
+    )
+    result = await bus.execute(req)
+    assert result.status in {"success", "error"}
+
+
+@pytest.mark.asyncio
+async def test_default_governance_denied_actions_alias_blocks_by_action_name():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:github:add_comment", "kwargs": {"owner": "acme", "repo": "demo", "pull_number": 1, "comment": "ok"}},
+        metadata={"denied_actions": ["add_comment"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "blocked"
+    assert result.output_payload["reason"] == "denied_adapter_actions"

--- a/tests/test_governance_bus.py
+++ b/tests/test_governance_bus.py
@@ -434,3 +434,17 @@ async def test_default_governance_denied_actions_alias_blocks_by_action_name():
     result = await bus.execute(req)
     assert result.status == "blocked"
     assert result.output_payload["reason"] == "denied_adapter_actions"
+
+
+@pytest.mark.asyncio
+async def test_default_governance_denied_actions_blocks_jira_transition_action_name():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:jira:transition_issue", "kwargs": {"issue_key": "ENG-1", "transition": "Done"}},
+        metadata={"denied_actions": ["transition_issue"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "blocked"
+    assert result.output_payload["reason"] == "denied_adapter_actions"

--- a/tests/test_governance_bus.py
+++ b/tests/test_governance_bus.py
@@ -321,3 +321,49 @@ async def test_default_governance_external_trigger_allowlist_blocks_non_member()
 
     assert result.status == "blocked"
     assert result.output_payload["reason"] == "external_allowlist"
+
+
+@pytest.mark.asyncio
+async def test_default_governance_denied_capability_ids_blocks_adapter_action():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:jira:read_issue", "kwargs": {"issue_key": "ENG-1"}},
+        metadata={"denied_capability_ids": ["adapter:jira:read_issue"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "blocked"
+    assert result.output_payload["reason"] == "denied_capability_ids"
+
+
+@pytest.mark.asyncio
+async def test_default_governance_allowed_capability_types_missing_match_blocks():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:jira:read_issue", "kwargs": {"issue_key": "ENG-1"}},
+        metadata={"allowed_capability_types": ["tool"]},
+    )
+    result = await bus.execute(req)
+    assert result.status == "blocked"
+    assert result.output_payload["reason"] == "allowed_capability_types"
+
+
+@pytest.mark.asyncio
+async def test_default_governance_malformed_capability_lists_do_not_crash():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "tool_task", "tool_name": "read", "kwargs": {"file_path": "README.md"}},
+        metadata={
+            "allowed_capability_ids": "not-a-list",
+            "denied_capability_ids": {"x": 1},
+            "allowed_capability_types": None,
+            "denied_adapter_actions": 7,
+        },
+    )
+    result = await bus.execute(req)
+    assert result.status in {"success", "error", "blocked"}

--- a/tests/test_governance_bus.py
+++ b/tests/test_governance_bus.py
@@ -10,7 +10,7 @@ from src.runtime.governance_bus import (
     build_default_governance_bus,
     _resolve_capability_context,
 )
-from src.runtime.execution_bus import resolve_task_capability_plan
+from src.runtime.task_capability_contracts import resolve_task_capability_contract
 
 
 @pytest.mark.asyncio
@@ -542,23 +542,23 @@ async def test_default_governance_allows_matching_identity_binding_for_external_
     assert result.status in {"success", "error"}
 
 
-def test_governance_and_execution_bus_share_primary_capability_for_github_review_task():
+def test_governance_context_matches_canonical_contract_for_github_review_task():
     req = make_execution_request(
         source_type="task",
         execution_type="task",
         input_payload={"task_type": "github_review_task", "owner": "acme", "repo": "demo", "pull_number": 1},
     )
     gov_context = _resolve_capability_context(req)
-    plan = resolve_task_capability_plan("github_review_task", req.input_payload)
+    plan = resolve_task_capability_contract("github_review_task", req.input_payload)
     assert gov_context["capability_id"] == plan["primary_capability_id"]
 
 
-def test_governance_and_execution_bus_share_primary_capability_for_jira_review_task():
+def test_governance_context_matches_canonical_contract_for_jira_review_task():
     req = make_execution_request(
         source_type="task",
         execution_type="task",
         input_payload={"task_type": "jira_workflow_review_task", "issue_key": "ENG-1"},
     )
     gov_context = _resolve_capability_context(req)
-    plan = resolve_task_capability_plan("jira_workflow_review_task", req.input_payload)
+    plan = resolve_task_capability_contract("jira_workflow_review_task", req.input_payload)
     assert gov_context["capability_id"] == plan["primary_capability_id"]

--- a/tests/test_governance_bus.py
+++ b/tests/test_governance_bus.py
@@ -8,7 +8,9 @@ from src.runtime.governance_bus import (
     GovernanceBus,
     GovernanceDecision,
     build_default_governance_bus,
+    _resolve_capability_context,
 )
+from src.runtime.execution_bus import resolve_task_capability_plan
 
 
 @pytest.mark.asyncio
@@ -538,3 +540,25 @@ async def test_default_governance_allows_matching_identity_binding_for_external_
     )
     result = await bus.execute(req)
     assert result.status in {"success", "error"}
+
+
+def test_governance_and_execution_bus_share_primary_capability_for_github_review_task():
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "github_review_task", "owner": "acme", "repo": "demo", "pull_number": 1},
+    )
+    gov_context = _resolve_capability_context(req)
+    plan = resolve_task_capability_plan("github_review_task", req.input_payload)
+    assert gov_context["capability_id"] == plan["primary_capability_id"]
+
+
+def test_governance_and_execution_bus_share_primary_capability_for_jira_review_task():
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "jira_workflow_review_task", "issue_key": "ENG-1"},
+    )
+    gov_context = _resolve_capability_context(req)
+    plan = resolve_task_capability_plan("jira_workflow_review_task", req.input_payload)
+    assert gov_context["capability_id"] == plan["primary_capability_id"]

--- a/tests/test_governance_bus.py
+++ b/tests/test_governance_bus.py
@@ -448,3 +448,24 @@ async def test_default_governance_denied_actions_blocks_jira_transition_action_n
     result = await bus.execute(req)
     assert result.status == "blocked"
     assert result.output_payload["reason"] == "denied_adapter_actions"
+
+
+@pytest.mark.asyncio
+async def test_default_governance_portal_style_metadata_combo_blocks_when_action_not_allowed():
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        policy_profile_id="portal-profile-v1",
+        input_payload={"task_type": "adapter_action_task", "action_id": "adapter:jira:transition_issue", "kwargs": {"issue_key": "ENG-1", "transition": "Done"}},
+        metadata={
+            "policy_profile_id": "portal-profile-v1",
+            "allowed_capability_types": ["action"],
+            "allowed_actions": ["add_comment"],
+            "external_triggered": True,
+            "governance_target": "adapter_action_task",
+        },
+    )
+    result = await bus.execute(req)
+    assert result.status == "blocked"
+    assert result.output_payload["reason"] == "allowed_adapter_actions"

--- a/tests/test_jira_workflow_review.py
+++ b/tests/test_jira_workflow_review.py
@@ -164,6 +164,27 @@ async def test_jira_workflow_review_skill_path_uses_bus_execute_skill(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_jira_workflow_review_routes_jira_actions_via_bus_helper(monkeypatch):
+    calls = []
+
+    async def _fake_bus_helper(action_id, kwargs, **_meta):
+        calls.append(action_id)
+        if action_id == "adapter:jira:read_issue":
+            return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
+        return {"success": True, "result": "ok", "error": None}
+
+    async def _fake_execute_skill(skill_name, **kwargs):
+        return SkillResult(success=True, output="ok", data={"approved": True})
+
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_adapter_action_via_bus", _fake_bus_helper)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
+
+    result = await run_jira_workflow_review({"issue_key": "PROJ-16", "skill_name": "review_skill"})
+    assert result["success"] is True
+    assert "adapter:jira:read_issue" in calls
+
+
+@pytest.mark.asyncio
 async def test_backward_compatible_direct_payload_path_without_skill_name(monkeypatch):
     async def _fake_execute_jira_workflow_action(action_name, kwargs):
         if action_name == "read_issue":

--- a/tests/test_jira_workflow_review.py
+++ b/tests/test_jira_workflow_review.py
@@ -18,7 +18,7 @@ async def test_jira_workflow_review_skill_success_applies_transition_and_reassig
             }
         return {"success": True, "result": f"{action_name}:ok", "error": None}
 
-    async def _fake_run_skill_execution(skill_name, **kwargs):
+    async def _fake_execute_skill(skill_name, **kwargs):
         assert skill_name == "review_skill"
         return SkillResult(
             success=True,
@@ -34,7 +34,7 @@ async def test_jira_workflow_review_skill_success_applies_transition_and_reassig
         )
 
     monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
-    monkeypatch.setattr("src.runtime.jira_workflow_review.run_skill_execution", _fake_run_skill_execution)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
 
     result = await run_jira_workflow_review(
         {
@@ -65,7 +65,7 @@ async def test_jira_workflow_review_failure_path_reassigns_without_success_trans
             return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
         return {"success": True, "result": f"{action_name}:ok", "error": None}
 
-    async def _fake_run_skill_execution(skill_name, **kwargs):
+    async def _fake_execute_skill(skill_name, **kwargs):
         return SkillResult(
             success=True,
             output="needs changes",
@@ -73,7 +73,7 @@ async def test_jira_workflow_review_failure_path_reassigns_without_success_trans
         )
 
     monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
-    monkeypatch.setattr("src.runtime.jira_workflow_review.run_skill_execution", _fake_run_skill_execution)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
 
     result = await run_jira_workflow_review(
         {
@@ -105,11 +105,11 @@ async def test_requester_resolution_from_issue_snapshot(monkeypatch):
             }
         return {"success": True, "result": "ok", "error": None}
 
-    async def _fake_run_skill_execution(skill_name, **kwargs):
+    async def _fake_execute_skill(skill_name, **kwargs):
         return SkillResult(success=True, output="ok", data={"approved": True})
 
     monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
-    monkeypatch.setattr("src.runtime.jira_workflow_review.run_skill_execution", _fake_run_skill_execution)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
 
     result = await run_jira_workflow_review(
         {
@@ -130,16 +130,37 @@ async def test_missing_structured_outcome_from_skill_fails(monkeypatch):
             return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
         return {"success": True, "result": "ok", "error": None}
 
-    async def _fake_run_skill_execution(skill_name, **kwargs):
+    async def _fake_execute_skill(skill_name, **kwargs):
         return SkillResult(success=True, output="ok", data={"unrelated": True})
 
     monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
-    monkeypatch.setattr("src.runtime.jira_workflow_review.run_skill_execution", _fake_run_skill_execution)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
 
     result = await run_jira_workflow_review({"issue_key": "PROJ-12", "skill_name": "review_skill"})
 
     assert result["success"] is False
     assert "structured workflow outcome" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_jira_workflow_review_skill_path_uses_bus_execute_skill(monkeypatch):
+    async def _fake_execute_jira_workflow_action(action_name, kwargs):
+        if action_name == "read_issue":
+            return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
+        return {"success": True, "result": "ok", "error": None}
+
+    async def _fake_execute_skill(skill_name, **kwargs):
+        return SkillResult(success=True, output="ok", data={"approved": True, "comment": "ok"})
+
+    async def _fail_direct(*_args, **_kwargs):
+        raise AssertionError("direct run_skill_execution bypass should not be used")
+
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.agents.executor.run_skill_execution", _fail_direct)
+
+    result = await run_jira_workflow_review({"issue_key": "PROJ-12", "skill_name": "review_skill"})
+    assert result["success"] is True
 
 
 @pytest.mark.asyncio
@@ -176,12 +197,12 @@ async def test_workflow_context_json_object_string_is_accepted(monkeypatch):
             return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
         return {"success": True, "result": "ok", "error": None}
 
-    async def _fake_run_skill_execution(skill_name, **kwargs):
+    async def _fake_execute_skill(skill_name, **kwargs):
         captured["workflow_context"] = kwargs.get("workflow_context")
         return SkillResult(success=True, output="ok", data={"approved": True, "comment": "c"})
 
     monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
-    monkeypatch.setattr("src.runtime.jira_workflow_review.run_skill_execution", _fake_run_skill_execution)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
 
     result = await run_jira_workflow_review(
         {
@@ -204,12 +225,12 @@ async def test_malformed_workflow_fields_emit_warning_and_continue(monkeypatch):
             return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
         return {"success": True, "result": "ok", "error": None}
 
-    async def _fake_run_skill_execution(skill_name, **kwargs):
+    async def _fake_execute_skill(skill_name, **kwargs):
         captured["skill_kwargs"] = kwargs
         return SkillResult(success=True, output="ok", data={"approved": True})
 
     monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
-    monkeypatch.setattr("src.runtime.jira_workflow_review.run_skill_execution", _fake_run_skill_execution)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
 
     result = await run_jira_workflow_review(
         {
@@ -241,11 +262,11 @@ async def test_mapping_fields_json_object_strings_are_accepted(monkeypatch):
             return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
         return {"success": True, "result": "ok", "error": None}
 
-    async def _fake_run_skill_execution(skill_name, **kwargs):
+    async def _fake_execute_skill(skill_name, **kwargs):
         return SkillResult(success=True, output="ok", data={"decision": "approved"})
 
     monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
-    monkeypatch.setattr("src.runtime.jira_workflow_review.run_skill_execution", _fake_run_skill_execution)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
 
     result = await run_jira_workflow_review(
         {
@@ -272,12 +293,12 @@ async def test_workflow_context_non_object_json_is_ignored(monkeypatch):
             return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
         return {"success": True, "result": "ok", "error": None}
 
-    async def _fake_run_skill_execution(skill_name, **kwargs):
+    async def _fake_execute_skill(skill_name, **kwargs):
         captured["workflow_context"] = kwargs.get("workflow_context")
         return SkillResult(success=True, output="ok", data={"approved": True})
 
     monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
-    monkeypatch.setattr("src.runtime.jira_workflow_review.run_skill_execution", _fake_run_skill_execution)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
 
     result = await run_jira_workflow_review(
         {

--- a/tests/test_leader_orchestration.py
+++ b/tests/test_leader_orchestration.py
@@ -392,6 +392,26 @@ async def test_load_coordination_run_state_falls_back_to_delegations(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_leader_orchestration_routes_adapter_actions_via_bus_helper(monkeypatch):
+    calls = []
+
+    async def _fake_bus_helper(action_id, kwargs, **_meta):
+        calls.append(action_id)
+        if action_id == "adapter:portal:get_coordination_run":
+            return {"success": True, "result": {"coordination_run_id": "coord-1", "status": "running", "rounds": []}, "error": None}
+        return {"success": True, "result": {"delegations": []}, "error": None}
+
+    async def _fail_direct(*_args, **_kwargs):
+        raise AssertionError("direct adapter executor path should not be used")
+
+    monkeypatch.setattr("src.runtime.leader_orchestration.execute_adapter_action_via_bus", _fake_bus_helper)
+    monkeypatch.setattr("src.runtime.adapter_executor.execute_adapter_action", _fail_direct)
+    state = await load_coordination_run_state(group_id="g-1", coordination_run_id="coord-1")
+    assert state["coordination_run_id"] == "coord-1"
+    assert "adapter:portal:get_coordination_run" in calls
+
+
+@pytest.mark.asyncio
 async def test_run_delegation_cycle_evaluation_mode_loads_run_state(monkeypatch):
     async def _fake_load(*, group_id, coordination_run_id):
         assert group_id == "g-1"

--- a/tests/test_task_capability_contracts.py
+++ b/tests/test_task_capability_contracts.py
@@ -1,0 +1,69 @@
+from src.runtime.execution_bus import resolve_task_capability_plan
+from src.runtime.task_capability_contracts import resolve_task_capability_contract
+
+
+def test_resolve_task_capability_contract_adapter_action_task_known_action():
+    plan = resolve_task_capability_contract("adapter_action_task", {"action_id": "ADAPTER:GITHUB:ADD_COMMENT"})
+
+    assert plan["primary_capability_id"] == "adapter:github:add_comment"
+    assert plan["capability_id"] == "adapter:github:add_comment"
+    assert plan["capability_type"] == "adapter_action"
+    assert plan["action_id"] == "adapter:github:add_comment"
+    assert "adapter:github:add_comment" in plan["involved_capability_ids"]
+
+
+def test_resolve_task_capability_contract_jira_workflow_review_task():
+    plan = resolve_task_capability_contract(
+        "jira_workflow_review_task",
+        {
+            "issue_key": "ENG-1",
+            "success_transition": "Done",
+            "assignee": "user-a",
+            "review_comment": "looks good",
+            "fields": {"priority": "High"},
+        },
+    )
+
+    assert plan["primary_capability_id"] == "adapter:jira:read_issue"
+    assert plan["capability_id"] == "adapter:jira:read_issue"
+    assert plan["action_id"] == "adapter:jira:read_issue"
+    assert plan["involved_capability_ids"] == [
+        "adapter:jira:add_comment",
+        "adapter:jira:assign_issue",
+        "adapter:jira:read_issue",
+        "adapter:jira:transition_issue",
+        "adapter:jira:update_issue",
+    ]
+
+
+def test_resolve_task_capability_contract_github_review_task():
+    plan = resolve_task_capability_contract("github_review_task", {"owner": "acme", "repo": "demo", "pull_number": 7})
+
+    assert plan["primary_capability_id"] == "adapter:github:review_pull_request"
+    assert plan["capability_id"] == "adapter:github:review_pull_request"
+    assert plan["action_id"] == "adapter:github:review_pull_request"
+    assert plan["involved_capability_ids"] == ["adapter:github:add_comment", "adapter:github:review_pull_request"]
+
+
+def test_resolve_task_capability_contract_delegation_task():
+    plan = resolve_task_capability_contract("delegation_task", {"skill_name": "Demo"})
+
+    assert plan["primary_capability_id"] == "skill:demo"
+    assert plan["capability_id"] == "skill:demo"
+    assert plan["capability_type"] == "skill"
+    assert plan["involved_capability_ids"] == ["skill:demo"]
+
+
+def test_execution_bus_resolve_task_capability_plan_delegates_to_canonical_contract(monkeypatch):
+    sentinel = {"primary_capability_id": "x", "capability_resolution": "resolved"}
+
+    def _fake(task_type, payload):
+        assert task_type == "adapter_action_task"
+        assert payload == {"action_id": "adapter:github:add_comment"}
+        return sentinel
+
+    monkeypatch.setattr("src.runtime.execution_bus.resolve_task_capability_contract", _fake)
+
+    plan = resolve_task_capability_plan("adapter_action_task", {"action_id": "adapter:github:add_comment"})
+
+    assert plan is sentinel

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -571,6 +571,45 @@ async def test_api_capabilities_capability_id_not_found_returns_empty(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_api_capabilities_filters_by_capability_id_and_type(monkeypatch):
+    from src.gateway import webchat
+
+    class _Registry:
+        def export_catalog_snapshot(self):
+            capabilities = [
+                {"capability_id": "tool:read", "type": "tool", "enabled": True},
+                {"capability_id": "tool:write", "type": "tool", "enabled": True},
+                {"capability_id": "adapter:jira:read_issue", "type": "adapter_action", "enabled": True},
+            ]
+            return {
+                "capabilities": capabilities,
+                "count": len(capabilities),
+                "catalog_version": "v-snap",
+                "generated_at": "2026-04-07T00:00:00Z",
+            }
+
+    monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
+
+    class _ByCapabilityIdRequest:
+        query = {"capability_id": "tool:write"}
+
+    by_id_response = await webchat.api_capabilities(_ByCapabilityIdRequest())
+    by_id_body = json.loads(by_id_response.body)
+    assert by_id_response.status == 200
+    assert by_id_body["count"] == 1
+    assert by_id_body["capabilities"] == [{"capability_id": "tool:write", "type": "tool", "enabled": True}]
+
+    class _ByTypeRequest:
+        query = {"type": "adapter_action"}
+
+    by_type_response = await webchat.api_capabilities(_ByTypeRequest())
+    by_type_body = json.loads(by_type_response.body)
+    assert by_type_response.status == 200
+    assert by_type_body["count"] == 1
+    assert by_type_body["capabilities"][0]["type"] == "adapter_action"
+
+
+@pytest.mark.asyncio
 async def test_api_tasks_execute_adapter_action_task_success(monkeypatch):
     from src.gateway import webchat
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -517,11 +517,17 @@ async def test_api_capabilities_returns_catalog_and_filters(monkeypatch):
     from src.gateway import webchat
 
     class _Registry:
-        def export_catalog(self):
-            return [
+        def export_catalog_snapshot(self):
+            capabilities = [
                 {"capability_id": "tool:read", "type": "tool", "enabled": True},
                 {"capability_id": "adapter:jira:read_issue", "type": "adapter_action", "enabled": False},
             ]
+            return {
+                "capabilities": capabilities,
+                "count": len(capabilities),
+                "catalog_version": "v-snap",
+                "generated_at": "2026-04-07T00:00:00Z",
+            }
 
     monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
 
@@ -533,6 +539,9 @@ async def test_api_capabilities_returns_catalog_and_filters(monkeypatch):
     assert response.status == 200
     assert body["count"] == 1
     assert body["capabilities"][0]["capability_id"] == "tool:read"
+    assert body["catalog_version"] == "v-snap"
+    assert body["generated_at"] == "2026-04-07T00:00:00Z"
+    assert body["supports_snapshot_contract"] is True
 
 
 @pytest.mark.asyncio
@@ -540,8 +549,13 @@ async def test_api_capabilities_capability_id_not_found_returns_empty(monkeypatc
     from src.gateway import webchat
 
     class _Registry:
-        def export_catalog(self):
-            return [{"capability_id": "tool:read", "type": "tool", "enabled": True}]
+        def export_catalog_snapshot(self):
+            return {
+                "capabilities": [{"capability_id": "tool:read", "type": "tool", "enabled": True}],
+                "count": 1,
+                "catalog_version": "v-snap",
+                "generated_at": "2026-04-07T00:00:00Z",
+            }
 
     monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
 
@@ -553,6 +567,7 @@ async def test_api_capabilities_capability_id_not_found_returns_empty(monkeypatc
     assert response.status == 200
     assert body["count"] == 0
     assert body["capabilities"] == []
+    assert body["catalog_version"] == "v-snap"
 
 
 @pytest.mark.asyncio

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -508,7 +508,51 @@ def test_routes_include_tasks_execute_and_existing_chat_route():
 
     routes = [r.resource.canonical for r in app.router.routes() if r.resource]
     assert "/api/tasks/execute" in routes
+    assert "/api/capabilities" in routes
     assert "/api/chat" in routes
+
+
+@pytest.mark.asyncio
+async def test_api_capabilities_returns_catalog_and_filters(monkeypatch):
+    from src.gateway import webchat
+
+    class _Registry:
+        def export_catalog(self):
+            return [
+                {"capability_id": "tool:read", "type": "tool", "enabled": True},
+                {"capability_id": "adapter:jira:read_issue", "type": "adapter_action", "enabled": False},
+            ]
+
+    monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
+
+    class _Request:
+        query = {"type": "tool", "enabled": "true"}
+
+    response = await webchat.api_capabilities(_Request())
+    body = json.loads(response.body)
+    assert response.status == 200
+    assert body["count"] == 1
+    assert body["capabilities"][0]["capability_id"] == "tool:read"
+
+
+@pytest.mark.asyncio
+async def test_api_capabilities_capability_id_not_found_returns_empty(monkeypatch):
+    from src.gateway import webchat
+
+    class _Registry:
+        def export_catalog(self):
+            return [{"capability_id": "tool:read", "type": "tool", "enabled": True}]
+
+    monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
+
+    class _Request:
+        query = {"capability_id": "adapter:jira:missing"}
+
+    response = await webchat.api_capabilities(_Request())
+    body = json.loads(response.body)
+    assert response.status == 200
+    assert body["count"] == 0
+    assert body["capabilities"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Provide a single, stable capability surface so runtime and external tools can discover and reason about available actions consistently.  
- Ensure governance and execution paths can consume Portal-provided capability allow/deny constraints and make blocking decisions at the runtime boundary.  
- Expose the runtime capability catalog via a simple HTTP API for Portal/debugging without changing existing Phase 1/2/3 execution semantics.

### Description
- Upgraded `DefaultCapabilityRegistry` with stable query APIs: `get`, `list_all`, `list_by_type`, `list_enabled`, `exists`, and `export_catalog` returning JSON-serializable records with the canonical fields `capability_id`, `type`, `name`, `input_schema`, `output_schema`, `policy_tags`, `requires_identity_binding`, `enabled`, `source_ref`, and `metadata`; added conservative read-only tool descriptors collection and normalized capability id formatting (`skill:...`, `adapter:...:...`, `channel_action:...`, `tool:...`).  
- Added capability-aware governance checks in `DefaultGovernanceBus.before_execute` that resolve a capability context per-request and honor metadata allow/deny fields (`allowed_capability_ids`, `denied_capability_ids`, `allowed_capability_types`, `denied_capability_types`, `allowed_adapter_actions`, `denied_adapter_actions`) with robust input tolerance and governance audit payloads.  
- Enriched `ExecutionBus` handling for task types to resolve capability surface: adapter tasks, Jira/GitHub review tasks, delegation/task-skills and tool tasks now include `capability_id`, `capability_type`, `policy_tags`, `requires_identity_binding`, and `capability_resolution` in runtime events and `output_payload`, and provide a clear unresolved fallback rather than silently ignoring missing descriptors.  
- Standardized adapter contract in `adapter_executor` to always return `success`, `error`, `result`, `system`, `action_name`, `action_id`, and `runtime_events` without changing business semantics.  
- Exposed a read-only runtime API `GET /api/capabilities` in `webchat` with query filters `type`, `enabled`, and `capability_id` using `capability_registry.export_catalog()`, returning `{ "capabilities": [...], "count": n }` and returning empty arrays (not 500) when no match is found.  
- Tests added/updated to cover `export_catalog` and filters, governance deny/allow behavior and malformed inputs, execution metadata enrichment and unresolved fallback semantics, and the web capabilities API.  

Short change summary (按要求):
- 新增 API: 新增 `GET /api/capabilities`（支持 `type`、`enabled`、`capability_id` 过滤）并返回稳定 JSON-serializable catalog。  
- 新增治理: 在 `before_execute` 中加入 capability 级别的 allow/deny 检查并产出 governance audit。  
- 新增测试: 补充/更新测试覆盖 registry 导出、治理拦截、执行路径的 capability metadata 以及 capabilities API。  
- 保持兼容点: 未重写 skill/runtime 主链，也未更改 `/api/tasks/execute` 外部 contract；adapter 业务语义保持不变，仅统一返回 contract。

### Testing
- Ran targeted pytest suites exercising modified code paths: `tests/test_capability_registry.py`, `tests/test_governance_bus.py`, `tests/test_execution_bus.py`, focused `tests/test_adapter_executor.py` cases, and `tests/test_webchat.py` capability-route cases.  
- Note: an initial test collection error occurred in this environment due to missing runtime config location (`/root/.efp/config.yaml`), which is environmental and not caused by the code changes; after preparing the environment the test run was repeated.  
- Final automated test result in this environment: selected/targeted suites passed (`123 passed`, 1 warning) for the exercised tests.  
- New/updated tests are included in the PR: `tests/test_capability_registry.py`, `tests/test_governance_bus.py`, `tests/test_execution_bus.py`, and `tests/test_webchat.py` (capabilities API checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d491de3fb8832aab2e9017b1af248f)