### PR TITLE
Add GitHub review `event` passthrough, normalize action-gate shapes, snapshot session metadata, and runtime fixes

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -401,8 +401,16 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
         commit_id = kwargs.get("commit_id")
         path = kwargs.get("path")
         line = kwargs.get("line")
+        event = kwargs.get("event", "COMMENT")
         result = await github_module.github_add_pr_review_comment(
-            owner, repo, pull_number, body, commit_id, path, line
+            owner=owner,
+            repo=repo,
+            pull_number=pull_number,
+            body=body,
+            commit_id=commit_id,
+            path=path,
+            line=line,
+            event=event,
         )
         return ToolResult(success=not result.lstrip().startswith("Error"), content=result)
     

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -275,7 +275,8 @@ async def _run_chat_via_execution_bus(
         },
         chat_handler=_chat_handler,
     )
-    output_payload = execution_result.output_payload if isinstance(execution_result.output_payload, dict) else {}
+    original_output_payload = execution_result.output_payload
+    output_payload = dict(original_output_payload) if isinstance(original_output_payload, dict) else {}
     output_payload["_execution_result"] = execution_result
     if execution_result.status == "error" or output_payload.get("error"):
         error_value = output_payload.get("error", "Execution bus error")

--- a/src/github/__init__.py
+++ b/src/github/__init__.py
@@ -178,12 +178,21 @@ async def github_add_pr_review_comment(
     body: str,
     commit_id: Optional[str] = None,
     path: Optional[str] = None,
-    line: Optional[int] = None
+    line: Optional[int] = None,
+    *,
+    event: str = "COMMENT",
 ) -> str:
     """Add a review comment to a PR."""
     try:
         result = await github_channel.add_pr_review_comment(
-            owner, repo, pull_number, body, commit_id, path, line
+            owner=owner,
+            repo=repo,
+            pull_number=pull_number,
+            body=body,
+            commit_id=commit_id,
+            path=path,
+            line=line,
+            event=event,
         )
         return f"Review comment added to PR #{pull_number}"
     except Exception as e:

--- a/src/github/api.py
+++ b/src/github/api.py
@@ -548,10 +548,11 @@ class GitHubChannel:
         repo: str,
         pull_number: int,
         body: str,
-        event: str = "COMMENT",
         commit_id: Optional[str] = None,
         path: Optional[str] = None,
-        line: Optional[int] = None
+        line: Optional[int] = None,
+        *,
+        event: str = "COMMENT",
     ) -> Dict[str, Any]:
         """Add a review comment to a pull request."""
         logger.info(f"Adding PR review comment {owner}/{repo}#{pull_number}")
@@ -895,15 +896,23 @@ async def github_add_pr_review_comment(
     repo: str,
     pull_number: int,
     body: str,
-    event: str = "COMMENT",
     commit_id: Optional[str] = None,
     path: Optional[str] = None,
-    line: Optional[int] = None
+    line: Optional[int] = None,
+    *,
+    event: str = "COMMENT",
 ) -> str:
     """Add a review comment to a PR."""
     try:
         result = await github_channel.add_pr_review_comment(
-            owner, repo, pull_number, body, event, commit_id, path, line
+            owner=owner,
+            repo=repo,
+            pull_number=pull_number,
+            body=body,
+            commit_id=commit_id,
+            path=path,
+            line=line,
+            event=event,
         )
         return f"Review comment added to PR #{pull_number}"
     except Exception as e:

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -1688,8 +1688,19 @@ def build_default_execution_bus(
 
             def _github_action_gate(action_id: str, _kwargs: Dict[str, Any]) -> Dict[str, Any] | None:
                 if action_id != secondary_action_id:
-                    return {"reason": "unsupported_secondary_action", "message": f"Unsupported secondary action: {action_id}"}
-                return _evaluate_secondary_action_gate(request=request, action_id=action_id)
+                    return {
+                        "blocked": True,
+                        "reason": "unsupported_secondary_action",
+                        "message": f"Unsupported secondary action: {action_id}",
+                    }
+                decision = _evaluate_secondary_action_gate(request=request, action_id=action_id)
+                if decision:
+                    return {
+                        "blocked": True,
+                        "reason": decision.get("reason"),
+                        "message": decision.get("message"),
+                    }
+                return {"blocked": False}
 
             review_result = await run_github_review_task(
                 {

--- a/src/runtime/github_review.py
+++ b/src/runtime/github_review.py
@@ -206,7 +206,20 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
 
         secondary_action_attempted = True
         gate = action_gate(secondary_action_id, action_payload) if action_gate else None
-        if gate is not None:
+        gate_reason = None
+        gate_message = None
+        is_blocked = False
+        if isinstance(gate, dict):
+            gate_reason = gate.get("reason")
+            gate_message = gate.get("message")
+            if "blocked" in gate:
+                is_blocked = bool(gate.get("blocked"))
+            else:
+                is_blocked = bool(gate)
+        elif gate is not None:
+            is_blocked = bool(gate)
+
+        if is_blocked:
             error_value = "capability policy blocked for secondary action"
             runtime_events.append(
                 _event(
@@ -214,8 +227,8 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
                     "blocked",
                     {
                         "secondary_action_id": secondary_action_id,
-                        "reason": gate.get("reason"),
-                        "message": gate.get("message"),
+                        "reason": gate_reason,
+                        "message": gate_message,
                     },
                 )
             )

--- a/src/runtime/jira_workflow_review.py
+++ b/src/runtime/jira_workflow_review.py
@@ -58,7 +58,7 @@ async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
     for warning in plan.normalization_warnings:
         runtime_events.append(
             _event(
-                "recovery.warning",
+                "task.jira_workflow_review.warning",
                 "warning",
                 plan.issue_key,
                 {"warning": warning},
@@ -187,7 +187,7 @@ async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
     if action_plan.get("reassignment_warning"):
         runtime_events.append(
             _event(
-                "recovery.warning",
+                "task.jira_workflow_review.warning",
                 "warning",
                 plan.issue_key,
                 {"warning": action_plan.get("reassignment_warning")},

--- a/src/runtime/runtime_adapter_execution.py
+++ b/src/runtime/runtime_adapter_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, Dict, Optional
 
 from src.runtime.chat_orchestration_adapter import execute_runtime_task_request
@@ -19,8 +20,12 @@ async def execute_adapter_action_via_bus(
     policy_profile_id: Optional[str] = None,
     context_ref: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
+    metadata_payload = dict(metadata or {})
+    if policy_profile_id:
+        metadata_payload["policy_profile_id"] = policy_profile_id
+
     result = await execute_runtime_task_request(
-        request_id=f"runtime-{action_id}",
+        request_id=f"runtime-{action_id}-{uuid.uuid4().hex}",
         source_type=source_type,
         source_ref=source_ref,
         session_id=session_id,
@@ -31,7 +36,7 @@ async def execute_adapter_action_via_bus(
             "action_id": action_id,
             "kwargs": dict(kwargs or {}),
         },
-        metadata={"policy_profile_id": policy_profile_id, **dict(metadata or {})} if policy_profile_id else dict(metadata or {}),
+        metadata=metadata_payload,
     )
     output = result.output_payload if isinstance(result.output_payload, dict) else {}
     return {

--- a/src/runtime/task_capability_contracts.py
+++ b/src/runtime/task_capability_contracts.py
@@ -37,7 +37,16 @@ def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) ->
         action_id = str(normalized_payload.get("action_id") or "").strip().lower()
         descriptor = registry.get(action_id) if action_id else None
         if descriptor is None:
-            return {**fallback, "primary_capability_id": action_id or None, "capability_id": action_id or None, "action_id": action_id or None}
+            if not action_id:
+                return fallback
+            return {
+                **fallback,
+                "primary_capability_id": action_id,
+                "capability_id": action_id,
+                "capability_type": "adapter_action",
+                "action_id": action_id,
+                "involved_capability_ids": [action_id],
+            }
         return {
             **fallback,
             "primary_capability_id": descriptor.capability_id,

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -1,6 +1,7 @@
 """Session management for Engineering Flow Platform with persistence and TTL support."""
 
 import asyncio
+from copy import deepcopy
 import json
 import logging
 import uuid
@@ -435,8 +436,9 @@ class SessionManager:
     async def set_last_execution_id(self, session_id: str, request_id: Optional[str]) -> None:
         """Record latest runtime execution request id in session metadata.
 
-        This updates in-memory session metadata; persistence is deferred to
-        normal session save paths (e.g. add_message autosave, save_all, shutdown).
+        This updates in-memory session metadata and schedules asynchronous
+        metadata persistence without blocking the current request path. This
+        pattern is used for lightweight metadata-only state transitions.
         """
         if not session_id or not request_id:
             return
@@ -500,12 +502,15 @@ class SessionManager:
         """Persist metadata-only state transitions without blocking request flow."""
         if not self.auto_save or not self.persistence_enabled:
             return
+        channel_snapshot = str(session.get("channel", ""))
+        messages_snapshot = deepcopy(session.get("history", []))
+        metadata_snapshot = deepcopy(session.get("metadata", {}))
         asyncio.create_task(
             session_persistence.save_session(
                 session_id=session_id,
-                channel=session.get("channel", ""),
-                messages=session.get("history", []),
-                metadata=session.get("metadata", {}),
+                channel=channel_snapshot,
+                messages=messages_snapshot,
+                metadata=metadata_snapshot,
             )
         )
 

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -2871,6 +2871,46 @@ async def test_github_review_task_secondary_action_denied_by_capability_policy(m
 
 
 @pytest.mark.asyncio
+async def test_execution_bus_github_action_gate_returns_normalized_blocked_shape(monkeypatch):
+    captured = {}
+
+    async def _fake_run_github_review_task(payload):
+        gate = payload["_action_gate"]
+        captured["allowed"] = gate("adapter:github:review_pull_request", {"owner": "acme"})
+        captured["denied"] = gate("adapter:github:add_comment", {"owner": "acme"})
+        return {
+            "success": True,
+            "review_summary": "ok",
+            "review_event": "COMMENT",
+            "review_written": True,
+            "comment_written": True,
+            "secondary_action_attempted": True,
+            "secondary_action_success": True,
+            "secondary_action_id": "adapter:github:review_pull_request",
+            "runtime_events": [],
+            "error": None,
+        }
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_github_review_task", _fake_run_github_review_task)
+
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "github_review_task", "owner": "acme", "repo": "demo", "pull_number": 88},
+        metadata={"allowed_adapter_actions": ["adapter:github:review_pull_request"]},
+    )
+    result = await bus.execute(req)
+
+    assert result.status == "success"
+    assert captured["allowed"] == {"blocked": False}
+    assert captured["denied"]["blocked"] is True
+    assert captured["denied"]["reason"] == "unsupported_secondary_action"
+    assert "Unsupported secondary action" in captured["denied"]["message"]
+    assert result.output_payload["secondary_action_decisions"][0]["decision"] == "applied"
+
+
+@pytest.mark.asyncio
 async def test_jira_workflow_review_task_transition_denied_adds_blocked_secondary_fields(monkeypatch):
     async def _fake_run_review(payload):
         gate = payload["_action_gate"]

--- a/tests/test_github_review.py
+++ b/tests/test_github_review.py
@@ -171,3 +171,67 @@ async def test_github_review_task_head_sha_match_still_writes_review(monkeypatch
     assert result["success"] is True
     assert captured["action_id"] == "adapter:github:review_pull_request"
     assert captured["kwargs"]["review_event"] == "APPROVE"
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_gate_with_blocked_false_allows_secondary_action(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(success=True, output="Looks good", data={"approved": True})
+
+    captured = {}
+
+    async def _fake_execute_adapter_action(action_id, kwargs):
+        captured["action_id"] = action_id
+        captured["kwargs"] = kwargs
+        return {"success": True, "error": None, "result": {"id": 7}, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action", _fake_execute_adapter_action)
+
+    result = await run_github_review_task(
+        {
+            "owner": "acme",
+            "repo": "demo",
+            "pull_number": 21,
+            "_action_gate": lambda *_args, **_kwargs: {"blocked": False},
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["action_id"] == "adapter:github:review_pull_request"
+    assert result["secondary_action_success"] is True
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_gate_with_blocked_true_blocks_secondary_action(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(success=True, output="Needs changes", data={"approved": False})
+
+    called = {"adapter": False}
+
+    async def _fake_execute_adapter_action(_action_id, _kwargs):
+        called["adapter"] = True
+        return {"success": True, "error": None, "result": {"id": 8}, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action", _fake_execute_adapter_action)
+
+    result = await run_github_review_task(
+        {
+            "owner": "acme",
+            "repo": "demo",
+            "pull_number": 22,
+            "_action_gate": lambda *_args, **_kwargs: {"blocked": True, "reason": "denied_by_policy"},
+        }
+    )
+
+    assert called["adapter"] is False
+    assert result["success"] is False
+    assert result["secondary_action_attempted"] is True
+    assert result["secondary_action_success"] is False
+    assert "capability policy blocked for secondary action" in str(result["error"])
+    assert any(evt.get("event_type") == "task.github_review.secondary_action.blocked" for evt in result["runtime_events"])

--- a/tests/test_github_tools.py
+++ b/tests/test_github_tools.py
@@ -258,9 +258,71 @@ async def test_github_get_pr_file_patch_dispatch_does_not_fail_on_error_word_in_
         return "**PR #1 File Patch: `x`**\n\n```diff\n+Error reporting path\n```"
 
     monkeypatch.setattr("src.github.github_get_pr_file_patch", fake_github_get_pr_file_patch)
-
     result = await execute_tool("github_get_pr_file_patch", owner="acme", repo="repo", pull_number=1, path="x")
     assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_github_review_comment_wrapper_preserves_positional_commit_binding(monkeypatch, github_modules):
+    github_module, _ = github_modules
+    captured = {}
+
+    async def _fake_add_pr_review_comment(**kwargs):
+        captured.update(kwargs)
+        return {"id": 1}
+
+    monkeypatch.setattr(github_module.github_channel, "add_pr_review_comment", _fake_add_pr_review_comment)
+
+    await github_module.github_add_pr_review_comment(
+        "acme",
+        "repo",
+        9,
+        "Inline note",
+        "deadbeef",
+        "src/app.py",
+        42,
+    )
+
+    assert captured["commit_id"] == "deadbeef"
+    assert captured["path"] == "src/app.py"
+    assert captured["line"] == 42
+    assert captured["event"] == "COMMENT"
+
+
+@pytest.mark.asyncio
+async def test_github_review_comment_wrapper_supports_keyword_event(monkeypatch, github_modules):
+    github_module, _ = github_modules
+    captured = {}
+
+    async def _fake_add_pr_review_comment(**kwargs):
+        captured.update(kwargs)
+        return {"id": 2}
+
+    monkeypatch.setattr(github_module.github_channel, "add_pr_review_comment", _fake_add_pr_review_comment)
+
+    await github_module.github_add_pr_review_comment(
+        owner="acme",
+        repo="repo",
+        pull_number=10,
+        body="Ship it",
+        event="APPROVE",
+    )
+
+    assert captured["event"] == "APPROVE"
+    assert captured["commit_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_rejects_invalid_event(github_modules):
+    _, github_api = github_modules
+    with pytest.raises(ValueError, match="event must be one of COMMENT, APPROVE, REQUEST_CHANGES"):
+        await github_api.github_channel.add_pr_review_comment(
+            owner="acme",
+            repo="repo",
+            pull_number=11,
+            body="Invalid",
+            event="NOT_REAL",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_jira_workflow_review.py
+++ b/tests/test_jira_workflow_review.py
@@ -266,7 +266,7 @@ async def test_malformed_workflow_fields_emit_warning_and_continue(monkeypatch):
 
     assert result["success"] is True
     assert captured["skill_kwargs"]["workflow_context"] == {}
-    warnings = [evt.get("detail_payload", {}).get("warning") for evt in result["runtime_events"] if evt.get("event_type") == "recovery.warning"]
+    warnings = [evt.get("detail_payload", {}).get("warning") for evt in result["runtime_events"] if evt.get("event_type") == "task.jira_workflow_review.warning"]
     assert "invalid_workflow_context_json" in warnings
     assert "invalid_skill_kwargs_type" in warnings
     assert "invalid_fields_on_success_type" in warnings
@@ -331,5 +331,5 @@ async def test_workflow_context_non_object_json_is_ignored(monkeypatch):
 
     assert result["success"] is True
     assert captured["workflow_context"] == {}
-    warnings = [evt.get("detail_payload", {}).get("warning") for evt in result["runtime_events"] if evt.get("event_type") == "recovery.warning"]
+    warnings = [evt.get("detail_payload", {}).get("warning") for evt in result["runtime_events"] if evt.get("event_type") == "task.jira_workflow_review.warning"]
     assert "invalid_workflow_context_type" in warnings

--- a/tests/test_runtime_adapter_execution.py
+++ b/tests/test_runtime_adapter_execution.py
@@ -1,0 +1,61 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_execute_adapter_action_via_bus_uses_unique_request_ids(monkeypatch):
+    from src.runtime import runtime_adapter_execution as module
+
+    captured_request_ids = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured_request_ids.append(kwargs["request_id"])
+        return type(
+            "R",
+            (),
+            {
+                "status": "success",
+                "output_payload": {"success": True, "result": {"ok": True}},
+                "runtime_events": [],
+            },
+        )()
+
+    monkeypatch.setattr(module, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+
+    await module.execute_adapter_action_via_bus("adapter:jira:read_issue", {"issue_key": "ABC-1"})
+    await module.execute_adapter_action_via_bus("adapter:jira:read_issue", {"issue_key": "ABC-1"})
+
+    assert len(captured_request_ids) == 2
+    assert captured_request_ids[0] != captured_request_ids[1]
+    assert captured_request_ids[0].startswith("runtime-adapter:jira:read_issue-")
+    assert captured_request_ids[1].startswith("runtime-adapter:jira:read_issue-")
+
+
+@pytest.mark.asyncio
+async def test_execute_adapter_action_via_bus_policy_profile_id_argument_overrides_metadata(monkeypatch):
+    from src.runtime import runtime_adapter_execution as module
+
+    captured = {}
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured.update(kwargs)
+        return type(
+            "R",
+            (),
+            {
+                "status": "success",
+                "output_payload": {"success": True, "result": {"ok": True}},
+                "runtime_events": [],
+            },
+        )()
+
+    monkeypatch.setattr(module, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+
+    await module.execute_adapter_action_via_bus(
+        "adapter:jira:read_issue",
+        {"issue_key": "ABC-1"},
+        metadata={"policy_profile_id": "from-metadata", "x": 1},
+        policy_profile_id="from-arg",
+    )
+
+    assert captured["metadata"]["policy_profile_id"] == "from-arg"
+    assert captured["metadata"]["x"] == 1

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,5 +1,6 @@
 """Tests for SessionManager."""
 
+import asyncio
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -173,12 +174,54 @@ class TestSessionManagerInfo:
         manager_module.session_persistence.save_session = _fake_save_session
         try:
             await fresh_session_manager.set_last_execution_id(session_id, "req-123")
+            await asyncio.sleep(0)
         finally:
             manager_module.session_persistence.save_session = original_save
 
         assert session["metadata"]["last_execution_id"] == "req-123"
         assert session["updated_at"]
-        assert save_calls == []
+        assert len(save_calls) == 1
+        assert save_calls[0]["session_id"] == session_id
+
+    @pytest.mark.asyncio
+    async def test_metadata_persist_uses_snapshots(self, fresh_session_manager):
+        import uuid
+        import asyncio
+
+        session_id = f"snapshot_meta_{uuid.uuid4().hex[:8]}"
+        session = await fresh_session_manager.get_session(session_id)
+        session["channel"] = "chat"
+        session["history"] = [{"id": "m1", "content": "before"}]
+        session["metadata"] = {"pending_delegations": [{"delegation_id": "d1"}]}
+
+        save_calls = []
+        gate = asyncio.Event()
+
+        async def _fake_save_session(**kwargs):
+            await gate.wait()
+            save_calls.append(kwargs)
+            return True
+
+        fresh_session_manager.auto_save = True
+        fresh_session_manager.persistence_enabled = True
+        from src.sessions import manager as manager_module
+        original_save = manager_module.session_persistence.save_session
+        manager_module.session_persistence.save_session = _fake_save_session
+        try:
+            await fresh_session_manager.set_last_execution_id(session_id, "req-1")
+            session["channel"] = "mutated-channel"
+            session["history"][0]["content"] = "after"
+            session["metadata"]["pending_delegations"][0]["delegation_id"] = "d2"
+            gate.set()
+            await asyncio.sleep(0)
+        finally:
+            manager_module.session_persistence.save_session = original_save
+
+        assert len(save_calls) == 1
+        saved = save_calls[0]
+        assert saved["channel"] == "chat"
+        assert saved["messages"][0]["content"] == "before"
+        assert saved["metadata"]["pending_delegations"][0]["delegation_id"] == "d1"
 
     @pytest.mark.asyncio
     async def test_add_message_still_uses_normal_persistence_path(self, fresh_session_manager):

--- a/tests/test_task_capability_contracts.py
+++ b/tests/test_task_capability_contracts.py
@@ -12,6 +12,17 @@ def test_resolve_task_capability_contract_adapter_action_task_known_action():
     assert "adapter:github:add_comment" in plan["involved_capability_ids"]
 
 
+def test_resolve_task_capability_contract_adapter_action_task_unknown_action_structurally_complete():
+    plan = resolve_task_capability_contract("adapter_action_task", {"action_id": "ADAPTER:GITHUB:UNKNOWN_REVIEW"})
+
+    assert plan["primary_capability_id"] == "adapter:github:unknown_review"
+    assert plan["capability_id"] == "adapter:github:unknown_review"
+    assert plan["action_id"] == "adapter:github:unknown_review"
+    assert plan["capability_type"] == "adapter_action"
+    assert plan["involved_capability_ids"] == ["adapter:github:unknown_review"]
+    assert plan["capability_resolution"] == "unresolved"
+
+
 def test_resolve_task_capability_contract_jira_workflow_review_task():
     plan = resolve_task_capability_contract(
         "jira_workflow_review_task",

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -239,6 +239,36 @@ async def test_chat_execution_bus_adapter_sets_request_path_metadata(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_chat_execution_bus_adapter_does_not_mutate_execution_output_payload(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+    original_payload = {"response": "ok"}
+
+    async def _fake_execute_chat_orchestration(**kwargs):
+        execution_result = type("R", (), {"status": "success", "output_payload": original_payload})()
+        captured["execution_result"] = execution_result
+        return execution_result
+
+    monkeypatch.setattr(webchat, "execute_chat_orchestration", _fake_execute_chat_orchestration)
+    monkeypatch.setattr(webchat, "run_chat_execution", lambda *args, **kwargs: {"response": "ignored"})
+
+    result = await webchat._run_chat_via_execution_bus(
+        agent=object(),
+        session_id="s-chat",
+        message="hello",
+        user_name="u1",
+        portal_user_id=None,
+        portal_user_name=None,
+    )
+
+    execution_result = captured["execution_result"]
+    assert result["_execution_result"] is execution_result
+    assert "_execution_result" not in execution_result.output_payload
+    assert result is not execution_result.output_payload
+
+
+@pytest.mark.asyncio
 async def test_chat_execution_bus_adapter_forwards_agent_id(monkeypatch):
     from src.gateway import webchat
 


### PR DESCRIPTION
### Motivation
- Ensure GitHub PR review comments support the `event` parameter and preserve positional commit/path/line bindings when calling the channel API.
- Normalize the shape of action-gate responses so runtime tasks can reliably detect blocked decisions and reason/message payloads.
- Prevent accidental mutation of orchestration `output_payload` objects and make adapter action requests use unique request ids and merged metadata.
- Avoid race conditions when persisting lightweight session metadata by snapshotting mutable session state.

### Description
- Added `event` keyword passthrough to the GitHub tool dispatcher and wrapper in `src/__init__.py`, `src/github/__init__.py`, and `src/github/api.py`, and updated the channel `add_pr_review_comment` signature and validation to accept `event` as a keyword-only argument and validate allowed values (`COMMENT`, `APPROVE`, `REQUEST_CHANGES`).
- Updated GitHub wrappers and callers to pass adapter arguments as keywords to preserve ordering/intent and ensure `commit_id`, `path`, `line`, and `event` are forwarded correctly.
- Normalized action-gate handling in `src/runtime/execution_bus.py` and `src/runtime/github_review.py` so gates can return either boolean or structured dicts with a `blocked` flag and `reason`/`message`; runtime events record the normalized reason/message.
- Prevented mutation of the orchestration `output_payload` in `src/gateway/webchat.py` by copying the dict when present and attaching `_execution_result` only to the returned copy.
- Made adapter-invocation request ids unique by appending a `uuid` in `src/runtime/runtime_adapter_execution.py` and merged `policy_profile_id` into metadata payloads.
- Snapshot mutable session fields (`channel`, `history`, `metadata`) with `deepcopy` before scheduling async persistence in `src/sessions/manager.py` to avoid racing writes seeing in-flight mutations.
- Improved `resolve_task_capability_contract` in `src/runtime/task_capability_contracts.py` to return a structurally complete contract for unknown `adapter_action_task` action ids (including `capability_type` and `involved_capability_ids`).
- Updated and added unit tests covering the above behaviors in multiple test modules, including `tests/test_github_tools.py`, `tests/test_github_review.py`, `tests/test_execution_bus.py`, `tests/test_runtime_adapter_execution.py`, `tests/test_session_manager.py`, `tests/test_task_capability_contracts.py`, and `tests/test_webchat.py`.

### Testing
- Ran the unit test suite with `pytest` covering the modified areas; new and updated tests include adapter action via bus uniqueness and metadata merging, GitHub review `event` passthrough and validation, normalized gate behavior, session metadata snapshotting, and webchat output payload immutability, and all tests passed.
- Specific new tests added: `test_execute_adapter_action_via_bus_uses_unique_request_ids`, `test_execute_adapter_action_via_bus_policy_profile_id_argument_overrides_metadata`, `test_github_review_comment_wrapper_preserves_positional_commit_binding`, `test_github_review_comment_wrapper_supports_keyword_event`, gate-related tests in `test_github_review.py` and `test_execution_bus.py`, and snapshot persistence tests in `tests/test_session_manager.py`; all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5fa5c5fa8832aa7cd86ae2f083963)