### PR TITLE
Route runtime adapter actions via ExecutionBus, tighten GitHub review comment API, and make session metadata persistence non-blocking

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -401,8 +401,16 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
         commit_id = kwargs.get("commit_id")
         path = kwargs.get("path")
         line = kwargs.get("line")
+        event = kwargs.get("event", "COMMENT")
         result = await github_module.github_add_pr_review_comment(
-            owner, repo, pull_number, body, commit_id, path, line
+            owner=owner,
+            repo=repo,
+            pull_number=pull_number,
+            body=body,
+            commit_id=commit_id,
+            path=path,
+            line=line,
+            event=event,
         )
         return ToolResult(success=not result.lstrip().startswith("Error"), content=result)
     

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -275,7 +275,8 @@ async def _run_chat_via_execution_bus(
         },
         chat_handler=_chat_handler,
     )
-    output_payload = execution_result.output_payload if isinstance(execution_result.output_payload, dict) else {}
+    original_output_payload = execution_result.output_payload
+    output_payload = dict(original_output_payload) if isinstance(original_output_payload, dict) else {}
     output_payload["_execution_result"] = execution_result
     if execution_result.status == "error" or output_payload.get("error"):
         error_value = output_payload.get("error", "Execution bus error")

--- a/src/github/__init__.py
+++ b/src/github/__init__.py
@@ -178,12 +178,21 @@ async def github_add_pr_review_comment(
     body: str,
     commit_id: Optional[str] = None,
     path: Optional[str] = None,
-    line: Optional[int] = None
+    line: Optional[int] = None,
+    *,
+    event: str = "COMMENT",
 ) -> str:
     """Add a review comment to a PR."""
     try:
         result = await github_channel.add_pr_review_comment(
-            owner, repo, pull_number, body, commit_id, path, line
+            owner=owner,
+            repo=repo,
+            pull_number=pull_number,
+            body=body,
+            commit_id=commit_id,
+            path=path,
+            line=line,
+            event=event,
         )
         return f"Review comment added to PR #{pull_number}"
     except Exception as e:

--- a/src/github/api.py
+++ b/src/github/api.py
@@ -548,18 +548,46 @@ class GitHubChannel:
         repo: str,
         pull_number: int,
         body: str,
-        event: str = "COMMENT",
         commit_id: Optional[str] = None,
         path: Optional[str] = None,
-        line: Optional[int] = None
+        line: Optional[int] = None,
+        *,
+        event: str = "COMMENT",
     ) -> Dict[str, Any]:
         """Add a review comment to a pull request."""
         logger.info(f"Adding PR review comment {owner}/{repo}#{pull_number}")
         normalized_event = str(event or "COMMENT").strip().upper()
         if normalized_event not in {"COMMENT", "APPROVE", "REQUEST_CHANGES"}:
             raise ValueError("event must be one of COMMENT, APPROVE, REQUEST_CHANGES")
-        
-        if path and line:
+
+        normalized_path: Optional[str]
+        if path is None:
+            normalized_path = None
+        elif isinstance(path, str):
+            stripped_path = path.strip()
+            normalized_path = stripped_path or None
+        else:
+            normalized_path = str(path).strip() or None
+
+        normalized_line: Optional[int]
+        if line is None:
+            normalized_line = None
+        else:
+            if not isinstance(line, int) or line <= 0:
+                raise ValueError("line must be a positive integer for inline PR review comments")
+            normalized_line = line
+
+        has_path = normalized_path is not None
+        has_line = normalized_line is not None
+        if has_path != has_line:
+            raise ValueError("path and line must be provided together for inline PR review comments")
+
+        if has_path and has_line:
+            if normalized_event != "COMMENT":
+                raise ValueError(
+                    "Inline PR review comments only support event='COMMENT'; "
+                    "APPROVE and REQUEST_CHANGES require the pull request reviews endpoint"
+                )
             # For inline comments, we need a real commit SHA
             commit_id_to_use = commit_id
             if not commit_id_to_use:
@@ -577,8 +605,8 @@ class GitHubChannel:
                 json={
                     "body": body,
                     "commit_id": commit_id_to_use,
-                    "path": path,
-                    "line": line,
+                    "path": normalized_path,
+                    "line": normalized_line,
                     "side": "RIGHT"
                 }
             )
@@ -895,15 +923,23 @@ async def github_add_pr_review_comment(
     repo: str,
     pull_number: int,
     body: str,
-    event: str = "COMMENT",
     commit_id: Optional[str] = None,
     path: Optional[str] = None,
-    line: Optional[int] = None
+    line: Optional[int] = None,
+    *,
+    event: str = "COMMENT",
 ) -> str:
     """Add a review comment to a PR."""
     try:
         result = await github_channel.add_pr_review_comment(
-            owner, repo, pull_number, body, event, commit_id, path, line
+            owner=owner,
+            repo=repo,
+            pull_number=pull_number,
+            body=body,
+            commit_id=commit_id,
+            path=path,
+            line=line,
+            event=event,
         )
         return f"Review comment added to PR #{pull_number}"
     except Exception as e:

--- a/src/runtime/adapter_executor.py
+++ b/src/runtime/adapter_executor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any, Dict
 import json
-import os
 from aiohttp import ClientSession
 
 from src.runtime.events import build_runtime_event

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -1688,8 +1688,19 @@ def build_default_execution_bus(
 
             def _github_action_gate(action_id: str, _kwargs: Dict[str, Any]) -> Dict[str, Any] | None:
                 if action_id != secondary_action_id:
-                    return {"reason": "unsupported_secondary_action", "message": f"Unsupported secondary action: {action_id}"}
-                return _evaluate_secondary_action_gate(request=request, action_id=action_id)
+                    return {
+                        "blocked": True,
+                        "reason": "unsupported_secondary_action",
+                        "message": f"Unsupported secondary action: {action_id}",
+                    }
+                decision = _evaluate_secondary_action_gate(request=request, action_id=action_id)
+                if decision:
+                    return {
+                        "blocked": True,
+                        "reason": decision.get("reason"),
+                        "message": decision.get("message"),
+                    }
+                return {"blocked": False}
 
             review_result = await run_github_review_task(
                 {

--- a/src/runtime/github_review.py
+++ b/src/runtime/github_review.py
@@ -7,8 +7,8 @@ import logging
 
 from src.agents.executor import execute_skill
 from src.github.api import github_channel
-from src.runtime.adapter_executor import execute_adapter_action
 from src.runtime.events import build_runtime_event
+from src.runtime.runtime_adapter_execution import execute_adapter_action_via_bus
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,21 @@ async def _get_current_pr_head_sha(owner: str, repo: str, pull_number: int) -> s
     if isinstance(sha, str) and sha.strip():
         return sha.strip()
     return None
+
+
+async def execute_github_review_action(action_id: str, kwargs: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+    execution_metadata = payload.get("_execution_metadata")
+    metadata = dict(execution_metadata) if isinstance(execution_metadata, dict) else None
+    return await execute_adapter_action_via_bus(
+        action_id,
+        kwargs,
+        source_type="runtime",
+        source_ref="github_review",
+        session_id=payload.get("session_id"),
+        agent_id=payload.get("agent_id"),
+        policy_profile_id=payload.get("policy_profile_id"),
+        metadata=metadata,
+    )
 
 
 async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -206,7 +221,20 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
 
         secondary_action_attempted = True
         gate = action_gate(secondary_action_id, action_payload) if action_gate else None
-        if gate is not None:
+        gate_reason = None
+        gate_message = None
+        is_blocked = False
+        if isinstance(gate, dict):
+            gate_reason = gate.get("reason")
+            gate_message = gate.get("message")
+            if "blocked" in gate:
+                is_blocked = bool(gate.get("blocked"))
+            else:
+                is_blocked = bool(gate)
+        elif gate is not None:
+            is_blocked = bool(gate)
+
+        if is_blocked:
             error_value = "capability policy blocked for secondary action"
             runtime_events.append(
                 _event(
@@ -214,15 +242,16 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
                     "blocked",
                     {
                         "secondary_action_id": secondary_action_id,
-                        "reason": gate.get("reason"),
-                        "message": gate.get("message"),
+                        "reason": gate_reason,
+                        "message": gate_message,
                     },
                 )
             )
         else:
-            add_comment_result = await execute_adapter_action(
+            add_comment_result = await execute_github_review_action(
                 secondary_action_id,
                 action_payload,
+                payload,
             )
             secondary_action_success = bool(add_comment_result.get("success"))
             actions_applied.append({"action_id": secondary_action_id, "success": secondary_action_success, "error": add_comment_result.get("error")})

--- a/src/runtime/jira_workflow_review.py
+++ b/src/runtime/jira_workflow_review.py
@@ -58,7 +58,7 @@ async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
     for warning in plan.normalization_warnings:
         runtime_events.append(
             _event(
-                "recovery.warning",
+                "task.jira_workflow_review.warning",
                 "warning",
                 plan.issue_key,
                 {"warning": warning},
@@ -187,7 +187,7 @@ async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
     if action_plan.get("reassignment_warning"):
         runtime_events.append(
             _event(
-                "recovery.warning",
+                "task.jira_workflow_review.warning",
                 "warning",
                 plan.issue_key,
                 {"warning": action_plan.get("reassignment_warning")},

--- a/src/runtime/portal_session_metadata_client.py
+++ b/src/runtime/portal_session_metadata_client.py
@@ -108,7 +108,7 @@ def build_session_metadata_payload(
     if snapshot_version:
         payload["snapshot_version"] = str(snapshot_version)
 
-    if pending_delegations:
+    if pending_delegations is not None:
         payload["pending_delegations_json"] = _safe_json(pending_delegations)
 
     trimmed_runtime_events = list(runtime_events or [])[-_MAX_RUNTIME_EVENTS:]

--- a/src/runtime/runtime_adapter_execution.py
+++ b/src/runtime/runtime_adapter_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, Dict, Optional
 
 from src.runtime.chat_orchestration_adapter import execute_runtime_task_request
@@ -19,11 +20,16 @@ async def execute_adapter_action_via_bus(
     policy_profile_id: Optional[str] = None,
     context_ref: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
+    metadata_payload = dict(metadata or {})
+    if policy_profile_id:
+        metadata_payload["policy_profile_id"] = policy_profile_id
+
     result = await execute_runtime_task_request(
-        request_id=f"runtime-{action_id}",
+        request_id=f"runtime-{action_id}-{uuid.uuid4().hex}",
         source_type=source_type,
         source_ref=source_ref,
         session_id=session_id,
+        agent_id=agent_id,
         execution_type="task",
         context_ref=context_ref,
         input_payload={
@@ -31,7 +37,7 @@ async def execute_adapter_action_via_bus(
             "action_id": action_id,
             "kwargs": dict(kwargs or {}),
         },
-        metadata={"policy_profile_id": policy_profile_id, **dict(metadata or {})} if policy_profile_id else dict(metadata or {}),
+        metadata=metadata_payload,
     )
     output = result.output_payload if isinstance(result.output_payload, dict) else {}
     return {

--- a/src/runtime/task_capability_contracts.py
+++ b/src/runtime/task_capability_contracts.py
@@ -37,7 +37,16 @@ def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) ->
         action_id = str(normalized_payload.get("action_id") or "").strip().lower()
         descriptor = registry.get(action_id) if action_id else None
         if descriptor is None:
-            return {**fallback, "primary_capability_id": action_id or None, "capability_id": action_id or None, "action_id": action_id or None}
+            if not action_id:
+                return fallback
+            return {
+                **fallback,
+                "primary_capability_id": action_id,
+                "capability_id": action_id,
+                "capability_type": "adapter_action",
+                "action_id": action_id,
+                "involved_capability_ids": [action_id],
+            }
         return {
             **fallback,
             "primary_capability_id": descriptor.capability_id,
@@ -101,11 +110,19 @@ def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) ->
         capability_id = f"skill:{skill_name}"
         descriptor = registry.get(capability_id)
         if descriptor is None:
-            return {**fallback, "primary_capability_id": capability_id, "capability_id": capability_id, "involved_capability_ids": [capability_id], "capability_type": "skill"}
+            return {
+                **fallback,
+                "primary_capability_id": capability_id,
+                "capability_id": capability_id,
+                "action_id": capability_id,
+                "involved_capability_ids": [capability_id],
+                "capability_type": "skill",
+            }
         return {
             **fallback,
             "primary_capability_id": descriptor.capability_id,
             "capability_id": descriptor.capability_id,
+            "action_id": descriptor.capability_id,
             "capability_type": descriptor.type,
             "involved_capability_ids": [descriptor.capability_id],
             "policy_tags": list(descriptor.policy_tags or []),
@@ -119,6 +136,9 @@ def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) ->
 def _resolve_involved_capability_ids_for_task(task_type: str, payload: Dict[str, Any]) -> list[str]:
     normalized_task_type = str(task_type or "").strip().lower()
     if normalized_task_type == "jira_workflow_review_task":
+        def _is_non_empty_mapping(value: Any) -> bool:
+            return isinstance(value, dict) and bool(value)
+
         involved = {"adapter:jira:read_issue"}
         has_transition = any(payload.get(key) for key in ("transition", "success_transition", "failure_transition"))
         has_assign = any(
@@ -126,7 +146,10 @@ def _resolve_involved_capability_ids_for_task(task_type: str, payload: Dict[str,
             for key in ("assignee", "success_reassign_to", "failure_reassign_to", "explicit_success_assignee", "explicit_failure_assignee")
         )
         has_comment = any(payload.get(key) for key in ("review_comment", "review_comment_template", "transition_comment"))
-        has_update = bool(payload.get("fields"))
+        has_update = any(
+            _is_non_empty_mapping(payload.get(key))
+            for key in ("fields", "fields_on_success", "fields_on_failure")
+        )
         if has_transition:
             involved.add("adapter:jira:transition_issue")
         if has_assign:

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -1,6 +1,7 @@
 """Session management for Engineering Flow Platform with persistence and TTL support."""
 
 import asyncio
+from copy import deepcopy
 import json
 import logging
 import uuid
@@ -435,8 +436,9 @@ class SessionManager:
     async def set_last_execution_id(self, session_id: str, request_id: Optional[str]) -> None:
         """Record latest runtime execution request id in session metadata.
 
-        This updates in-memory session metadata; persistence is deferred to
-        normal session save paths (e.g. add_message autosave, save_all, shutdown).
+        This updates in-memory session metadata and schedules asynchronous
+        metadata persistence without blocking the current request path. This
+        pattern is used for lightweight metadata-only state transitions.
         """
         if not session_id or not request_id:
             return
@@ -454,11 +456,12 @@ class SessionManager:
         metadata = session.setdefault("metadata", {})
         pending = metadata.get("pending_delegations")
         pending_list = list(pending) if isinstance(pending, list) else []
+        pending_dicts = [item for item in pending_list if isinstance(item, dict)]
         delegation_id = delegation_record.get("delegation_id")
         if delegation_id:
-            pending_list = [item for item in pending_list if item.get("delegation_id") != delegation_id]
-        pending_list.append(dict(delegation_record))
-        metadata["pending_delegations"] = pending_list
+            pending_dicts = [item for item in pending_dicts if item.get("delegation_id") != delegation_id]
+        pending_dicts.append(dict(delegation_record))
+        metadata["pending_delegations"] = pending_dicts
         session["updated_at"] = datetime.now().isoformat()
         self._schedule_metadata_persist(session_id, session)
 
@@ -500,14 +503,22 @@ class SessionManager:
         """Persist metadata-only state transitions without blocking request flow."""
         if not self.auto_save or not self.persistence_enabled:
             return
-        asyncio.create_task(
-            session_persistence.save_session(
-                session_id=session_id,
-                channel=session.get("channel", ""),
-                messages=session.get("history", []),
-                metadata=session.get("metadata", {}),
-            )
-        )
+        channel_snapshot = str(session.get("channel", ""))
+        messages_snapshot = deepcopy(session.get("history", []))
+        metadata_snapshot = deepcopy(session.get("metadata", {}))
+
+        async def _persist_metadata_snapshot() -> None:
+            try:
+                await session_persistence.save_session(
+                    session_id=session_id,
+                    channel=channel_snapshot,
+                    messages=messages_snapshot,
+                    metadata=metadata_snapshot,
+                )
+            except Exception:
+                logger.exception("Failed to persist metadata-only session update", extra={"session_id": session_id})
+
+        asyncio.create_task(_persist_metadata_snapshot())
 
     async def recover_session_state(self, session_id: str) -> Dict[str, Any]:
         """Recover runtime-facing session state through the runtime recovery pipeline."""

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -2871,6 +2871,46 @@ async def test_github_review_task_secondary_action_denied_by_capability_policy(m
 
 
 @pytest.mark.asyncio
+async def test_execution_bus_github_action_gate_returns_normalized_blocked_shape(monkeypatch):
+    captured = {}
+
+    async def _fake_run_github_review_task(payload):
+        gate = payload["_action_gate"]
+        captured["allowed"] = gate("adapter:github:review_pull_request", {"owner": "acme"})
+        captured["denied"] = gate("adapter:github:add_comment", {"owner": "acme"})
+        return {
+            "success": True,
+            "review_summary": "ok",
+            "review_event": "COMMENT",
+            "review_written": True,
+            "comment_written": True,
+            "secondary_action_attempted": True,
+            "secondary_action_success": True,
+            "secondary_action_id": "adapter:github:review_pull_request",
+            "runtime_events": [],
+            "error": None,
+        }
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_github_review_task", _fake_run_github_review_task)
+
+    bus = build_default_execution_bus()
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "github_review_task", "owner": "acme", "repo": "demo", "pull_number": 88},
+        metadata={"allowed_adapter_actions": ["adapter:github:review_pull_request"]},
+    )
+    result = await bus.execute(req)
+
+    assert result.status == "success"
+    assert captured["allowed"] == {"blocked": False}
+    assert captured["denied"]["blocked"] is True
+    assert captured["denied"]["reason"] == "unsupported_secondary_action"
+    assert "Unsupported secondary action" in captured["denied"]["message"]
+    assert result.output_payload["secondary_action_decisions"][0]["decision"] == "applied"
+
+
+@pytest.mark.asyncio
 async def test_jira_workflow_review_task_transition_denied_adds_blocked_secondary_fields(monkeypatch):
     async def _fake_run_review(payload):
         gate = payload["_action_gate"]

--- a/tests/test_github_review.py
+++ b/tests/test_github_review.py
@@ -18,13 +18,13 @@ async def test_github_review_task_maps_approved_to_approve_event(monkeypatch):
 
     captured = {}
 
-    async def _fake_execute_adapter_action(action_id, kwargs):
+    async def _fake_execute_adapter_action_via_bus(action_id, kwargs, **_meta):
         captured["action_id"] = action_id
         captured["kwargs"] = kwargs
         return {"success": True, "error": None, "result": {"id": 1}, "runtime_events": []}
 
     monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
-    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action", _fake_execute_adapter_action)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fake_execute_adapter_action_via_bus)
 
     result = await run_github_review_task({"owner": "acme", "repo": "demo", "pull_number": 1})
 
@@ -43,13 +43,13 @@ async def test_github_review_task_maps_rejected_to_request_changes_event(monkeyp
 
     captured = {}
 
-    async def _fake_execute_adapter_action(action_id, kwargs):
+    async def _fake_execute_adapter_action_via_bus(action_id, kwargs, **_meta):
         captured["action_id"] = action_id
         captured["kwargs"] = kwargs
         return {"success": True, "error": None, "result": {"id": 2}, "runtime_events": []}
 
     monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
-    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action", _fake_execute_adapter_action)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fake_execute_adapter_action_via_bus)
 
     result = await run_github_review_task({"owner": "acme", "repo": "demo", "pull_number": 2})
 
@@ -67,13 +67,13 @@ async def test_github_review_task_plain_summary_defaults_to_comment_event(monkey
 
     captured = {}
 
-    async def _fake_execute_adapter_action(action_id, kwargs):
+    async def _fake_execute_adapter_action_via_bus(action_id, kwargs, **_meta):
         captured["action_id"] = action_id
         captured["kwargs"] = kwargs
         return {"success": True, "error": None, "result": {"id": 3}, "runtime_events": []}
 
     monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
-    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action", _fake_execute_adapter_action)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fake_execute_adapter_action_via_bus)
 
     result = await run_github_review_task({"owner": "acme", "repo": "demo", "pull_number": 3})
 
@@ -91,13 +91,13 @@ async def test_github_review_task_explicit_issue_comment_fallback(monkeypatch):
 
     captured = {}
 
-    async def _fake_execute_adapter_action(action_id, kwargs):
+    async def _fake_execute_adapter_action_via_bus(action_id, kwargs, **_meta):
         captured["action_id"] = action_id
         captured["kwargs"] = kwargs
         return {"success": True, "error": None, "result": {"id": 4}, "runtime_events": []}
 
     monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
-    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action", _fake_execute_adapter_action)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fake_execute_adapter_action_via_bus)
 
     result = await run_github_review_task(
         {"owner": "acme", "repo": "demo", "pull_number": 4, "writeback_mode": "issue_comment"}
@@ -117,7 +117,7 @@ async def test_github_review_task_head_sha_mismatch_suppresses_writeback(monkeyp
 
     called = {"adapter": False}
 
-    async def _fake_execute_adapter_action(_action_id, _kwargs):
+    async def _fake_execute_adapter_action_via_bus(_action_id, _kwargs, **_meta):
         called["adapter"] = True
         return {"success": True, "error": None, "result": {"id": 5}, "runtime_events": []}
 
@@ -125,7 +125,7 @@ async def test_github_review_task_head_sha_mismatch_suppresses_writeback(monkeyp
         return "sha-new"
 
     monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
-    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action", _fake_execute_adapter_action)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fake_execute_adapter_action_via_bus)
     monkeypatch.setattr("src.runtime.github_review._get_current_pr_head_sha", _fake_get_current_pr_head_sha)
 
     result = await run_github_review_task(
@@ -152,7 +152,7 @@ async def test_github_review_task_head_sha_match_still_writes_review(monkeypatch
 
     captured = {}
 
-    async def _fake_execute_adapter_action(action_id, kwargs):
+    async def _fake_execute_adapter_action_via_bus(action_id, kwargs, **_meta):
         captured["action_id"] = action_id
         captured["kwargs"] = kwargs
         return {"success": True, "error": None, "result": {"id": 6}, "runtime_events": []}
@@ -161,7 +161,7 @@ async def test_github_review_task_head_sha_match_still_writes_review(monkeypatch
         return "sha-1"
 
     monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
-    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action", _fake_execute_adapter_action)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fake_execute_adapter_action_via_bus)
     monkeypatch.setattr("src.runtime.github_review._get_current_pr_head_sha", _fake_get_current_pr_head_sha)
 
     result = await run_github_review_task(
@@ -171,3 +171,107 @@ async def test_github_review_task_head_sha_match_still_writes_review(monkeypatch
     assert result["success"] is True
     assert captured["action_id"] == "adapter:github:review_pull_request"
     assert captured["kwargs"]["review_event"] == "APPROVE"
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_gate_with_blocked_false_allows_secondary_action(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(success=True, output="Looks good", data={"approved": True})
+
+    captured = {}
+
+    async def _fake_execute_adapter_action_via_bus(action_id, kwargs, **_meta):
+        captured["action_id"] = action_id
+        captured["kwargs"] = kwargs
+        return {"success": True, "error": None, "result": {"id": 7}, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fake_execute_adapter_action_via_bus)
+
+    result = await run_github_review_task(
+        {
+            "owner": "acme",
+            "repo": "demo",
+            "pull_number": 21,
+            "_action_gate": lambda *_args, **_kwargs: {"blocked": False},
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["action_id"] == "adapter:github:review_pull_request"
+    assert result["secondary_action_success"] is True
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_gate_with_blocked_true_blocks_secondary_action(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(success=True, output="Needs changes", data={"approved": False})
+
+    called = {"adapter": False}
+
+    async def _fake_execute_adapter_action_via_bus(_action_id, _kwargs, **_meta):
+        called["adapter"] = True
+        return {"success": True, "error": None, "result": {"id": 8}, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fake_execute_adapter_action_via_bus)
+
+    result = await run_github_review_task(
+        {
+            "owner": "acme",
+            "repo": "demo",
+            "pull_number": 22,
+            "_action_gate": lambda *_args, **_kwargs: {"blocked": True, "reason": "denied_by_policy"},
+        }
+    )
+
+    assert called["adapter"] is False
+    assert result["success"] is False
+    assert result["secondary_action_attempted"] is True
+    assert result["secondary_action_success"] is False
+    assert "capability policy blocked for secondary action" in str(result["error"])
+    assert any(evt.get("event_type") == "task.github_review.secondary_action.blocked" for evt in result["runtime_events"])
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_forwards_runtime_context_to_bus_helper(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(success=True, output="Looks good", data={"approved": True})
+
+    captured = {}
+
+    async def _fake_execute_adapter_action_via_bus(action_id, kwargs, **meta):
+        captured["action_id"] = action_id
+        captured["kwargs"] = kwargs
+        captured["meta"] = meta
+        return {"success": True, "error": None, "result": {"id": 9}, "runtime_events": []}
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fake_execute_adapter_action_via_bus)
+
+    result = await run_github_review_task(
+        {
+            "owner": "acme",
+            "repo": "demo",
+            "pull_number": 23,
+            "session_id": "s-123",
+            "agent_id": "agent-123",
+            "policy_profile_id": "pp-123",
+            "_execution_metadata": {"k": "v"},
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["action_id"] == "adapter:github:review_pull_request"
+    assert captured["meta"]["source_type"] == "runtime"
+    assert captured["meta"]["source_ref"] == "github_review"
+    assert captured["meta"]["session_id"] == "s-123"
+    assert captured["meta"]["agent_id"] == "agent-123"
+    assert captured["meta"]["policy_profile_id"] == "pp-123"
+    assert captured["meta"]["metadata"] == {"k": "v"}

--- a/tests/test_github_tools.py
+++ b/tests/test_github_tools.py
@@ -258,9 +258,234 @@ async def test_github_get_pr_file_patch_dispatch_does_not_fail_on_error_word_in_
         return "**PR #1 File Patch: `x`**\n\n```diff\n+Error reporting path\n```"
 
     monkeypatch.setattr("src.github.github_get_pr_file_patch", fake_github_get_pr_file_patch)
-
     result = await execute_tool("github_get_pr_file_patch", owner="acme", repo="repo", pull_number=1, path="x")
     assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_github_review_comment_wrapper_preserves_positional_commit_binding(monkeypatch, github_modules):
+    github_module, _ = github_modules
+    captured = {}
+
+    async def _fake_add_pr_review_comment(**kwargs):
+        captured.update(kwargs)
+        return {"id": 1}
+
+    monkeypatch.setattr(github_module.github_channel, "add_pr_review_comment", _fake_add_pr_review_comment)
+
+    await github_module.github_add_pr_review_comment(
+        "acme",
+        "repo",
+        9,
+        "Inline note",
+        "deadbeef",
+        "src/app.py",
+        42,
+    )
+
+    assert captured["commit_id"] == "deadbeef"
+    assert captured["path"] == "src/app.py"
+    assert captured["line"] == 42
+    assert captured["event"] == "COMMENT"
+
+
+@pytest.mark.asyncio
+async def test_github_review_comment_wrapper_supports_keyword_event(monkeypatch, github_modules):
+    github_module, _ = github_modules
+    captured = {}
+
+    async def _fake_add_pr_review_comment(**kwargs):
+        captured.update(kwargs)
+        return {"id": 2}
+
+    monkeypatch.setattr(github_module.github_channel, "add_pr_review_comment", _fake_add_pr_review_comment)
+
+    await github_module.github_add_pr_review_comment(
+        owner="acme",
+        repo="repo",
+        pull_number=10,
+        body="Ship it",
+        event="APPROVE",
+    )
+
+    assert captured["event"] == "APPROVE"
+    assert captured["commit_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_rejects_invalid_event(github_modules):
+    _, github_api = github_modules
+    with pytest.raises(ValueError, match="event must be one of COMMENT, APPROVE, REQUEST_CHANGES"):
+        await github_api.github_channel.add_pr_review_comment(
+            owner="acme",
+            repo="repo",
+            pull_number=11,
+            body="Invalid",
+            event="NOT_REAL",
+        )
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_rejects_inline_non_comment_event(github_modules):
+    _, github_api = github_modules
+    with pytest.raises(ValueError, match="Inline PR review comments only support event='COMMENT'"):
+        await github_api.github_channel.add_pr_review_comment(
+            owner="acme",
+            repo="repo",
+            pull_number=11,
+            body="Invalid",
+            path="x.py",
+            line=10,
+            event="APPROVE",
+        )
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_requires_path_and_line_together(github_modules):
+    _, github_api = github_modules
+    with pytest.raises(ValueError, match="path and line must be provided together"):
+        await github_api.github_channel.add_pr_review_comment(
+            owner="acme",
+            repo="repo",
+            pull_number=11,
+            body="Invalid",
+            path="x.py",
+            event="COMMENT",
+        )
+    with pytest.raises(ValueError, match="path and line must be provided together"):
+        await github_api.github_channel.add_pr_review_comment(
+            owner="acme",
+            repo="repo",
+            pull_number=11,
+            body="Invalid",
+            line=10,
+            event="COMMENT",
+        )
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_inline_comment_happy_path(monkeypatch, github_modules):
+    _, github_api = github_modules
+    captured = {}
+
+    async def _fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs.get("json", {})
+        return {"id": 123}
+
+    monkeypatch.setattr(github_api.github_channel, "_request", _fake_request)
+
+    result = await github_api.github_channel.add_pr_review_comment(
+        owner="acme",
+        repo="repo",
+        pull_number=12,
+        body="Inline comment",
+        commit_id="deadbeef",
+        path="x.py",
+        line=10,
+        event="COMMENT",
+    )
+
+    assert result["id"] == 123
+    assert captured["method"] == "POST"
+    assert captured["endpoint"] == "/repos/acme/repo/pulls/12/comments"
+    assert captured["json"]["commit_id"] == "deadbeef"
+    assert captured["json"]["path"] == "x.py"
+    assert captured["json"]["line"] == 10
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_blank_path_without_line_uses_reviews_endpoint(monkeypatch, github_modules):
+    _, github_api = github_modules
+    captured = {}
+
+    async def _fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs.get("json", {})
+        return {"id": 124}
+
+    monkeypatch.setattr(github_api.github_channel, "_request", _fake_request)
+
+    result = await github_api.github_channel.add_pr_review_comment(
+        owner="acme",
+        repo="repo",
+        pull_number=12,
+        body="Review comment",
+        path="",
+        line=None,
+        event="COMMENT",
+    )
+
+    assert result["id"] == 124
+    assert captured["endpoint"] == "/repos/acme/repo/pulls/12/reviews"
+    assert captured["json"]["event"] == "COMMENT"
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_whitespace_path_without_line_uses_reviews_endpoint(monkeypatch, github_modules):
+    _, github_api = github_modules
+    captured = {}
+
+    async def _fake_request(method, endpoint, **kwargs):
+        captured["endpoint"] = endpoint
+        return {"id": 125}
+
+    monkeypatch.setattr(github_api.github_channel, "_request", _fake_request)
+
+    result = await github_api.github_channel.add_pr_review_comment(
+        owner="acme",
+        repo="repo",
+        pull_number=12,
+        body="Review comment",
+        path="   ",
+        line=None,
+        event="COMMENT",
+    )
+
+    assert result["id"] == 125
+    assert captured["endpoint"] == "/repos/acme/repo/pulls/12/reviews"
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_blank_path_with_line_still_fails_pairing(github_modules):
+    _, github_api = github_modules
+    with pytest.raises(ValueError, match="path and line must be provided together"):
+        await github_api.github_channel.add_pr_review_comment(
+            owner="acme",
+            repo="repo",
+            pull_number=11,
+            body="Invalid",
+            path="",
+            line=10,
+            event="COMMENT",
+        )
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_rejects_non_positive_line_values(github_modules):
+    _, github_api = github_modules
+    with pytest.raises(ValueError, match="line must be a positive integer for inline PR review comments"):
+        await github_api.github_channel.add_pr_review_comment(
+            owner="acme",
+            repo="repo",
+            pull_number=11,
+            body="Invalid",
+            path="x.py",
+            line=0,
+            event="COMMENT",
+        )
+    with pytest.raises(ValueError, match="line must be a positive integer for inline PR review comments"):
+        await github_api.github_channel.add_pr_review_comment(
+            owner="acme",
+            repo="repo",
+            pull_number=11,
+            body="Invalid",
+            path="x.py",
+            line=-1,
+            event="COMMENT",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_jira_workflow_review.py
+++ b/tests/test_jira_workflow_review.py
@@ -266,7 +266,7 @@ async def test_malformed_workflow_fields_emit_warning_and_continue(monkeypatch):
 
     assert result["success"] is True
     assert captured["skill_kwargs"]["workflow_context"] == {}
-    warnings = [evt.get("detail_payload", {}).get("warning") for evt in result["runtime_events"] if evt.get("event_type") == "recovery.warning"]
+    warnings = [evt.get("detail_payload", {}).get("warning") for evt in result["runtime_events"] if evt.get("event_type") == "task.jira_workflow_review.warning"]
     assert "invalid_workflow_context_json" in warnings
     assert "invalid_skill_kwargs_type" in warnings
     assert "invalid_fields_on_success_type" in warnings
@@ -331,5 +331,5 @@ async def test_workflow_context_non_object_json_is_ignored(monkeypatch):
 
     assert result["success"] is True
     assert captured["workflow_context"] == {}
-    warnings = [evt.get("detail_payload", {}).get("warning") for evt in result["runtime_events"] if evt.get("event_type") == "recovery.warning"]
+    warnings = [evt.get("detail_payload", {}).get("warning") for evt in result["runtime_events"] if evt.get("event_type") == "task.jira_workflow_review.warning"]
     assert "invalid_workflow_context_type" in warnings

--- a/tests/test_portal_session_metadata_client.py
+++ b/tests/test_portal_session_metadata_client.py
@@ -38,6 +38,49 @@ def test_build_session_metadata_payload_includes_supported_fields_only():
     assert "metadata_json" in payload
 
 
+def test_build_session_metadata_payload_includes_pending_delegations_when_non_empty():
+    payload = build_session_metadata_payload(
+        last_execution_id="exec-1",
+        latest_event_type="task.completed",
+        latest_event_state="success",
+        snapshot_version=None,
+        runtime_events=[],
+        metadata={},
+        pending_delegations=[{"delegation_id": "d-1"}],
+    )
+
+    assert payload["pending_delegations_json"] == '[{"delegation_id": "d-1"}]'
+
+
+def test_build_session_metadata_payload_includes_pending_delegations_when_empty_list():
+    payload = build_session_metadata_payload(
+        last_execution_id="exec-1",
+        latest_event_type="task.completed",
+        latest_event_state="success",
+        snapshot_version=None,
+        runtime_events=[],
+        metadata={},
+        pending_delegations=[],
+    )
+
+    assert "pending_delegations_json" in payload
+    assert payload["pending_delegations_json"] == "[]"
+
+
+def test_build_session_metadata_payload_omits_pending_delegations_when_none():
+    payload = build_session_metadata_payload(
+        last_execution_id="exec-1",
+        latest_event_type="task.completed",
+        latest_event_state="success",
+        snapshot_version=None,
+        runtime_events=[],
+        metadata={},
+        pending_delegations=None,
+    )
+
+    assert "pending_delegations_json" not in payload
+
+
 def test_build_session_metadata_payload_canonical_keys_take_precedence_over_portal_aliases():
     payload = build_session_metadata_payload(
         last_execution_id="exec-3",

--- a/tests/test_runtime_adapter_execution.py
+++ b/tests/test_runtime_adapter_execution.py
@@ -1,0 +1,90 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_execute_adapter_action_via_bus_uses_unique_request_ids(monkeypatch):
+    from src.runtime import runtime_adapter_execution as module
+
+    captured_request_ids = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured_request_ids.append(kwargs["request_id"])
+        return type(
+            "R",
+            (),
+            {
+                "status": "success",
+                "output_payload": {"success": True, "result": {"ok": True}},
+                "runtime_events": [],
+            },
+        )()
+
+    monkeypatch.setattr(module, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+
+    await module.execute_adapter_action_via_bus("adapter:jira:read_issue", {"issue_key": "ABC-1"})
+    await module.execute_adapter_action_via_bus("adapter:jira:read_issue", {"issue_key": "ABC-1"})
+
+    assert len(captured_request_ids) == 2
+    assert captured_request_ids[0] != captured_request_ids[1]
+    assert captured_request_ids[0].startswith("runtime-adapter:jira:read_issue-")
+    assert captured_request_ids[1].startswith("runtime-adapter:jira:read_issue-")
+
+
+@pytest.mark.asyncio
+async def test_execute_adapter_action_via_bus_policy_profile_id_argument_overrides_metadata(monkeypatch):
+    from src.runtime import runtime_adapter_execution as module
+
+    captured = {}
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured.update(kwargs)
+        return type(
+            "R",
+            (),
+            {
+                "status": "success",
+                "output_payload": {"success": True, "result": {"ok": True}},
+                "runtime_events": [],
+            },
+        )()
+
+    monkeypatch.setattr(module, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+
+    await module.execute_adapter_action_via_bus(
+        "adapter:jira:read_issue",
+        {"issue_key": "ABC-1"},
+        metadata={"policy_profile_id": "from-metadata", "x": 1},
+        policy_profile_id="from-arg",
+    )
+
+    assert captured["metadata"]["policy_profile_id"] == "from-arg"
+    assert captured["metadata"]["x"] == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_adapter_action_via_bus_forwards_agent_id(monkeypatch):
+    from src.runtime import runtime_adapter_execution as module
+
+    captured = {}
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured.update(kwargs)
+        return type(
+            "R",
+            (),
+            {
+                "status": "success",
+                "output_payload": {"success": True, "result": {"ok": True}},
+                "runtime_events": [],
+            },
+        )()
+
+    monkeypatch.setattr(module, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+
+    await module.execute_adapter_action_via_bus(
+        "adapter:jira:read_issue",
+        {"issue_key": "ABC-1"},
+        agent_id="agent-123",
+    )
+
+    assert captured["agent_id"] == "agent-123"

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,5 +1,6 @@
 """Tests for SessionManager."""
 
+import asyncio
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -155,7 +156,7 @@ class TestSessionManagerInfo:
         assert info is None
 
     @pytest.mark.asyncio
-    async def test_set_last_execution_id_updates_in_memory_without_triggering_save(self, fresh_session_manager):
+    async def test_set_last_execution_id_updates_in_memory_and_schedules_metadata_persist(self, fresh_session_manager):
         import uuid
 
         session_id = f"exec_meta_{uuid.uuid4().hex[:8]}"
@@ -173,12 +174,109 @@ class TestSessionManagerInfo:
         manager_module.session_persistence.save_session = _fake_save_session
         try:
             await fresh_session_manager.set_last_execution_id(session_id, "req-123")
+            await asyncio.sleep(0)
         finally:
             manager_module.session_persistence.save_session = original_save
 
         assert session["metadata"]["last_execution_id"] == "req-123"
         assert session["updated_at"]
-        assert save_calls == []
+        assert len(save_calls) == 1
+        assert save_calls[0]["session_id"] == session_id
+
+    @pytest.mark.asyncio
+    async def test_metadata_persist_uses_snapshots(self, fresh_session_manager):
+        import uuid
+        import asyncio
+
+        session_id = f"snapshot_meta_{uuid.uuid4().hex[:8]}"
+        session = await fresh_session_manager.get_session(session_id)
+        session["channel"] = "chat"
+        session["history"] = [{"id": "m1", "content": "before"}]
+        session["metadata"] = {"pending_delegations": [{"delegation_id": "d1"}]}
+
+        save_calls = []
+        gate = asyncio.Event()
+
+        async def _fake_save_session(**kwargs):
+            await gate.wait()
+            save_calls.append(kwargs)
+            return True
+
+        fresh_session_manager.auto_save = True
+        fresh_session_manager.persistence_enabled = True
+        from src.sessions import manager as manager_module
+        original_save = manager_module.session_persistence.save_session
+        manager_module.session_persistence.save_session = _fake_save_session
+        try:
+            await fresh_session_manager.set_last_execution_id(session_id, "req-1")
+            session["channel"] = "mutated-channel"
+            session["history"][0]["content"] = "after"
+            session["metadata"]["pending_delegations"][0]["delegation_id"] = "d2"
+            gate.set()
+            await asyncio.sleep(0)
+        finally:
+            manager_module.session_persistence.save_session = original_save
+
+        assert len(save_calls) == 1
+        saved = save_calls[0]
+        assert saved["channel"] == "chat"
+        assert saved["messages"][0]["content"] == "before"
+        assert saved["metadata"]["pending_delegations"][0]["delegation_id"] == "d1"
+
+    @pytest.mark.asyncio
+    async def test_add_pending_delegation_ignores_corrupted_non_dict_entries(self, fresh_session_manager):
+        import uuid
+
+        session_id = f"pending_corrupt_{uuid.uuid4().hex[:8]}"
+        session = await fresh_session_manager.get_session(session_id)
+        session["metadata"]["pending_delegations"] = [None, "bad", {"delegation_id": "d1", "x": 1}, 123]
+
+        await fresh_session_manager.add_pending_delegation(session_id, {"delegation_id": "d2", "y": 2})
+
+        pending = session["metadata"]["pending_delegations"]
+        assert all(isinstance(item, dict) for item in pending)
+        assert {"delegation_id": "d1", "x": 1} in pending
+        assert {"delegation_id": "d2", "y": 2} in pending
+
+    @pytest.mark.asyncio
+    async def test_add_pending_delegation_replaces_existing_same_delegation_id(self, fresh_session_manager):
+        import uuid
+
+        session_id = f"pending_replace_{uuid.uuid4().hex[:8]}"
+        session = await fresh_session_manager.get_session(session_id)
+        session["metadata"]["pending_delegations"] = [None, {"delegation_id": "d1", "x": 1}, {"delegation_id": "d2", "old": True}]
+
+        await fresh_session_manager.add_pending_delegation(session_id, {"delegation_id": "d2", "y": 2})
+
+        pending = session["metadata"]["pending_delegations"]
+        assert all(isinstance(item, dict) for item in pending)
+        d2_items = [item for item in pending if item.get("delegation_id") == "d2"]
+        assert len(d2_items) == 1
+        assert d2_items[0] == {"delegation_id": "d2", "y": 2}
+
+    @pytest.mark.asyncio
+    async def test_metadata_persist_logs_background_failure(self, fresh_session_manager, caplog):
+        import uuid
+        import logging
+
+        session_id = f"persist_fail_{uuid.uuid4().hex[:8]}"
+
+        async def _fake_save_session(**_kwargs):
+            raise RuntimeError("boom")
+
+        fresh_session_manager.auto_save = True
+        fresh_session_manager.persistence_enabled = True
+        from src.sessions import manager as manager_module
+        original_save = manager_module.session_persistence.save_session
+        manager_module.session_persistence.save_session = _fake_save_session
+        caplog.set_level(logging.ERROR, logger="src.sessions.manager")
+        try:
+            await fresh_session_manager.set_last_execution_id(session_id, "req-1")
+            await asyncio.sleep(0)
+        finally:
+            manager_module.session_persistence.save_session = original_save
+
+        assert "Failed to persist metadata-only session update" in caplog.text
 
     @pytest.mark.asyncio
     async def test_add_message_still_uses_normal_persistence_path(self, fresh_session_manager):

--- a/tests/test_task_capability_contracts.py
+++ b/tests/test_task_capability_contracts.py
@@ -12,6 +12,17 @@ def test_resolve_task_capability_contract_adapter_action_task_known_action():
     assert "adapter:github:add_comment" in plan["involved_capability_ids"]
 
 
+def test_resolve_task_capability_contract_adapter_action_task_unknown_action_structurally_complete():
+    plan = resolve_task_capability_contract("adapter_action_task", {"action_id": "ADAPTER:GITHUB:UNKNOWN_REVIEW"})
+
+    assert plan["primary_capability_id"] == "adapter:github:unknown_review"
+    assert plan["capability_id"] == "adapter:github:unknown_review"
+    assert plan["action_id"] == "adapter:github:unknown_review"
+    assert plan["capability_type"] == "adapter_action"
+    assert plan["involved_capability_ids"] == ["adapter:github:unknown_review"]
+    assert plan["capability_resolution"] == "unresolved"
+
+
 def test_resolve_task_capability_contract_jira_workflow_review_task():
     plan = resolve_task_capability_contract(
         "jira_workflow_review_task",
@@ -34,6 +45,56 @@ def test_resolve_task_capability_contract_jira_workflow_review_task():
         "adapter:jira:transition_issue",
         "adapter:jira:update_issue",
     ]
+
+
+def test_resolve_task_capability_contract_jira_workflow_review_task_fields_on_success_triggers_update():
+    plan = resolve_task_capability_contract(
+        "jira_workflow_review_task",
+        {
+            "issue_key": "ENG-2",
+            "fields_on_success": {"summary": "Approved"},
+        },
+    )
+
+    assert "adapter:jira:update_issue" in plan["involved_capability_ids"]
+
+
+def test_resolve_task_capability_contract_jira_workflow_review_task_fields_on_failure_triggers_update():
+    plan = resolve_task_capability_contract(
+        "jira_workflow_review_task",
+        {
+            "issue_key": "ENG-3",
+            "fields_on_failure": {"summary": "Rejected"},
+        },
+    )
+
+    assert "adapter:jira:update_issue" in plan["involved_capability_ids"]
+
+
+def test_resolve_task_capability_contract_jira_workflow_review_task_empty_fields_on_outcomes_do_not_trigger_update():
+    plan = resolve_task_capability_contract(
+        "jira_workflow_review_task",
+        {
+            "issue_key": "ENG-4",
+            "fields_on_success": {},
+            "fields_on_failure": {},
+        },
+    )
+
+    assert "adapter:jira:update_issue" not in plan["involved_capability_ids"]
+
+
+def test_resolve_task_capability_contract_jira_workflow_review_task_invalid_fields_on_outcomes_do_not_trigger_update():
+    plan = resolve_task_capability_contract(
+        "jira_workflow_review_task",
+        {
+            "issue_key": "ENG-5",
+            "fields_on_success": "x",
+            "fields_on_failure": ["y"],
+        },
+    )
+
+    assert "adapter:jira:update_issue" not in plan["involved_capability_ids"]
 
 
 def test_resolve_task_capability_contract_github_review_task():
@@ -60,8 +121,20 @@ def test_resolve_task_capability_contract_delegation_task():
 
     assert plan["primary_capability_id"] == "skill:demo"
     assert plan["capability_id"] == "skill:demo"
+    assert plan["action_id"] == "skill:demo"
     assert plan["capability_type"] == "skill"
     assert plan["involved_capability_ids"] == ["skill:demo"]
+
+
+def test_resolve_task_capability_contract_delegation_task_unresolved_sets_action_id():
+    plan = resolve_task_capability_contract("delegation_task", {"skill_name": "Missing"})
+
+    assert plan["primary_capability_id"] == "skill:missing"
+    assert plan["capability_id"] == "skill:missing"
+    assert plan["action_id"] == "skill:missing"
+    assert plan["capability_type"] == "skill"
+    assert plan["involved_capability_ids"] == ["skill:missing"]
+    assert plan["capability_resolution"] == "unresolved"
 
 
 def test_execution_bus_resolve_task_capability_plan_delegates_to_canonical_contract(monkeypatch):

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -239,6 +239,36 @@ async def test_chat_execution_bus_adapter_sets_request_path_metadata(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_chat_execution_bus_adapter_does_not_mutate_execution_output_payload(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+    original_payload = {"response": "ok"}
+
+    async def _fake_execute_chat_orchestration(**kwargs):
+        execution_result = type("R", (), {"status": "success", "output_payload": original_payload})()
+        captured["execution_result"] = execution_result
+        return execution_result
+
+    monkeypatch.setattr(webchat, "execute_chat_orchestration", _fake_execute_chat_orchestration)
+    monkeypatch.setattr(webchat, "run_chat_execution", lambda *args, **kwargs: {"response": "ignored"})
+
+    result = await webchat._run_chat_via_execution_bus(
+        agent=object(),
+        session_id="s-chat",
+        message="hello",
+        user_name="u1",
+        portal_user_id=None,
+        portal_user_name=None,
+    )
+
+    execution_result = captured["execution_result"]
+    assert result["_execution_result"] is execution_result
+    assert "_execution_result" not in execution_result.output_payload
+    assert result is not execution_result.output_payload
+
+
+@pytest.mark.asyncio
 async def test_chat_execution_bus_adapter_forwards_agent_id(monkeypatch):
     from src.gateway import webchat
 


### PR DESCRIPTION
### Motivation

- Route runtime-internal adapter actions through the ExecutionBus to centralize context, policy and auditing for adapter calls.
- Make GitHub PR review comment handling more explicit and robust by accepting an `event` parameter and validating inline comment inputs.
- Avoid mutating execution outputs returned from orchestration adapters and make lightweight session metadata writes non-blocking and resilient.
- Normalize capability resolution and action-gate shapes so task workflows can consistently evaluate and report blocked/allowed decisions.

### Description

- Add `src/runtime/runtime_adapter_execution.py` with `execute_adapter_action_via_bus` which routes adapter actions via `execute_runtime_task_request`, generates unique `request_id`s and merges `policy_profile_id` into metadata.
- Update `src/runtime/github_review.py` to call the new bus helper (`execute_adapter_action_via_bus`) and to interpret action gate shapes (`blocked` boolean and optional `reason`/`message`).
- Change `src/github/api.py` and `src/github/__init__.py` to accept a keyword-only `event` for `add_pr_review_comment`, normalize `path`/`line` inputs, validate `event` values, and route inline vs review-submission requests correctly; also update the top-level tool dispatcher in `src/__init__.py` to pass named args and default `event`.
- Modify `src/gateway/webchat.py` to copy the orchestration `output_payload` into a fresh dict so the original `execution_result.output_payload` is not mutated while still embedding `_execution_result` in the returned payload.
- Update `src/runtime/execution_bus.py` to return a normalized blocked/allowed shape from the GitHub review task action gate and to propagate gate decision details into runtime events.
- Make session metadata persistence non-blocking in `src/sessions/manager.py` by snapshotting `channel`, `history`, and `metadata` with `deepcopy`, persisting in a background task, sanitizing `pending_delegations` to only include dicts, and logging background persistence failures.
- Improve `src/runtime/task_capability_contracts.py` to populate `action_id` and `capability_type` for unresolved adapter/skill entries and to better detect non-empty mapping fields for JIRA update decisions.
- Add and adjust unit tests across the suite to cover the new runtime bus helper, GitHub comment validations/paths, execution bus gate normalization, session metadata snapshotting and non-blocking persistence, webchat payload immutability, and capability resolution.

### Testing

- Ran the unit test suite targeting the changed areas including `tests/test_runtime_adapter_execution.py`, `tests/test_github_review.py`, `tests/test_github_tools.py`, `tests/test_execution_bus.py`, `tests/test_session_manager.py`, `tests/test_task_capability_contracts.py`, `tests/test_portal_session_metadata_client.py`, and `tests/test_webchat.py` as part of the CI patch validation.
- All newly added and updated automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5fa5c5fa8832aa7cd86ae2f083963)