### PR TITLE
Fix github review failure errors, expose review `event` in tool schema, and clarify Portal base URL error

### DIFF
--- a/src/github/__init__.py
+++ b/src/github/__init__.py
@@ -456,7 +456,7 @@ def get_tools_schemas() -> list:
             "type": "function",
             "function": {
                 "name": "github_add_pr_review_comment",
-                "description": "Add a review comment to a PR (can specify file path and line number)",
+                "description": "Add a PR review comment or submit a review event. Inline file comments require both path and line; APPROVE/REQUEST_CHANGES are submitted as review events (non-inline).",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -466,7 +466,13 @@ def get_tools_schemas() -> list:
                         "body": {"type": "string", "description": "Comment text"},
                         "commit_id": {"type": "string", "description": "Commit SHA (optional)"},
                         "path": {"type": "string", "description": "File path for line comment (optional)"},
-                        "line": {"type": "integer", "description": "Line number for line comment (optional)"}
+                        "line": {"type": "integer", "description": "Line number for line comment (optional)"},
+                        "event": {
+                            "type": "string",
+                            "description": "Review event. Use COMMENT for a normal review comment, APPROVE to approve the PR, REQUEST_CHANGES to request changes.",
+                            "enum": ["COMMENT", "APPROVE", "REQUEST_CHANGES"],
+                            "default": "COMMENT",
+                        },
                     },
                     "required": ["owner", "repo", "pull_number", "body"]
                 }

--- a/src/runtime/adapter_executor.py
+++ b/src/runtime/adapter_executor.py
@@ -344,7 +344,13 @@ async def execute_portal_control_plane_action(action_name: str, kwargs: Dict[str
     payload = dict(kwargs or {})
     base_url = get_portal_internal_base_url()
     if not base_url:
-        return {"success": False, "error": "PORTAL_INTERNAL_BASE_URL is not configured", "system": "portal", "action_name": action, "result": None}
+        return {
+            "success": False,
+            "error": "Portal internal base URL is not configured; set PORTAL_INTERNAL_BASE_URL or server.portal_internal_base_url",
+            "system": "portal",
+            "action_name": action,
+            "result": None,
+        }
 
     if action not in {
         "create_delegation",

--- a/src/runtime/github_review.py
+++ b/src/runtime/github_review.py
@@ -126,11 +126,25 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     skill_error = getattr(skill_result, "error", None)
     skill_output = getattr(skill_result, "output", "")
     skill_data = getattr(skill_result, "data", {}) if isinstance(getattr(skill_result, "data", None), dict) else {}
+    normalized_skill_error = skill_error
+    if not skill_success:
+        if isinstance(skill_error, str):
+            normalized_skill_error = skill_error.strip() or None
+        elif skill_error:
+            normalized_skill_error = str(skill_error).strip() or None
+        else:
+            normalized_skill_error = None
+
+        if not normalized_skill_error:
+            if isinstance(skill_output, str) and skill_output.strip():
+                normalized_skill_error = skill_output.strip()
+            else:
+                normalized_skill_error = f"GitHub review skill '{skill_name}' failed without an explicit error"
 
     runtime_events = [_event("task.github_review.skill.completed" if skill_success else "task.github_review.skill.failed", "completed" if skill_success else "failed", {
         "skill_name": skill_name,
         "success": skill_success,
-        "error": skill_error,
+        "error": normalized_skill_error,
     })]
 
     review_event, review_summary = _normalize_review_writeback(skill_output, skill_data, review_comment_input)
@@ -141,7 +155,7 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     secondary_action_attempted = False
     secondary_action_success = False
     actions_applied = []
-    error_value = skill_error
+    error_value = normalized_skill_error
 
     if skill_success and review_summary:
         action_payload = {

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -129,6 +129,29 @@ async def test_execute_adapter_action_portal_create_delegation_missing_required_
 
 
 @pytest.mark.asyncio
+async def test_execute_adapter_action_portal_missing_base_url_mentions_env_and_config(monkeypatch):
+    monkeypatch.delenv("PORTAL_INTERNAL_BASE_URL", raising=False)
+    monkeypatch.setattr("src.runtime.adapter_executor.get_portal_internal_base_url", lambda: "")
+
+    result = await execute_adapter_action(
+        "adapter:portal:create_delegation",
+        {
+            "group_id": "g-1",
+            "leader_agent_id": "leader-1",
+            "assignee_agent_id": "agent-1",
+            "objective": "Review",
+            "visibility": "leader_only",
+            "skill_name": "skill",
+        },
+    )
+
+    assert result["success"] is False
+    assert result["system"] == "portal"
+    assert "PORTAL_INTERNAL_BASE_URL" in result["error"]
+    assert "server.portal_internal_base_url" in result["error"]
+
+
+@pytest.mark.asyncio
 async def test_execute_adapter_action_portal_create_delegation_missing_skill_name_fails(monkeypatch):
     monkeypatch.setenv("PORTAL_INTERNAL_BASE_URL", "https://portal.internal")
     result = await execute_adapter_action(

--- a/tests/test_github_review.py
+++ b/tests/test_github_review.py
@@ -284,3 +284,50 @@ async def test_github_review_task_forwards_runtime_context_to_bus_helper(monkeyp
     assert captured["meta"]["agent_id"] == "agent-123"
     assert captured["meta"]["policy_profile_id"] == "pp-123"
     assert captured["meta"]["metadata"] == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_failed_skill_without_error_uses_output_as_error(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(
+            success=False,
+            error=None,
+            output="Review skill failed because repository context was unavailable",
+            data={},
+        )
+
+    async def _fail_bus_call(*_args, **_kwargs):
+        raise AssertionError("secondary write-back should not run for failed skill")
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fail_bus_call)
+
+    result = await run_github_review_task({"owner": "acme", "repo": "demo", "pull_number": 24})
+
+    assert result["success"] is False
+    assert result["error"] == "Review skill failed because repository context was unavailable"
+    failed_events = [evt for evt in result["runtime_events"] if evt.get("event_type") == "task.github_review.failed"]
+    assert failed_events
+    assert failed_events[-1]["detail_payload"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_failed_skill_without_error_or_output_uses_generic_error(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(success=False, error=None, output="", data={})
+
+    async def _fail_bus_call(*_args, **_kwargs):
+        raise AssertionError("secondary write-back should not run for failed skill")
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fail_bus_call)
+
+    result = await run_github_review_task({"owner": "acme", "repo": "demo", "pull_number": 25})
+
+    assert result["success"] is False
+    assert "GitHub review skill 'review-pull-request' failed without an explicit error" in result["error"]
+    assert result["secondary_action_attempted"] is False

--- a/tests/test_github_tools.py
+++ b/tests/test_github_tools.py
@@ -372,6 +372,22 @@ async def test_github_review_comment_wrapper_message_for_request_changes_event(m
     assert result == "Changes requested on PR #22"
 
 
+def test_github_add_pr_review_comment_schema_includes_event_enum(github_modules):
+    github_module, _ = github_modules
+
+    schemas = github_module.get_tools_schemas()
+    review_comment_schema = next(
+        schema
+        for schema in schemas
+        if schema.get("type") == "function"
+        and schema.get("function", {}).get("name") == "github_add_pr_review_comment"
+    )
+    event_schema = review_comment_schema["function"]["parameters"]["properties"]["event"]
+
+    assert event_schema["enum"] == ["COMMENT", "APPROVE", "REQUEST_CHANGES"]
+    assert event_schema["default"] == "COMMENT"
+
+
 @pytest.mark.asyncio
 async def test_channel_add_pr_review_comment_rejects_invalid_event(github_modules):
     _, github_api = github_modules


### PR DESCRIPTION
### Motivation
- Ensure `run_github_review_task` never returns `success=False` with `error=None` so callers always get a meaningful failure message. 
- Make the GitHub tool schema usable for approval/changes review flows by exposing an `event` parameter. 
- Improve operator-facing Portal error text to correctly mention both supported configuration sources when the internal base URL is missing.

### Description
- Normalize failed skill errors in `run_github_review_task` to prefer the existing `error` (normalized), then a stripped non-empty `output`, then a deterministic fallback message `GitHub review skill '{skill_name}' failed without an explicit error`, and use the normalized value in the skill-failed runtime event and return payload; changes live in `src/runtime/github_review.py`. 
- Add an optional `event` parameter to the `github_add_pr_review_comment` tool schema with `type: string`, `enum: ["COMMENT","APPROVE","REQUEST_CHANGES"]`, and `default: "COMMENT"`, and update the function description to clarify inline vs review-event behavior; changes live in `src/github/__init__.py`. 
- Replace the Portal missing-base-url error string with the clearer message `Portal internal base URL is not configured; set PORTAL_INTERNAL_BASE_URL or server.portal_internal_base_url` while preserving the return contract; change in `src/runtime/adapter_executor.py`.
- Added focused tests and small test updates to validate the three fixes without changing unrelated behaviors.

### Testing
- Added tests: `test_github_review_task_failed_skill_without_error_uses_output_as_error` and `test_github_review_task_failed_skill_without_error_or_output_uses_generic_error` in `tests/test_github_review.py` to validate normalized error fallbacks. 
- Added `test_github_add_pr_review_comment_schema_includes_event_enum` in `tests/test_github_tools.py` to assert the `event` enum and default. 
- Added `test_execute_adapter_action_portal_missing_base_url_mentions_env_and_config` in `tests/test_adapter_executor.py` to assert the Portal error message references both configuration sources. 
- Ran `pytest -q tests/test_github_review.py tests/test_github_tools.py tests/test_adapter_executor.py` and the test suite passed (`67 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d649a48f1c832aab47c0e0e8c07ea5)