### PR TITLE
Add PR review `event` option, normalize commit_id, refine subagent listing, and improve portal error messaging

### DIFF
--- a/src/agents/subagent.py
+++ b/src/agents/subagent.py
@@ -137,17 +137,21 @@ def list_active_subagent_summaries(
     parent_session_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Return serializable summaries for active sub-agent sessions."""
+    active_statuses = {"started", "running"}
     summaries: List[Dict[str, Any]] = []
     for session_key, state in _subagent_sessions.items():
         if session_key_prefix and not session_key.startswith(session_key_prefix):
             continue
         if parent_session_id is not None and state.get("parent_session_id") != parent_session_id:
             continue
+        status = state.get("status")
+        if status not in active_statuses:
+            continue
         summaries.append(
             {
                 "session_key": session_key,
                 "task": state.get("task"),
-                "status": state.get("status"),
+                "status": status,
                 "model": state.get("model"),
                 "thinking": state.get("thinking"),
                 "created_at": state.get("created_at"),

--- a/src/github/__init__.py
+++ b/src/github/__init__.py
@@ -456,7 +456,7 @@ def get_tools_schemas() -> list:
             "type": "function",
             "function": {
                 "name": "github_add_pr_review_comment",
-                "description": "Add a review comment to a PR (can specify file path and line number)",
+                "description": "Add a PR review comment or submit a review event. Inline file comments require both path and line; APPROVE/REQUEST_CHANGES are submitted as review events (non-inline).",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -466,7 +466,13 @@ def get_tools_schemas() -> list:
                         "body": {"type": "string", "description": "Comment text"},
                         "commit_id": {"type": "string", "description": "Commit SHA (optional)"},
                         "path": {"type": "string", "description": "File path for line comment (optional)"},
-                        "line": {"type": "integer", "description": "Line number for line comment (optional)"}
+                        "line": {"type": "integer", "description": "Line number for line comment (optional)"},
+                        "event": {
+                            "type": "string",
+                            "description": "Review event. Use COMMENT for a normal review comment, APPROVE to approve the PR, REQUEST_CHANGES to request changes.",
+                            "enum": ["COMMENT", "APPROVE", "REQUEST_CHANGES"],
+                            "default": "COMMENT",
+                        },
                     },
                     "required": ["owner", "repo", "pull_number", "body"]
                 }

--- a/src/github/api.py
+++ b/src/github/api.py
@@ -569,6 +569,15 @@ class GitHubChannel:
         else:
             normalized_path = str(path).strip() or None
 
+        normalized_commit_id: Optional[str]
+        if commit_id is None:
+            normalized_commit_id = None
+        elif isinstance(commit_id, str):
+            stripped_commit_id = commit_id.strip()
+            normalized_commit_id = stripped_commit_id or None
+        else:
+            normalized_commit_id = str(commit_id).strip() or None
+
         normalized_line: Optional[int]
         if line is None:
             normalized_line = None
@@ -589,7 +598,7 @@ class GitHubChannel:
                     "APPROVE and REQUEST_CHANGES require the pull request reviews endpoint"
                 )
             # For inline comments, we need a real commit SHA
-            commit_id_to_use = commit_id
+            commit_id_to_use = normalized_commit_id
             if not commit_id_to_use:
                 pr = await self._request(
                     "GET",

--- a/src/runtime/adapter_executor.py
+++ b/src/runtime/adapter_executor.py
@@ -344,7 +344,13 @@ async def execute_portal_control_plane_action(action_name: str, kwargs: Dict[str
     payload = dict(kwargs or {})
     base_url = get_portal_internal_base_url()
     if not base_url:
-        return {"success": False, "error": "PORTAL_INTERNAL_BASE_URL is not configured", "system": "portal", "action_name": action, "result": None}
+        return {
+            "success": False,
+            "error": "Portal internal base URL is not configured; set PORTAL_INTERNAL_BASE_URL or server.portal_internal_base_url",
+            "system": "portal",
+            "action_name": action,
+            "result": None,
+        }
 
     if action not in {
         "create_delegation",

--- a/src/runtime/github_review.py
+++ b/src/runtime/github_review.py
@@ -126,11 +126,25 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     skill_error = getattr(skill_result, "error", None)
     skill_output = getattr(skill_result, "output", "")
     skill_data = getattr(skill_result, "data", {}) if isinstance(getattr(skill_result, "data", None), dict) else {}
+    normalized_skill_error = skill_error
+    if not skill_success:
+        if isinstance(skill_error, str):
+            normalized_skill_error = skill_error.strip() or None
+        elif skill_error:
+            normalized_skill_error = str(skill_error).strip() or None
+        else:
+            normalized_skill_error = None
+
+        if not normalized_skill_error:
+            if isinstance(skill_output, str) and skill_output.strip():
+                normalized_skill_error = skill_output.strip()
+            else:
+                normalized_skill_error = f"GitHub review skill '{skill_name}' failed without an explicit error"
 
     runtime_events = [_event("task.github_review.skill.completed" if skill_success else "task.github_review.skill.failed", "completed" if skill_success else "failed", {
         "skill_name": skill_name,
         "success": skill_success,
-        "error": skill_error,
+        "error": normalized_skill_error,
     })]
 
     review_event, review_summary = _normalize_review_writeback(skill_output, skill_data, review_comment_input)
@@ -141,7 +155,7 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     secondary_action_attempted = False
     secondary_action_success = False
     actions_applied = []
-    error_value = skill_error
+    error_value = normalized_skill_error
 
     if skill_success and review_summary:
         action_payload = {

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -129,6 +129,29 @@ async def test_execute_adapter_action_portal_create_delegation_missing_required_
 
 
 @pytest.mark.asyncio
+async def test_execute_adapter_action_portal_missing_base_url_mentions_env_and_config(monkeypatch):
+    monkeypatch.delenv("PORTAL_INTERNAL_BASE_URL", raising=False)
+    monkeypatch.setattr("src.runtime.adapter_executor.get_portal_internal_base_url", lambda: "")
+
+    result = await execute_adapter_action(
+        "adapter:portal:create_delegation",
+        {
+            "group_id": "g-1",
+            "leader_agent_id": "leader-1",
+            "assignee_agent_id": "agent-1",
+            "objective": "Review",
+            "visibility": "leader_only",
+            "skill_name": "skill",
+        },
+    )
+
+    assert result["success"] is False
+    assert result["system"] == "portal"
+    assert "PORTAL_INTERNAL_BASE_URL" in result["error"]
+    assert "server.portal_internal_base_url" in result["error"]
+
+
+@pytest.mark.asyncio
 async def test_execute_adapter_action_portal_create_delegation_missing_skill_name_fails(monkeypatch):
     monkeypatch.setenv("PORTAL_INTERNAL_BASE_URL", "https://portal.internal")
     result = await execute_adapter_action(

--- a/tests/test_github_review.py
+++ b/tests/test_github_review.py
@@ -284,3 +284,50 @@ async def test_github_review_task_forwards_runtime_context_to_bus_helper(monkeyp
     assert captured["meta"]["agent_id"] == "agent-123"
     assert captured["meta"]["policy_profile_id"] == "pp-123"
     assert captured["meta"]["metadata"] == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_failed_skill_without_error_uses_output_as_error(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(
+            success=False,
+            error=None,
+            output="Review skill failed because repository context was unavailable",
+            data={},
+        )
+
+    async def _fail_bus_call(*_args, **_kwargs):
+        raise AssertionError("secondary write-back should not run for failed skill")
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fail_bus_call)
+
+    result = await run_github_review_task({"owner": "acme", "repo": "demo", "pull_number": 24})
+
+    assert result["success"] is False
+    assert result["error"] == "Review skill failed because repository context was unavailable"
+    failed_events = [evt for evt in result["runtime_events"] if evt.get("event_type") == "task.github_review.failed"]
+    assert failed_events
+    assert failed_events[-1]["detail_payload"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_failed_skill_without_error_or_output_uses_generic_error(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(success=False, error=None, output="", data={})
+
+    async def _fail_bus_call(*_args, **_kwargs):
+        raise AssertionError("secondary write-back should not run for failed skill")
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fail_bus_call)
+
+    result = await run_github_review_task({"owner": "acme", "repo": "demo", "pull_number": 25})
+
+    assert result["success"] is False
+    assert "GitHub review skill 'review-pull-request' failed without an explicit error" in result["error"]
+    assert result["secondary_action_attempted"] is False

--- a/tests/test_github_tools.py
+++ b/tests/test_github_tools.py
@@ -372,6 +372,22 @@ async def test_github_review_comment_wrapper_message_for_request_changes_event(m
     assert result == "Changes requested on PR #22"
 
 
+def test_github_add_pr_review_comment_schema_includes_event_enum(github_modules):
+    github_module, _ = github_modules
+
+    schemas = github_module.get_tools_schemas()
+    review_comment_schema = next(
+        schema
+        for schema in schemas
+        if schema.get("type") == "function"
+        and schema.get("function", {}).get("name") == "github_add_pr_review_comment"
+    )
+    event_schema = review_comment_schema["function"]["parameters"]["properties"]["event"]
+
+    assert event_schema["enum"] == ["COMMENT", "APPROVE", "REQUEST_CHANGES"]
+    assert event_schema["default"] == "COMMENT"
+
+
 @pytest.mark.asyncio
 async def test_channel_add_pr_review_comment_rejects_invalid_event(github_modules):
     _, github_api = github_modules
@@ -451,6 +467,69 @@ async def test_channel_add_pr_review_comment_inline_comment_happy_path(monkeypat
     assert captured["method"] == "POST"
     assert captured["endpoint"] == "/repos/acme/repo/pulls/12/comments"
     assert captured["json"]["commit_id"] == "deadbeef"
+    assert captured["json"]["path"] == "x.py"
+    assert captured["json"]["line"] == 10
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_strips_inline_commit_id(monkeypatch, github_modules):
+    _, github_api = github_modules
+    captured = {}
+
+    async def _fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs.get("json", {})
+        return {"id": 126}
+
+    monkeypatch.setattr(github_api.github_channel, "_request", _fake_request)
+
+    result = await github_api.github_channel.add_pr_review_comment(
+        owner="acme",
+        repo="repo",
+        pull_number=12,
+        body="Inline comment",
+        commit_id="  deadbeef  ",
+        path="x.py",
+        line=10,
+        event="COMMENT",
+    )
+
+    assert result["id"] == 126
+    assert captured["endpoint"] == "/repos/acme/repo/pulls/12/comments"
+    assert captured["json"]["commit_id"] == "deadbeef"
+    assert captured["json"]["path"] == "x.py"
+    assert captured["json"]["line"] == 10
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_blank_commit_id_falls_back_to_head_sha(monkeypatch, github_modules):
+    _, github_api = github_modules
+    captured = {}
+
+    async def _fake_request(method, endpoint, **kwargs):
+        if method == "GET" and endpoint == "/repos/acme/repo/pulls/12":
+            return {"head": {"sha": "abc123"}}
+        if method == "POST" and endpoint == "/repos/acme/repo/pulls/12/comments":
+            captured["json"] = kwargs.get("json", {})
+            return {"id": 127}
+        raise AssertionError(f"Unexpected request: {method} {endpoint}")
+
+    monkeypatch.setattr(github_api.github_channel, "_request", _fake_request)
+
+    result = await github_api.github_channel.add_pr_review_comment(
+        owner="acme",
+        repo="repo",
+        pull_number=12,
+        body="Inline comment",
+        commit_id="   ",
+        path="x.py",
+        line=10,
+        event="COMMENT",
+    )
+
+    assert result["id"] == 127
+    assert captured["json"]["commit_id"] == "abc123"
     assert captured["json"]["path"] == "x.py"
     assert captured["json"]["line"] == 10
 

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -330,11 +330,66 @@ class TestSubAgentIntegration:
             "created_at": "2026-01-01T00:00:01Z",
             "parent_session_id": "s-b",
         }
+        _subagent_sessions["sa-3"] = {
+            "session_key": "sa-3",
+            "task": "t3",
+            "status": "completed",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:02Z",
+            "parent_session_id": "s-a",
+        }
 
         filtered = list_active_subagent_summaries(parent_session_id="s-a")
         assert len(filtered) == 1
         assert filtered[0]["session_key"] == "sa-1"
         assert filtered[0]["parent_session_id"] == "s-a"
+        _subagent_sessions.clear()
+
+    def test_list_active_subagent_summaries_excludes_completed_and_failed_entries(self):
+        from src.agents.subagent import _subagent_sessions, list_active_subagent_summaries
+
+        _subagent_sessions.clear()
+        _subagent_sessions["sa-started"] = {
+            "session_key": "sa-started",
+            "task": "t1",
+            "status": "started",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:00Z",
+            "parent_session_id": "s-1",
+        }
+        _subagent_sessions["sa-running"] = {
+            "session_key": "sa-running",
+            "task": "t2",
+            "status": "running",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:01Z",
+            "parent_session_id": "s-1",
+        }
+        _subagent_sessions["sa-completed"] = {
+            "session_key": "sa-completed",
+            "task": "t3",
+            "status": "completed",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:02Z",
+            "parent_session_id": "s-1",
+        }
+        _subagent_sessions["sa-failed"] = {
+            "session_key": "sa-failed",
+            "task": "t4",
+            "status": "failed",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:03Z",
+            "parent_session_id": "s-1",
+        }
+
+        summaries = list_active_subagent_summaries()
+        session_keys = [item["session_key"] for item in summaries]
+        assert session_keys == ["sa-started", "sa-running"]
         _subagent_sessions.clear()
     
     def test_spawn_and_cleanup(self):


### PR DESCRIPTION
### Motivation

- Ensure PR review comments support explicit review events and validate inline/comment semantics, while normalizing `commit_id` inputs for inline comments.
- Make `list_active_subagent_summaries` return only active sessions and exclude completed/failed entries.
- Improve diagnostics when the portal internal base URL is not configured and provide clearer error messaging.
- Surface clearer skill failure messages from the GitHub review runtime when a skill fails without an explicit error.

### Description

- Update `list_active_subagent_summaries` in `src/agents/subagent.py` to only include sessions with `status` in `{"started","running"}` and skip non-active statuses.
- Extend the tools schema in `src/github/__init__.py` for `github_add_pr_review_comment` to include an `event` parameter with an `enum` of `COMMENT/APPROVE/REQUEST_CHANGES` and a default of `COMMENT`, and improve the description.
- Harden `GitHubChannel.add_pr_review_comment` in `src/github/api.py` by validating and normalizing `event`, `path`, `line`, and `commit_id`; require positive integer `line` for inline comments; enforce that inline comments only support `COMMENT`; and strip/normalize `commit_id` before use (falling back to PR head SHA when blank).
- Improve error text in `execute_portal_control_plane_action` (`src/runtime/adapter_executor.py`) to mention both the `PORTAL_INTERNAL_BASE_URL` environment variable and the `server.portal_internal_base_url` configuration option.
- In `src/runtime/github_review.py` normalize skill failure output into a usable `error` string by preferring `skill.error`, then `skill.output`, and finally a generic message when a skill fails without an explicit error, and propagate that into runtime events and returned error values.
- Add and update unit tests to cover the new behavior and edge cases across portal adapter, GitHub channel/skills, and subagent session listing.

### Testing

- Added/updated tests: `tests/test_adapter_executor.py::test_execute_adapter_action_portal_missing_base_url_mentions_env_and_config`, `tests/test_github_review.py::test_github_review_task_failed_skill_without_error_uses_output_as_error`, `tests/test_github_review.py::test_github_review_task_failed_skill_without_error_or_output_uses_generic_error`, `tests/test_github_tools.py::test_github_add_pr_review_comment_schema_includes_event_enum`, `tests/test_github_tools.py::test_channel_add_pr_review_comment_strips_inline_commit_id`, `tests/test_github_tools.py::test_channel_add_pr_review_comment_blank_commit_id_falls_back_to_head_sha`, and `tests/test_subagent.py::test_list_active_subagent_summaries_excludes_completed_and_failed_entries`.
- Ran the unit test suite (`pytest`) against the modified code and the test cases covering the changes passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d649a48f1c832aab47c0e0e8c07ea5)