### PR TITLE
Session filtering, Jira client reuse, GitHub PR review enhancements, and skill-error normalization

### DIFF
--- a/src/agents/subagent.py
+++ b/src/agents/subagent.py
@@ -137,17 +137,21 @@ def list_active_subagent_summaries(
     parent_session_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Return serializable summaries for active sub-agent sessions."""
+    active_statuses = {"started", "running"}
     summaries: List[Dict[str, Any]] = []
     for session_key, state in _subagent_sessions.items():
         if session_key_prefix and not session_key.startswith(session_key_prefix):
             continue
         if parent_session_id is not None and state.get("parent_session_id") != parent_session_id:
             continue
+        status = state.get("status")
+        if status not in active_statuses:
+            continue
         summaries.append(
             {
                 "session_key": session_key,
                 "task": state.get("task"),
-                "status": state.get("status"),
+                "status": status,
                 "model": state.get("model"),
                 "thinking": state.get("thinking"),
                 "created_at": state.get("created_at"),

--- a/src/cron/jira_reconciliation.py
+++ b/src/cron/jira_reconciliation.py
@@ -67,25 +67,37 @@ class JiraReconciliationRunner:
             "failure_transition": cls._first_non_empty(rule, "failure_transition"),
         }
 
-    async def _get_json(self, path: str) -> Dict[str, Any]:
+    async def _get_json(self, path: str, *, session: ClientSession | None = None) -> Dict[str, Any]:
         url = f"{self._base_url()}{path}"
-        async with ClientSession(headers=self._headers()) as session:
+        if session is not None:
             async with session.get(url) as response:
                 data = await response.json(content_type=None)
                 if response.status >= 400:
                     raise RuntimeError(f"HTTP {response.status}: {data}")
                 return data if isinstance(data, dict) else {"items": data}
+        async with ClientSession(headers=self._headers()) as temp_session:
+            async with temp_session.get(url) as response:
+                data = await response.json(content_type=None)
+                if response.status >= 400:
+                    raise RuntimeError(f"HTTP {response.status}: {data}")
+                return data if isinstance(data, dict) else {"items": data}
 
-    async def _post_json(self, path: str, payload: Dict[str, Any]) -> None:
+    async def _post_json(self, path: str, payload: Dict[str, Any], *, session: ClientSession | None = None) -> None:
         url = f"{self._base_url()}{path}"
-        async with ClientSession(headers=self._headers()) as session:
+        if session is not None:
             async with session.post(url, json=payload) as response:
                 if response.status >= 400:
                     body = await response.text()
                     raise RuntimeError(f"HTTP {response.status}: {body}")
+            return
+        async with ClientSession(headers=self._headers()) as temp_session:
+            async with temp_session.post(url, json=payload) as response:
+                if response.status >= 400:
+                    body = await response.text()
+                    raise RuntimeError(f"HTTP {response.status}: {body}")
 
-    async def fetch_enabled_workflow_rules(self) -> List[Dict[str, Any]]:
-        data = await self._get_json("/api/internal/workflow-transition-rules")
+    async def fetch_enabled_workflow_rules(self, *, session: ClientSession | None = None) -> List[Dict[str, Any]]:
+        data = await self._get_json("/api/internal/workflow-transition-rules", session=session)
         rules = data.get("items") if isinstance(data.get("items"), list) else data.get("rules")
         if not isinstance(rules, list):
             return []
@@ -98,8 +110,8 @@ class JiraReconciliationRunner:
                 normalized_rules.append(normalized)
         return normalized_rules
 
-    async def fetch_identity_bindings(self) -> List[Dict[str, Any]]:
-        data = await self._get_json("/api/internal/agent-identity-bindings")
+    async def fetch_identity_bindings(self, *, session: ClientSession | None = None) -> List[Dict[str, Any]]:
+        data = await self._get_json("/api/internal/agent-identity-bindings", session=session)
         items = data.get("items") if isinstance(data.get("items"), list) else []
         return [item for item in items if isinstance(item, dict)]
 
@@ -176,44 +188,45 @@ class JiraReconciliationRunner:
             return
 
         try:
-            rules = await self.fetch_enabled_workflow_rules()
-            identity_bindings = await self.fetch_identity_bindings()
+            async with ClientSession(headers=self._headers()) as session:
+                rules = await self.fetch_enabled_workflow_rules(session=session)
+                identity_bindings = await self.fetch_identity_bindings(session=session)
+
+                for rule in rules:
+                    project_keys = [str(x).strip() for x in (rule.get("project_keys") or []) if str(x).strip()]
+                    trigger_statuses = [str(x).strip() for x in (rule.get("trigger_statuses") or []) if str(x).strip()]
+
+                    if not project_keys:
+                        continue
+
+                    jql = f"project IN ({','.join(project_keys)})"
+                    if trigger_statuses:
+                        quoted = ",".join(f'\"{s}\"' for s in trigger_statuses)
+                        jql = f"{jql} AND status IN ({quoted})"
+
+                    try:
+                        search_result = await jira_channel.search_issues(jql, max_results=50)
+                    except Exception as exc:
+                        logger.warning("Jira reconciliation search failed for rule=%s: %s", rule.get("id"), exc)
+                        continue
+
+                    issues = search_result.get("issues") if isinstance(search_result, dict) and isinstance(search_result.get("issues"), list) else []
+                    for issue in issues:
+                        try:
+                            ingress_payload = self.build_external_event_ingress_request(rule=rule, issue=issue, identity_bindings=identity_bindings)
+                            if not ingress_payload:
+                                continue
+                            await self._post_json("/api/internal/external-events/ingest", ingress_payload, session=session)
+                        except Exception as exc:
+                            logger.warning(
+                                "Jira reconciliation ingest failed for rule=%s issue=%s: %s",
+                                rule.get("id"),
+                                issue.get("key") if isinstance(issue, dict) else None,
+                                exc,
+                            )
         except Exception as exc:
             logger.warning("Jira reconciliation failed to load Portal control-plane exports: %s", exc)
             return
-
-        for rule in rules:
-            project_keys = [str(x).strip() for x in (rule.get("project_keys") or []) if str(x).strip()]
-            trigger_statuses = [str(x).strip() for x in (rule.get("trigger_statuses") or []) if str(x).strip()]
-
-            if not project_keys:
-                continue
-
-            jql = f"project IN ({','.join(project_keys)})"
-            if trigger_statuses:
-                quoted = ",".join(f'\"{s}\"' for s in trigger_statuses)
-                jql = f"{jql} AND status IN ({quoted})"
-
-            try:
-                search_result = await jira_channel.search_issues(jql, max_results=50)
-            except Exception as exc:
-                logger.warning("Jira reconciliation search failed for rule=%s: %s", rule.get("id"), exc)
-                continue
-
-            issues = search_result.get("issues") if isinstance(search_result, dict) and isinstance(search_result.get("issues"), list) else []
-            for issue in issues:
-                try:
-                    ingress_payload = self.build_external_event_ingress_request(rule=rule, issue=issue, identity_bindings=identity_bindings)
-                    if not ingress_payload:
-                        continue
-                    await self._post_json("/api/internal/external-events/ingest", ingress_payload)
-                except Exception as exc:
-                    logger.warning(
-                        "Jira reconciliation ingest failed for rule=%s issue=%s: %s",
-                        rule.get("id"),
-                        issue.get("key") if isinstance(issue, dict) else None,
-                        exc,
-                    )
 
     async def start(self) -> None:
         self.running = True

--- a/src/github/__init__.py
+++ b/src/github/__init__.py
@@ -456,7 +456,7 @@ def get_tools_schemas() -> list:
             "type": "function",
             "function": {
                 "name": "github_add_pr_review_comment",
-                "description": "Add a review comment to a PR (can specify file path and line number)",
+                "description": "Add a PR review comment or submit a review event. Inline file comments require both path and line; APPROVE/REQUEST_CHANGES are submitted as review events (non-inline).",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -466,7 +466,13 @@ def get_tools_schemas() -> list:
                         "body": {"type": "string", "description": "Comment text"},
                         "commit_id": {"type": "string", "description": "Commit SHA (optional)"},
                         "path": {"type": "string", "description": "File path for line comment (optional)"},
-                        "line": {"type": "integer", "description": "Line number for line comment (optional)"}
+                        "line": {"type": "integer", "description": "Line number for line comment (optional)"},
+                        "event": {
+                            "type": "string",
+                            "description": "Review event. Use COMMENT for a normal review comment, APPROVE to approve the PR, REQUEST_CHANGES to request changes.",
+                            "enum": ["COMMENT", "APPROVE", "REQUEST_CHANGES"],
+                            "default": "COMMENT",
+                        },
                     },
                     "required": ["owner", "repo", "pull_number", "body"]
                 }

--- a/src/github/api.py
+++ b/src/github/api.py
@@ -569,6 +569,15 @@ class GitHubChannel:
         else:
             normalized_path = str(path).strip() or None
 
+        normalized_commit_id: Optional[str]
+        if commit_id is None:
+            normalized_commit_id = None
+        elif isinstance(commit_id, str):
+            stripped_commit_id = commit_id.strip()
+            normalized_commit_id = stripped_commit_id or None
+        else:
+            normalized_commit_id = str(commit_id).strip() or None
+
         normalized_line: Optional[int]
         if line is None:
             normalized_line = None
@@ -589,7 +598,7 @@ class GitHubChannel:
                     "APPROVE and REQUEST_CHANGES require the pull request reviews endpoint"
                 )
             # For inline comments, we need a real commit SHA
-            commit_id_to_use = commit_id
+            commit_id_to_use = normalized_commit_id
             if not commit_id_to_use:
                 pr = await self._request(
                     "GET",

--- a/src/runtime/adapter_executor.py
+++ b/src/runtime/adapter_executor.py
@@ -344,7 +344,13 @@ async def execute_portal_control_plane_action(action_name: str, kwargs: Dict[str
     payload = dict(kwargs or {})
     base_url = get_portal_internal_base_url()
     if not base_url:
-        return {"success": False, "error": "PORTAL_INTERNAL_BASE_URL is not configured", "system": "portal", "action_name": action, "result": None}
+        return {
+            "success": False,
+            "error": "Portal internal base URL is not configured; set PORTAL_INTERNAL_BASE_URL or server.portal_internal_base_url",
+            "system": "portal",
+            "action_name": action,
+            "result": None,
+        }
 
     if action not in {
         "create_delegation",

--- a/src/runtime/github_review.py
+++ b/src/runtime/github_review.py
@@ -126,11 +126,25 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     skill_error = getattr(skill_result, "error", None)
     skill_output = getattr(skill_result, "output", "")
     skill_data = getattr(skill_result, "data", {}) if isinstance(getattr(skill_result, "data", None), dict) else {}
+    normalized_skill_error = skill_error
+    if not skill_success:
+        if isinstance(skill_error, str):
+            normalized_skill_error = skill_error.strip() or None
+        elif skill_error:
+            normalized_skill_error = str(skill_error).strip() or None
+        else:
+            normalized_skill_error = None
+
+        if not normalized_skill_error:
+            if isinstance(skill_output, str) and skill_output.strip():
+                normalized_skill_error = skill_output.strip()
+            else:
+                normalized_skill_error = f"GitHub review skill '{skill_name}' failed without an explicit error"
 
     runtime_events = [_event("task.github_review.skill.completed" if skill_success else "task.github_review.skill.failed", "completed" if skill_success else "failed", {
         "skill_name": skill_name,
         "success": skill_success,
-        "error": skill_error,
+        "error": normalized_skill_error,
     })]
 
     review_event, review_summary = _normalize_review_writeback(skill_output, skill_data, review_comment_input)
@@ -141,7 +155,7 @@ async def run_github_review_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     secondary_action_attempted = False
     secondary_action_success = False
     actions_applied = []
-    error_value = skill_error
+    error_value = normalized_skill_error
 
     if skill_success and review_summary:
         action_payload = {

--- a/src/runtime/jira_workflow_review.py
+++ b/src/runtime/jira_workflow_review.py
@@ -89,6 +89,26 @@ async def run_jira_workflow_review(payload: Dict[str, Any]) -> Dict[str, Any]:
             issue_snapshot=issue_snapshot,
             skill_name=plan.skill_name,
         )
+    if outcome.outcome_type == "failed":
+        normalized_error = outcome.summary or "review_skill_failed"
+        return _build_failure(
+            issue_key=plan.issue_key,
+            error=normalized_error,
+            actions_applied=actions_applied,
+            workflow_outcome="failed",
+            approved=None,
+            issue_snapshot=issue_snapshot,
+            skill_name=plan.skill_name,
+            reassignment_target=None,
+            runtime_events=[
+                _event(
+                    "task.jira_workflow_review.failed",
+                    "failed",
+                    plan.issue_key,
+                    {"error": normalized_error, "skill_name": plan.skill_name},
+                )
+            ],
+        )
 
     action_plan = derive_workflow_actions_from_outcome(plan=plan, outcome=outcome, issue_snapshot=issue_snapshot)
 
@@ -248,11 +268,23 @@ async def _resolve_review_outcome(plan, issue_snapshot: Any) -> JiraWorkflowRevi
     }
     skill_result = await execute_skill(plan.skill_name, _use_execution_bus=True, **skill_kwargs)
     if not getattr(skill_result, "success", False):
+        raw_error = getattr(skill_result, "error", None)
+        raw_output = getattr(skill_result, "output", "")
+        normalized_error = ""
+        if isinstance(raw_error, str) and raw_error.strip():
+            normalized_error = raw_error.strip()
+        elif raw_error:
+            normalized_error = str(raw_error).strip()
+        if not normalized_error:
+            if isinstance(raw_output, str) and raw_output.strip():
+                normalized_error = raw_output.strip()
+            else:
+                normalized_error = "Jira workflow review skill failed without an explicit error"
         return JiraWorkflowReviewOutcome(
-            approved=False,
-            outcome_type="rejected",
-            summary=getattr(skill_result, "error", None),
-            comment=getattr(skill_result, "error", None),
+            approved=None,
+            outcome_type="failed",
+            summary=normalized_error,
+            comment=None,
             data=getattr(skill_result, "data", {}) if isinstance(getattr(skill_result, "data", None), dict) else {},
         )
     return normalize_skill_review_outcome(skill_result)

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -129,6 +129,29 @@ async def test_execute_adapter_action_portal_create_delegation_missing_required_
 
 
 @pytest.mark.asyncio
+async def test_execute_adapter_action_portal_missing_base_url_mentions_env_and_config(monkeypatch):
+    monkeypatch.delenv("PORTAL_INTERNAL_BASE_URL", raising=False)
+    monkeypatch.setattr("src.runtime.adapter_executor.get_portal_internal_base_url", lambda: "")
+
+    result = await execute_adapter_action(
+        "adapter:portal:create_delegation",
+        {
+            "group_id": "g-1",
+            "leader_agent_id": "leader-1",
+            "assignee_agent_id": "agent-1",
+            "objective": "Review",
+            "visibility": "leader_only",
+            "skill_name": "skill",
+        },
+    )
+
+    assert result["success"] is False
+    assert result["system"] == "portal"
+    assert "PORTAL_INTERNAL_BASE_URL" in result["error"]
+    assert "server.portal_internal_base_url" in result["error"]
+
+
+@pytest.mark.asyncio
 async def test_execute_adapter_action_portal_create_delegation_missing_skill_name_fails(monkeypatch):
     monkeypatch.setenv("PORTAL_INTERNAL_BASE_URL", "https://portal.internal")
     result = await execute_adapter_action(

--- a/tests/test_github_review.py
+++ b/tests/test_github_review.py
@@ -284,3 +284,50 @@ async def test_github_review_task_forwards_runtime_context_to_bus_helper(monkeyp
     assert captured["meta"]["agent_id"] == "agent-123"
     assert captured["meta"]["policy_profile_id"] == "pp-123"
     assert captured["meta"]["metadata"] == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_failed_skill_without_error_uses_output_as_error(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(
+            success=False,
+            error=None,
+            output="Review skill failed because repository context was unavailable",
+            data={},
+        )
+
+    async def _fail_bus_call(*_args, **_kwargs):
+        raise AssertionError("secondary write-back should not run for failed skill")
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fail_bus_call)
+
+    result = await run_github_review_task({"owner": "acme", "repo": "demo", "pull_number": 24})
+
+    assert result["success"] is False
+    assert result["error"] == "Review skill failed because repository context was unavailable"
+    failed_events = [evt for evt in result["runtime_events"] if evt.get("event_type") == "task.github_review.failed"]
+    assert failed_events
+    assert failed_events[-1]["detail_payload"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_failed_skill_without_error_or_output_uses_generic_error(monkeypatch):
+    from src.runtime.github_review import run_github_review_task
+
+    async def _fake_execute_skill(*_args, **_kwargs):
+        return _SkillResult(success=False, error=None, output="", data={})
+
+    async def _fail_bus_call(*_args, **_kwargs):
+        raise AssertionError("secondary write-back should not run for failed skill")
+
+    monkeypatch.setattr("src.runtime.github_review.execute_skill", _fake_execute_skill)
+    monkeypatch.setattr("src.runtime.github_review.execute_adapter_action_via_bus", _fail_bus_call)
+
+    result = await run_github_review_task({"owner": "acme", "repo": "demo", "pull_number": 25})
+
+    assert result["success"] is False
+    assert "GitHub review skill 'review-pull-request' failed without an explicit error" in result["error"]
+    assert result["secondary_action_attempted"] is False

--- a/tests/test_github_tools.py
+++ b/tests/test_github_tools.py
@@ -372,6 +372,22 @@ async def test_github_review_comment_wrapper_message_for_request_changes_event(m
     assert result == "Changes requested on PR #22"
 
 
+def test_github_add_pr_review_comment_schema_includes_event_enum(github_modules):
+    github_module, _ = github_modules
+
+    schemas = github_module.get_tools_schemas()
+    review_comment_schema = next(
+        schema
+        for schema in schemas
+        if schema.get("type") == "function"
+        and schema.get("function", {}).get("name") == "github_add_pr_review_comment"
+    )
+    event_schema = review_comment_schema["function"]["parameters"]["properties"]["event"]
+
+    assert event_schema["enum"] == ["COMMENT", "APPROVE", "REQUEST_CHANGES"]
+    assert event_schema["default"] == "COMMENT"
+
+
 @pytest.mark.asyncio
 async def test_channel_add_pr_review_comment_rejects_invalid_event(github_modules):
     _, github_api = github_modules
@@ -451,6 +467,69 @@ async def test_channel_add_pr_review_comment_inline_comment_happy_path(monkeypat
     assert captured["method"] == "POST"
     assert captured["endpoint"] == "/repos/acme/repo/pulls/12/comments"
     assert captured["json"]["commit_id"] == "deadbeef"
+    assert captured["json"]["path"] == "x.py"
+    assert captured["json"]["line"] == 10
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_strips_inline_commit_id(monkeypatch, github_modules):
+    _, github_api = github_modules
+    captured = {}
+
+    async def _fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs.get("json", {})
+        return {"id": 126}
+
+    monkeypatch.setattr(github_api.github_channel, "_request", _fake_request)
+
+    result = await github_api.github_channel.add_pr_review_comment(
+        owner="acme",
+        repo="repo",
+        pull_number=12,
+        body="Inline comment",
+        commit_id="  deadbeef  ",
+        path="x.py",
+        line=10,
+        event="COMMENT",
+    )
+
+    assert result["id"] == 126
+    assert captured["endpoint"] == "/repos/acme/repo/pulls/12/comments"
+    assert captured["json"]["commit_id"] == "deadbeef"
+    assert captured["json"]["path"] == "x.py"
+    assert captured["json"]["line"] == 10
+
+
+@pytest.mark.asyncio
+async def test_channel_add_pr_review_comment_blank_commit_id_falls_back_to_head_sha(monkeypatch, github_modules):
+    _, github_api = github_modules
+    captured = {}
+
+    async def _fake_request(method, endpoint, **kwargs):
+        if method == "GET" and endpoint == "/repos/acme/repo/pulls/12":
+            return {"head": {"sha": "abc123"}}
+        if method == "POST" and endpoint == "/repos/acme/repo/pulls/12/comments":
+            captured["json"] = kwargs.get("json", {})
+            return {"id": 127}
+        raise AssertionError(f"Unexpected request: {method} {endpoint}")
+
+    monkeypatch.setattr(github_api.github_channel, "_request", _fake_request)
+
+    result = await github_api.github_channel.add_pr_review_comment(
+        owner="acme",
+        repo="repo",
+        pull_number=12,
+        body="Inline comment",
+        commit_id="   ",
+        path="x.py",
+        line=10,
+        event="COMMENT",
+    )
+
+    assert result["id"] == 127
+    assert captured["json"]["commit_id"] == "abc123"
     assert captured["json"]["path"] == "x.py"
     assert captured["json"]["line"] == 10
 

--- a/tests/test_jira_reconciliation.py
+++ b/tests/test_jira_reconciliation.py
@@ -11,7 +11,7 @@ async def test_jira_reconciliation_consumes_portal_contract_and_posts_ingress_pa
     runner = jira_reconciliation.JiraReconciliationRunner()
     posts = []
 
-    async def _fake_get_json(path):
+    async def _fake_get_json(path, *, session=None):
         if path.endswith("workflow-transition-rules"):
             return {
                 "items": [
@@ -29,7 +29,7 @@ async def test_jira_reconciliation_consumes_portal_contract_and_posts_ingress_pa
             return {"items": [{"agent_id": "a-1", "provider_type": "jira"}]}
         raise AssertionError("unexpected path")
 
-    async def _fake_post_json(path, payload):
+    async def _fake_post_json(path, payload, *, session=None):
         posts.append((path, payload))
 
     async def _fake_search_issues(jql, max_results=50):
@@ -79,7 +79,7 @@ async def test_jira_reconciliation_issue_failure_does_not_break_loop(monkeypatch
     runner = jira_reconciliation.JiraReconciliationRunner()
     posts = []
 
-    async def _fake_get_json(path):
+    async def _fake_get_json(path, *, session=None):
         if path.endswith("workflow-transition-rules"):
             return {
                 "items": [
@@ -94,7 +94,7 @@ async def test_jira_reconciliation_issue_failure_does_not_break_loop(monkeypatch
             }
         return {"items": []}
 
-    async def _fake_post_json(path, payload):
+    async def _fake_post_json(path, payload, *, session=None):
         if payload["issue_key"] == "ENG-1":
             raise RuntimeError("boom")
         posts.append((path, payload))
@@ -116,6 +116,69 @@ async def test_jira_reconciliation_issue_failure_does_not_break_loop(monkeypatch
 
     assert len(posts) == 1
     assert posts[0][1]["issue_key"] == "ENG-2"
+
+
+@pytest.mark.asyncio
+async def test_jira_reconciliation_reuses_single_client_session_per_run(monkeypatch):
+    from src.cron import jira_reconciliation
+
+    runner = jira_reconciliation.JiraReconciliationRunner()
+    session_constructors = []
+    sessions_seen = []
+    posts = []
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def _fake_client_session(*args, **kwargs):
+        session = _FakeSession()
+        session_constructors.append(session)
+        return session
+
+    async def _fake_get_json(path, *, session=None):
+        sessions_seen.append(session)
+        if path.endswith("workflow-transition-rules"):
+            return {
+                "items": [
+                    {
+                        "id": "r-1",
+                        "system_type": "jira",
+                        "is_enabled": True,
+                        "project_key": "ENG",
+                        "trigger_status": "In Progress",
+                    }
+                ]
+            }
+        return {"items": [{"agent_id": "a-1", "provider_type": "jira"}]}
+
+    async def _fake_post_json(path, payload, *, session=None):
+        sessions_seen.append(session)
+        posts.append((path, payload))
+
+    async def _fake_search_issues(_jql, max_results=50):
+        return {
+            "issues": [
+                {"key": "ENG-1", "fields": {"project": {"key": "ENG"}, "issuetype": {"name": "Bug"}, "status": {"name": "In Progress"}}},
+                {"key": "ENG-2", "fields": {"project": {"key": "ENG"}, "issuetype": {"name": "Task"}, "status": {"name": "In Progress"}}},
+            ]
+        }
+
+    monkeypatch.setattr("src.cron.jira_reconciliation.ClientSession", _fake_client_session)
+    monkeypatch.setattr(runner, "_get_json", _fake_get_json)
+    monkeypatch.setattr(runner, "_post_json", _fake_post_json)
+    monkeypatch.setattr("src.cron.jira_reconciliation.jira_channel.search_issues", _fake_search_issues)
+    monkeypatch.setattr(runner, "_base_url", lambda: "https://portal.internal")
+
+    await runner.reconcile_once()
+
+    assert len(session_constructors) == 1
+    assert sessions_seen
+    assert all(session is session_constructors[0] for session in sessions_seen)
+    assert [payload["issue_key"] for _, payload in posts] == ["ENG-1", "ENG-2"]
 
 
 def test_build_external_event_ingress_request_shape():

--- a/tests/test_jira_workflow_review.py
+++ b/tests/test_jira_workflow_review.py
@@ -95,6 +95,60 @@ async def test_jira_workflow_review_failure_path_reassigns_without_success_trans
 
 
 @pytest.mark.asyncio
+async def test_jira_workflow_review_skill_execution_failure_short_circuits_without_side_effects(monkeypatch):
+    calls = []
+
+    async def _fake_execute_jira_workflow_action(action_name, kwargs):
+        calls.append((action_name, dict(kwargs)))
+        if action_name == "read_issue":
+            return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
+        return {"success": True, "result": "ok", "error": None}
+
+    async def _fake_execute_skill(skill_name, **kwargs):
+        return SkillResult(success=False, error="temporary skill failure", output="", data={})
+
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
+
+    result = await run_jira_workflow_review({"issue_key": "PROJ-200", "skill_name": "review_skill"})
+
+    assert result["success"] is False
+    assert result["workflow_outcome"] == "failed"
+    assert result["approved"] is None
+    assert result["error"] == "temporary skill failure"
+    assert result["actions_applied"] == []
+    assert [name for name, _ in calls] == ["read_issue"]
+    assert any(evt.get("event_type") == "task.jira_workflow_review.failed" for evt in result["runtime_events"])
+
+
+@pytest.mark.asyncio
+async def test_jira_workflow_review_skill_failure_without_error_uses_output_or_generic_message(monkeypatch):
+    async def _fake_execute_jira_workflow_action(action_name, kwargs):
+        if action_name == "read_issue":
+            return {"success": True, "result": {"key": kwargs["issue_key"]}, "error": None}
+        return {"success": True, "result": "ok", "error": None}
+
+    results = [
+        SkillResult(success=False, error=None, output="skill output failure reason", data={}),
+        SkillResult(success=False, error=None, output="", data={}),
+    ]
+
+    async def _fake_execute_skill(skill_name, **kwargs):
+        return results.pop(0)
+
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_jira_workflow_action", _fake_execute_jira_workflow_action)
+    monkeypatch.setattr("src.runtime.jira_workflow_review.execute_skill", _fake_execute_skill)
+
+    first = await run_jira_workflow_review({"issue_key": "PROJ-201", "skill_name": "review_skill"})
+    second = await run_jira_workflow_review({"issue_key": "PROJ-202", "skill_name": "review_skill"})
+
+    assert first["success"] is False
+    assert first["error"] == "skill output failure reason"
+    assert second["success"] is False
+    assert "Jira workflow review skill failed without an explicit error" in second["error"]
+
+
+@pytest.mark.asyncio
 async def test_requester_resolution_from_issue_snapshot(monkeypatch):
     async def _fake_execute_jira_workflow_action(action_name, kwargs):
         if action_name == "read_issue":

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -330,11 +330,66 @@ class TestSubAgentIntegration:
             "created_at": "2026-01-01T00:00:01Z",
             "parent_session_id": "s-b",
         }
+        _subagent_sessions["sa-3"] = {
+            "session_key": "sa-3",
+            "task": "t3",
+            "status": "completed",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:02Z",
+            "parent_session_id": "s-a",
+        }
 
         filtered = list_active_subagent_summaries(parent_session_id="s-a")
         assert len(filtered) == 1
         assert filtered[0]["session_key"] == "sa-1"
         assert filtered[0]["parent_session_id"] == "s-a"
+        _subagent_sessions.clear()
+
+    def test_list_active_subagent_summaries_excludes_completed_and_failed_entries(self):
+        from src.agents.subagent import _subagent_sessions, list_active_subagent_summaries
+
+        _subagent_sessions.clear()
+        _subagent_sessions["sa-started"] = {
+            "session_key": "sa-started",
+            "task": "t1",
+            "status": "started",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:00Z",
+            "parent_session_id": "s-1",
+        }
+        _subagent_sessions["sa-running"] = {
+            "session_key": "sa-running",
+            "task": "t2",
+            "status": "running",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:01Z",
+            "parent_session_id": "s-1",
+        }
+        _subagent_sessions["sa-completed"] = {
+            "session_key": "sa-completed",
+            "task": "t3",
+            "status": "completed",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:02Z",
+            "parent_session_id": "s-1",
+        }
+        _subagent_sessions["sa-failed"] = {
+            "session_key": "sa-failed",
+            "task": "t4",
+            "status": "failed",
+            "model": "gpt-4",
+            "thinking": "low",
+            "created_at": "2026-01-01T00:00:03Z",
+            "parent_session_id": "s-1",
+        }
+
+        summaries = list_active_subagent_summaries()
+        session_keys = [item["session_key"] for item in summaries]
+        assert session_keys == ["sa-started", "sa-running"]
         _subagent_sessions.clear()
     
     def test_spawn_and_cleanup(self):


### PR DESCRIPTION
### Motivation
- Limit what `list_active_subagent_summaries` returns to currently active sub-agent sessions and make session listing predictable.
- Reduce HTTP connection churn in the Jira reconciliation cron by reusing a single `ClientSession` per run and allow `_get_json`/`_post_json` callers to pass a session.
- Add explicit support for GitHub PR review `event` semantics and normalize inline `commit_id` handling for review comments.
- Normalize and surface clearer error text when review/workflow skills fail to avoid silent failures and prevent unintended side-effects.

### Description
- Updated `src/agents/subagent.py` to filter `list_active_subagent_summaries` to only return statuses in `{"started","running"}`.
- Modified `src/cron/jira_reconciliation.py` to accept an optional `session` in `_get_json` and `_post_json`, to create and reuse a single `ClientSession` inside `reconcile_once`, and to pass the session through to fetch/post calls.
- Extended the GitHub tool schema in `src/github/__init__.py` to document the new `event` parameter for `github_add_pr_review_comment` and added the enum/default.
- Implemented `event` handling and `commit_id` normalization in `src/github/api.py`, using a stripped `commit_id` for inline comments and falling back to PR head SHA when blank.
- Improved portal adapter error message in `src/runtime/adapter_executor.py` to mention both the environment variable and config key when the portal base URL is missing.
- Normalized skill failure messages in `src/runtime/github_review.py` and `src/runtime/jira_workflow_review.py` so that when a skill fails without an explicit error the code uses the skill `output` or a generic message and short-circuits without applying side effects.
- Added and updated unit tests across multiple test modules to verify the new behaviours and edge cases: `tests/test_subagent.py`, `tests/test_jira_reconciliation.py`, `tests/test_jira_workflow_review.py`, `tests/test_github_tools.py`, `tests/test_github_review.py`, and `tests/test_adapter_executor.py`.

### Testing
- Ran the unit tests covering changes to adapters, GitHub helpers, Jira reconciliation, sub-agent listing, and workflow review logic (`tests/test_adapter_executor.py`, `tests/test_github_tools.py`, `tests/test_github_review.py`, `tests/test_jira_reconciliation.py`, `tests/test_jira_workflow_review.py`, `tests/test_subagent.py`) and verified the added tests exercise the new edge cases.
- All modified and newly added automated tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d649a48f1c832aab47c0e0e8c07ea5)