### PR TITLE
Scoped EventBus listeners and true streaming for /api/chat/stream

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -69,6 +69,39 @@ def _run_post_tool_hooks_via_governance(**kwargs):
 
     return run_post_tool_hooks(**kwargs)
 
+
+
+def _enrich_runtime_event_context(
+    data: Dict[str, Any],
+    *,
+    session_id: str,
+    agent_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    group_id: Optional[str] = None,
+    coordination_run_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fill runtime event context fields when absent, preserving explicit payload values."""
+    merged: Dict[str, Any] = dict(data or {})
+    context_fields = {
+        "session_id": session_id,
+        "agent_id": agent_id,
+        "task_id": task_id,
+        "group_id": group_id,
+        "coordination_run_id": coordination_run_id,
+    }
+    for key, value in context_fields.items():
+        existing = merged.get(key)
+        if existing is not None and (not isinstance(existing, str) or existing.strip()):
+            continue
+        if value is None:
+            continue
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                continue
+        merged[key] = value
+    return merged
+
 # Context variable for skill workdir - async-safe
 _skill_workdir: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar('skill_workdir', default=None)
 
@@ -793,28 +826,36 @@ You have access to the following tools. When a user asks you to do something tha
         # Supports both simple callbacks and asyncio.Queue
         def send_event(event_type: str, data: dict):
             """Send event via stream_callback and event bus."""
+            event_data = _enrich_runtime_event_context(
+                data,
+                session_id=session_id,
+                agent_id=self.agent_id,
+                task_id=data.get("task_id"),
+                group_id=data.get("group_id") or data.get("portal_group_id"),
+                coordination_run_id=data.get("coordination_run_id") or data.get("portal_coordination_run_id"),
+            )
             # Also log to tracer for persistence
             if event_type == 'llm_thinking':
                 try:
                     from src.skills import get_tracer
                     tracer_instance = get_tracer()
-                    message = data.get('message', '')
+                    message = event_data.get('message', '')
                     if message:
                         tracer_instance.log_thinking(message)
                 except Exception:
                     pass  # Tracer may not be initialized
-            
+
             # Emit to event bus for WebSocket clients
             try:
                 from src.gateway.event_bus import emit_agent_event_sync
-                emit_agent_event_sync(event_type, data)
+                emit_agent_event_sync(event_type, event_data)
             except Exception as e:
                 logger.info(f"Event bus emit error: {e}")
-            
+
             # Also send via callback if provided
             if stream_callback:
                 import json
-                event = json.dumps({"type": event_type, **data})
+                event = json.dumps({"type": event_type, **event_data})
                 try:
                     # Check if it's an asyncio.Queue
                     if hasattr(stream_callback, 'put'):
@@ -1656,8 +1697,16 @@ You have access to the following tools. When a user asks you to do something tha
         def send_skill_event(event_type: str, data: dict):
             """Send skill event via stream_callback if available, and also emit to event_bus for WebSocket."""
             import json
-            event = json.dumps({"type": event_type, "data": data})
-            
+            event_data = _enrich_runtime_event_context(
+                data,
+                session_id=session_id,
+                agent_id=self.agent_id,
+                task_id=data.get("task_id"),
+                group_id=data.get("group_id") or data.get("portal_group_id"),
+                coordination_run_id=data.get("coordination_run_id") or data.get("portal_coordination_run_id"),
+            )
+            event = json.dumps({"type": event_type, "data": event_data})
+
             # Send via stream_callback (for SSE)
             if stream_callback:
                 try:
@@ -1667,11 +1716,11 @@ You have access to the following tools. When a user asks you to do something tha
                         stream_callback(event)
                 except Exception:
                     pass  # Ignore callback errors
-            
+
             # Also emit to event_bus for WebSocket listeners
             try:
                 from src.gateway.event_bus import event_bus
-                event_bus.emit_sync(event_type, data)
+                event_bus.emit_sync(event_type, event_data)
             except Exception:
                 pass  # Ignore if event_bus not available
 
@@ -1746,9 +1795,17 @@ You have access to the following tools. When a user asks you to do something tha
         def send_skill_event(event_type: str, data: dict):
             """Send skill event via stream_callback if available, and also emit to event_bus for WebSocket."""
             import json
-            event = json.dumps({"type": event_type, "data": data})
-            logger.debug(f"[SkillMode] [EVENT] type={event_type}, data={safe_preview(data, 200)}")
-            
+            event_data = _enrich_runtime_event_context(
+                data,
+                session_id=session_id,
+                agent_id=self.agent_id,
+                task_id=data.get("task_id"),
+                group_id=data.get("group_id") or data.get("portal_group_id"),
+                coordination_run_id=data.get("coordination_run_id") or data.get("portal_coordination_run_id"),
+            )
+            event = json.dumps({"type": event_type, "data": event_data})
+            logger.debug(f"[SkillMode] [EVENT] type={event_type}, data={safe_preview(event_data, 200)}")
+
             # Send via stream_callback (for SSE)
             if stream_callback:
                 try:
@@ -1758,11 +1815,11 @@ You have access to the following tools. When a user asks you to do something tha
                         stream_callback(event)
                 except Exception:
                     pass  # Ignore callback errors
-            
+
             # Also emit to event_bus for WebSocket listeners
             try:
                 from src.gateway.event_bus import event_bus
-                event_bus.emit_sync(event_type, data)
+                event_bus.emit_sync(event_type, event_data)
             except Exception:
                 pass  # Ignore if event_bus not available
 

--- a/src/gateway/event_bus.py
+++ b/src/gateway/event_bus.py
@@ -6,72 +6,132 @@ agent events in real-time.
 
 import asyncio
 import logging
-from typing import Callable, Dict, List, Any
+from dataclasses import dataclass
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
+
+_SUPPORTED_FILTER_KEYS = {
+    "agent_id",
+    "session_id",
+    "task_id",
+    "group_id",
+    "coordination_run_id",
+}
+
+
+@dataclass
+class _ListenerRecord:
+    queue: asyncio.Queue
+    filters: Dict[str, str]
 
 
 class EventBus:
     """Simple in-memory event bus for agent events."""
-    
+
     def __init__(self):
-        self._listeners: List[asyncio.Queue] = []
+        self._listeners: List[_ListenerRecord] = []
         self._lock = asyncio.Lock()
-    
-    async def add_listener(self, queue: asyncio.Queue):
+
+    @staticmethod
+    def _normalize_filters(filters: Dict[str, str] | None = None) -> Dict[str, str]:
+        normalized: Dict[str, str] = {}
+        for key, value in (filters or {}).items():
+            if key not in _SUPPORTED_FILTER_KEYS:
+                continue
+            normalized_value = str(value).strip() if value is not None else ""
+            if normalized_value:
+                normalized[key] = normalized_value
+        return normalized
+
+    @staticmethod
+    def _event_matches_filters(event_type: str, data: Dict[str, Any], filters: Dict[str, str]) -> bool:
+        del event_type  # reserved for future event-type specific matching
+        if not filters:
+            return True
+
+        for key, expected_value in filters.items():
+            if key == "agent_id":
+                candidates = [data.get("agent_id")]
+            elif key == "session_id":
+                candidates = [data.get("session_id")]
+            elif key == "task_id":
+                candidates = [data.get("task_id"), data.get("current_task_id"), data.get("portal_task_id")]
+            elif key == "group_id":
+                candidates = [data.get("group_id"), data.get("portal_group_id")]
+            elif key == "coordination_run_id":
+                candidates = [
+                    data.get("coordination_run_id"),
+                    data.get("current_coordination_run_id"),
+                    data.get("portal_coordination_run_id"),
+                ]
+            else:
+                return False
+
+            comparable_candidates = [str(candidate).strip() for candidate in candidates if candidate is not None and str(candidate).strip()]
+            if not comparable_candidates:
+                return False
+            if expected_value not in comparable_candidates:
+                return False
+
+        return True
+
+    async def add_listener(self, queue: asyncio.Queue, filters: Dict[str, str] | None = None):
         """Add a listener (WebSocket connection) to receive events."""
+        listener_record = _ListenerRecord(queue=queue, filters=self._normalize_filters(filters))
         async with self._lock:
-            self._listeners.append(queue)
-            logger.info(f"Event listener added. Total listeners: {len(self._listeners)}")
-    
+            self._listeners.append(listener_record)
+            logger.info("Event listener added. Total listeners: %d", len(self._listeners))
+
     async def remove_listener(self, queue: asyncio.Queue):
         """Remove a listener."""
         async with self._lock:
-            if queue in self._listeners:
-                self._listeners.remove(queue)
-                logger.info(f"Event listener removed. Total listeners: {len(self._listeners)}")
-    
+            self._listeners = [listener for listener in self._listeners if listener.queue is not queue]
+            logger.info("Event listener removed. Total listeners: %d", len(self._listeners))
+
     async def emit(self, event_type: str, data: Dict[str, Any]):
-        """Emit an event to all listeners."""
+        """Emit an event to matching listeners."""
         import json
+
         event = json.dumps({
             "type": event_type,
             "data": data,
             "ts": asyncio.get_event_loop().time()
         })
-        
+
         async with self._lock:
             listeners = list(self._listeners)
-        
+
         for listener in listeners:
+            if not self._event_matches_filters(event_type, data, listener.filters):
+                continue
             try:
-                listener.put_nowait(event)
+                listener.queue.put_nowait(event)
             except Exception as e:
                 logger.error(f"Error sending event to listener: {e}")
-    
+
     def emit_sync(self, event_type: str, data: Dict[str, Any]):
         """Synchronous emit for use in callbacks.
-        
+
         This is called from sync callbacks, so we need to be careful about the event loop.
         """
         import json
         logger.info(f"[EventBus] emit_sync: {event_type}")
-        
+
         event = json.dumps({
             "type": event_type,
             "data": data,
             "ts": 0
         })
-        
-        # Add directly to all listener queues - this works from sync context
-        # We iterate over a copy of the list
+
         listeners = list(self._listeners)
-        
+
         for listener in listeners:
+            if not self._event_matches_filters(event_type, data, listener.filters):
+                continue
             try:
-                # Try non-blocking put
-                listener.put_nowait(event)
-                logger.info(f"[EventBus] Event sent to listener")
+                listener.queue.put_nowait(event)
+                logger.info("[EventBus] Event sent to listener")
             except Exception as e:
                 logger.error(f"[EventBus] Error: {e}")
 

--- a/src/gateway/events.py
+++ b/src/gateway/events.py
@@ -22,11 +22,19 @@ async def handle_websocket(request: web.Request) -> WebSocketResponse:
     
     # Create a queue for this connection
     queue = asyncio.Queue()
-    
+
+    query = request.rel_url.query
+    filter_keys = ("session_id", "task_id", "group_id", "coordination_run_id", "agent_id")
+    filters = {key: str(query.get(key, "")).strip() for key in filter_keys if str(query.get(key, "")).strip()}
+
     # Register this connection as a listener
-    await event_bus.add_listener(queue)
-    
-    logger.info(f"WebSocket client connected. Total listeners: {len(event_bus._listeners)}")
+    await event_bus.add_listener(queue, filters=filters)
+
+    logger.info(
+        "WebSocket client connected. filters=%s total_listeners=%d",
+        filters,
+        len(event_bus._listeners),
+    )
     
     async def read_events():
         """Background task to read from queue and send to WebSocket."""

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -758,12 +758,14 @@ async def api_chat(request: web.Request) -> web.Response:
 
 async def api_chat_stream(request: web.Request) -> web.StreamResponse:
     """Handle streaming chat API requests (Server-Sent Events).
-    
+
     POST /api/chat/stream
     Body: {"message": "...", "session_id": "optional"}
-    
+
     Returns: text/event-stream with chunks of the response
     """
+    response: Optional[web.StreamResponse] = None
+    run_task: Optional[asyncio.Task] = None
     try:
         data = await request.json()
         message = (data.get('message') or '').strip()
@@ -771,11 +773,11 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         portal_user_id, portal_user_name = _extract_portal_identity(request, data)
         execution_metadata = _extract_trusted_control_plane_metadata(request, data)
         effective_user_name = _resolve_chat_display_user_name(data, portal_user_name)
-        
+
         if not message:
             response = web.json_response({'error': 'Empty message'}, status=400)
             return response
-        
+
         # Create streaming response
         response = web.StreamResponse(
             status=200,
@@ -786,19 +788,17 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
                 'X-Accel-Buffering': 'no',  # Disable nginx buffering
             }
         )
-        
+
         await response.prepare(request)
-        
+
         # Send start event
         await response.write(f"event: start\ndata: {json.dumps({'session_id': session_id})}\n\n".encode())
-        
-        # Create an async queue for streaming events
-        import asyncio
+
         event_queue = asyncio.Queue()
-        
+
         # Get model from config
         model = global_config.llm.get('model', 'gpt-5-mini')
-        
+
         # Run agent and stream response
         runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
         agent = AgentCore(
@@ -807,20 +807,31 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             agent_id=runtime_agent_id,
             agent_name=runtime_agent_name,
         )
-        
-        # Pass the queue to the agent for real-time events
-        result = await _run_chat_via_execution_bus(
-            agent=agent,
-            message=message,
-            session_id=session_id,
-            user_name=effective_user_name,
-            portal_user_id=portal_user_id,
-            portal_user_name=portal_user_name,
-            stream_callback=event_queue,
-            request_path="/api/chat/stream",
-            execution_metadata=execution_metadata,
-            agent_id=runtime_agent_id,
+
+        run_task = asyncio.create_task(
+            _run_chat_via_execution_bus(
+                agent=agent,
+                message=message,
+                session_id=session_id,
+                user_name=effective_user_name,
+                portal_user_id=portal_user_id,
+                portal_user_name=portal_user_name,
+                stream_callback=event_queue,
+                request_path="/api/chat/stream",
+                execution_metadata=execution_metadata,
+                agent_id=runtime_agent_id,
+            )
         )
+
+        while not run_task.done() or not event_queue.empty():
+            try:
+                event = await asyncio.wait_for(event_queue.get(), timeout=0.15)
+                escaped = str(event).replace('\n', '\\n').replace('\r', '\\r')
+                await response.write(f"event: progress\ndata: {escaped}\n\n".encode())
+            except asyncio.TimeoutError:
+                continue
+
+        result = await run_task
         execution_result = result.get("_execution_result")
         if runtime_agent_id and execution_result is not None:
             publish_fields = extract_session_metadata_publish_fields(
@@ -837,21 +848,9 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
                 )
             except Exception:
                 logger.warning("Best-effort session metadata publish failed for streaming chat path", exc_info=True)
-        
-        # Stream events from queue while agent is running
-        while not event_queue.empty():
-            try:
-                event = await asyncio.wait_for(event_queue.get(), timeout=0.1)
-                escaped = event.replace('\n', '\\n').replace('\r', '\\r')
-                await response.write(f"event: progress\ndata: {escaped}\n\n".encode())
-            except asyncio.TimeoutError:
-                break
-            except Exception as e:
-                logger.error(f"Error streaming event: {e}")
-        
-        response_text = result.get("response", "") if result else ""
+
         usage = result.get("usage", {}) if result else {}
-        
+
         # Record usage
         if usage:
             provider = global_config.llm.get('provider', 'openai')
@@ -864,19 +863,19 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
                 session_id=session_id,
                 task_type="chat"
             )
-        
+
         # Send usage data
         usage_data = json.dumps({
             'usage': usage,
             'session_id': session_id,
         })
         await response.write(f"event: usage\ndata: {usage_data}\n\n".encode())
-        
+
         # Send done event
         await response.write(f"event: done\ndata: \n\n".encode())
-        
+
         return response
-        
+
     except json.JSONDecodeError:
         response = web.json_response({'error': 'Invalid JSON'}, status=400)
         return response
@@ -887,11 +886,14 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         raise
     except Exception as e:
         logger.error(f"Stream error: {e}")
-        error_data = json.dumps({'error': str(e)})
-        try:
-            await response.write(f"event: error\ndata: {error_data}\n\n".encode())
-        except Exception:
-            pass
+        if response is not None and run_task is not None:
+            error_data = json.dumps({'error': str(e)})
+            try:
+                await response.write(f"event: error\ndata: {error_data}\n\n".encode())
+                await response.write(f"event: done\ndata: \n\n".encode())
+            except Exception:
+                pass
+            return response
         return web.Response(status=500, text=str(e))
 
 

--- a/tests/test_agent_event_context.py
+++ b/tests/test_agent_event_context.py
@@ -1,0 +1,191 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src import ToolResult
+from src.agents.core import Agent
+
+
+class _Tracer:
+    def start_execution(self, **kwargs):
+        return "exec-ctx-1"
+
+    def log_tool_call(self, *args, **kwargs):
+        return None
+
+    def complete_execution(self, *args, **kwargs):
+        return None
+
+    def get_events_for_ui(self, **kwargs):
+        return []
+
+    def log_thinking(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_entry(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_step(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_action(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_complete(self, *args, **kwargs):
+        return None
+
+
+class _SessionManager:
+    def __init__(self):
+        self.messages = []
+
+    async def add_message(self, session_id, role, content, extra=None, wait_for_save=False):
+        self.messages.append({"session_id": session_id, "role": role, "content": content, **(extra or {})})
+        return f"m-{len(self.messages)}"
+
+    async def get_history(self, session_id):
+        return [m for m in self.messages if m.get("session_id") == session_id]
+
+    async def set_active_skill_session(self, _session_id, _state):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_main_loop_tool_call_event_emits_session_and_agent_context(monkeypatch):
+    from src.agents import core as core_mod
+
+    captured_events = []
+
+    def _capture_emit(event_type, data):
+        captured_events.append((event_type, data))
+
+    async def _no_fastlane(*args, **kwargs):
+        return None
+
+    async def _fake_execute_tool(**kwargs):
+        return ToolResult(True, "ok")
+
+    responses = [
+        {"content": "", "function_calls": [{"call_id": "c1", "name": "allowed_tool", "arguments": "{}"}], "usage": {}},
+        {"content": "done", "function_calls": [], "usage": {}},
+    ]
+
+    async def _fake_responses(**kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr("src.skills.get_tracer", lambda: _Tracer())
+    monkeypatch.setattr(core_mod, "session_manager", _SessionManager())
+    monkeypatch.setattr("src.agents.fastlane.process_fastlane_command", _no_fastlane)
+    monkeypatch.setattr(core_mod, "memory_system", SimpleNamespace(build_context_with_search=lambda **kwargs: ""))
+    monkeypatch.setattr(core_mod, "llm_client", SimpleNamespace(responses=_fake_responses, default_provider="openai"))
+    monkeypatch.setattr(core_mod, "_execute_tool_via_runtime_bus", _fake_execute_tool)
+    monkeypatch.setattr("src.gateway.event_bus.emit_agent_event_sync", _capture_emit)
+    monkeypatch.setattr(
+        "src.skills.skill_registry",
+        SimpleNamespace(_initialized=True, load_skills=lambda: None, match_skill=lambda *_: []),
+    )
+
+    agent = Agent.__new__(Agent)
+    agent.system_prompt = "base"
+    agent.tools = [{"function": {"name": "allowed_tool", "description": "ok"}}]
+    agent.include_memory = False
+    agent.think_level = SimpleNamespace(value="off")
+    agent.model = None
+    agent.memory_update_manager = None
+    agent.agent_id = "agent-ctx"
+    agent.agent_name = "AgentCtx"
+
+    result = await agent.process("run tool", session_id="s1")
+    assert result["response"] == "done"
+
+    tool_call_event = next(data for event_type, data in captured_events if event_type == "tool_call" and data.get("status") == "executing")
+    assert tool_call_event["session_id"] == "s1"
+    assert tool_call_event["agent_id"] == "agent-ctx"
+
+
+@pytest.mark.asyncio
+async def test_start_skill_mode_events_include_session_and_agent_context(monkeypatch):
+    from src.agents import core as core_mod
+
+    captured_events = []
+
+    class _Bus:
+        def emit_sync(self, event_type, data):
+            captured_events.append((event_type, data))
+
+    async def _fake_generate_initial_skill_plan(skill, message, model=None):
+        return "goal", ["step-1"], {}
+
+    async def _fake_continue_skill_mode(**kwargs):
+        return {"response": "continued", "usage": {}, "events": [], "user_message_id": kwargs["user_message_id"]}
+
+    monkeypatch.setattr("src.skills.get_tracer", lambda: _Tracer())
+    monkeypatch.setattr(core_mod, "session_manager", _SessionManager())
+    monkeypatch.setattr(core_mod, "generate_initial_skill_plan", _fake_generate_initial_skill_plan)
+    monkeypatch.setattr("src.gateway.event_bus.event_bus", _Bus())
+
+    agent = Agent.__new__(Agent)
+    agent.model = None
+    agent.agent_id = "agent-ctx"
+    agent.agent_name = "AgentCtx"
+    agent._continue_skill_mode = _fake_continue_skill_mode
+
+    skill = SimpleNamespace(name="skill-a", path="")
+
+    result = await agent._start_skill_mode(
+        message="do thing",
+        session_id="s1",
+        user_message_id="u1",
+        skill=skill,
+    )
+
+    assert result["response"] == "continued"
+    first_event = captured_events[0]
+    assert first_event[0] == "skill_mode_start"
+    assert first_event[1]["session_id"] == "s1"
+    assert first_event[1]["agent_id"] == "agent-ctx"
+
+
+@pytest.mark.asyncio
+async def test_filtered_event_bus_listener_receives_skill_event_with_session_context(monkeypatch):
+    from src.agents import core as core_mod
+    from src.gateway.event_bus import event_bus
+
+    async def _fake_generate_initial_skill_plan(skill, message, model=None):
+        return "goal", ["step-1"], {}
+
+    async def _fake_continue_skill_mode(**kwargs):
+        return {"response": "continued", "usage": {}, "events": [], "user_message_id": kwargs["user_message_id"]}
+
+    monkeypatch.setattr("src.skills.get_tracer", lambda: _Tracer())
+    monkeypatch.setattr(core_mod, "session_manager", _SessionManager())
+    monkeypatch.setattr(core_mod, "generate_initial_skill_plan", _fake_generate_initial_skill_plan)
+
+    queue = asyncio.Queue()
+    await event_bus.add_listener(queue, filters={"session_id": "s1"})
+
+    agent = Agent.__new__(Agent)
+    agent.model = None
+    agent.agent_id = "agent-ctx"
+    agent.agent_name = "AgentCtx"
+    agent._continue_skill_mode = _fake_continue_skill_mode
+
+    skill = SimpleNamespace(name="skill-a", path="")
+
+    try:
+        await agent._start_skill_mode(
+            message="do thing",
+            session_id="s1",
+            user_message_id="u1",
+            skill=skill,
+        )
+
+        raw_event = await asyncio.wait_for(queue.get(), timeout=1.0)
+        event = json.loads(raw_event)
+        assert event["type"] == "skill_mode_start"
+        assert event["data"]["session_id"] == "s1"
+        assert event["data"]["agent_id"] == "agent-ctx"
+    finally:
+        await event_bus.remove_listener(queue)

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,72 @@
+import asyncio
+import json
+
+import pytest
+
+from src.gateway.event_bus import EventBus
+
+
+@pytest.mark.asyncio
+async def test_event_bus_unfiltered_listener_receives_all_events():
+    bus = EventBus()
+    queue = asyncio.Queue()
+    await bus.add_listener(queue)
+
+    await bus.emit("task.progress", {"session_id": "s1"})
+    await bus.emit("task.progress", {"session_id": "s2"})
+
+    first = json.loads(await queue.get())
+    second = json.loads(await queue.get())
+    assert first["type"] == "task.progress"
+    assert first["data"]["session_id"] == "s1"
+    assert "ts" in first
+    assert second["data"]["session_id"] == "s2"
+
+
+@pytest.mark.asyncio
+async def test_event_bus_session_filter_only_receives_matching_session():
+    bus = EventBus()
+    queue = asyncio.Queue()
+    await bus.add_listener(queue, filters={"session_id": " s-1 "})
+
+    await bus.emit("task.progress", {"session_id": "s-2", "task_id": "t"})
+    await bus.emit("task.progress", {"session_id": "s-1", "task_id": "t"})
+
+    event = json.loads(await queue.get())
+    assert event["data"]["session_id"] == "s-1"
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_event_bus_task_filter_matches_alias_fields():
+    bus = EventBus()
+    queue_current = asyncio.Queue()
+    queue_portal = asyncio.Queue()
+    await bus.add_listener(queue_current, filters={"task_id": "task-1"})
+    await bus.add_listener(queue_portal, filters={"task_id": "task-2"})
+
+    await bus.emit("task.progress", {"current_task_id": "task-1"})
+    bus.emit_sync("task.progress", {"portal_task_id": "task-2"})
+
+    current_event = json.loads(await queue_current.get())
+    portal_event = json.loads(await queue_portal.get())
+    assert current_event["data"]["current_task_id"] == "task-1"
+    assert portal_event["data"]["portal_task_id"] == "task-2"
+
+
+@pytest.mark.asyncio
+async def test_event_bus_group_and_coordination_filters():
+    bus = EventBus()
+    queue = asyncio.Queue()
+    await bus.add_listener(
+        queue,
+        filters={"group_id": "group-1", "coordination_run_id": "coord-1"},
+    )
+
+    await bus.emit("coord.update", {"group_id": "group-1", "coordination_run_id": "coord-2"})
+    await bus.emit("coord.update", {"portal_group_id": "group-1", "current_coordination_run_id": "coord-1"})
+
+    event = json.loads(await queue.get())
+    assert event["data"]["portal_group_id"] == "group-1"
+    assert event["data"]["current_coordination_run_id"] == "coord-1"
+    assert queue.empty()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.gateway import events
+
+
+class _FakeWS:
+    def __init__(self):
+        self.closed = False
+
+    async def prepare(self, request):
+        return self
+
+    async def send_str(self, _data):
+        return None
+
+    def exception(self):
+        return None
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+@pytest.mark.asyncio
+async def test_handle_websocket_passes_query_filters_to_event_bus(monkeypatch):
+    captured = {}
+
+    async def _fake_add_listener(queue, filters=None):
+        captured["queue"] = queue
+        captured["filters"] = filters
+
+    async def _fake_remove_listener(_queue):
+        captured["removed"] = True
+
+    monkeypatch.setattr(events.web, "WebSocketResponse", _FakeWS)
+    monkeypatch.setattr(events.event_bus, "add_listener", _fake_add_listener)
+    monkeypatch.setattr(events.event_bus, "remove_listener", _fake_remove_listener)
+    monkeypatch.setattr(events.event_bus, "_listeners", [])
+
+    request = SimpleNamespace(
+        rel_url=SimpleNamespace(
+            query={
+                "session_id": " s-1 ",
+                "task_id": "t-1",
+                "group_id": "",
+                "coordination_run_id": "coord-1",
+                "agent_id": "agent-1",
+            }
+        )
+    )
+
+    ws = await events.handle_websocket(request)
+
+    assert isinstance(ws, _FakeWS)
+    assert captured["filters"] == {
+        "session_id": "s-1",
+        "task_id": "t-1",
+        "coordination_run_id": "coord-1",
+        "agent_id": "agent-1",
+    }
+    assert captured.get("removed") is True

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -711,6 +711,56 @@ async def test_api_chat_publish_failure_does_not_break_response(monkeypatch):
     assert resp.status == 200
 
 
+
+
+@pytest.mark.asyncio
+async def test_api_chat_stream_emits_progress_before_done_while_task_running(monkeypatch):
+    from src.gateway import webchat
+
+    observed = {"task_running_during_progress": False}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        stream_callback = kwargs["stream_callback"]
+        await stream_callback.put('{"type":"progress","step":1}')
+        await asyncio.sleep(0.2)
+        return {"response": "ok", "usage": {}}
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            decoded = data.decode()
+            if "event: progress" in decoded:
+                pending_tasks = [t for t in asyncio.all_tasks() if not t.done()]
+                observed["task_running_during_progress"] = any(
+                    getattr(getattr(t, "get_coro", lambda: None)(), "__name__", "") == "_fake_run_chat_via_execution_bus"
+                    for t in pending_tasks
+                )
+            self.writes.append(decoded)
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-live-stream"}
+
+    response = await webchat.api_chat_stream(_Request())
+
+    progress_index = next(i for i, chunk in enumerate(response.writes) if "event: progress" in chunk)
+    done_index = next(i for i, chunk in enumerate(response.writes) if "event: done" in chunk)
+    assert progress_index < done_index
+    assert observed["task_running_during_progress"] is True
 @pytest.mark.asyncio
 async def test_api_chat_stream_trusted_portal_metadata_passed_to_execution_bus(monkeypatch):
     from src.gateway import webchat


### PR DESCRIPTION
### Motivation
- Fix excessive broadcast behavior where `/api/events` delivered every runtime event to all sockets, and make `/api/chat/stream` emit progress SSEs while execution is still running.  
- Honor websocket-scoped subscriptions (e.g. `session_id`) so Portal can connect with `?session_id=...` and only receive matching runtime events.  
- Make minimal, surgical changes restricted to the gateway event bus, websocket registration, and streaming path while preserving payload shapes and portal-trusted metadata behavior.

### Description
- Replaced raw list-of-queues in `src/gateway/event_bus.py` with listener records (`queue` + `filters`) and added `_normalize_filters` and `_event_matches_filters` to implement scoped matching for `agent_id`, `session_id`, `task_id` (with `current_task_id`/`portal_task_id` aliases), `group_id` (including `portal_group_id`), and `coordination_run_id` (including aliases).  
- Applied the same filtering when delivering events in both `emit()` and `emit_sync()` and preserved the existing outbound wrapper JSON shape (`{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e76907e8832a8f937cac22310d4b)