### PR TITLE
Use manifest.storage as canonical bundle ref for collect/design skills

### DIFF
--- a/skills/collect_requirements_to_bundle/skill.py
+++ b/skills/collect_requirements_to_bundle/skill.py
@@ -117,7 +117,7 @@ async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Di
             "bundle": {
                 "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
                 "scope": manifest.get("scope", {}),
-                "summary": manifest.get("summary", {}),
+                "summary": (manifest.get("scope", {}) or {}).get("summary", ""),
             },
             "sources": {
                 "jira": jira_payload,

--- a/skills/collect_requirements_to_bundle/skill.py
+++ b/skills/collect_requirements_to_bundle/skill.py
@@ -14,7 +14,8 @@ from src.runtime.requirement_bundle_assets import (
     load_bundle_manifest,
     parse_bundle_ref,
     read_github_doc_text,
-    write_requirements_doc,
+    resolve_target_bundle_ref,
+    write_requirements_doc_for_ref,
 )
 
 
@@ -83,7 +84,8 @@ async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Di
         if not github_channel.is_configured():
             return SkillResult(success=False, error="GitHub integration is not configured")
 
-        parsed_ref, manifest = await load_bundle_manifest(bundle_ref)
+        input_ref, manifest = await load_bundle_manifest(bundle_ref)
+        target_ref = resolve_target_bundle_ref(input_ref, manifest)
         normalized_sources = dict(sources or {})
         jira_ids = [str(item).strip() for item in normalized_sources.get("jira", []) if str(item).strip()]
         confluence_ids = [str(item).strip() for item in normalized_sources.get("confluence", []) if str(item).strip()]
@@ -98,11 +100,22 @@ async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Di
 
         jira_payload = await _load_jira_sources(jira_ids) if jira_ids else []
         confluence_payload = await _load_confluence_sources(confluence_ids) if confluence_ids else []
-        github_payload = await _load_github_doc_sources(bundle_ref, github_docs) if github_docs else []
+        github_payload = (
+            await _load_github_doc_sources(
+                {
+                    "repo": target_ref.repo_full_name,
+                    "path": target_ref.path,
+                    "branch": target_ref.branch,
+                },
+                github_docs,
+            )
+            if github_docs
+            else []
+        )
 
         prompt_context = {
             "bundle": {
-                "bundle_id": manifest.get("bundle_id") or manifest.get("id") or parsed_ref.path,
+                "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
                 "scope": manifest.get("scope", {}),
                 "summary": manifest.get("summary", {}),
             },
@@ -126,7 +139,7 @@ async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Di
         structured = _extract_json_dict(str(llm_response.get("content") or ""))
 
         requirements_doc = {
-            "bundle_id": manifest.get("bundle_id") or manifest.get("id") or parsed_ref.path,
+            "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
             "sources": {
                 "jira": jira_ids,
                 "confluence": confluence_ids,
@@ -144,7 +157,7 @@ async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Di
             ),
         }
 
-        write_result = await write_requirements_doc(bundle_ref, requirements_doc)
+        write_result = await write_requirements_doc_for_ref(target_ref, requirements_doc)
         commit_sha = ((write_result.get("commit") or {}).get("sha")) if isinstance(write_result, dict) else None
         warnings: List[str] = []
         if figma_refs:
@@ -155,11 +168,11 @@ async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Di
             output="requirements.yaml updated",
             data={
                 "bundle_ref": {
-                    "repo": parsed_ref.repo_full_name,
-                    "path": parsed_ref.path,
-                    "branch": parsed_ref.branch,
+                    "repo": target_ref.repo_full_name,
+                    "path": target_ref.path,
+                    "branch": target_ref.branch,
                 },
-                "updated_files": [f"{parsed_ref.path}/requirements.yaml"],
+                "updated_files": [f"{target_ref.path}/requirements.yaml"],
                 "commit_sha": commit_sha,
                 "summary": "Collected bundle requirements from configured sources",
                 "warnings": warnings,

--- a/skills/collect_requirements_to_bundle/skill.py
+++ b/skills/collect_requirements_to_bundle/skill.py
@@ -14,6 +14,7 @@ from src.runtime.requirement_bundle_assets import (
     load_bundle_manifest,
     parse_bundle_ref,
     read_github_doc_text,
+    resolve_bundle_links,
     resolve_target_bundle_ref,
     write_requirements_doc_for_ref,
 )
@@ -86,6 +87,7 @@ async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Di
 
         input_ref, manifest = await load_bundle_manifest(bundle_ref)
         target_ref = resolve_target_bundle_ref(input_ref, manifest)
+        requirements_file, _ = resolve_bundle_links(manifest)
         normalized_sources = dict(sources or {})
         jira_ids = [str(item).strip() for item in normalized_sources.get("jira", []) if str(item).strip()]
         confluence_ids = [str(item).strip() for item in normalized_sources.get("confluence", []) if str(item).strip()]
@@ -157,7 +159,9 @@ async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Di
             ),
         }
 
-        write_result = await write_requirements_doc_for_ref(target_ref, requirements_doc)
+        write_result = await write_requirements_doc_for_ref(
+            target_ref, requirements_doc, requirements_file=requirements_file
+        )
         commit_sha = ((write_result.get("commit") or {}).get("sha")) if isinstance(write_result, dict) else None
         warnings: List[str] = []
         if figma_refs:
@@ -172,7 +176,7 @@ async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Di
                     "path": target_ref.path,
                     "branch": target_ref.branch,
                 },
-                "updated_files": [f"{target_ref.path}/requirements.yaml"],
+                "updated_files": [f"{target_ref.path}/{requirements_file}"],
                 "commit_sha": commit_sha,
                 "summary": "Collected bundle requirements from configured sources",
                 "warnings": warnings,

--- a/skills/design_test_cases_from_bundle/skill.py
+++ b/skills/design_test_cases_from_bundle/skill.py
@@ -10,8 +10,9 @@ from src.runtime.requirement_bundle_assets import (
     RequirementBundleError,
     build_test_design_context,
     load_bundle_manifest,
-    load_requirements_doc,
-    write_test_cases_doc,
+    load_requirements_doc_for_ref,
+    resolve_target_bundle_ref,
+    write_test_cases_doc_for_ref,
 )
 
 JSON_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.DOTALL | re.IGNORECASE)
@@ -36,8 +37,9 @@ def _extract_json_dict(raw: str) -> Dict[str, Any]:
 )
 async def design_test_cases_from_bundle(bundle_ref: Dict[str, Any]) -> SkillResult:
     try:
-        parsed_ref, manifest = await load_bundle_manifest(bundle_ref)
-        _, requirements_doc = await load_requirements_doc(bundle_ref)
+        input_ref, manifest = await load_bundle_manifest(bundle_ref)
+        target_ref = resolve_target_bundle_ref(input_ref, manifest)
+        requirements_doc = await load_requirements_doc_for_ref(target_ref)
         designable_fields = (
             requirements_doc.get("functional_requirements") or [],
             requirements_doc.get("business_rules") or [],
@@ -64,11 +66,11 @@ async def design_test_cases_from_bundle(bundle_ref: Dict[str, Any]) -> SkillResu
         structured = _extract_json_dict(str(llm_response.get("content") or ""))
 
         payload = {
-            "bundle_id": manifest.get("bundle_id") or manifest.get("id") or parsed_ref.path,
+            "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
             "generated_from_requirements_commit": "",
             "test_cases": structured.get("test_cases", []),
         }
-        write_result = await write_test_cases_doc(bundle_ref, payload)
+        write_result = await write_test_cases_doc_for_ref(target_ref, payload)
         commit_sha = ((write_result.get("commit") or {}).get("sha")) if isinstance(write_result, dict) else None
 
         return SkillResult(
@@ -76,11 +78,11 @@ async def design_test_cases_from_bundle(bundle_ref: Dict[str, Any]) -> SkillResu
             output="test-cases.yaml updated",
             data={
                 "bundle_ref": {
-                    "repo": parsed_ref.repo_full_name,
-                    "path": parsed_ref.path,
-                    "branch": parsed_ref.branch,
+                    "repo": target_ref.repo_full_name,
+                    "path": target_ref.path,
+                    "branch": target_ref.branch,
                 },
-                "updated_files": [f"{parsed_ref.path}/test-cases.yaml"],
+                "updated_files": [f"{target_ref.path}/test-cases.yaml"],
                 "commit_sha": commit_sha,
                 "summary": "Designed test cases from requirement bundle context",
             },

--- a/skills/design_test_cases_from_bundle/skill.py
+++ b/skills/design_test_cases_from_bundle/skill.py
@@ -11,6 +11,7 @@ from src.runtime.requirement_bundle_assets import (
     build_test_design_context,
     load_bundle_manifest,
     load_requirements_doc_for_ref,
+    resolve_bundle_links,
     resolve_target_bundle_ref,
     write_test_cases_doc_for_ref,
 )
@@ -39,7 +40,8 @@ async def design_test_cases_from_bundle(bundle_ref: Dict[str, Any]) -> SkillResu
     try:
         input_ref, manifest = await load_bundle_manifest(bundle_ref)
         target_ref = resolve_target_bundle_ref(input_ref, manifest)
-        requirements_doc = await load_requirements_doc_for_ref(target_ref)
+        requirements_file, test_cases_file = resolve_bundle_links(manifest)
+        requirements_doc = await load_requirements_doc_for_ref(target_ref, requirements_file=requirements_file)
         designable_fields = (
             requirements_doc.get("functional_requirements") or [],
             requirements_doc.get("business_rules") or [],
@@ -70,7 +72,7 @@ async def design_test_cases_from_bundle(bundle_ref: Dict[str, Any]) -> SkillResu
             "generated_from_requirements_commit": "",
             "test_cases": structured.get("test_cases", []),
         }
-        write_result = await write_test_cases_doc_for_ref(target_ref, payload)
+        write_result = await write_test_cases_doc_for_ref(target_ref, payload, test_cases_file=test_cases_file)
         commit_sha = ((write_result.get("commit") or {}).get("sha")) if isinstance(write_result, dict) else None
 
         return SkillResult(
@@ -82,7 +84,7 @@ async def design_test_cases_from_bundle(bundle_ref: Dict[str, Any]) -> SkillResu
                     "path": target_ref.path,
                     "branch": target_ref.branch,
                 },
-                "updated_files": [f"{target_ref.path}/test-cases.yaml"],
+                "updated_files": [f"{target_ref.path}/{test_cases_file}"],
                 "commit_sha": commit_sha,
                 "summary": "Designed test cases from requirement bundle context",
             },

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -38,6 +38,23 @@ class GitHubDocRef:
     path: str
 
 
+def _allowed_github_hosts() -> set[str]:
+    hosts = {"github.com"}
+
+    hostname = str(getattr(github_channel, "hostname", "") or "").strip().lower()
+    if hostname:
+        hosts.add(hostname)
+
+    base_url = str(getattr(github_channel, "base_url", "") or "").strip()
+    if base_url:
+        normalized_base_url = base_url if "://" in base_url else f"https://{base_url.lstrip('/')}"
+        parsed_base_url = urlparse(normalized_base_url)
+        if parsed_base_url.netloc:
+            hosts.add(parsed_base_url.netloc.lower())
+
+    return hosts
+
+
 def parse_bundle_ref(bundle_ref: Dict[str, Any]) -> BundleRef:
     if not isinstance(bundle_ref, dict):
         raise RequirementBundleError("bundle_ref must be an object")
@@ -85,7 +102,7 @@ def parse_github_doc_ref(raw: str, default_ref: BundleRef) -> GitHubDocRef:
 
     if normalized.startswith("http://") or normalized.startswith("https://"):
         parsed = urlparse(normalized)
-        if parsed.netloc.lower() != "github.com":
+        if parsed.netloc.lower() not in _allowed_github_hosts():
             raise RequirementBundleError(f"Unsupported GitHub doc URL host: {parsed.netloc}")
         parts = [part for part in parsed.path.split("/") if part]
         # /owner/repo/blob/branch/path/to/file
@@ -232,6 +249,10 @@ def validate_bundle_manifest(manifest: Dict[str, Any]) -> None:
     for key in required_top_level:
         if key not in manifest:
             raise RequirementBundleError(f"bundle.yaml missing required field: {key}")
+    for key in ("bundle_id", "title", "status"):
+        value = manifest.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise RequirementBundleError(f"bundle.yaml field '{key}' must be a non-empty string")
 
     scope = manifest.get("scope")
     if not isinstance(scope, dict):
@@ -239,6 +260,9 @@ def validate_bundle_manifest(manifest: Dict[str, Any]) -> None:
     for key in ("domain", "summary"):
         if key not in scope:
             raise RequirementBundleError(f"bundle.yaml missing required field: scope.{key}")
+        value = scope.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise RequirementBundleError(f"bundle.yaml field 'scope.{key}' must be a non-empty string")
 
     storage = manifest.get("storage")
     if not isinstance(storage, dict):
@@ -246,6 +270,15 @@ def validate_bundle_manifest(manifest: Dict[str, Any]) -> None:
     for key in ("repo", "path", "base_branch", "working_branch"):
         if key not in storage:
             raise RequirementBundleError(f"bundle.yaml missing required field: storage.{key}")
+        value = storage.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise RequirementBundleError(f"bundle.yaml field 'storage.{key}' must be a non-empty string")
+    repo_full = str(storage.get("repo") or "").strip()
+    if "/" not in repo_full:
+        raise RequirementBundleError("bundle.yaml field 'storage.repo' must be in 'owner/repo' format")
+    owner, repo = repo_full.split("/", 1)
+    if not owner or not repo:
+        raise RequirementBundleError("bundle.yaml field 'storage.repo' must be in 'owner/repo' format")
 
     links = manifest.get("links")
     if not isinstance(links, dict):
@@ -253,6 +286,9 @@ def validate_bundle_manifest(manifest: Dict[str, Any]) -> None:
     for key in ("requirements_file", "test_cases_file"):
         if key not in links:
             raise RequirementBundleError(f"bundle.yaml missing required field: links.{key}")
+        value = links.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise RequirementBundleError(f"bundle.yaml field 'links.{key}' must be a non-empty string")
 
 
 def validate_requirements_doc(requirements_doc: Dict[str, Any]) -> None:

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -156,6 +156,22 @@ async def load_bundle_manifest(bundle_ref: Dict[str, Any]) -> Tuple[BundleRef, D
     return ref, manifest
 
 
+def resolve_bundle_links(manifest: Dict[str, Any]) -> tuple[str, str]:
+    links = manifest.get("links")
+    if not isinstance(links, dict):
+        raise RequirementBundleError("bundle.yaml field 'links' must be an object")
+
+    requirements_file = str(links.get("requirements_file") or "").strip().strip("/")
+    test_cases_file = str(links.get("test_cases_file") or "").strip().strip("/")
+
+    if not requirements_file:
+        raise RequirementBundleError("bundle.yaml field 'links.requirements_file' must be a non-empty string")
+    if not test_cases_file:
+        raise RequirementBundleError("bundle.yaml field 'links.test_cases_file' must be a non-empty string")
+
+    return requirements_file, test_cases_file
+
+
 def resolve_target_bundle_ref(input_ref: BundleRef, manifest: Dict[str, Any]) -> BundleRef:
     storage = manifest.get("storage")
     if storage is None:
@@ -170,8 +186,8 @@ def resolve_target_bundle_ref(input_ref: BundleRef, manifest: Dict[str, Any]) ->
     return parse_bundle_ref({"repo": repo_full, "path": path, "branch": branch})
 
 
-async def load_requirements_doc_for_ref(ref: BundleRef) -> Dict[str, Any]:
-    requirements = await read_bundle_yaml(ref, "requirements.yaml")
+async def load_requirements_doc_for_ref(ref: BundleRef, requirements_file: str = "requirements.yaml") -> Dict[str, Any]:
+    requirements = await read_bundle_yaml(ref, requirements_file)
     validate_requirements_doc(requirements)
     return requirements
 
@@ -201,12 +217,14 @@ async def write_requirements_doc(bundle_ref: Dict[str, Any], payload: Dict[str, 
     return await write_requirements_doc_for_ref(ref, payload)
 
 
-async def write_requirements_doc_for_ref(ref: BundleRef, payload: Dict[str, Any]) -> Dict[str, Any]:
+async def write_requirements_doc_for_ref(
+    ref: BundleRef, payload: Dict[str, Any], requirements_file: str = "requirements.yaml"
+) -> Dict[str, Any]:
     return await write_bundle_yaml(
         ref,
-        "requirements.yaml",
+        requirements_file,
         payload,
-        f"chore(requirement-bundle): update requirements.yaml for {ref.path}",
+        f"chore(requirement-bundle): update {requirements_file} for {ref.path}",
     )
 
 
@@ -215,12 +233,14 @@ async def write_test_cases_doc(bundle_ref: Dict[str, Any], payload: Dict[str, An
     return await write_test_cases_doc_for_ref(ref, payload)
 
 
-async def write_test_cases_doc_for_ref(ref: BundleRef, payload: Dict[str, Any]) -> Dict[str, Any]:
+async def write_test_cases_doc_for_ref(
+    ref: BundleRef, payload: Dict[str, Any], test_cases_file: str = "test-cases.yaml"
+) -> Dict[str, Any]:
     return await write_bundle_yaml(
         ref,
-        "test-cases.yaml",
+        test_cases_file,
         payload,
-        f"chore(requirement-bundle): update test-cases.yaml for {ref.path}",
+        f"chore(requirement-bundle): update {test_cases_file} for {ref.path}",
     )
 
 

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -139,10 +139,29 @@ async def load_bundle_manifest(bundle_ref: Dict[str, Any]) -> Tuple[BundleRef, D
     return ref, manifest
 
 
-async def load_requirements_doc(bundle_ref: Dict[str, Any]) -> Tuple[BundleRef, Dict[str, Any]]:
-    ref = parse_bundle_ref(bundle_ref)
+def resolve_target_bundle_ref(input_ref: BundleRef, manifest: Dict[str, Any]) -> BundleRef:
+    storage = manifest.get("storage")
+    if storage is None:
+        storage = {}
+    if not isinstance(storage, dict):
+        raise RequirementBundleError("bundle.yaml field 'storage' must be an object")
+
+    repo_full = str(storage.get("repo") or input_ref.repo_full_name).strip()
+    path = str(storage.get("path") or input_ref.path).strip().strip("/")
+    branch = str(storage.get("working_branch") or input_ref.branch).strip()
+
+    return parse_bundle_ref({"repo": repo_full, "path": path, "branch": branch})
+
+
+async def load_requirements_doc_for_ref(ref: BundleRef) -> Dict[str, Any]:
     requirements = await read_bundle_yaml(ref, "requirements.yaml")
     validate_requirements_doc(requirements)
+    return requirements
+
+
+async def load_requirements_doc(bundle_ref: Dict[str, Any]) -> Tuple[BundleRef, Dict[str, Any]]:
+    ref = parse_bundle_ref(bundle_ref)
+    requirements = await load_requirements_doc_for_ref(ref)
     return ref, requirements
 
 
@@ -162,6 +181,10 @@ async def write_bundle_yaml(ref: BundleRef, relative_file: str, payload: Dict[st
 
 async def write_requirements_doc(bundle_ref: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
     ref = parse_bundle_ref(bundle_ref)
+    return await write_requirements_doc_for_ref(ref, payload)
+
+
+async def write_requirements_doc_for_ref(ref: BundleRef, payload: Dict[str, Any]) -> Dict[str, Any]:
     return await write_bundle_yaml(
         ref,
         "requirements.yaml",
@@ -172,6 +195,10 @@ async def write_requirements_doc(bundle_ref: Dict[str, Any], payload: Dict[str, 
 
 async def write_test_cases_doc(bundle_ref: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
     ref = parse_bundle_ref(bundle_ref)
+    return await write_test_cases_doc_for_ref(ref, payload)
+
+
+async def write_test_cases_doc_for_ref(ref: BundleRef, payload: Dict[str, Any]) -> Dict[str, Any]:
     return await write_bundle_yaml(
         ref,
         "test-cases.yaml",

--- a/tests/test_requirement_bundle_tasks.py
+++ b/tests/test_requirement_bundle_tasks.py
@@ -10,6 +10,7 @@ from src.runtime.requirement_bundle_assets import (
     build_test_design_context,
     parse_github_doc_ref,
     parse_bundle_ref,
+    resolve_target_bundle_ref,
 )
 
 
@@ -248,7 +249,90 @@ async def test_design_skill_reads_requirements_and_writes_test_cases(monkeypatch
 
     assert result.success is True
     assert writes and writes[0]["path"].endswith("test-cases.yaml")
-    assert writes[0]["branch"] == "bundle/2"
+    assert writes[0]["branch"] == "bundle/1"
+
+
+@pytest.mark.asyncio
+async def test_collect_skill_respects_manifest_working_branch(monkeypatch):
+    writes = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        if path.endswith("bundle.yaml"):
+            return {"content": _b64(_valid_manifest_yaml("rb-working-collect").replace("working_branch: bundle/1", "working_branch: bundle/checkout/abcd1234"))}
+        if path == "docs/spec.md" and ref == "bundle/checkout/abcd1234":
+            return {"content": _b64("# Canonical Spec")}
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append({"owner": owner, "repo": repo, "path": path, "content": content, "branch": branch})
+        return {"commit": {"sha": "sha-canonical-req"}}
+
+    async def _fake_chat(self, **_kwargs):
+        return {
+            "content": "{\"summary\":{},\"functional_requirements\":[\"FR-1\"],\"business_rules\":[],\"acceptance_criteria\":[],\"edge_cases\":[],\"quality_flags\":{\"ambiguities\":[],\"conflicts\":[],\"missing_information\":[]}}"
+        }
+
+    async def _fake_text(*args, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.github_channel.is_configured", lambda: True)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.jira_get_issue", _fake_text)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.jira_get_issue_by_url", _fake_text)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.confluence_get_page", _fake_text)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.confluence_get_page_by_url", _fake_text)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await collect_requirements_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "main"},
+        sources={"github_docs": ["docs/spec.md"]},
+    )
+
+    assert result.success is True
+    assert writes and writes[0]["branch"] == "bundle/checkout/abcd1234"
+    assert result.data["bundle_ref"]["branch"] == "bundle/checkout/abcd1234"
+
+
+@pytest.mark.asyncio
+async def test_design_skill_reads_writes_via_manifest_working_branch(monkeypatch):
+    writes = []
+    reads = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        reads.append((path, ref))
+        if path.endswith("bundle.yaml") and ref == "main":
+            yaml = _valid_manifest_yaml("rb-working-design").replace("working_branch: bundle/1", "working_branch: bundle/checkout/abcd1234")
+            return {"content": _b64(yaml)}
+        if path.endswith("requirements.yaml") and ref == "bundle/checkout/abcd1234":
+            return {
+                "content": _b64(
+                    "bundle_id: rb-working-design\nsources: {}\nsummary: {text: ok}\nfunctional_requirements: [FR-1]\nbusiness_rules: []\nacceptance_criteria: []\nedge_cases: []\nquality_flags:\n  ambiguities: []\n  conflicts: []\n  missing_information: []\n"
+                )
+            }
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append({"path": path, "branch": branch})
+        return {"commit": {"sha": "sha-canonical-tc"}}
+
+    async def _fake_chat(self, **_kwargs):
+        return {
+            "content": "{\"test_cases\":[{\"case_id\":\"TC-1\",\"title\":\"happy\",\"category\":\"functional\",\"priority\":\"P1\",\"preconditions\":[],\"steps\":[],\"expected_results\":[],\"traceability\":[\"FR-1\"]}]}"
+        }
+
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await design_test_cases_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "main"}
+    )
+
+    assert result.success is True
+    assert ("requirement-bundles/payments/maker/requirements.yaml", "bundle/checkout/abcd1234") in reads
+    assert writes and writes[0]["branch"] == "bundle/checkout/abcd1234"
+    assert result.data["bundle_ref"]["branch"] == "bundle/checkout/abcd1234"
 
 
 @pytest.mark.asyncio
@@ -381,3 +465,20 @@ def test_build_test_design_context_is_trimmed():
         "edge_cases",
         "quality_flags",
     }
+
+
+def test_resolve_target_bundle_ref_prefers_manifest_storage():
+    input_ref = parse_bundle_ref({"repo": "acme/assets", "path": "bundle/input", "branch": "main"})
+    manifest = {
+        "storage": {
+            "repo": "org/target-repo",
+            "path": "bundle/target",
+            "working_branch": "bundle/checkout/abcd1234",
+        }
+    }
+
+    resolved = resolve_target_bundle_ref(input_ref, manifest)
+
+    assert resolved.repo_full_name == "org/target-repo"
+    assert resolved.path == "bundle/target"
+    assert resolved.branch == "bundle/checkout/abcd1234"

--- a/tests/test_requirement_bundle_tasks.py
+++ b/tests/test_requirement_bundle_tasks.py
@@ -10,6 +10,7 @@ from src.runtime.requirement_bundle_assets import (
     build_test_design_context,
     parse_github_doc_ref,
     parse_bundle_ref,
+    resolve_bundle_links,
     resolve_target_bundle_ref,
     validate_bundle_manifest,
 )
@@ -19,7 +20,9 @@ def _b64(text: str) -> str:
     return base64.b64encode(text.encode("utf-8")).decode("utf-8")
 
 
-def _valid_manifest_yaml(bundle_id: str = "rb-1") -> str:
+def _valid_manifest_yaml(
+    bundle_id: str = "rb-1", requirements_file: str = "requirements.yaml", test_cases_file: str = "test-cases.yaml"
+) -> str:
     return (
         f"bundle_id: {bundle_id}\n"
         "title: Maker Checker\n"
@@ -33,8 +36,8 @@ def _valid_manifest_yaml(bundle_id: str = "rb-1") -> str:
         "  base_branch: main\n"
         "  working_branch: bundle/1\n"
         "links:\n"
-        "  requirements_file: requirements.yaml\n"
-        "  test_cases_file: test-cases.yaml\n"
+        f"  requirements_file: {requirements_file}\n"
+        f"  test_cases_file: {test_cases_file}\n"
     )
 
 
@@ -289,6 +292,45 @@ async def test_collect_prompt_uses_scope_summary_from_manifest(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_collect_skill_writes_custom_requirements_file_from_manifest_links(monkeypatch):
+    writes = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        if path.endswith("bundle.yaml"):
+            return {
+                "content": _b64(
+                    _valid_manifest_yaml(
+                        "rb-custom-links-collect", requirements_file="docs/reqs.yaml", test_cases_file="outputs/tc.yaml"
+                    )
+                )
+            }
+        if path == "docs/spec.md":
+            return {"content": _b64("# Spec")}
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append({"path": path, "branch": branch})
+        return {"commit": {"sha": "sha-custom-collect"}}
+
+    async def _fake_chat(self, **kwargs):
+        return {"content": "{\"summary\":{},\"functional_requirements\":[\"a\"],\"business_rules\":[],\"acceptance_criteria\":[],\"edge_cases\":[],\"quality_flags\":{\"ambiguities\":[],\"conflicts\":[],\"missing_information\":[]}}"}
+
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.github_channel.is_configured", lambda: True)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await collect_requirements_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"},
+        sources={"github_docs": ["docs/spec.md"]},
+    )
+
+    assert result.success is True
+    assert writes and writes[0]["path"] == "requirement-bundles/payments/maker/docs/reqs.yaml"
+    assert result.data["updated_files"] == ["requirement-bundles/payments/maker/docs/reqs.yaml"]
+
+
+@pytest.mark.asyncio
 async def test_design_skill_reads_requirements_and_writes_test_cases(monkeypatch):
     writes = []
 
@@ -323,6 +365,52 @@ async def test_design_skill_reads_requirements_and_writes_test_cases(monkeypatch
     assert result.success is True
     assert writes and writes[0]["path"].endswith("test-cases.yaml")
     assert writes[0]["branch"] == "bundle/1"
+
+
+@pytest.mark.asyncio
+async def test_design_skill_reads_writes_custom_linked_files(monkeypatch):
+    writes = []
+    reads = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        reads.append((path, ref))
+        if path.endswith("bundle.yaml"):
+            return {
+                "content": _b64(
+                    _valid_manifest_yaml(
+                        "rb-custom-links-design", requirements_file="docs/reqs.yaml", test_cases_file="outputs/tc.yaml"
+                    )
+                )
+            }
+        if path.endswith("docs/reqs.yaml"):
+            return {
+                "content": _b64(
+                    "bundle_id: rb-custom-links-design\nsources: {}\nsummary: {text: ok}\nfunctional_requirements: [FR-1]\nbusiness_rules: []\nacceptance_criteria: []\nedge_cases: []\nquality_flags:\n  ambiguities: []\n  conflicts: []\n  missing_information: []\n"
+                )
+            }
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append({"path": path, "branch": branch})
+        return {"commit": {"sha": "sha-custom-design"}}
+
+    async def _fake_chat(self, **_kwargs):
+        return {
+            "content": "{\"test_cases\":[{\"case_id\":\"TC-1\",\"title\":\"happy\",\"category\":\"functional\",\"priority\":\"P1\",\"preconditions\":[],\"steps\":[],\"expected_results\":[],\"traceability\":[\"FR-1\"]}]}"
+        }
+
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await design_test_cases_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"}
+    )
+
+    assert result.success is True
+    assert ("requirement-bundles/payments/maker/docs/reqs.yaml", "bundle/1") in reads
+    assert writes and writes[0]["path"] == "requirement-bundles/payments/maker/outputs/tc.yaml"
+    assert result.data["updated_files"] == ["requirement-bundles/payments/maker/outputs/tc.yaml"]
 
 
 @pytest.mark.asyncio
@@ -545,6 +633,20 @@ def test_validate_bundle_manifest_rejects_blank_required_fields():
     }
     with pytest.raises(RequirementBundleError, match="storage.working_branch"):
         validate_bundle_manifest(blank_working_branch)
+
+
+def test_resolve_bundle_links_uses_manifest_links():
+    manifest = {
+        "links": {
+            "requirements_file": " docs/reqs.yaml ",
+            "test_cases_file": "/outputs/tc.yaml/",
+        }
+    }
+
+    requirements_file, test_cases_file = resolve_bundle_links(manifest)
+
+    assert requirements_file == "docs/reqs.yaml"
+    assert test_cases_file == "outputs/tc.yaml"
 
 
 def test_build_test_design_context_is_trimmed():

--- a/tests/test_requirement_bundle_tasks.py
+++ b/tests/test_requirement_bundle_tasks.py
@@ -11,6 +11,7 @@ from src.runtime.requirement_bundle_assets import (
     parse_github_doc_ref,
     parse_bundle_ref,
     resolve_target_bundle_ref,
+    validate_bundle_manifest,
 )
 
 
@@ -213,6 +214,78 @@ async def test_collect_skill_supports_github_blob_url_cross_repo(monkeypatch):
     )
     assert result.success is True
     assert ("org", "repo", "docs/spec.md", "main") in observed
+
+
+@pytest.mark.asyncio
+async def test_collect_skill_supports_enterprise_github_blob_url(monkeypatch):
+    observed = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        observed.append((owner, repo, path, ref))
+        if path.endswith("bundle.yaml"):
+            return {"content": _b64(_valid_manifest_yaml("rb-gh-enterprise"))}
+        if owner == "org" and repo == "repo" and path == "docs/spec.md" and ref == "main":
+            return {"content": _b64("# Enterprise Spec")}
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        return {"commit": {"sha": "sha"}}
+
+    async def _fake_chat(self, **kwargs):
+        return {"content": "{\"summary\":{},\"functional_requirements\":[\"a\"],\"business_rules\":[],\"acceptance_criteria\":[],\"edge_cases\":[],\"quality_flags\":{\"ambiguities\":[],\"conflicts\":[],\"missing_information\":[]}}"}
+
+    async def _fake_text(*args, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.github_channel.is_configured", lambda: True)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.jira_get_issue", _fake_text)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.jira_get_issue_by_url", _fake_text)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.confluence_get_page", _fake_text)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.confluence_get_page_by_url", _fake_text)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.hostname", "github.company.com")
+
+    result = await collect_requirements_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"},
+        sources={"github_docs": ["https://github.company.com/org/repo/blob/main/docs/spec.md"]},
+    )
+    assert result.success is True
+    assert ("org", "repo", "docs/spec.md", "main") in observed
+
+
+@pytest.mark.asyncio
+async def test_collect_prompt_uses_scope_summary_from_manifest(monkeypatch):
+    seen_prompt = {"payload": None}
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        if path.endswith("bundle.yaml"):
+            return {"content": _b64(_valid_manifest_yaml("rb-summary"))}
+        if path == "docs/spec.md":
+            return {"content": _b64("# Spec")}
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        return {"commit": {"sha": "sha"}}
+
+    async def _fake_chat(self, **kwargs):
+        seen_prompt["payload"] = json.loads(kwargs["messages"][0]["content"])
+        return {"content": "{\"summary\":{},\"functional_requirements\":[\"a\"],\"business_rules\":[],\"acceptance_criteria\":[],\"edge_cases\":[],\"quality_flags\":{\"ambiguities\":[],\"conflicts\":[],\"missing_information\":[]}}"}
+
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.github_channel.is_configured", lambda: True)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await collect_requirements_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"},
+        sources={"github_docs": ["docs/spec.md"]},
+    )
+
+    assert result.success is True
+    assert seen_prompt["payload"] is not None
+    assert seen_prompt["payload"]["bundle"]["summary"] == "maker checker"
 
 
 @pytest.mark.asyncio
@@ -438,6 +511,40 @@ def test_parse_github_doc_ref_blob_url():
     assert parsed.repo == "repo"
     assert parsed.branch == "main"
     assert parsed.path == "docs/spec.md"
+
+
+def test_validate_bundle_manifest_rejects_blank_required_fields():
+    blank_scope_summary = {
+        "bundle_id": "rb-1",
+        "title": "Maker Checker",
+        "status": "draft",
+        "scope": {"domain": "payments", "summary": "   "},
+        "storage": {
+            "repo": "acme/assets",
+            "path": "requirement-bundles/payments/maker",
+            "base_branch": "main",
+            "working_branch": "bundle/1",
+        },
+        "links": {"requirements_file": "requirements.yaml", "test_cases_file": "test-cases.yaml"},
+    }
+    with pytest.raises(RequirementBundleError, match="scope.summary"):
+        validate_bundle_manifest(blank_scope_summary)
+
+    blank_working_branch = {
+        "bundle_id": "rb-1",
+        "title": "Maker Checker",
+        "status": "draft",
+        "scope": {"domain": "payments", "summary": "maker checker"},
+        "storage": {
+            "repo": "acme/assets",
+            "path": "requirement-bundles/payments/maker",
+            "base_branch": "main",
+            "working_branch": "   ",
+        },
+        "links": {"requirements_file": "requirements.yaml", "test_cases_file": "test-cases.yaml"},
+    }
+    with pytest.raises(RequirementBundleError, match="storage.working_branch"):
+        validate_bundle_manifest(blank_working_branch)
 
 
 def test_build_test_design_context_is_trimmed():


### PR DESCRIPTION
### Motivation
- Fix inconsistency where runtime used the portal-provided `bundle_ref` (e.g. `branch=main`) for reads/writes instead of the canonical target declared in `bundle.yaml.storage`, which could cause collect/design skills to read or write the wrong branch/repo/path.

### Description
- Add `resolve_target_bundle_ref(input_ref, manifest)` in `src/runtime/requirement_bundle_assets.py` to compute a canonical `BundleRef` from `manifest.storage.repo/path/working_branch` with fallbacks to the input ref and validation via `parse_bundle_ref`.
- Add ref-centric helpers `load_requirements_doc_for_ref`, `write_requirements_doc_for_ref`, and `write_test_cases_doc_for_ref`, and make existing dict-based APIs delegate to them to preserve compatibility.
- Update `collect_requirements_to_bundle` to resolve `target_ref` after manifest load and use it for repo-relative GitHub doc resolution, writing `requirements.yaml`, and for the returned `bundle_ref`/`updated_files`.
- Update `design_test_cases_from_bundle` to resolve `target_ref` after manifest load and use it to read `requirements.yaml`, write `test-cases.yaml`, and for the returned `bundle_ref`/`updated_files`.

### Testing
- Ran `pytest -q tests/test_requirement_bundle_tasks.py` and all tests passed (`16 passed`).
- Added tests that assert collect/design use `manifest.storage.working_branch` for reads/writes and a helper test verifying manifest storage overrides input ref.
- Modified files: `src/runtime/requirement_bundle_assets.py`, `skills/collect_requirements_to_bundle/skill.py`, `skills/design_test_cases_from_bundle/skill.py`, and `tests/test_requirement_bundle_tasks.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7448af6ac832aa73abf362a25f9fe)