### PR TITLE
Support manifest_ref passthrough and dual-ref manifest loading for RequirementBundle skills

### DIFF
--- a/skills/collect_requirements_to_bundle/skill.py
+++ b/skills/collect_requirements_to_bundle/skill.py
@@ -80,13 +80,17 @@ async def _load_github_doc_sources(bundle_ref: Dict[str, Any], doc_paths: List[s
     name="collect_requirements_to_bundle",
     description="Collect requirements from sources and write requirements.yaml in RequirementBundle.",
 )
-async def collect_requirements_to_bundle(bundle_ref: Dict[str, Any], sources: Dict[str, Any] | None = None) -> SkillResult:
+async def collect_requirements_to_bundle(
+    bundle_ref: Dict[str, Any],
+    sources: Dict[str, Any] | None = None,
+    manifest_ref: Dict[str, Any] | None = None,
+) -> SkillResult:
     try:
         if not github_channel.is_configured():
             return SkillResult(success=False, error="GitHub integration is not configured")
 
-        input_ref, manifest = await load_bundle_manifest(bundle_ref)
-        target_ref = resolve_target_bundle_ref(input_ref, manifest)
+        manifest_source_ref, manifest = await load_bundle_manifest(bundle_ref, manifest_ref=manifest_ref)
+        target_ref = resolve_target_bundle_ref(manifest_source_ref, manifest)
         requirements_file, _ = resolve_bundle_links(manifest)
         normalized_sources = dict(sources or {})
         jira_ids = [str(item).strip() for item in normalized_sources.get("jira", []) if str(item).strip()]

--- a/skills/design_test_cases_from_bundle/skill.py
+++ b/skills/design_test_cases_from_bundle/skill.py
@@ -36,10 +36,13 @@ def _extract_json_dict(raw: str) -> Dict[str, Any]:
     name="design_test_cases_from_bundle",
     description="Generate test-cases.yaml from RequirementBundle requirements.yaml",
 )
-async def design_test_cases_from_bundle(bundle_ref: Dict[str, Any]) -> SkillResult:
+async def design_test_cases_from_bundle(
+    bundle_ref: Dict[str, Any],
+    manifest_ref: Dict[str, Any] | None = None,
+) -> SkillResult:
     try:
-        input_ref, manifest = await load_bundle_manifest(bundle_ref)
-        target_ref = resolve_target_bundle_ref(input_ref, manifest)
+        manifest_source_ref, manifest = await load_bundle_manifest(bundle_ref, manifest_ref=manifest_ref)
+        target_ref = resolve_target_bundle_ref(manifest_source_ref, manifest)
         requirements_file, test_cases_file = resolve_bundle_links(manifest)
         requirements_doc = await load_requirements_doc_for_ref(target_ref, requirements_file=requirements_file)
         designable_fields = (

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -1046,7 +1046,7 @@ def build_default_execution_bus(
         skill_name = str(request.input_payload.get("skill_name") or default_skill_name).strip() or default_skill_name
         skill_kwargs = dict(request.input_payload.get("skill_kwargs") or {})
 
-        for passthrough_key in ("bundle_ref", "sources"):
+        for passthrough_key in ("bundle_ref", "manifest_ref", "sources"):
             if passthrough_key in request.input_payload and passthrough_key not in skill_kwargs:
                 skill_kwargs[passthrough_key] = request.input_payload.get(passthrough_key)
 

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -149,8 +149,11 @@ async def read_bundle_yaml(ref: BundleRef, relative_file: str) -> Dict[str, Any]
     return dict(parsed)
 
 
-async def load_bundle_manifest(bundle_ref: Dict[str, Any]) -> Tuple[BundleRef, Dict[str, Any]]:
-    ref = parse_bundle_ref(bundle_ref)
+async def load_bundle_manifest(
+    bundle_ref: Dict[str, Any],
+    manifest_ref: Dict[str, Any] | None = None,
+) -> Tuple[BundleRef, Dict[str, Any]]:
+    ref = parse_bundle_ref(manifest_ref or bundle_ref)
     manifest = await read_bundle_yaml(ref, "bundle.yaml")
     validate_bundle_manifest(manifest)
     return ref, manifest

--- a/tests/test_requirement_bundle_tasks.py
+++ b/tests/test_requirement_bundle_tasks.py
@@ -497,6 +497,96 @@ async def test_design_skill_reads_writes_via_manifest_working_branch(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_collect_skill_reads_manifest_from_manifest_ref_and_writes_to_target_ref(monkeypatch):
+    writes = []
+    reads = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        reads.append((path, ref))
+        if path.endswith("bundle.yaml") and ref == "main":
+            yaml = _valid_manifest_yaml("rb-dual-collect").replace("working_branch: bundle/1", "working_branch: bundle/checkout/abcd1234")
+            return {"content": _b64(yaml)}
+        if path == "docs/spec.md" and ref == "bundle/checkout/abcd1234":
+            return {"content": _b64("# Canonical Spec")}
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append({"path": path, "branch": branch})
+        return {"commit": {"sha": "sha-dual-collect"}}
+
+    async def _fake_chat(self, **_kwargs):
+        return {
+            "content": "{\"summary\":{},\"functional_requirements\":[\"FR-1\"],\"business_rules\":[],\"acceptance_criteria\":[],\"edge_cases\":[],\"quality_flags\":{\"ambiguities\":[],\"conflicts\":[],\"missing_information\":[]}}"
+        }
+
+    async def _fake_text(*args, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.github_channel.is_configured", lambda: True)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.jira_get_issue", _fake_text)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.jira_get_issue_by_url", _fake_text)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.confluence_get_page", _fake_text)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.confluence_get_page_by_url", _fake_text)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await collect_requirements_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/checkout/abcd1234"},
+        manifest_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "main"},
+        sources={"github_docs": ["docs/spec.md"]},
+    )
+
+    assert result.success is True
+    assert ("requirement-bundles/payments/maker/bundle.yaml", "main") in reads
+    assert writes and writes[0]["branch"] == "bundle/checkout/abcd1234"
+    assert result.data["bundle_ref"]["branch"] == "bundle/checkout/abcd1234"
+
+
+@pytest.mark.asyncio
+async def test_design_skill_reads_manifest_from_manifest_ref_and_reads_writes_target_ref(monkeypatch):
+    writes = []
+    reads = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        reads.append((path, ref))
+        if path.endswith("bundle.yaml") and ref == "main":
+            yaml = _valid_manifest_yaml("rb-dual-design").replace("working_branch: bundle/1", "working_branch: bundle/checkout/abcd1234")
+            return {"content": _b64(yaml)}
+        if path.endswith("requirements.yaml") and ref == "bundle/checkout/abcd1234":
+            return {
+                "content": _b64(
+                    "bundle_id: rb-dual-design\nsources: {}\nsummary: {text: ok}\nfunctional_requirements: [FR-1]\nbusiness_rules: []\nacceptance_criteria: []\nedge_cases: []\nquality_flags:\n  ambiguities: []\n  conflicts: []\n  missing_information: []\n"
+                )
+            }
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append({"path": path, "branch": branch})
+        return {"commit": {"sha": "sha-dual-design"}}
+
+    async def _fake_chat(self, **_kwargs):
+        return {
+            "content": "{\"test_cases\":[{\"case_id\":\"TC-1\",\"title\":\"happy\",\"category\":\"functional\",\"priority\":\"P1\",\"preconditions\":[],\"steps\":[],\"expected_results\":[],\"traceability\":[\"FR-1\"]}]}"
+        }
+
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await design_test_cases_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/checkout/abcd1234"},
+        manifest_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "main"},
+    )
+
+    assert result.success is True
+    assert ("requirement-bundles/payments/maker/bundle.yaml", "main") in reads
+    assert ("requirement-bundles/payments/maker/requirements.yaml", "bundle/checkout/abcd1234") in reads
+    assert writes and writes[0]["branch"] == "bundle/checkout/abcd1234"
+    assert result.data["bundle_ref"]["branch"] == "bundle/checkout/abcd1234"
+
+
+@pytest.mark.asyncio
 async def test_collect_skill_invalid_bundle_ref_returns_clear_error(monkeypatch):
     monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.github_channel.is_configured", lambda: True)
     result = await collect_requirements_skill.execute(bundle_ref={"repo": "bad-format"}, sources={})


### PR DESCRIPTION
### Motivation
- The runtime previously only accepted a single `bundle_ref` and always read `bundle.yaml` from that ref, which breaks Portal scenarios where the manifest is read from an entry branch (e.g. `main`) while requirements/testcases live on a canonical working branch (e.g. `bundle/...`).
- The goal is a minimal, backward-compatible change so skills can receive an optional `manifest_ref` to read the manifest while keeping all requirements/testcase read/write behavior on the canonical `bundle_ref` derived from the manifest.
- Changes must not alter the task protocol structure or rewrite the `ExecutionBus` architecture beyond adding passthrough of the new key. 

### Description
- Added `manifest_ref` passthrough in `ExecutionBus._execute_skill_backed_task` so `skill_kwargs` receive `bundle_ref`, `manifest_ref`, and `sources` from the task payload when present (`src/runtime/execution_bus.py`).
- Extended `load_bundle_manifest` signature to `load_bundle_manifest(bundle_ref, manifest_ref=None)` and implemented priority reading from `manifest_ref` when supplied, otherwise falling back to `bundle_ref`, while returning the actual ref used to read the manifest (`src/runtime/requirement_bundle_assets.py`).
- Updated `collect_requirements_to_bundle` to accept an optional `manifest_ref`, call `manifest_source_ref, manifest = await load_bundle_manifest(bundle_ref, manifest_ref=manifest_ref)`, resolve the canonical `target_ref` with `resolve_target_bundle_ref(manifest_source_ref, manifest)`, and keep reading/writing requirements and GitHub docs relative to `target_ref` while returning the canonical `bundle_ref` in `SkillResult.data` (`skills/collect_requirements_to_bundle/skill.py`).
- Updated `design_test_cases_from_bundle` to accept an optional `manifest_ref`, use `manifest_ref` to load manifest and derive `target_ref`, then continue to read requirements and write test-cases on `target_ref` while returning canonical `bundle_ref` (`skills/design_test_cases_from_bundle/skill.py`).
- Added dual-ref integration tests covering the two scenarios: collect reads manifest from `manifest_ref` (e.g. `main`) and writes requirements to the canonical working branch (e.g. `bundle/checkout/abcd1234`), and design reads manifest from `manifest_ref` while reading/writing requirements/test-cases on the canonical branch (`tests/test_requirement_bundle_tasks.py`).

### Testing
- Ran the updated test file with `pytest -q tests/test_requirement_bundle_tasks.py`, which executed 24 tests and all passed (`24 passed`).
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75357aa7c832a9bab9f4f952fa014)