### PR TITLE
Enhance runtime task observability with trace context and boundary logs

### DIFF
--- a/skills/collect_requirements_to_bundle/skill.py
+++ b/skills/collect_requirements_to_bundle/skill.py
@@ -19,6 +19,7 @@ from src.runtime.requirement_bundle_assets import (
     resolve_target_bundle_ref,
     write_requirements_doc_for_ref,
 )
+from src.utils.redaction import sanitize_exception_message
 
 
 JSON_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.DOTALL | re.IGNORECASE)
@@ -219,8 +220,16 @@ async def collect_requirements_to_bundle(
             },
         )
     except RequirementBundleError as exc:
-        logger.warning("Collect requirements skill failed | error_class=%s", exc.__class__.__name__)
+        logger.warning(
+            "Collect requirements skill failed | action=collect_requirements_to_bundle error_class=%s error=%s",
+            exc.__class__.__name__,
+            sanitize_exception_message(exc),
+        )
         return SkillResult(success=False, error=str(exc))
     except Exception as exc:
-        logger.warning("Collect requirements skill failed | error_class=%s", exc.__class__.__name__)
+        logger.warning(
+            "Collect requirements skill failed | action=collect_requirements_to_bundle error_class=%s error=%s",
+            exc.__class__.__name__,
+            sanitize_exception_message(exc),
+        )
         return SkillResult(success=False, error=f"collect_requirements_to_bundle failed: {exc}")

--- a/skills/collect_requirements_to_bundle/skill.py
+++ b/skills/collect_requirements_to_bundle/skill.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from typing import Any, Dict, List
 
@@ -21,6 +22,7 @@ from src.runtime.requirement_bundle_assets import (
 
 
 JSON_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.DOTALL | re.IGNORECASE)
+logger = logging.getLogger(__name__)
 
 
 def _strip_json_fence(text: str) -> str:
@@ -89,14 +91,30 @@ async def collect_requirements_to_bundle(
         if not github_channel.is_configured():
             return SkillResult(success=False, error="GitHub integration is not configured")
 
-        manifest_source_ref, manifest = await load_bundle_manifest(bundle_ref, manifest_ref=manifest_ref)
-        target_ref = resolve_target_bundle_ref(manifest_source_ref, manifest)
-        requirements_file, _ = resolve_bundle_links(manifest)
         normalized_sources = dict(sources or {})
         jira_ids = [str(item).strip() for item in normalized_sources.get("jira", []) if str(item).strip()]
         confluence_ids = [str(item).strip() for item in normalized_sources.get("confluence", []) if str(item).strip()]
         github_docs = [str(item).strip() for item in normalized_sources.get("github_docs", []) if str(item).strip()]
         figma_refs = [str(item).strip() for item in normalized_sources.get("figma", []) if str(item).strip()]
+        logger.info(
+            "Collect requirements skill start | bundle_ref=%s has_manifest_ref=%s jira_count=%s confluence_count=%s github_docs_count=%s figma_count=%s",
+            {"repo": bundle_ref.get("repo"), "path": bundle_ref.get("path"), "branch": bundle_ref.get("branch")} if isinstance(bundle_ref, dict) else {},
+            bool(manifest_ref),
+            len(jira_ids),
+            len(confluence_ids),
+            len(github_docs),
+            len(figma_refs),
+        )
+
+        manifest_source_ref, manifest = await load_bundle_manifest(bundle_ref, manifest_ref=manifest_ref)
+        target_ref = resolve_target_bundle_ref(manifest_source_ref, manifest)
+        requirements_file, _ = resolve_bundle_links(manifest)
+        logger.info(
+            "Collect requirements manifest resolved | manifest_ref=%s target_ref=%s requirements_file=%s",
+            {"repo": manifest_source_ref.repo_full_name, "path": manifest_source_ref.path, "branch": manifest_source_ref.branch},
+            {"repo": target_ref.repo_full_name, "path": target_ref.path, "branch": target_ref.branch},
+            requirements_file,
+        )
         supported_source_count = len(jira_ids) + len(confluence_ids) + len(github_docs)
         if supported_source_count <= 0:
             error = "At least one supported source is required"
@@ -104,8 +122,11 @@ async def collect_requirements_to_bundle(
                 error = f"{error}; figma is ignored in MVP"
             return SkillResult(success=False, error=error)
 
+        logger.info("Collect requirements load sources start | jira_count=%s confluence_count=%s github_docs_count=%s", len(jira_ids), len(confluence_ids), len(github_docs))
         jira_payload = await _load_jira_sources(jira_ids) if jira_ids else []
+        logger.debug("Collect requirements load jira done | count=%s", len(jira_payload))
         confluence_payload = await _load_confluence_sources(confluence_ids) if confluence_ids else []
+        logger.debug("Collect requirements load confluence done | count=%s", len(confluence_payload))
         github_payload = (
             await _load_github_doc_sources(
                 {
@@ -118,6 +139,7 @@ async def collect_requirements_to_bundle(
             if github_docs
             else []
         )
+        logger.debug("Collect requirements load github docs done | count=%s", len(github_payload))
 
         prompt_context = {
             "bundle": {
@@ -133,6 +155,7 @@ async def collect_requirements_to_bundle(
         }
 
         llm = LLMClient()
+        logger.info("Collect requirements llm request start")
         llm_response = await llm.chat(
             system_prompt=(
                 "You are a requirements analyst. Return STRICT JSON only (no markdown, no prose) with keys: "
@@ -142,6 +165,7 @@ async def collect_requirements_to_bundle(
             messages=[{"role": "user", "content": json.dumps(prompt_context, ensure_ascii=False)}],
             temperature=0.1,
         )
+        logger.info("Collect requirements llm request done | response_content_length=%s", len(str(llm_response.get("content") or "")))
         structured = _extract_json_dict(str(llm_response.get("content") or ""))
 
         requirements_doc = {
@@ -163,14 +187,22 @@ async def collect_requirements_to_bundle(
             ),
         }
 
+        logger.info(
+            "Collect requirements write start | target_ref=%s requirements_file=%s",
+            {"repo": target_ref.repo_full_name, "path": target_ref.path, "branch": target_ref.branch},
+            requirements_file,
+        )
         write_result = await write_requirements_doc_for_ref(
             target_ref, requirements_doc, requirements_file=requirements_file
         )
         commit_sha = ((write_result.get("commit") or {}).get("sha")) if isinstance(write_result, dict) else None
+        logger.info("Collect requirements write done | requirements_file=%s has_commit_sha=%s", requirements_file, bool(commit_sha))
         warnings: List[str] = []
         if figma_refs:
             warnings.append("figma sources are ignored in MVP")
+            logger.info("Collect requirements figma ignored in MVP | figma_count=%s", len(figma_refs))
 
+        logger.info("Collect requirements skill finish | success=%s has_commit_sha=%s", True, bool(commit_sha))
         return SkillResult(
             success=True,
             output="requirements.yaml updated",
@@ -187,6 +219,8 @@ async def collect_requirements_to_bundle(
             },
         )
     except RequirementBundleError as exc:
+        logger.warning("Collect requirements skill failed | error_class=%s", exc.__class__.__name__)
         return SkillResult(success=False, error=str(exc))
     except Exception as exc:
+        logger.warning("Collect requirements skill failed | error_class=%s", exc.__class__.__name__)
         return SkillResult(success=False, error=f"collect_requirements_to_bundle failed: {exc}")

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import uuid
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -24,6 +25,7 @@ from src.utils.file_parser import parse_file
 from src.utils.truncate import truncate
 from src.utils.redaction import safe_preview, safe_log_field, sanitize_exception_message
 from src.utils.internal_api_keys import get_portal_internal_api_key, get_runtime_internal_api_key
+from src.utils.logger import clear_log_context, set_log_context
 
 
 from ruamel.yaml import YAML
@@ -199,6 +201,31 @@ def _build_internal_auth_error_response(status_code: int, message: str) -> web.R
     return web.json_response({"error": message}, status=status_code)
 
 
+def _sanitize_trace_value(value: Any, max_len: int = 128) -> Optional[str]:
+    if value is None:
+        return None
+    cleaned = re.sub(r"[\x00-\x1f\x7f]+", "", str(value)).strip()
+    if not cleaned:
+        return None
+    return cleaned[:max_len]
+
+
+def _extract_task_trace_headers(request: web.Request) -> Dict[str, Optional[str]]:
+    headers = getattr(request, "headers", {}) or {}
+    trace = {
+        "trace_id": _sanitize_trace_value(headers.get("X-Trace-Id")),
+        "span_id": _sanitize_trace_value(headers.get("X-Span-Id")),
+        "parent_span_id": _sanitize_trace_value(headers.get("X-Parent-Span-Id")),
+        "portal_task_id": _sanitize_trace_value(headers.get("X-Portal-Task-Id")),
+        "portal_dispatch_id": _sanitize_trace_value(headers.get("X-Portal-Dispatch-Id")),
+    }
+    if not trace["trace_id"]:
+        trace["trace_id"] = f"rt-{uuid.uuid4().hex}"
+    if not trace["span_id"]:
+        trace["span_id"] = uuid.uuid4().hex[:16]
+    return trace
+
+
 def _authorize_internal_runtime_request(request: web.Request) -> Optional[web.Response]:
     expected_key = get_runtime_internal_api_key()
     if not expected_key:
@@ -300,7 +327,7 @@ def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str]
     runtime_agent_id: Optional[str] = None
     runtime_agent_name: Optional[str] = None
 
-    app = request.app
+    app = getattr(request, "app", {}) or {}
 
     try:
         global_config.reload()
@@ -902,12 +929,48 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
 
     POST /api/tasks/execute
     """
+    clear_log_context()
+    trace_headers = _extract_task_trace_headers(request)
+    set_log_context(
+        trace_id=trace_headers.get("trace_id"),
+        span_id=trace_headers.get("span_id"),
+        parent_span_id=trace_headers.get("parent_span_id"),
+        portal_task_id=trace_headers.get("portal_task_id"),
+        portal_dispatch_id=trace_headers.get("portal_dispatch_id"),
+        path="/api/tasks/execute",
+    )
     try:
         auth_error = _authorize_internal_runtime_request(request)
         if auth_error is not None:
+            expected_key = get_runtime_internal_api_key()
+            headers = getattr(request, "headers", {}) or {}
+            provided_key = str(headers.get("X-Internal-Api-Key") or "").strip()
+            logger.warning(
+                "Task execute auth rejected | expected_key_configured=%s provided_key_present=%s status_code=%s",
+                bool(expected_key),
+                bool(provided_key),
+                getattr(auth_error, "status", 401),
+            )
             return auth_error
         data = await request.json()
         parsed = _parse_task_execute_request(data)
+        set_log_context(
+            request_id=f"task-{parsed['task_id']}",
+            task_id=parsed["task_id"],
+            portal_task_id=trace_headers.get("portal_task_id") or parsed["task_id"],
+        )
+        logger.debug(
+            "Task execute request parsed | task_id=%s task_type=%s source=%s has_session_id=%s shared_context_ref=%s has_context_ref=%s metadata_keys=%s input_payload_keys=%s",
+            parsed["task_id"],
+            parsed["task_type"],
+            parsed["source"] or "portal",
+            bool(parsed["session_id"]),
+            parsed["shared_context_ref"] or "-",
+            bool(parsed["context_ref"]),
+            sorted(parsed["metadata"].keys()),
+            sorted(parsed["input_payload"].keys()),
+        )
+        execution_started_at = time.perf_counter()
 
         merged_input_payload = dict(parsed["input_payload"])
         merged_input_payload["task_type"] = parsed["task_type"]
@@ -917,7 +980,11 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
 
         metadata = dict(parsed["metadata"])
         metadata["task_id"] = parsed["task_id"]
-        metadata["portal_task_id"] = parsed["task_id"]
+        metadata["trace_id"] = trace_headers.get("trace_id")
+        metadata["span_id"] = trace_headers.get("span_id")
+        metadata["parent_span_id"] = trace_headers.get("parent_span_id")
+        metadata["portal_dispatch_id"] = trace_headers.get("portal_dispatch_id")
+        metadata["portal_task_id"] = metadata.get("portal_task_id") or trace_headers.get("portal_task_id") or parsed["task_id"]
         metadata["path"] = "/api/tasks/execute"
         metadata["external_triggered"] = True
         metadata["auto_run"] = True
@@ -929,6 +996,14 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
         if parsed["shared_context_ref"]:
             metadata["shared_context_ref"] = parsed["shared_context_ref"]
         runtime_agent_id, _runtime_agent_name = _resolve_runtime_agent_identity(request)
+        set_log_context(agent_id=runtime_agent_id)
+        logger.info(
+            "Task execute dispatch start | task_id=%s task_type=%s request_id=%s runtime_agent_id=%s",
+            parsed["task_id"],
+            parsed["task_type"],
+            f"task-{parsed['task_id']}",
+            runtime_agent_id or "-",
+        )
 
         execution_result = await execute_runtime_task_request(
             request_id=f"task-{parsed['task_id']}",
@@ -972,6 +1047,8 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
             "runtime_events": _json_compatible(execution_result.runtime_events),
             "next_action_hint": execution_result.next_action_hint,
             "audit_ref": execution_result.audit_ref,
+            "trace_id": trace_headers.get("trace_id"),
+            "portal_dispatch_id": trace_headers.get("portal_dispatch_id"),
         }
         if status in {"error", "blocked"}:
             if isinstance(output_payload, dict):
@@ -979,6 +1056,14 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
             else:
                 response_payload["error"] = str(output_payload)
 
+        logger.info(
+            "Task execute dispatch end | status=%s runtime_events_count=%s artifacts_type=%s has_next_action_hint=%s duration_ms=%s",
+            status,
+            len(execution_result.runtime_events or []),
+            type(execution_result.artifacts).__name__,
+            bool(execution_result.next_action_hint),
+            int((time.perf_counter() - execution_started_at) * 1000),
+        )
         return web.json_response(response_payload)
     except (json.JSONDecodeError, ContentTypeError):
         return web.json_response({"error": "Invalid JSON"}, status=400)
@@ -987,6 +1072,8 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
     except Exception as exc:
         logger.error("Task execution API error: %s", sanitize_exception_message(exc), exc_info=True)
         return web.json_response({"error": "Internal server error"}, status=500)
+    finally:
+        clear_log_context()
 
 
 def _parse_bool_query(value: Optional[str]) -> Optional[bool]:

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -33,6 +33,7 @@ from src.runtime.governance_bus import (
 from src.runtime.github_review import run_github_review_task
 from src.runtime.jira_workflow_review import run_jira_workflow_review
 from src.runtime.leader_orchestration import dispatch_task_breakdown_as_delegations, run_delegation_cycle
+from src.utils.redaction import safe_preview, sanitize_exception_message
 
 logger = logging.getLogger(__name__)
 
@@ -58,16 +59,45 @@ class ExecutionBus:
         self._handlers[execution_type] = handler
 
     async def execute(self, request: ExecutionRequest) -> ExecutionResult:
+        payload = request.input_payload if isinstance(request.input_payload, dict) else {}
+        logger.info(
+            "ExecutionBus.execute start | execution_type=%s request_id=%s session_id=%s agent_id=%s source_type=%s task_type=%s",
+            request.execution_type,
+            request.request_id,
+            request.session_id or "-",
+            request.agent_id or "-",
+            request.source_type or "-",
+            payload.get("task_type") if isinstance(payload.get("task_type"), str) else "-",
+        )
         await self._persist_last_execution_id(request)
         decision = await self._safe_before_governance(request)
         if decision is not None and not decision.allowed:
+            logger.warning(
+                "ExecutionBus governance blocked | request_id=%s execution_type=%s task_type=%s reason=%s",
+                request.request_id,
+                request.execution_type,
+                payload.get("task_type") if isinstance(payload.get("task_type"), str) else "-",
+                decision.reason or "governance_blocked",
+            )
             result = self._blocked_result(request, reason=decision.reason, audit=decision.audit_record)
             final_result = await self._safe_after_governance(request, result)
             self._emit_terminal_lifecycle_event(request, final_result)
+            logger.info(
+                "ExecutionBus.execute end | request_id=%s final_status=%s runtime_events_count=%s audit_ref=%s",
+                request.request_id,
+                final_result.status,
+                len(final_result.runtime_events or []),
+                final_result.audit_ref or "-",
+            )
             return final_result
         self._emit_lifecycle_event("execution.started", request, "started", {"status": "started"})
         handler = self._handlers.get(request.execution_type)
         if handler is None:
+            logger.error(
+                "ExecutionBus missing handler | execution_type=%s request_id=%s",
+                request.execution_type,
+                request.request_id,
+            )
             result = make_execution_result(
                 request_id=request.request_id,
                 status="blocked",
@@ -75,14 +105,36 @@ class ExecutionBus:
             )
             final_result = await self._safe_after_governance(request, result)
             self._emit_terminal_lifecycle_event(request, final_result)
+            logger.info(
+                "ExecutionBus.execute end | request_id=%s final_status=%s runtime_events_count=%s audit_ref=%s",
+                request.request_id,
+                final_result.status,
+                len(final_result.runtime_events or []),
+                final_result.audit_ref or "-",
+            )
             return final_result
 
         try:
             raw_result = await handler(request)
             result = self._normalize_result(request, raw_result)
+            logger.debug(
+                "ExecutionBus handler normalized | request_id=%s execution_type=%s status=%s output_summary=%s",
+                request.request_id,
+                request.execution_type,
+                result.status,
+                safe_preview(summarize_output_payload(result.output_payload), 240),
+            )
         except Exception as exc:
             error_audit = await self._safe_on_error_governance(request, exc)
-            logger.exception("ExecutionBus handler failed for %s", request.execution_type)
+            logger.exception(
+                "ExecutionBus handler failed | execution_type=%s request_id=%s task_type=%s agent_id=%s error_class=%s error=%s",
+                request.execution_type,
+                request.request_id,
+                payload.get("task_type") if isinstance(payload.get("task_type"), str) else "-",
+                request.agent_id or "-",
+                exc.__class__.__name__,
+                sanitize_exception_message(exc),
+            )
             error_payload = _build_error_payload(exc, request.execution_type)
             result = make_execution_result(
                 request_id=request.request_id,
@@ -100,10 +152,24 @@ class ExecutionBus:
                 )
             final_result = await self._safe_after_governance(request, result)
             self._emit_terminal_lifecycle_event(request, final_result)
+            logger.info(
+                "ExecutionBus.execute end | request_id=%s final_status=%s runtime_events_count=%s audit_ref=%s",
+                request.request_id,
+                final_result.status,
+                len(final_result.runtime_events or []),
+                final_result.audit_ref or "-",
+            )
             return final_result
 
         final_result = await self._safe_after_governance(request, result)
         self._emit_terminal_lifecycle_event(request, final_result)
+        logger.info(
+            "ExecutionBus.execute end | request_id=%s final_status=%s runtime_events_count=%s audit_ref=%s",
+            request.request_id,
+            final_result.status,
+            len(final_result.runtime_events or []),
+            final_result.audit_ref or "-",
+        )
         return final_result
 
     async def _persist_last_execution_id(self, request: ExecutionRequest) -> None:
@@ -312,6 +378,13 @@ class ExecutionBus:
                 "execution_type": request.execution_type,
             },
         )
+        metadata = request.metadata if isinstance(request.metadata, dict) else {}
+        detail = payload.get("detail_payload")
+        if isinstance(detail, dict):
+            if isinstance(metadata.get("trace_id"), str) and metadata.get("trace_id").strip():
+                detail["trace_id"] = metadata.get("trace_id").strip()
+            if isinstance(metadata.get("portal_dispatch_id"), str) and metadata.get("portal_dispatch_id").strip():
+                detail["portal_dispatch_id"] = metadata.get("portal_dispatch_id").strip()
         try:
             self._event_emitter(legacy_type_map.get(event_type, "execution_event"), payload)
         except Exception:
@@ -1045,16 +1118,79 @@ def build_default_execution_bus(
         capability = resolve_task_capability_plan(task_type, request.input_payload)
         skill_name = str(request.input_payload.get("skill_name") or default_skill_name).strip() or default_skill_name
         skill_kwargs = dict(request.input_payload.get("skill_kwargs") or {})
+        logger.debug(
+            "Skill-backed task resolved | task_id=%s task_type=%s skill_name=%s capability_id=%s capability_type=%s",
+            task_id or "-",
+            task_type,
+            skill_name,
+            capability.get("capability_id"),
+            capability.get("capability_type"),
+        )
 
         for passthrough_key in ("bundle_ref", "manifest_ref", "sources"):
             if passthrough_key in request.input_payload and passthrough_key not in skill_kwargs:
                 skill_kwargs[passthrough_key] = request.input_payload.get(passthrough_key)
 
         skill_kwargs.setdefault("session_id", request.session_id)
+        sources = request.input_payload.get("sources") if isinstance(request.input_payload.get("sources"), dict) else {}
+        bundle_ref = request.input_payload.get("bundle_ref") if isinstance(request.input_payload.get("bundle_ref"), dict) else {}
+        manifest_ref = request.input_payload.get("manifest_ref") if isinstance(request.input_payload.get("manifest_ref"), dict) else {}
+        logger.debug(
+            "Skill-backed task input summary | task_type=%s jira_count=%s confluence_count=%s github_docs_count=%s figma_count=%s bundle_ref=%s manifest_ref=%s",
+            task_type,
+            len(_as_list_of_strings(sources.get("jira"))),
+            len(_as_list_of_strings(sources.get("confluence"))),
+            len(_as_list_of_strings(sources.get("github_docs"))),
+            len(_as_list_of_strings(sources.get("figma"))),
+            safe_preview(
+                {
+                    "repo": bundle_ref.get("repo"),
+                    "path": bundle_ref.get("path"),
+                    "branch": bundle_ref.get("branch"),
+                },
+                120,
+            ),
+            safe_preview(
+                {
+                    "repo": manifest_ref.get("repo"),
+                    "path": manifest_ref.get("path"),
+                    "branch": manifest_ref.get("branch"),
+                },
+                120,
+            ),
+        )
         try:
+            logger.info(
+                "Skill-backed task start | request_id=%s task_type=%s skill_name=%s task_id=%s",
+                request.request_id,
+                task_type,
+                skill_name,
+                task_id or "-",
+            )
             skill_result = await run_skill_execution(skill_name, _via_execution_bus=True, **skill_kwargs)
             normalized_skill = bus._normalize_result(request, skill_result)
+            normalized_output = normalized_skill.output_payload if isinstance(normalized_skill.output_payload, dict) else {}
+            normalized_data = normalized_output.get("data") if isinstance(normalized_output.get("data"), dict) else {}
+            logger.info(
+                "Skill-backed task end | request_id=%s task_type=%s skill_name=%s success=%s bundle_ref=%s updated_files_count=%s has_commit_sha=%s summary=%s",
+                request.request_id,
+                task_type,
+                skill_name,
+                normalized_skill.status not in {"error", "blocked"},
+                safe_preview(normalized_data.get("bundle_ref"), 120),
+                len(normalized_data.get("updated_files") or []) if isinstance(normalized_data.get("updated_files"), list) else 0,
+                bool(normalized_data.get("commit_sha")),
+                safe_preview(normalized_data.get("summary") or normalized_output.get("output"), 120),
+            )
         except Exception as exc:
+            logger.exception(
+                "Skill-backed task failed | request_id=%s task_type=%s skill_name=%s error_class=%s error=%s",
+                request.request_id,
+                task_type,
+                skill_name,
+                exc.__class__.__name__,
+                sanitize_exception_message(exc),
+            )
             normalized_skill = make_execution_result(
                 request_id=request.request_id,
                 status="error",

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -10,10 +10,52 @@ from urllib.parse import urlparse
 from ruamel.yaml import YAML
 
 from src.github import github_channel
+from src.utils.redaction import safe_preview, sanitize_exception_message
 
 _yaml = YAML()
 _yaml.default_flow_style = False
 logger = logging.getLogger(__name__)
+
+
+def _log_bundle_asset_failure(
+    action: str,
+    exc: Exception,
+    *,
+    ref: "BundleRef | None" = None,
+    relative_file: str | None = None,
+    raw: str | None = None,
+    extra: Dict[str, Any] | None = None,
+) -> None:
+    fields: Dict[str, Any] = {
+        "action": action,
+        "error_class": exc.__class__.__name__,
+        "error": sanitize_exception_message(exc),
+    }
+    if ref is not None:
+        fields["repo"] = ref.repo_full_name
+        fields["path"] = ref.path
+        fields["branch"] = ref.branch
+    if relative_file:
+        fields["relative_file"] = relative_file
+    if raw is not None:
+        fields["raw_preview"] = safe_preview(raw, 120)
+    if isinstance(extra, dict):
+        filtered_extra = {k: v for k, v in extra.items() if v is not None}
+        if filtered_extra:
+            fields["extra"] = filtered_extra
+
+    logger.warning(
+        "Bundle asset action failed | action=%s error_class=%s error=%s repo=%s path=%s branch=%s relative_file=%s raw_preview=%s extra=%s",
+        fields.get("action"),
+        fields.get("error_class"),
+        fields.get("error"),
+        fields.get("repo", "-"),
+        fields.get("path", "-"),
+        fields.get("branch", "-"),
+        fields.get("relative_file", "-"),
+        fields.get("raw_preview", "-"),
+        safe_preview(fields.get("extra"), 160) if "extra" in fields else "-",
+    )
 
 
 @dataclass(frozen=True)
@@ -127,7 +169,9 @@ def parse_github_doc_ref(raw: str, default_ref: BundleRef) -> GitHubDocRef:
 
 
 async def read_github_doc_text(raw: str, default_ref: BundleRef) -> tuple[GitHubDocRef, str]:
-    logger.debug("Read GitHub doc start | input_kind=%s", "url" if "://" in str(raw or "") else "repo_relative_path")
+    input_kind = "url" if "://" in str(raw or "") else "repo_relative_path"
+    logger.debug("Read GitHub doc start | input_kind=%s", input_kind)
+    doc_ref: GitHubDocRef | None = None
     try:
         doc_ref = parse_github_doc_ref(raw, default_ref)
         logger.debug(
@@ -151,10 +195,33 @@ async def read_github_doc_text(raw: str, default_ref: BundleRef) -> tuple[GitHub
             ) from exc
         logger.info("Read GitHub doc success | owner=%s repo=%s branch=%s path=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path)
         return doc_ref, decoded
-    except RequirementBundleError:
+    except RequirementBundleError as exc:
+        _log_bundle_asset_failure(
+            "read_github_doc_text",
+            exc,
+            raw=raw if doc_ref is None else None,
+            extra={
+                "input_kind": input_kind,
+                "owner": doc_ref.owner if doc_ref is not None else None,
+                "repo_name": doc_ref.repo if doc_ref is not None else None,
+                "doc_branch": doc_ref.branch if doc_ref is not None else None,
+                "doc_path": doc_ref.path if doc_ref is not None else None,
+            },
+        )
         raise
     except Exception as exc:
-        logger.warning("Read GitHub doc unexpected failure | error_class=%s", exc.__class__.__name__)
+        _log_bundle_asset_failure(
+            "read_github_doc_text",
+            exc,
+            raw=raw if doc_ref is None else None,
+            extra={
+                "input_kind": input_kind,
+                "owner": doc_ref.owner if doc_ref is not None else None,
+                "repo_name": doc_ref.repo if doc_ref is not None else None,
+                "doc_branch": doc_ref.branch if doc_ref is not None else None,
+                "doc_path": doc_ref.path if doc_ref is not None else None,
+            },
+        )
         raise
 
 
@@ -172,6 +239,7 @@ async def load_bundle_manifest(
     bundle_ref: Dict[str, Any],
     manifest_ref: Dict[str, Any] | None = None,
 ) -> Tuple[BundleRef, Dict[str, Any]]:
+    ref: BundleRef | None = None
     try:
         ref = parse_bundle_ref(manifest_ref or bundle_ref)
         logger.info("Load bundle manifest start | repo=%s path=%s branch=%s", ref.repo_full_name, ref.path, ref.branch)
@@ -179,29 +247,34 @@ async def load_bundle_manifest(
         validate_bundle_manifest(manifest)
         logger.info("Load bundle manifest success | repo=%s path=%s branch=%s", ref.repo_full_name, ref.path, ref.branch)
         return ref, manifest
-    except RequirementBundleError:
+    except RequirementBundleError as exc:
+        _log_bundle_asset_failure("load_bundle_manifest", exc, ref=ref, relative_file="bundle.yaml")
         raise
     except Exception as exc:
-        logger.warning("Load bundle manifest failure | error_class=%s", exc.__class__.__name__)
+        _log_bundle_asset_failure("load_bundle_manifest", exc, ref=ref, relative_file="bundle.yaml")
         raise
 
 
 def resolve_bundle_links(manifest: Dict[str, Any]) -> tuple[str, str]:
     logger.debug("Resolve bundle links start")
-    links = manifest.get("links")
-    if not isinstance(links, dict):
-        raise RequirementBundleError("bundle.yaml field 'links' must be an object")
+    try:
+        links = manifest.get("links")
+        if not isinstance(links, dict):
+            raise RequirementBundleError("bundle.yaml field 'links' must be an object")
 
-    requirements_file = str(links.get("requirements_file") or "").strip().strip("/")
-    test_cases_file = str(links.get("test_cases_file") or "").strip().strip("/")
+        requirements_file = str(links.get("requirements_file") or "").strip().strip("/")
+        test_cases_file = str(links.get("test_cases_file") or "").strip().strip("/")
 
-    if not requirements_file:
-        raise RequirementBundleError("bundle.yaml field 'links.requirements_file' must be a non-empty string")
-    if not test_cases_file:
-        raise RequirementBundleError("bundle.yaml field 'links.test_cases_file' must be a non-empty string")
+        if not requirements_file:
+            raise RequirementBundleError("bundle.yaml field 'links.requirements_file' must be a non-empty string")
+        if not test_cases_file:
+            raise RequirementBundleError("bundle.yaml field 'links.test_cases_file' must be a non-empty string")
 
-    logger.debug("Resolve bundle links success | requirements_file=%s test_cases_file=%s", requirements_file, test_cases_file)
-    return requirements_file, test_cases_file
+        logger.debug("Resolve bundle links success | requirements_file=%s test_cases_file=%s", requirements_file, test_cases_file)
+        return requirements_file, test_cases_file
+    except RequirementBundleError as exc:
+        _log_bundle_asset_failure("resolve_bundle_links", exc)
+        raise
 
 
 def resolve_target_bundle_ref(input_ref: BundleRef, manifest: Dict[str, Any]) -> BundleRef:
@@ -242,14 +315,18 @@ async def write_bundle_yaml(ref: BundleRef, relative_file: str, payload: Dict[st
     stream = io.StringIO()
     _yaml.dump(payload, stream)
     file_path = f"{ref.path}/{relative_file}".strip("/")
-    result = await github_channel.create_or_update_file(
-        ref.owner,
-        ref.repo,
-        file_path,
-        stream.getvalue(),
-        commit_message,
-        branch=ref.branch,
-    )
+    try:
+        result = await github_channel.create_or_update_file(
+            ref.owner,
+            ref.repo,
+            file_path,
+            stream.getvalue(),
+            commit_message,
+            branch=ref.branch,
+        )
+    except Exception as exc:
+        _log_bundle_asset_failure("write_bundle_yaml", exc, ref=ref, relative_file=relative_file)
+        raise
     commit_sha = ((result.get("commit") or {}).get("sha")) if isinstance(result, dict) else None
     logger.info(
         "Write bundle YAML done | repo=%s path=%s branch=%s relative_file=%s has_commit_sha=%s",
@@ -277,12 +354,31 @@ async def write_requirements_doc_for_ref(
         ref.branch,
         requirements_file,
     )
-    return await write_bundle_yaml(
-        ref,
-        requirements_file,
-        payload,
-        f"chore(requirement-bundle): update {requirements_file} for {ref.path}",
-    )
+    try:
+        result = await write_bundle_yaml(
+            ref,
+            requirements_file,
+            payload,
+            f"chore(requirement-bundle): update {requirements_file} for {ref.path}",
+        )
+        commit_sha = ((result.get("commit") or {}).get("sha")) if isinstance(result, dict) else None
+        logger.info(
+            "Write requirements doc done | repo=%s path=%s branch=%s requirements_file=%s has_commit_sha=%s",
+            ref.repo_full_name,
+            ref.path,
+            ref.branch,
+            requirements_file,
+            bool(commit_sha),
+        )
+        return result
+    except Exception as exc:
+        _log_bundle_asset_failure(
+            "write_requirements_doc_for_ref",
+            exc,
+            ref=ref,
+            relative_file=requirements_file,
+        )
+        raise
 
 
 async def write_test_cases_doc(bundle_ref: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import io
+import logging
 from dataclasses import dataclass
 from typing import Any, Dict, Tuple
 from urllib.parse import urlparse
@@ -12,6 +13,7 @@ from src.github import github_channel
 
 _yaml = YAML()
 _yaml.default_flow_style = False
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -125,18 +127,35 @@ def parse_github_doc_ref(raw: str, default_ref: BundleRef) -> GitHubDocRef:
 
 
 async def read_github_doc_text(raw: str, default_ref: BundleRef) -> tuple[GitHubDocRef, str]:
-    doc_ref = parse_github_doc_ref(raw, default_ref)
-    file_data = await github_channel.get_file(doc_ref.owner, doc_ref.repo, doc_ref.path, doc_ref.branch)
-    content = file_data.get("content")
-    if not isinstance(content, str) or not content.strip():
-        raise RequirementBundleError(f"File not found or empty: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}")
+    logger.debug("Read GitHub doc start | input_kind=%s", "url" if "://" in str(raw or "") else "repo_relative_path")
     try:
-        decoded = base64.b64decode(content).decode("utf-8")
-    except Exception as exc:  # pragma: no cover - defensive
-        raise RequirementBundleError(
-            f"Failed to decode file content: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}"
-        ) from exc
-    return doc_ref, decoded
+        doc_ref = parse_github_doc_ref(raw, default_ref)
+        logger.debug(
+            "Read GitHub doc resolved | owner=%s repo=%s branch=%s path=%s",
+            doc_ref.owner,
+            doc_ref.repo,
+            doc_ref.branch,
+            doc_ref.path,
+        )
+        file_data = await github_channel.get_file(doc_ref.owner, doc_ref.repo, doc_ref.path, doc_ref.branch)
+        content = file_data.get("content")
+        if not isinstance(content, str) or not content.strip():
+            logger.warning("Read GitHub doc missing content | owner=%s repo=%s branch=%s path=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path)
+            raise RequirementBundleError(f"File not found or empty: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}")
+        try:
+            decoded = base64.b64decode(content).decode("utf-8")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Read GitHub doc decode failed | owner=%s repo=%s branch=%s path=%s error=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path, exc.__class__.__name__)
+            raise RequirementBundleError(
+                f"Failed to decode file content: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}"
+            ) from exc
+        logger.info("Read GitHub doc success | owner=%s repo=%s branch=%s path=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path)
+        return doc_ref, decoded
+    except RequirementBundleError:
+        raise
+    except Exception as exc:
+        logger.warning("Read GitHub doc unexpected failure | error_class=%s", exc.__class__.__name__)
+        raise
 
 
 async def read_bundle_yaml(ref: BundleRef, relative_file: str) -> Dict[str, Any]:
@@ -153,13 +172,22 @@ async def load_bundle_manifest(
     bundle_ref: Dict[str, Any],
     manifest_ref: Dict[str, Any] | None = None,
 ) -> Tuple[BundleRef, Dict[str, Any]]:
-    ref = parse_bundle_ref(manifest_ref or bundle_ref)
-    manifest = await read_bundle_yaml(ref, "bundle.yaml")
-    validate_bundle_manifest(manifest)
-    return ref, manifest
+    try:
+        ref = parse_bundle_ref(manifest_ref or bundle_ref)
+        logger.info("Load bundle manifest start | repo=%s path=%s branch=%s", ref.repo_full_name, ref.path, ref.branch)
+        manifest = await read_bundle_yaml(ref, "bundle.yaml")
+        validate_bundle_manifest(manifest)
+        logger.info("Load bundle manifest success | repo=%s path=%s branch=%s", ref.repo_full_name, ref.path, ref.branch)
+        return ref, manifest
+    except RequirementBundleError:
+        raise
+    except Exception as exc:
+        logger.warning("Load bundle manifest failure | error_class=%s", exc.__class__.__name__)
+        raise
 
 
 def resolve_bundle_links(manifest: Dict[str, Any]) -> tuple[str, str]:
+    logger.debug("Resolve bundle links start")
     links = manifest.get("links")
     if not isinstance(links, dict):
         raise RequirementBundleError("bundle.yaml field 'links' must be an object")
@@ -172,6 +200,7 @@ def resolve_bundle_links(manifest: Dict[str, Any]) -> tuple[str, str]:
     if not test_cases_file:
         raise RequirementBundleError("bundle.yaml field 'links.test_cases_file' must be a non-empty string")
 
+    logger.debug("Resolve bundle links success | requirements_file=%s test_cases_file=%s", requirements_file, test_cases_file)
     return requirements_file, test_cases_file
 
 
@@ -202,10 +231,18 @@ async def load_requirements_doc(bundle_ref: Dict[str, Any]) -> Tuple[BundleRef, 
 
 
 async def write_bundle_yaml(ref: BundleRef, relative_file: str, payload: Dict[str, Any], commit_message: str) -> Dict[str, Any]:
+    logger.info(
+        "Write bundle YAML start | repo=%s path=%s branch=%s relative_file=%s commit_type=%s",
+        ref.repo_full_name,
+        ref.path,
+        ref.branch,
+        relative_file,
+        commit_message.split(":")[0] if ":" in commit_message else "generic",
+    )
     stream = io.StringIO()
     _yaml.dump(payload, stream)
     file_path = f"{ref.path}/{relative_file}".strip("/")
-    return await github_channel.create_or_update_file(
+    result = await github_channel.create_or_update_file(
         ref.owner,
         ref.repo,
         file_path,
@@ -213,6 +250,16 @@ async def write_bundle_yaml(ref: BundleRef, relative_file: str, payload: Dict[st
         commit_message,
         branch=ref.branch,
     )
+    commit_sha = ((result.get("commit") or {}).get("sha")) if isinstance(result, dict) else None
+    logger.info(
+        "Write bundle YAML done | repo=%s path=%s branch=%s relative_file=%s has_commit_sha=%s",
+        ref.repo_full_name,
+        ref.path,
+        ref.branch,
+        relative_file,
+        bool(commit_sha),
+    )
+    return result
 
 
 async def write_requirements_doc(bundle_ref: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -223,6 +270,13 @@ async def write_requirements_doc(bundle_ref: Dict[str, Any], payload: Dict[str, 
 async def write_requirements_doc_for_ref(
     ref: BundleRef, payload: Dict[str, Any], requirements_file: str = "requirements.yaml"
 ) -> Dict[str, Any]:
+    logger.debug(
+        "Write requirements doc start | repo=%s path=%s branch=%s requirements_file=%s",
+        ref.repo_full_name,
+        ref.path,
+        ref.branch,
+        requirements_file,
+    )
     return await write_bundle_yaml(
         ref,
         requirements_file,

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -11,6 +11,7 @@ This module provides comprehensive logging setup with:
 import logging
 import sys
 import os
+import contextvars
 from datetime import datetime
 from pathlib import Path
 from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
@@ -22,10 +23,62 @@ from src.utils.redaction import redact_text, redact_value, safe_preview, safe_lo
 
 
 # Custom log format with detailed info
-DEFAULT_FORMAT = "%(asctime)s | %(levelname)-8s | %(filename)s:%(lineno)d | %(funcName)s | %(message)s"
+DEFAULT_FORMAT = (
+    "%(asctime)s | %(levelname)-8s | %(filename)s:%(lineno)d | %(funcName)s | "
+    "trace=%(trace_id)s span=%(span_id)s parent=%(parent_span_id)s "
+    "request=%(request_id)s task=%(task_id)s portal_task=%(portal_task_id)s "
+    "dispatch=%(portal_dispatch_id)s agent=%(agent_id)s path=%(path)s | %(message)s"
+)
 
 # Structured log format (JSON)
 STRUCTURED_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(filename)s:%(lineno)d | %(funcName)s | %(message)s"
+
+_LOG_CONTEXT_FIELDS = (
+    "trace_id",
+    "span_id",
+    "parent_span_id",
+    "request_id",
+    "task_id",
+    "portal_task_id",
+    "portal_dispatch_id",
+    "agent_id",
+    "path",
+)
+_LOG_CONTEXT_DEFAULTS = {field: "-" for field in _LOG_CONTEXT_FIELDS}
+_log_context_var: contextvars.ContextVar[Dict[str, str]] = contextvars.ContextVar(
+    "efp_log_context",
+    default=dict(_LOG_CONTEXT_DEFAULTS),
+)
+
+
+def get_log_context() -> Dict[str, str]:
+    context = _log_context_var.get()
+    if not isinstance(context, dict):
+        return dict(_LOG_CONTEXT_DEFAULTS)
+    merged = dict(_LOG_CONTEXT_DEFAULTS)
+    for field in _LOG_CONTEXT_FIELDS:
+        value = context.get(field)
+        if isinstance(value, str) and value.strip():
+            merged[field] = value.strip()
+    return merged
+
+
+def set_log_context(**fields: Any) -> contextvars.Token:
+    existing = get_log_context()
+    for key, value in fields.items():
+        if key not in _LOG_CONTEXT_DEFAULTS:
+            continue
+        text = str(value).strip() if value is not None else ""
+        existing[key] = text or "-"
+    return _log_context_var.set(existing)
+
+
+def clear_log_context() -> None:
+    _log_context_var.set(dict(_LOG_CONTEXT_DEFAULTS))
+
+
+def reset_log_context(token: contextvars.Token) -> None:
+    _log_context_var.reset(token)
 
 
 
@@ -55,6 +108,8 @@ class RedactingFilter(logging.Filter):
                 fallback = f"{fallback} | args={sanitize_log_line(sanitized_args)}"
             record.msg = fallback
             record.args = ()
+        for key, value in get_log_context().items():
+            setattr(record, key, value)
         return True
 
 

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -8,6 +8,7 @@ from src.runtime.execution_bus import ExecutionBus, build_default_execution_bus
 from src.runtime.events import build_runtime_event
 from src.runtime.governance import GovernanceHooks
 from src.runtime.governance_bus import GovernanceDecision
+from src.runtime.governance_bus import GovernanceBus
 from src.runtime.capability_registry import CapabilityDescriptor
 
 
@@ -415,6 +416,92 @@ async def test_execution_bus_async_governance_on_error_is_awaited():
 
     assert result.status == "error"
     assert governance.error_seen == ("chat", "RuntimeError")
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_execute_logs_request_context(caplog):
+    async def task_handler(_request):
+        return {"status": "success", "response": "ok"}
+
+    bus = ExecutionBus(handlers={"task": task_handler})
+    req = make_execution_request(
+        request_id="req-log-1",
+        source_type="task",
+        execution_type="task",
+        session_id="session-1",
+        agent_id="agent-1",
+        input_payload={"task_type": "adapter_action_task"},
+    )
+    with caplog.at_level("INFO"):
+        result = await bus.execute(req)
+    assert result.status == "success"
+    assert "ExecutionBus.execute start" in caplog.text
+    assert "request_id=req-log-1" in caplog.text
+    assert "execution_type=task" in caplog.text
+    assert "task_type=adapter_action_task" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_logs_blocked_no_handler_and_exception(caplog):
+    async def _bad(_request):
+        raise RuntimeError("boom")
+
+    class _BlockGovernance(GovernanceBus):
+        async def before_execute(self, _request):
+            return GovernanceDecision(allowed=False, reason="denied")
+
+        async def after_execute(self, _request, result):
+            return result
+
+        async def on_error(self, _request, _error):
+            return None
+
+    blocked_bus = ExecutionBus(governance=_BlockGovernance())
+    blocked_req = make_execution_request(request_id="req-blocked", source_type="chat", execution_type="chat")
+
+    no_handler_bus = ExecutionBus()
+    no_handler_req = make_execution_request(request_id="req-no-handler", source_type="chat", execution_type="missing")
+
+    exception_bus = ExecutionBus(handlers={"chat": _bad})
+    exception_req = make_execution_request(
+        request_id="req-exception",
+        source_type="chat",
+        execution_type="chat",
+        input_payload={"task_type": "requirement_bundle_collect_task"},
+    )
+
+    with caplog.at_level("WARNING"):
+        await blocked_bus.execute(blocked_req)
+        await no_handler_bus.execute(no_handler_req)
+        await exception_bus.execute(exception_req)
+
+    assert "ExecutionBus governance blocked" in caplog.text
+    assert "ExecutionBus missing handler" in caplog.text
+    assert "ExecutionBus handler failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_lifecycle_event_includes_trace_id_from_metadata():
+    emitted = []
+
+    async def chat_handler(_request):
+        return {"response": "ok"}
+
+    bus = ExecutionBus(
+        handlers={"chat": chat_handler},
+        event_emitter=lambda event_type, payload: emitted.append((event_type, payload)),
+    )
+    req = make_execution_request(
+        request_id="req-trace-1",
+        source_type="chat",
+        execution_type="chat",
+        metadata={"trace_id": "trace-1", "portal_dispatch_id": "dispatch-1"},
+    )
+    await bus.execute(req)
+    assert emitted
+    first_payload = emitted[0][1]
+    assert first_payload["detail_payload"]["trace_id"] == "trace-1"
+    assert first_payload["detail_payload"]["portal_dispatch_id"] == "dispatch-1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -38,6 +38,8 @@ from src.utils.logger import (
     STRUCTURED_FORMAT,
     RedactingFilter,
     RedactingFormatter,
+    set_log_context,
+    clear_log_context,
 )
 
 
@@ -309,6 +311,47 @@ class TestRedactionIntegration:
         assert "supersecret" not in out
         assert "hunter2" not in out
         assert "***REDACTED***" in out
+
+    def test_default_format_includes_trace_fields_with_bound_context(self):
+        stream = io.StringIO()
+        logger = logging.getLogger("trace_context_bound")
+        logger.handlers = []
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(RedactingFormatter(DEFAULT_FORMAT))
+        handler.addFilter(RedactingFilter())
+        logger.addHandler(handler)
+
+        set_log_context(trace_id="trace-1", request_id="req-1", task_id="task-1", path="/api/tasks/execute")
+        try:
+            logger.info("hello")
+        finally:
+            clear_log_context()
+
+        output = stream.getvalue()
+        assert "trace=trace-1" in output
+        assert "request=req-1" in output
+        assert "task=task-1" in output
+        assert "path=/api/tasks/execute" in output
+
+    def test_default_format_uses_dash_without_context(self):
+        stream = io.StringIO()
+        logger = logging.getLogger("trace_context_empty")
+        logger.handlers = []
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(RedactingFormatter(DEFAULT_FORMAT))
+        handler.addFilter(RedactingFilter())
+        logger.addHandler(handler)
+
+        clear_log_context()
+        logger.info("hello")
+        output = stream.getvalue()
+        assert "trace=-" in output
+        assert "request=-" in output
+        assert "path=-" in output
 
     def test_exception_traceback_is_redacted(self):
         stream = io.StringIO()

--- a/tests/test_requirement_bundle_tasks.py
+++ b/tests/test_requirement_bundle_tasks.py
@@ -7,12 +7,16 @@ from skills.collect_requirements_to_bundle.skill import collect_requirements_to_
 from skills.design_test_cases_from_bundle.skill import design_test_cases_from_bundle as design_test_cases_skill
 from src.runtime.requirement_bundle_assets import (
     RequirementBundleError,
+    BundleRef,
     build_test_design_context,
+    load_bundle_manifest,
     parse_github_doc_ref,
     parse_bundle_ref,
+    read_github_doc_text,
     resolve_bundle_links,
     resolve_target_bundle_ref,
     validate_bundle_manifest,
+    write_requirements_doc_for_ref,
 )
 
 
@@ -100,6 +104,83 @@ async def test_collect_skill_reads_manifest_and_writes_requirements(monkeypatch,
     assert "requirement-bundles/payments/maker/docs/spec.md" not in observed_paths
     assert "Collect requirements skill start" in caplog.text
     assert "Collect requirements skill finish" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_load_bundle_manifest_failure_logs_reason(monkeypatch, caplog):
+    async def _fake_get_file(owner, repo, path, ref=""):
+        if path.endswith("bundle.yaml"):
+            return {"content": _b64("bundle_id: rb-err\ntitle: bad\nstatus: draft\n")}
+        raise AssertionError(path)
+
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RequirementBundleError):
+            await load_bundle_manifest(
+                {"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"}
+            )
+
+    assert "Bundle asset action failed | action=load_bundle_manifest" in caplog.text
+    assert "bundle.yaml missing required field" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_read_github_doc_text_failure_logs_reason(monkeypatch, caplog):
+    async def _fake_get_file(owner, repo, path, ref=""):
+        return {"content": ""}
+
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    default_ref = BundleRef(owner="acme", repo="assets", path="bundles/a", branch="main")
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RequirementBundleError):
+            await read_github_doc_text("docs/spec.md", default_ref)
+
+    assert "Bundle asset action failed | action=read_github_doc_text" in caplog.text
+    assert "File not found or empty" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_write_requirements_doc_failure_logs_ref_and_file(monkeypatch, caplog):
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    ref = BundleRef(owner="acme", repo="assets", path="requirement-bundles/payments/maker", branch="bundle/1")
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError):
+            await write_requirements_doc_for_ref(
+                ref,
+                {"bundle_id": "rb-1", "sources": {}, "summary": {}, "functional_requirements": [], "business_rules": [], "acceptance_criteria": [], "edge_cases": [], "quality_flags": {"ambiguities": [], "conflicts": [], "missing_information": []}},
+                requirements_file="docs/requirements.yaml",
+            )
+
+    assert "Bundle asset action failed | action=write_bundle_yaml" in caplog.text
+    assert "Bundle asset action failed | action=write_requirements_doc_for_ref" in caplog.text
+    assert "repo=acme/assets" in caplog.text
+    assert "relative_file=docs/requirements.yaml" in caplog.text
+    assert "write failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_collect_skill_failure_logs_sanitized_reason(monkeypatch, caplog):
+    async def _raise_manifest(*_args, **_kwargs):
+        raise RequirementBundleError("manifest invalid")
+
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.github_channel.is_configured", lambda: True)
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.load_bundle_manifest", _raise_manifest)
+
+    with caplog.at_level("WARNING"):
+        result = await collect_requirements_skill.execute(
+            bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"},
+            sources={"github_docs": ["docs/spec.md"]},
+        )
+
+    assert result.success is False
+    assert "action=collect_requirements_to_bundle" in caplog.text
+    assert "manifest invalid" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_requirement_bundle_tasks.py
+++ b/tests/test_requirement_bundle_tasks.py
@@ -42,7 +42,7 @@ def _valid_manifest_yaml(
 
 
 @pytest.mark.asyncio
-async def test_collect_skill_reads_manifest_and_writes_requirements(monkeypatch):
+async def test_collect_skill_reads_manifest_and_writes_requirements(monkeypatch, caplog):
     writes = []
     observed_paths = []
 
@@ -86,10 +86,11 @@ async def test_collect_skill_reads_manifest_and_writes_requirements(monkeypatch)
     monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.jira_get_issue", _fake_jira_issue)
     monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.confluence_get_page", _fake_confluence_page)
 
-    result = await collect_requirements_skill.execute(
-        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"},
-        sources={"jira": ["PAY-101"], "confluence": ["9876"], "github_docs": ["docs/spec.md"], "figma": ["fig-1"]},
-    )
+    with caplog.at_level("INFO"):
+        result = await collect_requirements_skill.execute(
+            bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"},
+            sources={"jira": ["PAY-101"], "confluence": ["9876"], "github_docs": ["docs/spec.md"], "figma": ["fig-1"]},
+        )
 
     assert result.success is True
     assert writes and writes[0]["branch"] == "bundle/1"
@@ -97,6 +98,8 @@ async def test_collect_skill_reads_manifest_and_writes_requirements(monkeypatch)
     assert "figma sources are ignored in MVP" in result.data.get("warnings", [])
     assert "docs/spec.md" in observed_paths
     assert "requirement-bundles/payments/maker/docs/spec.md" not in observed_paths
+    assert "Collect requirements skill start" in caplog.text
+    assert "Collect requirements skill finish" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -1230,6 +1230,29 @@ async def test_api_tasks_execute_requires_internal_api_key_not_configured(monkey
 
 
 @pytest.mark.asyncio
+async def test_api_tasks_execute_not_configured_logs_auth_summary(monkeypatch, caplog):
+    from src.gateway import webchat
+
+    monkeypatch.delenv("RUNTIME_INTERNAL_API_KEY", raising=False)
+    monkeypatch.setattr(webchat.global_config, "get", lambda *_args, **_kwargs: "")
+
+    class _Request:
+        headers = {"X-Trace-Id": "trace-auth-503", "X-Portal-Dispatch-Id": "dispatch-1"}
+
+        async def json(self):
+            raise AssertionError("json() should not be called when auth fails")
+
+    with caplog.at_level("WARNING"):
+        response = await webchat.api_tasks_execute(_Request())
+
+    body = json.loads(response.body)
+    assert response.status == 503
+    assert body == {"error": "Runtime internal api key is not configured"}
+    assert "expected_key_configured=False" in caplog.text
+    assert "provided_key_present=False" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_api_tasks_execute_requires_internal_api_key_missing_header(monkeypatch):
     from src.gateway import webchat
 
@@ -1532,3 +1555,59 @@ async def test_api_tasks_execute_blocked_result_returns_ok_false(monkeypatch):
     assert body["ok"] is False
     assert body["status"] == "blocked"
     assert body["error"] == "blocked by policy"
+
+
+@pytest.mark.asyncio
+async def test_api_tasks_execute_tracing_headers_merge_to_metadata_and_response(monkeypatch):
+    from src.gateway import webchat
+    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
+
+    captured = {}
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured.update(kwargs)
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"success": True},
+                "artifacts": {},
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(webchat, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+
+    class _Request:
+        headers = {
+            **INTERNAL_HEADERS,
+            "X-Trace-Id": "trace-200",
+            "X-Span-Id": "span-200",
+            "X-Parent-Span-Id": "parent-200",
+            "X-Portal-Task-Id": "portal-task-200",
+            "X-Portal-Dispatch-Id": "dispatch-200",
+        }
+
+        async def json(self):
+            return {
+                "task_id": "task-200",
+                "task_type": "adapter_action_task",
+                "input_payload": {"action_id": "jira.transition"},
+                "metadata": {"custom": "value"},
+            }
+
+    response = await webchat.api_tasks_execute(_Request())
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert captured["metadata"]["trace_id"] == "trace-200"
+    assert captured["metadata"]["span_id"] == "span-200"
+    assert captured["metadata"]["parent_span_id"] == "parent-200"
+    assert captured["metadata"]["portal_dispatch_id"] == "dispatch-200"
+    assert captured["metadata"]["portal_task_id"] == "portal-task-200"
+    assert body["trace_id"] == "trace-200"
+    assert body["portal_dispatch_id"] == "dispatch-200"


### PR DESCRIPTION
### Motivation
- Portal calls into runtime `/api/tasks/execute` can surface 503/401/400 but runtime logs lack structured trace context to quickly distinguish auth, validation, execution-bus, skill or asset I/O issues.
- The change aims to add request-scoped tracing context and high-value boundary logs while preserving existing API semantics and error bodies for 503/401/400.
- Keep changes minimal and additive: no OpenTelemetry, no secrets in logs, and no behavioral changes to execution status semantics.

### Description
- Add request-scoped log context support in `src/utils/logger.py` using `contextvars` and inject `trace_id/span_id/parent_span_id/request_id/task_id/portal_task_id/portal_dispatch_id/agent_id/path` into `LogRecord`, and extend `DEFAULT_FORMAT` to include those fields; keep redaction behavior intact (files changed: `src/utils/logger.py`).
- Enhance runtime task entry in `src/gateway/webchat.py` to extract/sanitize tracing headers (`X-Trace-Id`, `X-Span-Id`, `X-Parent-Span-Id`, `X-Portal-Task-Id`, `X-Portal-Dispatch-Id`), bind log context early, log auth outcome (presence/configured flags only), emit request-parse summary, add trace fields into `metadata`, and add-only `trace_id`/`portal_dispatch_id` to 200 payloads (file changed: `src/gateway/webchat.py`).
- Improve `ExecutionBus` diagnostics in `src/runtime/execution_bus.py` with entry/blocked/no-handler/handler-normalized/handler-failed/final logs, include safe output summaries and sanitized exception context, and inject `trace_id`/`portal_dispatch_id` additively into lifecycle event `detail_payload`; also add targeted logs in `_execute_skill_backed_task` for capability resolution, source counts, skill start/end and sanitized errors (file changed: `src/runtime/execution_bus.py`).
- Add I/O boundary logs for requirement bundles and GitHub asset operations and safe summaries in `src/runtime/requirement_bundle_assets.py`, and add skill-level I/O/LLM/write boundary logs in `skills/collect_requirements_to_bundle/skill.py`; these logs are explicit about counts, refs, commit presence and avoid source/LLM/full payloads (files changed: `src/runtime/requirement_bundle_assets.py`, `skills/collect_requirements_to_bundle/skill.py`).
- Tests updated/added to assert log-context formatting and propagation and lightweight caplog checks: `tests/test_logger.py`, `tests/test_webchat.py`, `tests/test_execution_bus.py`, `tests/test_requirement_bundle_tasks.py` (files changed: tests under `tests/`).

### Testing
- Ran `pytest tests/test_logger.py -q` and it passed: all logger/redaction and trace-context formatter assertions succeeded (44 passed).
- Ran `pytest tests/test_webchat.py -q -k "api_tasks_execute"` to exercise the enhanced `/api/tasks/execute` flows and those targeted tests passed (12 selected passed); the full `tests/test_webchat.py` still reports unrelated template/static file assertions failing (static/template existence/contents) which are pre-existing and outside the scope of these tracing changes.
- Ran `pytest tests/test_execution_bus.py -q` and `pytest tests/test_requirement_bundle_tasks.py -q` and both test files passed (ExecutionBus focused tests and requirement-bundle skill tests passed).
- Notes on compatibility risks: changes are additive for observability only, but `DEFAULT_FORMAT` now includes trace fields which may require updating external log parsers if they relied on the previous raw format; API error shapes and auth return codes remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d766c0a9b0832aa8073b0bad253ded)