### PR TITLE
Disable runtime internal API-key enforcement for Portal-only topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ llm:
 
 ```yaml
 server:
-  runtime_internal_api_key: "change-me"  # Portal -> EFP (/api/tasks/execute, /api/capabilities)
-  portal_internal_api_key: "change-me"   # Portal -> EFP trusted chat metadata/identity
+  runtime_internal_api_key: "change-me"  # Reserved for future re-enable; not currently enforced by runtime endpoints
+  portal_internal_api_key: "change-me"   # Reserved for future re-enable; not currently enforced for portal trust
   jira_reconciliation_enabled: false     # Runtime scheduled Jira reconciliation loop
   jira_reconciliation_interval_seconds: 300
 ```
@@ -91,6 +91,8 @@ server:
 Environment variables override config values:
 - `RUNTIME_INTERNAL_API_KEY`
 - `PORTAL_INTERNAL_API_KEY`
+  
+> Note: runtime currently does not enforce these internal API keys in the Portal-only internal-VPC topology.
 
 Reconciliation/session contract notes:
 - Jira reconciliation fallback publishes to Portal via `/api/internal/external-events/ingest` using Portal `ExternalEventIngressRequest`-compatible fields (`workflow_review_requested`, `payload_json`, `project_key`, `issue_key`, etc.).
@@ -205,17 +207,15 @@ engineering-flow-platform/
 
 | Endpoint | Method | Description | Required Header |
 |----------|--------|-------------|-----------------|
-| `/api/tasks/execute` | POST | Runtime task execution bridge | `X-Internal-Api-Key` |
-| `/api/capabilities` | GET | Runtime capability snapshot/filter API | `X-Internal-Api-Key` |
+| `/api/tasks/execute` | POST | Runtime task execution bridge | none (internal network / Portal proxy topology) |
+| `/api/capabilities` | GET | Runtime capability snapshot/filter API | none (internal network / Portal proxy topology) |
 
 ### Phase 5 Trust Contract (Portal ↔ Runtime)
 
 - `/api/chat` and `/api/chat/stream` remain usable for direct runtime chat.
 - Governance/capability metadata is only applied for **trusted Portal requests**.
 - Trusted chat request requires:
-  - `X-Portal-Author-Source: portal`
-  - and, when `PORTAL_INTERNAL_API_KEY` (or `server.portal_internal_api_key`) is configured,
-    `X-Portal-Internal-Api-Key`.
+  - `X-Portal-Author-Source: portal`.
 - `portal_user_id` / `portal_user_name` are trusted identity headers only (`X-Portal-User-Id`, `X-Portal-User-Name`).
 
 For complete control-plane contract details, see `docs/control_plane_contract.md`.
@@ -223,16 +223,13 @@ For complete control-plane contract details, see `docs/control_plane_contract.md
 ### Portal Control-Plane Integration (Operator Minimum)
 
 1. **Portal -> EFP trusted chat**  
-   Headers: `X-Portal-Author-Source: portal` and (when configured) `X-Portal-Internal-Api-Key`  
-   Key source on EFP: `PORTAL_INTERNAL_API_KEY` (env) or `server.portal_internal_api_key`.
+   Header: `X-Portal-Author-Source: portal`.
 
 2. **Portal -> EFP internal runtime endpoints** (`/api/tasks/execute`, `/api/capabilities`)  
-   Header: `X-Internal-Api-Key`  
-   Key source on EFP: `RUNTIME_INTERNAL_API_KEY` (env) or `server.runtime_internal_api_key`.
+   No internal API-key header required in current deployment mode.
 
 3. **EFP adapter -> Portal internal APIs** (`adapter:portal:*`)  
    Requires `PORTAL_INTERNAL_BASE_URL` (env) or `server.portal_internal_base_url`.  
-   Uses `X-Internal-Api-Key` from `PORTAL_INTERNAL_API_KEY` (env) or `server.portal_internal_api_key`.  
    Optional legacy token: `PORTAL_INTERNAL_AUTH_TOKEN` (env) or `server.portal_internal_auth_token`.
 
 ### Sessions

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -162,8 +162,8 @@ workspace:
 server:
   host: "0.0.0.0"  # Listen on all interfaces
   port: 8000       # Default port
-  runtime_internal_api_key: "change-me"  # Internal Portal -> Runtime control-plane key (X-Internal-Api-Key)
-  portal_internal_api_key: "change-me"   # Trusted Portal -> Runtime chat identity/metadata key (X-Portal-Internal-Api-Key)
+  runtime_internal_api_key: "change-me"  # Reserved for future internal Portal -> Runtime API-key enforcement
+  portal_internal_api_key: "change-me"   # Reserved for future trusted Portal -> Runtime chat key enforcement
   portal_internal_base_url: "https://portal.internal"  # Runtime -> Portal internal API base URL (adapter:portal:*)
   portal_internal_auth_token: ""  # Optional legacy Runtime -> Portal bearer token; env/config supported, env takes precedence
   jira_reconciliation_enabled: false  # Enable scheduled Jira reconciliation -> Portal external event ingest

--- a/docs/control_plane_contract.md
+++ b/docs/control_plane_contract.md
@@ -7,8 +7,6 @@ This document defines the Portal ↔ EFP runtime trust boundaries.
 - Direct runtime chat is allowed without Portal.
 - Trusted Portal metadata/identity is only accepted when request is trusted:
   - `X-Portal-Author-Source: portal`
-  - and if configured (`PORTAL_INTERNAL_API_KEY` or `server.portal_internal_api_key`):
-    `X-Portal-Internal-Api-Key`
 - Portal identity is header-only:
   - `X-Portal-User-Id`
   - `X-Portal-User-Name`
@@ -17,26 +15,22 @@ This document defines the Portal ↔ EFP runtime trust boundaries.
 ## 2) Runtime Internal Endpoints
 
 - `/api/tasks/execute` and `/api/capabilities` are internal control-plane endpoints.
-- They require `X-Internal-Api-Key`.
-- Key source (runtime side):
-  - `RUNTIME_INTERNAL_API_KEY` (env) first
-  - fallback `server.runtime_internal_api_key` in config
+- They currently do **not** require `X-Internal-Api-Key` (internal key enforcement is intentionally disabled for Portal-only internal-VPC deployments).
 
 ## 3) Runtime Adapter → Portal Internal API Contract
 
 - `adapter:portal:*` actions call Portal internal APIs with:
   - base URL from `PORTAL_INTERNAL_BASE_URL` env, fallback `server.portal_internal_base_url`
-  - `X-Internal-Api-Key` (from `PORTAL_INTERNAL_API_KEY` env, fallback `server.portal_internal_api_key`)
   - optional `Authorization: Bearer <PORTAL_INTERNAL_AUTH_TOKEN>` (legacy compatibility; env first, fallback `server.portal_internal_auth_token`)
-- This is Runtime → Portal API auth and is distinct from chat trust header `X-Portal-Internal-Api-Key`.
+- Runtime no longer emits `X-Internal-Api-Key` on these calls.
 
 ## 4) Key Pairing Matrix
 
 | Chain | EFP setting | Portal side should provide |
 |---|---|---|
-| Portal → EFP `/api/tasks/execute`, `/api/capabilities` | `server.runtime_internal_api_key` or `RUNTIME_INTERNAL_API_KEY` | `X-Internal-Api-Key` |
-| Portal → EFP trusted chat metadata/identity | `server.portal_internal_api_key` or `PORTAL_INTERNAL_API_KEY` | `X-Portal-Internal-Api-Key` |
-| Runtime adapter (`adapter:portal:*`) → Portal internal API | `server.portal_internal_base_url` / `PORTAL_INTERNAL_BASE_URL`; `server.portal_internal_api_key` / `PORTAL_INTERNAL_API_KEY`; optional `server.portal_internal_auth_token` / `PORTAL_INTERNAL_AUTH_TOKEN` | `X-Internal-Api-Key` (+ optional `Authorization`) |
+| Portal → EFP `/api/tasks/execute`, `/api/capabilities` | `server.runtime_internal_api_key` or `RUNTIME_INTERNAL_API_KEY` | none required (currently permissive) |
+| Portal → EFP trusted chat metadata/identity | `X-Portal-Author-Source: portal` | `X-Portal-User-Id`, `X-Portal-User-Name` (optional) |
+| Runtime adapter (`adapter:portal:*`) → Portal internal API | `server.portal_internal_base_url` / `PORTAL_INTERNAL_BASE_URL`; optional `server.portal_internal_auth_token` / `PORTAL_INTERNAL_AUTH_TOKEN` | optional `Authorization` |
 
 ## 5) Jira Reconciliation Contract (Runtime Fallback)
 

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -6,7 +6,6 @@ UNIQUE_MARKER_12345
 """
 
 import asyncio
-import hmac
 import json
 import logging
 import os
@@ -24,7 +23,6 @@ init_storage()
 from src.utils.file_parser import parse_file
 from src.utils.truncate import truncate
 from src.utils.redaction import safe_preview, safe_log_field, sanitize_exception_message
-from src.utils.internal_api_keys import get_portal_internal_api_key, get_runtime_internal_api_key
 from src.utils.logger import clear_log_context, set_log_context
 
 
@@ -110,13 +108,7 @@ def _extract_portal_identity(request: web.Request, data: Dict[str, Any]) -> tupl
 def _is_trusted_portal_request(request: web.Request) -> bool:
     headers = getattr(request, "headers", {}) or {}
     portal_source = str(headers.get("X-Portal-Author-Source") or "").strip().lower()
-    if portal_source != "portal":
-        return False
-    expected_internal_key = get_portal_internal_api_key()
-    if not expected_internal_key:
-        return True
-    provided_internal_key = str(headers.get("X-Portal-Internal-Api-Key") or "").strip()
-    return hmac.compare_digest(provided_internal_key, expected_internal_key)
+    return portal_source == "portal"
 
 
 def _resolve_chat_display_user_name(data: Dict[str, Any], portal_user_name: Optional[str]) -> str:
@@ -230,13 +222,9 @@ def _extract_task_trace_headers(request: web.Request) -> Dict[str, Optional[str]
 
 
 def _authorize_internal_runtime_request(request: web.Request) -> Optional[web.Response]:
-    expected_key = get_runtime_internal_api_key()
-    if not expected_key:
-        return _build_internal_auth_error_response(503, "Runtime internal api key is not configured")
-    headers = getattr(request, "headers", {}) or {}
-    provided_key = str(headers.get("X-Internal-Api-Key") or "").strip()
-    if not provided_key or not hmac.compare_digest(provided_key, expected_key):
-        return _build_internal_auth_error_response(401, "Invalid internal api key")
+    # Internal API-key enforcement is intentionally disabled for the current
+    # Portal-only deployment topology (internal VPC + Portal proxy path).
+    # Keep this helper as a no-op so existing call sites remain stable.
     return None
 
 
@@ -945,15 +933,6 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
     try:
         auth_error = _authorize_internal_runtime_request(request)
         if auth_error is not None:
-            expected_key = get_runtime_internal_api_key()
-            headers = getattr(request, "headers", {}) or {}
-            provided_key = str(headers.get("X-Internal-Api-Key") or "").strip()
-            logger.warning(
-                "Task execute auth rejected | expected_key_configured=%s provided_key_present=%s status_code=%s",
-                bool(expected_key),
-                bool(provided_key),
-                getattr(auth_error, "status", 401),
-            )
             return auth_error
         data = await request.json()
         parsed = _parse_task_execute_request(data)

--- a/src/utils/internal_api_keys.py
+++ b/src/utils/internal_api_keys.py
@@ -47,7 +47,4 @@ def build_portal_internal_api_headers(include_content_type: bool = True) -> Dict
     token = get_portal_internal_auth_token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    api_key = get_portal_internal_api_key()
-    if api_key:
-        headers["X-Internal-Api-Key"] = api_key
     return headers

--- a/tests/test_adapter_boundaries.py
+++ b/tests/test_adapter_boundaries.py
@@ -115,7 +115,6 @@ def test_subagent_sessions_spawn_uses_execute_subagent_orchestration(monkeypatch
 @pytest.mark.asyncio
 async def test_webchat_tasks_execute_uses_execute_runtime_task_request(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", "runtime-internal-key")
     webchat.runtime_task_tracker.reset()
 
     captured = {}
@@ -141,7 +140,7 @@ async def test_webchat_tasks_execute_uses_execute_runtime_task_request(monkeypat
     monkeypatch.setattr(webchat, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
     class _Request:
-        headers = {"X-Internal-Api-Key": "runtime-internal-key"}
+        headers = {}
         async def json(self):
             return {
                 "task_id": "task-rt-1",

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -309,7 +309,6 @@ async def test_execute_adapter_action_portal_delete_task_agent_uses_delete(monke
 
 
 def test_build_portal_headers_no_longer_emits_config_fallback_api_key(monkeypatch):
-    monkeypatch.delenv("PORTAL_INTERNAL_API_KEY", raising=False)
     monkeypatch.delenv("PORTAL_INTERNAL_AUTH_TOKEN", raising=False)
     monkeypatch.setattr(
         "src.utils.internal_api_keys.global_config.get",
@@ -324,7 +323,6 @@ def test_build_portal_headers_no_longer_emits_config_fallback_api_key(monkeypatc
 
 
 def test_build_portal_headers_keeps_auth_token_without_internal_api_key(monkeypatch):
-    monkeypatch.delenv("PORTAL_INTERNAL_API_KEY", raising=False)
     monkeypatch.setenv("PORTAL_INTERNAL_AUTH_TOKEN", "legacy-token")
     monkeypatch.setattr(
         "src.utils.internal_api_keys.global_config.get",

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -179,7 +179,6 @@ async def test_execute_adapter_action_portal_create_delegation_normalizes_struct
         return {"success": True, "error": None, "result": {"delegation_id": "d-1"}}
 
     monkeypatch.setenv("PORTAL_INTERNAL_BASE_URL", "https://portal.internal")
-    monkeypatch.setenv("PORTAL_INTERNAL_API_KEY", "tok-1")
     monkeypatch.setattr("src.runtime.adapter_executor._post_portal_json", _fake_post)
 
     result = await execute_adapter_action(
@@ -201,7 +200,7 @@ async def test_execute_adapter_action_portal_create_delegation_normalizes_struct
     assert result["success"] is True
     assert result["system"] == "portal"
     assert captured["url"] == "https://portal.internal/api/internal/agent-delegations"
-    assert captured["headers"]["X-Internal-Api-Key"] == "tok-1"
+    assert "X-Internal-Api-Key" not in captured["headers"]
     assert "X-Portal-Internal-Api-Key" not in captured["headers"]
     assert isinstance(captured["payload"]["scoped_context_payload_json"], str)
     assert isinstance(captured["payload"]["input_artifacts_json"], str)
@@ -219,7 +218,6 @@ async def test_execute_adapter_action_portal_read_actions_use_get(monkeypatch):
         return {"success": True, "error": None, "result": {"items": []}}
 
     monkeypatch.setenv("PORTAL_INTERNAL_BASE_URL", "https://portal.internal")
-    monkeypatch.setenv("PORTAL_INTERNAL_API_KEY", "k-1")
     monkeypatch.setattr("src.runtime.adapter_executor._get_portal_json", _fake_get)
 
     result_a = await execute_adapter_action("adapter:portal:list_group_delegations", {"group_id": "group-1"})
@@ -238,7 +236,7 @@ async def test_execute_adapter_action_portal_read_actions_use_get(monkeypatch):
     assert captured[2][0] == "https://portal.internal/api/internal/agent-groups/group-1/coordination-runs"
     assert captured[3][0] == "https://portal.internal/api/internal/coordination-runs/coord-1"
     assert captured[4][0] == "https://portal.internal/api/internal/agent-groups/group-1/specialist-pool"
-    assert captured[0][1]["X-Internal-Api-Key"] == "k-1"
+    assert "X-Internal-Api-Key" not in captured[0][1]
 
 
 @pytest.mark.asyncio
@@ -252,7 +250,6 @@ async def test_execute_adapter_action_portal_create_task_agent_uses_post_and_nor
         return {"success": True, "error": None, "result": {"agent_id": "ta-1"}}
 
     monkeypatch.setenv("PORTAL_INTERNAL_BASE_URL", "https://portal.internal")
-    monkeypatch.setenv("PORTAL_INTERNAL_API_KEY", "k-1")
     monkeypatch.setattr("src.runtime.adapter_executor._post_portal_json", _fake_post)
 
     result = await execute_adapter_action(
@@ -271,7 +268,7 @@ async def test_execute_adapter_action_portal_create_task_agent_uses_post_and_nor
     assert captured["url"] == "https://portal.internal/api/internal/agent-groups/group-1/task-agents"
     assert isinstance(captured["payload"]["metadata"], str)
     assert isinstance(captured["payload"]["tags"], str)
-    assert captured["headers"]["X-Internal-Api-Key"] == "k-1"
+    assert "X-Internal-Api-Key" not in captured["headers"]
 
 
 @pytest.mark.asyncio
@@ -299,7 +296,6 @@ async def test_execute_adapter_action_portal_delete_task_agent_uses_delete(monke
         return {"success": True, "error": None, "result": {"deleted": True}}
 
     monkeypatch.setenv("PORTAL_INTERNAL_BASE_URL", "https://portal.internal")
-    monkeypatch.setenv("PORTAL_INTERNAL_API_KEY", "k-1")
     monkeypatch.setattr("src.runtime.adapter_executor._delete_portal_json", _fake_delete)
 
     result = await execute_adapter_action(
@@ -309,10 +305,10 @@ async def test_execute_adapter_action_portal_delete_task_agent_uses_delete(monke
 
     assert result["success"] is True
     assert captured["url"] == "https://portal.internal/api/internal/agent-groups/group-1/task-agents/ta-1"
-    assert captured["headers"]["X-Internal-Api-Key"] == "k-1"
+    assert "X-Internal-Api-Key" not in captured["headers"]
 
 
-def test_build_portal_headers_uses_config_fallback_api_key(monkeypatch):
+def test_build_portal_headers_no_longer_emits_config_fallback_api_key(monkeypatch):
     monkeypatch.delenv("PORTAL_INTERNAL_API_KEY", raising=False)
     monkeypatch.delenv("PORTAL_INTERNAL_AUTH_TOKEN", raising=False)
     monkeypatch.setattr(
@@ -323,11 +319,11 @@ def test_build_portal_headers_uses_config_fallback_api_key(monkeypatch):
     headers = _build_portal_headers()
 
     assert headers["Content-Type"] == "application/json"
-    assert headers["X-Internal-Api-Key"] == "cfg-key"
+    assert "X-Internal-Api-Key" not in headers
     assert "Authorization" not in headers
 
 
-def test_build_portal_headers_keeps_auth_token_and_config_fallback_api_key(monkeypatch):
+def test_build_portal_headers_keeps_auth_token_without_internal_api_key(monkeypatch):
     monkeypatch.delenv("PORTAL_INTERNAL_API_KEY", raising=False)
     monkeypatch.setenv("PORTAL_INTERNAL_AUTH_TOKEN", "legacy-token")
     monkeypatch.setattr(
@@ -338,7 +334,7 @@ def test_build_portal_headers_keeps_auth_token_and_config_fallback_api_key(monke
     headers = _build_portal_headers()
 
     assert headers["Authorization"] == "Bearer legacy-token"
-    assert headers["X-Internal-Api-Key"] == "cfg-key-2"
+    assert "X-Internal-Api-Key" not in headers
 
 
 @pytest.mark.asyncio

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -415,6 +415,23 @@ def test_build_portal_internal_api_headers_auth_token_env_precedence(monkeypatch
     assert headers["Authorization"] == "Bearer tok-env"
 
 
+def test_build_portal_internal_api_headers_contract_with_and_without_auth_token(monkeypatch):
+    monkeypatch.delenv("PORTAL_INTERNAL_AUTH_TOKEN", raising=False)
+
+    headers_without_token = build_portal_internal_api_headers(include_content_type=True)
+    assert headers_without_token["Content-Type"] == "application/json"
+    assert "Authorization" not in headers_without_token
+    assert "X-Internal-Api-Key" not in headers_without_token
+    assert "X-Portal-Internal-Api-Key" not in headers_without_token
+
+    monkeypatch.setenv("PORTAL_INTERNAL_AUTH_TOKEN", "token-123")
+    headers_with_token = build_portal_internal_api_headers(include_content_type=True)
+    assert headers_with_token["Content-Type"] == "application/json"
+    assert headers_with_token["Authorization"] == "Bearer token-123"
+    assert "X-Internal-Api-Key" not in headers_with_token
+    assert "X-Portal-Internal-Api-Key" not in headers_with_token
+
+
 @pytest.mark.asyncio
 async def test_create_portal_delegation_from_runtime_normalizes_result(monkeypatch):
     async def _fake_execute_adapter_action(action_id, kwargs):

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -1246,7 +1246,7 @@ async def test_api_capabilities_ignores_bad_internal_api_key_header(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_api_capabilities_allows_config_based_internal_api_key(monkeypatch):
+async def test_api_capabilities_ignores_configured_runtime_internal_api_key(monkeypatch):
     from src.gateway import webchat
 
     monkeypatch.delenv("RUNTIME_INTERNAL_API_KEY", raising=False)
@@ -1308,7 +1308,6 @@ async def test_api_tasks_execute_does_not_require_internal_api_key_not_configure
 async def test_api_tasks_execute_not_configured_does_not_log_auth_rejection(monkeypatch, caplog):
     from src.gateway import webchat
 
-    monkeypatch.delenv("RUNTIME_INTERNAL_API_KEY", raising=False)
     monkeypatch.setattr(webchat.global_config, "get", lambda *_args, **_kwargs: "")
     webchat.runtime_task_tracker.reset()
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 INTERNAL_API_KEY = "runtime-internal-key"
-INTERNAL_HEADERS = {"X-Internal-Api-Key": INTERNAL_API_KEY}
+INTERNAL_HEADERS = {}
 
 
 class TestWebChatTemplate:
@@ -519,7 +519,6 @@ async def test_api_chat_trusted_portal_metadata_passed_to_execution_bus(monkeypa
         captured.update(kwargs)
         return {"response": "ok", "usage": {}}
 
-    monkeypatch.setenv("PORTAL_INTERNAL_API_KEY", "portal-secret")
     monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
     monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
     monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
@@ -531,7 +530,6 @@ async def test_api_chat_trusted_portal_metadata_passed_to_execution_bus(monkeypa
         app = {}
         headers = {
             "X-Portal-Author-Source": "portal",
-            "X-Portal-Internal-Api-Key": "portal-secret",
         }
 
         async def json(self):
@@ -783,14 +781,12 @@ async def test_api_chat_stream_trusted_portal_metadata_passed_to_execution_bus(m
         async def write(self, data):
             self.writes.append(data)
 
-    monkeypatch.delenv("PORTAL_INTERNAL_API_KEY", raising=False)
-    monkeypatch.setenv("PORTAL_INTERNAL_API_KEY", "portal-secret-stream")
     monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
     monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
 
     class _Request:
         app = {}
-        headers = {"X-Portal-Author-Source": "portal", "X-Portal-Internal-Api-Key": "portal-secret-stream"}
+        headers = {"X-Portal-Author-Source": "portal"}
 
         async def json(self):
             return {
@@ -924,7 +920,7 @@ async def test_api_chat_direct_runtime_user_name_does_not_become_portal_identity
 
 
 @pytest.mark.asyncio
-async def test_portal_trust_uses_config_fallback_internal_key(monkeypatch):
+async def test_portal_trust_uses_portal_source_header_only(monkeypatch):
     from src.gateway import webchat
 
     captured = {}
@@ -933,12 +929,6 @@ async def test_portal_trust_uses_config_fallback_internal_key(monkeypatch):
         captured.update(kwargs)
         return {"response": "ok", "usage": {}}
 
-    monkeypatch.delenv("PORTAL_INTERNAL_API_KEY", raising=False)
-    monkeypatch.setattr(
-        webchat.global_config,
-        "get",
-        lambda key, default=None: "portal-cfg-key" if key == "server.portal_internal_api_key" else default,
-    )
     monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
     monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
     monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
@@ -950,7 +940,6 @@ async def test_portal_trust_uses_config_fallback_internal_key(monkeypatch):
         app = {}
         headers = {
             "X-Portal-Author-Source": "portal",
-            "X-Portal-Internal-Api-Key": "portal-cfg-key",
             "X-Portal-User-Id": "portal-u",
             "X-Portal-User-Name": "portal-name",
         }
@@ -1158,36 +1147,44 @@ async def test_api_capabilities_filters_by_capability_id_and_type(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_api_capabilities_requires_internal_api_key_not_configured(monkeypatch):
+async def test_api_capabilities_does_not_require_runtime_internal_api_key(monkeypatch):
     from src.gateway import webchat
 
     monkeypatch.delenv("RUNTIME_INTERNAL_API_KEY", raising=False)
-    monkeypatch.setattr(webchat.global_config, "get", lambda *_args, **_kwargs: "")
+    monkeypatch.setattr(webchat.global_config, "get", lambda key, default=None: default)
+
+    class _Registry:
+        def export_catalog_snapshot(self):
+            return {"capabilities": [{"capability_id": "tool:read", "type": "tool", "enabled": True}], "count": 1, "catalog_version": "v", "generated_at": "2026-04-07T00:00:00Z"}
+
+    monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
 
     class _Request:
         headers = {}
         query = {}
 
     response = await webchat.api_capabilities(_Request())
-    body = json.loads(response.body)
-    assert response.status == 503
-    assert body == {"error": "Runtime internal api key is not configured"}
+    assert response.status == 200
 
 
 @pytest.mark.asyncio
-async def test_api_capabilities_requires_internal_api_key_invalid(monkeypatch):
+async def test_api_capabilities_ignores_bad_internal_api_key_header(monkeypatch):
     from src.gateway import webchat
 
     monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
+
+    class _Registry:
+        def export_catalog_snapshot(self):
+            return {"capabilities": [{"capability_id": "tool:read", "type": "tool", "enabled": True}], "count": 1, "catalog_version": "v", "generated_at": "2026-04-07T00:00:00Z"}
+
+    monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
 
     class _Request:
         headers = {"X-Internal-Api-Key": "bad-key"}
         query = {}
 
     response = await webchat.api_capabilities(_Request())
-    body = json.loads(response.body)
-    assert response.status == 401
-    assert body == {"error": "Invalid internal api key"}
+    assert response.status == 200
 
 
 @pytest.mark.asyncio
@@ -1204,7 +1201,7 @@ async def test_api_capabilities_allows_config_based_internal_api_key(monkeypatch
     monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
 
     class _Request:
-        headers = {"X-Internal-Api-Key": "cfg-key"}
+        headers = {}
         query = {"enabled": "true"}
 
     response = await webchat.api_capabilities(_Request())
@@ -1212,81 +1209,156 @@ async def test_api_capabilities_allows_config_based_internal_api_key(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_requires_internal_api_key_not_configured(monkeypatch):
+async def test_api_tasks_execute_does_not_require_internal_api_key_not_configured(monkeypatch):
     from src.gateway import webchat
 
     monkeypatch.delenv("RUNTIME_INTERNAL_API_KEY", raising=False)
     monkeypatch.setattr(webchat.global_config, "get", lambda *_args, **_kwargs: "")
+    webchat.runtime_task_tracker.reset()
 
     class _Request:
         headers = {}
 
         async def json(self):
-            raise AssertionError("json() should not be called when auth fails")
+            return {"task_id": "task-no-key-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"success": True},
+                "artifacts": {},
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    spawned = []
+    monkeypatch.setattr(webchat, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(webchat, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
     response = await webchat.api_tasks_execute(_Request())
-    body = json.loads(response.body)
-    assert response.status == 503
-    assert body == {"error": "Runtime internal api key is not configured"}
+    assert response.status == 202
+    await spawned[0]
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_not_configured_logs_auth_summary(monkeypatch, caplog):
+async def test_api_tasks_execute_not_configured_does_not_log_auth_rejection(monkeypatch, caplog):
     from src.gateway import webchat
 
     monkeypatch.delenv("RUNTIME_INTERNAL_API_KEY", raising=False)
     monkeypatch.setattr(webchat.global_config, "get", lambda *_args, **_kwargs: "")
+    webchat.runtime_task_tracker.reset()
 
     class _Request:
         headers = {"X-Trace-Id": "trace-auth-503", "X-Portal-Dispatch-Id": "dispatch-1"}
 
         async def json(self):
-            raise AssertionError("json() should not be called when auth fails")
+            return {"task_id": "task-no-key-2", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"success": True},
+                "artifacts": {},
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    spawned = []
+    monkeypatch.setattr(webchat, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(webchat, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
     with caplog.at_level("WARNING"):
         response = await webchat.api_tasks_execute(_Request())
 
-    body = json.loads(response.body)
-    assert response.status == 503
-    assert body == {"error": "Runtime internal api key is not configured"}
-    assert "expected_key_configured=False" in caplog.text
-    assert "provided_key_present=False" in caplog.text
+    assert response.status == 202
+    assert "auth rejected" not in caplog.text.lower()
+    await spawned[0]
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_requires_internal_api_key_missing_header(monkeypatch):
+async def test_api_tasks_execute_ignores_missing_internal_api_key_header(monkeypatch):
     from src.gateway import webchat
 
     monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
+    webchat.runtime_task_tracker.reset()
 
     class _Request:
         headers = {}
 
         async def json(self):
-            raise AssertionError("json() should not be called when auth fails")
+            return {"task_id": "task-key-missing-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"success": True},
+                "artifacts": {},
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    spawned = []
+    monkeypatch.setattr(webchat, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(webchat, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
     response = await webchat.api_tasks_execute(_Request())
-    body = json.loads(response.body)
-    assert response.status == 401
-    assert body == {"error": "Invalid internal api key"}
+    assert response.status == 202
+    await spawned[0]
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_requires_internal_api_key_wrong_header(monkeypatch):
+async def test_api_tasks_execute_ignores_wrong_internal_api_key_header(monkeypatch):
     from src.gateway import webchat
 
     monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
+    webchat.runtime_task_tracker.reset()
 
     class _Request:
         headers = {"X-Internal-Api-Key": "wrong"}
 
         async def json(self):
-            raise AssertionError("json() should not be called when auth fails")
+            return {"task_id": "task-key-wrong-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"success": True},
+                "artifacts": {},
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    spawned = []
+    monkeypatch.setattr(webchat, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(webchat, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
     response = await webchat.api_tasks_execute(_Request())
-    body = json.loads(response.body)
-    assert response.status == 401
-    assert body == {"error": "Invalid internal api key"}
+    assert response.status == 202
+    await spawned[0]
 
 
 @pytest.mark.asyncio
@@ -1732,7 +1804,6 @@ async def test_api_tasks_execute_accepts_without_waiting_for_terminal_result(mon
 @pytest.mark.asyncio
 async def test_api_task_status_pending_and_auth(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
 
     class _ExecuteRequest:
@@ -1757,7 +1828,7 @@ async def test_api_task_status_pending_and_auth(monkeypatch):
         match_info = {"task_id": "task-pending-1"}
 
     bad_auth_response = await webchat.api_task_status(_StatusBadAuth())
-    assert bad_auth_response.status == 401
+    assert bad_auth_response.status == 200
 
     class _StatusRequest:
         headers = INTERNAL_HEADERS

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -166,6 +166,71 @@ def test_edit_delete_routes_registered():
     assert '/api/sessions/{session_id}/messages/{message_id}/delete-from-here' in routes
 
 
+class _HeaderOnlyRequest:
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+def test_authorize_internal_runtime_request_noop_when_key_unset_and_header_missing(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.delenv("RUNTIME_INTERNAL_API_KEY", raising=False)
+    assert webchat._authorize_internal_runtime_request(_HeaderOnlyRequest()) is None
+
+
+def test_authorize_internal_runtime_request_noop_when_key_set_and_header_missing(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
+    assert webchat._authorize_internal_runtime_request(_HeaderOnlyRequest()) is None
+
+
+def test_authorize_internal_runtime_request_noop_when_key_set_and_header_wrong(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
+    assert webchat._authorize_internal_runtime_request(_HeaderOnlyRequest({"X-Internal-Api-Key": "wrong"})) is None
+
+
+def test_authorize_internal_runtime_request_noop_when_key_set_and_header_valid(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
+    assert webchat._authorize_internal_runtime_request(_HeaderOnlyRequest({"X-Internal-Api-Key": INTERNAL_API_KEY})) is None
+
+
+def test_is_trusted_portal_request_true_for_portal_source():
+    from src.gateway import webchat
+
+    assert webchat._is_trusted_portal_request(_HeaderOnlyRequest({"X-Portal-Author-Source": "portal"})) is True
+
+
+def test_is_trusted_portal_request_false_when_missing_source():
+    from src.gateway import webchat
+
+    assert webchat._is_trusted_portal_request(_HeaderOnlyRequest({})) is False
+
+
+def test_is_trusted_portal_request_false_for_non_portal_source():
+    from src.gateway import webchat
+
+    assert webchat._is_trusted_portal_request(_HeaderOnlyRequest({"X-Portal-Author-Source": "runtime"})) is False
+
+
+def test_is_trusted_portal_request_ignores_internal_key_env_and_headers(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setenv("PORTAL_INTERNAL_API_KEY", "portal-secret")
+    trusted = webchat._is_trusted_portal_request(
+        _HeaderOnlyRequest({"X-Portal-Author-Source": "portal", "X-Portal-Internal-Api-Key": "wrong"})
+    )
+    untrusted = webchat._is_trusted_portal_request(
+        _HeaderOnlyRequest({"X-Portal-Author-Source": "runtime", "X-Portal-Internal-Api-Key": "portal-secret"})
+    )
+    assert trusted is True
+    assert untrusted is False
+
+
 @pytest.mark.asyncio
 async def test_chat_execution_bus_adapter_non_stream(monkeypatch):
     from src.gateway import webchat
@@ -561,7 +626,6 @@ async def test_api_chat_untrusted_request_ignores_governance_metadata(monkeypatc
         captured.update(kwargs)
         return {"response": "ok", "usage": {}}
 
-    monkeypatch.delenv("PORTAL_INTERNAL_API_KEY", raising=False)
     monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
     monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
     monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
@@ -595,7 +659,6 @@ async def test_api_chat_flattens_policy_context_derived_runtime_rules(monkeypatc
         captured.update(kwargs)
         return {"response": "ok", "usage": {}}
 
-    monkeypatch.delenv("PORTAL_INTERNAL_API_KEY", raising=False)
     monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
     monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
     monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
@@ -976,7 +1039,6 @@ async def test_api_chat_stream_trusted_request_does_not_accept_body_portal_ident
         async def write(self, data):
             self.writes.append(data)
 
-    monkeypatch.delenv("PORTAL_INTERNAL_API_KEY", raising=False)
     monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
     monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
 
@@ -1045,7 +1107,6 @@ def test_routes_include_tasks_execute_and_existing_chat_route():
 @pytest.mark.asyncio
 async def test_api_capabilities_returns_catalog_and_filters(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
 
     class _Registry:
         def export_catalog_snapshot(self):
@@ -1079,7 +1140,6 @@ async def test_api_capabilities_returns_catalog_and_filters(monkeypatch):
 @pytest.mark.asyncio
 async def test_api_capabilities_capability_id_not_found_returns_empty(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
 
     class _Registry:
         def export_catalog_snapshot(self):
@@ -1107,7 +1167,6 @@ async def test_api_capabilities_capability_id_not_found_returns_empty(monkeypatc
 @pytest.mark.asyncio
 async def test_api_capabilities_filters_by_capability_id_and_type(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
 
     class _Registry:
         def export_catalog_snapshot(self):
@@ -1171,7 +1230,6 @@ async def test_api_capabilities_does_not_require_runtime_internal_api_key(monkey
 async def test_api_capabilities_ignores_bad_internal_api_key_header(monkeypatch):
     from src.gateway import webchat
 
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
 
     class _Registry:
         def export_catalog_snapshot(self):
@@ -1291,7 +1349,6 @@ async def test_api_tasks_execute_not_configured_does_not_log_auth_rejection(monk
 async def test_api_tasks_execute_ignores_missing_internal_api_key_header(monkeypatch):
     from src.gateway import webchat
 
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
 
     class _Request:
@@ -1328,7 +1385,6 @@ async def test_api_tasks_execute_ignores_missing_internal_api_key_header(monkeyp
 async def test_api_tasks_execute_ignores_wrong_internal_api_key_header(monkeypatch):
     from src.gateway import webchat
 
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
 
     class _Request:
@@ -1364,7 +1420,6 @@ async def test_api_tasks_execute_ignores_wrong_internal_api_key_header(monkeypat
 @pytest.mark.asyncio
 async def test_api_tasks_execute_adapter_action_task_success(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
 
     captured = {}
@@ -1457,7 +1512,6 @@ async def test_api_tasks_execute_adapter_action_task_success(monkeypatch):
 @pytest.mark.asyncio
 async def test_api_tasks_execute_jira_workflow_review_task_success(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
     spawned = []
 
@@ -1509,7 +1563,6 @@ async def test_api_tasks_execute_jira_workflow_review_task_success(monkeypatch):
 @pytest.mark.asyncio
 async def test_api_tasks_execute_github_review_task_reaches_execution_bus(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
     spawned = []
 
@@ -1577,7 +1630,6 @@ async def test_api_tasks_execute_github_review_task_reaches_execution_bus(monkey
 @pytest.mark.asyncio
 async def test_api_tasks_execute_missing_task_type_returns_400(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
 
     class _Request:
         headers = INTERNAL_HEADERS
@@ -1596,7 +1648,6 @@ async def test_api_tasks_execute_missing_task_type_returns_400(monkeypatch):
 @pytest.mark.asyncio
 async def test_api_tasks_execute_non_object_input_payload_returns_400(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
 
     class _Request:
         headers = INTERNAL_HEADERS
@@ -1616,7 +1667,6 @@ async def test_api_tasks_execute_non_object_input_payload_returns_400(monkeypatc
 @pytest.mark.asyncio
 async def test_api_tasks_execute_non_object_context_ref_returns_400(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
 
     class _Request:
         headers = INTERNAL_HEADERS
@@ -1637,7 +1687,6 @@ async def test_api_tasks_execute_non_object_context_ref_returns_400(monkeypatch)
 @pytest.mark.asyncio
 async def test_api_tasks_execute_blocked_result_returns_ok_false(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
     spawned = []
 
@@ -1688,7 +1737,6 @@ async def test_api_tasks_execute_blocked_result_returns_ok_false(monkeypatch):
 @pytest.mark.asyncio
 async def test_api_tasks_execute_tracing_headers_merge_to_metadata_and_response(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
 
     captured = {}
@@ -1757,7 +1805,6 @@ async def test_api_tasks_execute_tracing_headers_merge_to_metadata_and_response(
 @pytest.mark.asyncio
 async def test_api_tasks_execute_accepts_without_waiting_for_terminal_result(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
 
     started = asyncio.Event()
@@ -1846,7 +1893,6 @@ async def test_api_task_status_pending_and_auth(monkeypatch):
 @pytest.mark.asyncio
 async def test_api_task_status_returns_error_payload_when_background_crashes(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
     spawned = []
 
@@ -1879,7 +1925,6 @@ async def test_api_task_status_returns_error_payload_when_background_crashes(mon
 @pytest.mark.asyncio
 async def test_api_tasks_execute_spawn_failure_removes_pending_record(monkeypatch):
     from src.gateway import webchat
-    monkeypatch.setenv("RUNTIME_INTERNAL_API_KEY", INTERNAL_API_KEY)
     webchat.runtime_task_tracker.reset()
 
     monkeypatch.setattr(webchat, "_spawn_runtime_background_task", lambda _coro: (_ for _ in ()).throw(RuntimeError("spawn failed")))


### PR DESCRIPTION
### Motivation
- Temporarily remove application-layer Portal↔Runtime API-key enforcement so the runtime accepts Portal-proxied requests in an internal-VPC Portal-only deployment without changing the broader trust model.
- Preserve the existing Portal-origin trust concept (`X-Portal-Author-Source: portal`) and keep Runtime→Portal base-URL and optional auth-token behavior intact for adapter calls.
- Make a minimal, focused change to avoid refactors and keep compatibility for future re-introduction of keys.

### Description
- Made `_authorize_internal_runtime_request` in `src/gateway/webchat.py` an explicit permissive no-op (returns `None`) and added comments documenting that enforcement is intentionally disabled for this deployment model.
- Simplified `_is_trusted_portal_request` in `src/gateway/webchat.py` to only require `X-Portal-Author-Source == portal` and removed the `X-Portal-Internal-Api-Key` check and related hmac/config usage; removed now-unused imports in the file.
- Updated `src/utils/internal_api_keys.py` so `build_portal_internal_api_headers()` no longer emits `X-Internal-Api-Key`, while retaining `Content-Type`, optional `Authorization: Bearer ...`, and the `PORTAL_INTERNAL_BASE_URL` helpers; left getter helpers in place for compatibility.
- Adjusted Runtime adapter and session publish flows to keep using `build_portal_internal_api_headers(include_content_type=True)` and `PORTAL_INTERNAL_BASE_URL` without emitting `X-Internal-Api-Key` (no behavioral changes to URLs or action routing).
- Updated tests to match the new contract: removed assertions expecting 503/401 on missing/invalid runtime keys and removed expectations that Runtime→Portal calls include `X-Internal-Api-Key`; modified `tests/test_webchat.py`, `tests/test_adapter_executor.py`, and `tests/test_adapter_boundaries.py` accordingly.
- Updated focused documentation and config comments (`README.md`, `docs/control_plane_contract.md`, `config.yaml.example`) to reflect that runtime endpoints are currently permissive in the Portal-only internal-VPC topology while keeping `PORTAL_INTERNAL_BASE_URL` support documented.

### Testing
- Ran targeted unit tests: `pytest -q tests/test_webchat.py tests/test_adapter_executor.py tests/test_adapter_boundaries.py`, all tests passed (`101 passed`).
- Performed repository search for key tokens (`X-Internal-Api-Key`, `X-Portal-Internal-Api-Key`, `RUNTIME_INTERNAL_API_KEY`, `PORTAL_INTERNAL_API_KEY`) and verified runtime request-acceptance paths no longer require these keys.
- Updated/added tests verify that Portal-origin detection still requires `X-Portal-Author-Source: portal`, runtime internal endpoints work without `RUNTIME_INTERNAL_API_KEY`, and Runtime→Portal header builder no longer emits `X-Internal-Api-Key`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3b7ab840832a9379d9181363cca8)