### PR TITLE
Add dedicated /api/server-files namespace for workspace file management

### DIFF
--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -34,6 +34,11 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _runtime_workspace_root() -> Path:
+    """Canonical runtime workspace root."""
+    return (Path.home() / ".efp" / "workspace").resolve()
+
+
 def verify_discord_signature(payload: bytes, signature: str, secret: str) -> bool:
     """Verify Discord webhook signature using HMAC SHA-256.
 
@@ -793,7 +798,7 @@ class Gateway:
 
             logger.info("[Memory] Starting background bootstrap...")
 
-            workspace = runtime_config.session.get("workspace", "/root/.efp/workspace")
+            workspace = runtime_config.session.get("workspace", str(_runtime_workspace_root()))
 
             # Create daily memories (without LLM for now)
             created_daily = await ensure_daily_memories(

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -464,7 +464,7 @@ class Gateway:
         # Get file path (fixed path) - not applicable for daily_notes
         content = ""
         if name != "daily_notes":
-            workspace = Path.home() / ".efp" / "workspace"
+            workspace = _runtime_workspace_root()
             file_path = workspace / f"{name.upper()}.md"
             if file_path.exists():
                 content = file_path.read_text(encoding="utf-8")
@@ -495,7 +495,7 @@ class Gateway:
             
             # Update file content if provided
             if "content" in data:
-                workspace = Path.home() / ".efp" / "workspace"
+                workspace = _runtime_workspace_root()
                 workspace.mkdir(parents=True, exist_ok=True)
                 file_path = workspace / f"{name.upper()}.md"
                 file_path.write_text(data["content"], encoding="utf-8")

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1960,14 +1960,15 @@
         await refreshFileList();
     }
 
-    async function showFileExplorer(path = '/root') {
+    async function showFileExplorer(path = '') {
         fileExplorerPanel.classList.add('show');
         fileExplorerContent.innerHTML = '<div class="loading">Loading...</div>';
         const feTitle = document.getElementById('fileExplorerTitle');
         if (feTitle) feTitle.textContent = 'Server Files';
 
         try {
-            const response = await fetch(`/api/files?path=${encodeURIComponent(path)}`);
+            const browseUrl = path ? `/api/server-files?path=${encodeURIComponent(path)}` : '/api/server-files';
+            const response = await fetch(browseUrl);
             const data = await response.json();
 
             if (data.error) {
@@ -1975,17 +1976,22 @@
                 return;
             }
 
-            const pathParts = data.path.split('/').filter(p => p);
+            const rootPath = data.root_path || '';
+            const activePath = data.path || rootPath;
+            let pathParts = [];
+            if (rootPath && activePath.startsWith(rootPath)) {
+                const relativePath = activePath.slice(rootPath.length).replace(/^\/+/, '');
+                pathParts = relativePath ? relativePath.split('/') : [];
+            } else {
+                pathParts = activePath.split('/').filter(p => p);
+            }
+
             let pathHtml = '<div class="file-explorer-path">';
-            pathHtml += '<button data-path="/">🏠</button>';
-            let currentPath = '';
-            let isFirst = true;
+            pathHtml += '<button data-path="">workspace</button>';
+            let currentPath = rootPath;
             pathParts.forEach(part => {
-                currentPath += '/' + part;
-                if (!isFirst) {
-                    pathHtml += '<span class="separator">/</span>';
-                }
-                isFirst = false;
+                currentPath = currentPath ? `${currentPath}/${part}` : part;
+                pathHtml += '<span class="separator">/</span>';
                 pathHtml += '<button data-path="' + currentPath + '">' + escapeHtml(part) + '</button>';
             });
             pathHtml += '</div>';
@@ -2063,15 +2069,67 @@
     const fileViewerTitleText = document.getElementById('fileViewerTitleText');
     const fileViewerContent = document.getElementById('fileViewerContent');
 
+    function getFileNameFromPath(path) {
+        const parts = (path || '').split('/').filter(Boolean);
+        return parts.length ? parts[parts.length - 1] : 'workspace-file';
+    }
+
+    function shouldInlinePreview(path) {
+        const lowerPath = (path || '').toLowerCase();
+        const imageExt = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'];
+        const pdfExt = ['.pdf'];
+        const audioExt = ['.mp3', '.wav', '.ogg', '.m4a', '.aac', '.flac'];
+        const videoExt = ['.mp4', '.webm', '.mov', '.mkv', '.avi'];
+        return [...imageExt, ...pdfExt, ...audioExt, ...videoExt].some(ext => lowerPath.endsWith(ext));
+    }
+
+    function renderInlinePreview(path) {
+        const encodedPath = encodeURIComponent(path);
+        const contentUrl = `/api/server-files/content?path=${encodedPath}`;
+        const lowerPath = (path || '').toLowerCase();
+        const isImage = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'].some(ext => lowerPath.endsWith(ext));
+        const isPdf = lowerPath.endsWith('.pdf');
+        const isAudio = ['.mp3', '.wav', '.ogg', '.m4a', '.aac', '.flac'].some(ext => lowerPath.endsWith(ext));
+        const isVideo = ['.mp4', '.webm', '.mov', '.mkv', '.avi'].some(ext => lowerPath.endsWith(ext));
+
+        let viewer = `<div class="file-explorer-error">Preview not available</div>`;
+        if (isImage) {
+            viewer = `<img src="${contentUrl}" alt="${escapeHtml(getFileNameFromPath(path))}" style="max-width:100%;max-height:70vh;object-fit:contain;" />`;
+        } else if (isPdf) {
+            viewer = `<iframe src="${contentUrl}" style="width:100%;height:70vh;border:0;" title="${escapeHtml(getFileNameFromPath(path))}"></iframe>`;
+        } else if (isAudio) {
+            viewer = `<audio controls src="${contentUrl}" style="width:100%;"></audio>`;
+        } else if (isVideo) {
+            viewer = `<video controls src="${contentUrl}" style="max-width:100%;max-height:70vh;"></video>`;
+        }
+
+        fileViewerContent.innerHTML = `
+            <div class="file-viewer-info">
+                <span>${escapeHtml(path)}</span>
+            </div>
+            <div class="file-viewer-media">${viewer}</div>
+        `;
+    }
+
     async function showFileViewer(path) {
         fileViewerPanel.classList.add('show');
         fileViewerContent.innerHTML = '<div class="loading">Loading...</div>';
+        fileViewerTitleText.textContent = getFileNameFromPath(path);
 
         try {
-            const response = await fetch(`/api/files/read?path=${encodeURIComponent(path)}`);
+            if (shouldInlinePreview(path)) {
+                renderInlinePreview(path);
+                return;
+            }
+
+            const response = await fetch(`/api/server-files/read?path=${encodeURIComponent(path)}`);
             const data = await response.json();
 
             if (data.error) {
+                if ((data.error || '').includes('/api/server-files/content')) {
+                    renderInlinePreview(path);
+                    return;
+                }
                 fileViewerContent.innerHTML = `<div class="file-explorer-error">${escapeHtml(data.error)}</div>`;
                 return;
             }

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -3035,7 +3035,8 @@ def setup_webchat_routes(app: web.Application):
         GET  /api/tasks/{task_id} - Runtime task status for portal polling
         GET  /api/sessions - List recent sessions
         GET  /api/sessions/{session_id} - Load session messages
-        GET  /api/files    - Browse files
+        GET  /api/server-files - Browse workspace files (primary API)
+        GET  /api/files    - Legacy compatibility alias for server file browse
         GET  /api/usage   - Get usage stats
         POST /api/clear   - Clear session
         GET  /api/skills  - Get available skills
@@ -3051,13 +3052,16 @@ def setup_webchat_routes(app: web.Application):
     app.router.add_get('/api/sessions', api_sessions)
     app.router.add_get('/api/sessions/{session_id}', api_load_session)
     app.router.add_get('/api/sessions/{session_id}/chatlog', api_session_chatlog)
-    app.router.add_get('/api/files', api_browse_files)
-    app.router.add_get('/api/files/read', api_read_file)
+    # Primary workspace path-based API
     app.router.add_get('/api/server-files', api_server_files_browse)
     app.router.add_get('/api/server-files/read', api_server_files_read)
     app.router.add_get('/api/server-files/content', api_server_files_content)
     app.router.add_post('/api/server-files/upload', api_server_files_upload)
     app.router.add_get('/api/server-files/download', api_server_files_download)
+
+    # Legacy compatibility aliases for older clients (path-based)
+    app.router.add_get('/api/files', api_browse_files)
+    app.router.add_get('/api/files/read', api_read_file)
     app.router.add_get('/api/usage', api_usage)
     app.router.add_post('/api/clear', api_clear)
     app.router.add_post('/api/sessions/{session_id}/messages/{message_id}/edit', api_edit_message)
@@ -3101,13 +3105,13 @@ def setup_webchat_routes(app: web.Application):
     logger.info("  GET  /api/tasks/{task_id} - Runtime task status for portal polling")
     logger.info("  GET  /api/sessions - List recent sessions")
     logger.info("  GET  /api/sessions/{id} - Load session messages")
-    logger.info("  GET  /api/files    - Browse files")
-    logger.info("  GET  /api/files/read - Read file content")
     logger.info("  GET  /api/server-files - Browse workspace files")
     logger.info("  GET  /api/server-files/read - Read text file content")
     logger.info("  GET  /api/server-files/content - Inline file content")
     logger.info("  POST /api/server-files/upload - Upload/extract files into workspace")
     logger.info("  GET  /api/server-files/download - Download file(s) from workspace")
+    logger.info("  GET  /api/files (legacy alias) - Compatibility browse route")
+    logger.info("  GET  /api/files/read (legacy alias) - Compatibility text-read route")
     logger.info("  GET  /api/usage   - Get usage stats")
     logger.info("  POST /api/clear   - Clear session")
     logger.info("  GET  /api/skills  - Get available skills")

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -3035,8 +3035,9 @@ def setup_webchat_routes(app: web.Application):
         GET  /api/tasks/{task_id} - Runtime task status for portal polling
         GET  /api/sessions - List recent sessions
         GET  /api/sessions/{session_id} - Load session messages
-        GET  /api/server-files - Browse workspace files (primary API)
-        GET  /api/files    - Legacy compatibility alias for server file browse
+        GET  /api/server-files/* - Canonical path-based workspace file API
+        GET  /api/files and /api/files/read - Legacy path-based compatibility aliases
+        /api/files/{file_id}* - File-ID attachment APIs (separate from path-based server files)
         GET  /api/usage   - Get usage stats
         POST /api/clear   - Clear session
         GET  /api/skills  - Get available skills
@@ -3074,7 +3075,7 @@ def setup_webchat_routes(app: web.Application):
     app.router.add_post('/api/copilot/auth/start', api_copilot_auth_start)
     app.router.add_post('/api/copilot/auth/check', api_copilot_auth_check)
     
-    # File upload/parse routes
+    # Attachment APIs (file-id based, separate from path-based server-files routes)
     app.router.add_post('/api/files/upload', api_files_upload)
     app.router.add_post('/api/files/parse', api_files_parse)
     app.router.add_get('/api/files/list', api_files_list)
@@ -3112,6 +3113,7 @@ def setup_webchat_routes(app: web.Application):
     logger.info("  GET  /api/server-files/download - Download file(s) from workspace")
     logger.info("  GET  /api/files (legacy alias) - Compatibility browse route")
     logger.info("  GET  /api/files/read (legacy alias) - Compatibility text-read route")
+    logger.info("  /api/files/{file_id}* - Attachment APIs (file-id based, separate namespace)")
     logger.info("  GET  /api/usage   - Get usage stats")
     logger.info("  POST /api/clear   - Clear session")
     logger.info("  GET  /api/skills  - Get available skills")

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -12,8 +12,13 @@ import os
 import re
 import uuid
 import time
+import io
+import mimetypes
+import shutil
+import zipfile
 from datetime import datetime
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any, Dict, List, Optional
 from aiohttp import web, ContentTypeError
 import sys
@@ -1463,92 +1468,289 @@ async def api_session_chatlog(request: web.Request) -> web.Response:
         return web.json_response({'error': str(e)}, status=500)
 
 
-async def api_browse_files(request: web.Request) -> web.Response:
-    """Browse file directory.
-    
-    GET /api/files?path=/workspace
-    Returns: List of files and directories
-    """
+def _workspace_root() -> Path:
+    return (Path.home() / ".efp" / "workspace").resolve()
+
+
+def _is_within_root(path: Path, root: Path) -> bool:
     try:
-        # Default to /root for file browser
-        path = request.query.get('path', '/root')
-        base_path = Path(path)
-        
+        return path == root or root in path.parents
+    except Exception:
+        return False
+
+
+def _resolve_server_file_path(raw_path: Optional[str]) -> Path:
+    """Resolve user-supplied path against workspace root and enforce boundary."""
+    root = _workspace_root()
+    value = (raw_path or "").strip()
+    if not value:
+        candidate = root
+    else:
+        supplied = Path(value)
+        if supplied.is_absolute():
+            candidate = supplied.resolve(strict=False)
+        else:
+            candidate = (root / supplied).resolve(strict=False)
+
+    if not _is_within_root(candidate, root):
+        raise web.HTTPBadRequest(text=json.dumps({"error": "Path must be within workspace root"}), content_type="application/json")
+    return candidate
+
+
+def _server_file_language(path: Path) -> str:
+    language_map = {
+        '.py': 'python',
+        '.js': 'javascript',
+        '.ts': 'typescript',
+        '.html': 'html',
+        '.css': 'css',
+        '.json': 'json',
+        '.md': 'markdown',
+        '.yaml': 'yaml',
+        '.yml': 'yaml',
+        '.sh': 'bash',
+        '.sql': 'sql',
+        '.xml': 'xml',
+        '.csv': 'csv',
+    }
+    return language_map.get(path.suffix.lower(), 'text')
+
+
+def _server_file_content_type(path: Path) -> str:
+    return mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+
+
+def _create_server_files_zip(paths: List[Path]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for entry in paths:
+            if entry.is_dir():
+                for root, _, files in os.walk(entry):
+                    for file_name in files:
+                        file_path = Path(root) / file_name
+                        arcname = file_path.relative_to(entry.parent)
+                        zf.write(file_path, str(arcname))
+            elif entry.is_file():
+                zf.write(entry, entry.name)
+    return buffer.getvalue()
+
+
+async def api_server_files_browse(request: web.Request) -> web.Response:
+    """Browse workspace files rooted at ~/.efp/workspace."""
+    try:
+        base_path = _resolve_server_file_path(request.query.get('path'))
+        logger.debug("[server-files] browse path=%s", base_path)
+
         if not base_path.exists():
-            return web.json_response({'error': 'Path not found', 'path': path}, status=404)
-        
+            return web.json_response({'error': 'Path not found', 'path': str(base_path)}, status=404)
+        if not base_path.is_dir():
+            return web.json_response({'error': 'Path is not a directory', 'path': str(base_path)}, status=400)
+
         items = []
-        for item in sorted(base_path.iterdir()):
-            items.append({
+        for item in sorted(base_path.iterdir(), key=lambda value: (not value.is_dir(), value.name.lower())):
+            data = {
                 'name': item.name,
                 'path': str(item.resolve()),
                 'is_dir': item.is_dir(),
                 'is_file': item.is_file(),
-            })
-        
-        return web.json_response({'path': str(base_path.resolve()), 'items': items})
+            }
+            if item.is_file():
+                data['size'] = item.stat().st_size
+            items.append(data)
+
+        return web.json_response({
+            'root_path': str(_workspace_root()),
+            'path': str(base_path.resolve()),
+            'items': items,
+        })
+    except web.HTTPBadRequest as exc:
+        return web.json_response(json.loads(exc.text), status=400)
     except Exception as e:
-        logger.error(f"Error browsing files: {e}")
+        logger.error(f"Error browsing server files: {e}")
         return web.json_response({'error': str(e)}, status=500)
 
 
-async def api_read_file(request: web.Request) -> web.Response:
-    """Read file content.
-    
-    GET /api/files/read?path=/path/to/file
-    Returns: File content and metadata
-    """
+async def api_server_files_read(request: web.Request) -> web.Response:
+    """Read UTF-8 text files under workspace root."""
     try:
-        path = request.query.get('path', '')
-        if not path:
-            return web.json_response({'error': 'Path required'}, status=400)
-        
-        file_path = Path(path)
-        
+        file_path = _resolve_server_file_path(request.query.get('path'))
         if not file_path.exists():
-            return web.json_response({'error': 'File not found', 'path': path}, status=404)
-        
+            return web.json_response({'error': 'File not found', 'path': str(file_path)}, status=404)
         if not file_path.is_file():
-            return web.json_response({'error': 'Not a file', 'path': path}, status=400)
-        
-        # Read file content
-        content = file_path.read_text(encoding='utf-8')
-        
-        # Determine language for syntax highlighting
-        ext = file_path.suffix.lower()
-        language_map = {
-            '.py': 'python',
-            '.js': 'javascript',
-            '.ts': 'typescript',
-            '.html': 'html',
-            '.css': 'css',
-            '.json': 'json',
-            '.md': 'markdown',
-            '.yaml': 'yaml',
-            '.yml': 'yaml',
-            '.sh': 'bash',
-            '.sql': 'sql',
-            '.xml': 'xml',
-            '.csv': 'csv',
-        }
-        language = language_map.get(ext, 'text')
-        
+            return web.json_response({'error': 'Not a file', 'path': str(file_path)}, status=400)
+
+        try:
+            content = file_path.read_text(encoding='utf-8')
+        except UnicodeDecodeError:
+            return web.json_response({
+                'error': 'Cannot read binary file; use /api/server-files/content for inline preview',
+                'path': str(file_path),
+            }, status=400)
+
         return web.json_response({
             'path': str(file_path.resolve()),
             'name': file_path.name,
             'size': file_path.stat().st_size,
             'content': content,
-            'language': language,
+            'language': _server_file_language(file_path),
+            'content_type': _server_file_content_type(file_path),
         })
-    except UnicodeDecodeError:
-        # Binary file
-        return web.json_response({
-            'error': 'Cannot read binary file',
-            'path': path,
-        }, status=400)
+    except web.HTTPBadRequest as exc:
+        return web.json_response(json.loads(exc.text), status=400)
     except Exception as e:
-        logger.error(f"Error reading file: {e}")
+        logger.error(f"Error reading server file: {e}")
         return web.json_response({'error': str(e)}, status=500)
+
+
+async def api_server_files_content(request: web.Request) -> web.Response:
+    """Serve file bytes for inline browser preview."""
+    try:
+        file_path = _resolve_server_file_path(request.query.get('path'))
+        logger.debug("[server-files] content path=%s", file_path)
+        if not file_path.exists():
+            return web.json_response({'error': 'File not found', 'path': str(file_path)}, status=404)
+        if not file_path.is_file():
+            return web.json_response({'error': 'Not a file', 'path': str(file_path)}, status=400)
+
+        response = web.FileResponse(file_path)
+        response.content_type = _server_file_content_type(file_path)
+        response.headers['Content-Disposition'] = f'inline; filename="{file_path.name}"'
+        return response
+    except web.HTTPBadRequest as exc:
+        return web.json_response(json.loads(exc.text), status=400)
+    except Exception as e:
+        logger.error(f"Error serving server file content: {e}")
+        return web.json_response({'error': str(e)}, status=500)
+
+
+async def api_server_files_upload(request: web.Request) -> web.Response:
+    """Upload files to workspace root (with optional ZIP extraction)."""
+    try:
+        reader = await request.multipart()
+        upload_field = None
+        target_path_raw: Optional[str] = None
+
+        while True:
+            field = await reader.next()
+            if field is None:
+                break
+            if field.name == 'path':
+                target_path_raw = await field.text()
+            elif field.name == 'file' and upload_field is None:
+                upload_field = field
+
+        if upload_field is None:
+            return web.json_response({'success': False, 'error': 'file is required'}, status=400)
+
+        target_dir = _resolve_server_file_path(target_path_raw)
+        if not target_dir.exists():
+            return web.json_response({'success': False, 'error': 'Target path not found'}, status=404)
+        if not target_dir.is_dir():
+            return web.json_response({'success': False, 'error': 'Target path must be a directory'}, status=400)
+
+        filename = Path(upload_field.filename or 'upload.bin').name
+        logger.info("[server-files] upload target=%s filename=%s", target_dir, filename)
+        payload = await upload_field.read(decode=False)
+
+        if filename.lower().endswith('.zip'):
+            try:
+                archive = zipfile.ZipFile(io.BytesIO(payload))
+            except zipfile.BadZipFile:
+                return web.json_response({'success': False, 'error': 'Invalid ZIP archive'}, status=400)
+
+            items: List[str] = []
+            extracted_count = 0
+            with archive:
+                for member in archive.infolist():
+                    member_path = PurePosixPath(member.filename)
+                    if not member.filename or member.filename.endswith('/'):
+                        continue
+                    if member_path.is_absolute() or '..' in member_path.parts:
+                        return web.json_response({'success': False, 'error': f'Unsafe ZIP entry: {member.filename}'}, status=400)
+
+                    destination = (target_dir / Path(*member_path.parts)).resolve(strict=False)
+                    if not _is_within_root(destination, target_dir):
+                        return web.json_response({'success': False, 'error': f'Unsafe ZIP entry: {member.filename}'}, status=400)
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    with archive.open(member, 'r') as source, open(destination, 'wb') as sink:
+                        shutil.copyfileobj(source, sink)
+                    items.append(str(destination))
+                    extracted_count += 1
+
+            logger.info("[server-files] zip extract target=%s count=%s", target_dir, extracted_count)
+            return web.json_response({
+                'success': True,
+                'mode': 'zip_extract',
+                'target_path': str(target_dir),
+                'uploaded_filename': filename,
+                'extracted_count': extracted_count,
+                'items': items,
+            })
+
+        destination = (target_dir / filename).resolve(strict=False)
+        if not _is_within_root(destination, target_dir):
+            return web.json_response({'success': False, 'error': 'Invalid target filename'}, status=400)
+        with open(destination, 'wb') as output:
+            output.write(payload)
+
+        return web.json_response({
+            'success': True,
+            'mode': 'file_save',
+            'target_path': str(target_dir),
+            'uploaded_filename': filename,
+            'saved_path': str(destination),
+        })
+    except web.HTTPBadRequest as exc:
+        return web.json_response({'success': False, **json.loads(exc.text)}, status=400)
+    except Exception as e:
+        logger.error(f"Error uploading server file: {e}")
+        return web.json_response({'success': False, 'error': str(e)}, status=500)
+
+
+async def api_server_files_download(request: web.Request) -> web.Response:
+    """Download one or more files/directories rooted under workspace."""
+    try:
+        raw_paths = list(request.query.getall('paths', []))
+        if not raw_paths and request.query.get('path'):
+            raw_paths.append(request.query.get('path', ''))
+        if not raw_paths:
+            return web.json_response({'success': False, 'error': 'path is required'}, status=400)
+
+        resolved_paths = [_resolve_server_file_path(raw) for raw in raw_paths if raw is not None]
+        for resolved in resolved_paths:
+            if not resolved.exists():
+                return web.json_response({'success': False, 'error': 'File not found', 'path': str(resolved)}, status=404)
+
+        logger.debug("[server-files] download paths=%s", ",".join(str(path) for path in resolved_paths))
+        if len(resolved_paths) == 1 and resolved_paths[0].is_file():
+            file_path = resolved_paths[0]
+            response = web.FileResponse(file_path)
+            response.content_type = _server_file_content_type(file_path)
+            response.headers['Content-Disposition'] = f'attachment; filename="{file_path.name}"'
+            return response
+
+        archive = await asyncio.to_thread(_create_server_files_zip, resolved_paths)
+        archive_name = f"{resolved_paths[0].name}.zip" if len(resolved_paths) == 1 else "files.zip"
+        return web.Response(
+            body=archive,
+            content_type='application/zip',
+            headers={'Content-Disposition': f'attachment; filename="{archive_name}"'},
+        )
+    except web.HTTPBadRequest as exc:
+        return web.json_response({'success': False, **json.loads(exc.text)}, status=400)
+    except Exception as e:
+        logger.error(f"Error downloading server files: {e}")
+        return web.json_response({'success': False, 'error': str(e)}, status=500)
+
+
+async def api_browse_files(request: web.Request) -> web.Response:
+    """Backward-compatible alias for legacy file browsing endpoint."""
+    return await api_server_files_browse(request)
+
+
+async def api_read_file(request: web.Request) -> web.Response:
+    """Backward-compatible alias for legacy text file reader endpoint."""
+    return await api_server_files_read(request)
 
 
 async def api_usage(request: web.Request) -> web.Response:
@@ -2778,178 +2980,8 @@ async def api_files_get(request: web.Request) -> web.Response:
 
 
 async def api_files_download(request: web.Request) -> web.Response:
-    """Download files.
-    
-    GET /api/files/download?paths=<file_path>
-    GET /api/files/download?paths=<file1>&paths=<file2>&...  (multiple)
-    
-    Returns:
-        200: File or ZIP archive
-        404: File not found
-    """
-    try:
-        import io
-        import os
-        import zipfile
-        from pathlib import Path
-        from typing import List
-        
-        # Get file paths from query param (support multiple 'paths')
-        # Collect all 'paths' and 'path' values from query string
-        file_paths = []
-        for key, value in request.query.items():
-            if key == 'paths' or key == 'path':
-                if value:
-                    file_paths.append(value)
-        
-        if not file_paths:
-            return web.json_response({
-                'success': False,
-                'error': 'path is required'
-            }, status=400)
-        
-        # Security: restrict paths to workspace directory
-        workspace_root = Path.home() / ".efp" / "workspace"
-        
-        def is_safe_path(path: str) -> bool:
-            """Check if path is within workspace directory."""
-            try:
-                resolved = Path(path).resolve()
-                # Check if resolved path is within workspace
-                return str(resolved).startswith(str(workspace_root))
-            except Exception:
-                return False
-        
-        # Validate all paths are within workspace
-        for fp in file_paths:
-            if not is_safe_path(fp):
-                return web.json_response({
-                    'success': False,
-                    'error': 'Path must be within workspace directory'
-                }, status=400)
-        
-        # Handle single file or directory
-        if len(file_paths) == 1:
-            file_path = file_paths[0]
-            try:
-                resolved_path = Path(file_path).resolve()
-            except Exception:
-                return web.json_response({
-                    'success': False,
-                    'error': 'Invalid path'
-                }, status=400)
-            
-            if not resolved_path.exists():
-                return web.json_response({
-                    'success': False,
-                    'error': 'File not found'
-                }, status=404)
-            
-            # If it's a directory, create a ZIP of the entire directory
-            if resolved_path.is_dir():
-                def create_dir_zip():
-                    buffer = io.BytesIO()
-                    with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-                        for root, dirs, files in os.walk(resolved_path):
-                            for file in files:
-                                file_path = os.path.join(root, file)
-                                arcname = os.path.relpath(file_path, resolved_path.parent)
-                                zf.write(file_path, arcname)
-                    return buffer.getvalue()
-                
-                content = await asyncio.to_thread(create_dir_zip)
-                
-                response = web.Response(
-                    body=content,
-                    content_type='application/zip',
-                    headers={
-                        'Content-Disposition': f'attachment; filename="{resolved_path.name}.zip"'
-                    }
-                )
-                return response
-            
-            # Single file download
-            if not resolved_path.is_file():
-                return web.json_response({
-                    'success': False,
-                    'error': 'File not found'
-                }, status=404)
-            
-            # Determine content type
-            content_type = 'application/octet-stream'
-            suffix = resolved_path.suffix.lower()
-            if suffix == '.md':
-                content_type = 'text/markdown'
-            elif suffix == '.txt':
-                content_type = 'text/plain'
-            elif suffix == '.json':
-                content_type = 'application/json'
-            elif suffix == '.py':
-                content_type = 'text/x-python'
-            elif suffix in ['.jpg', '.jpeg']:
-                content_type = 'image/jpeg'
-            elif suffix == '.png':
-                content_type = 'image/png'
-            elif suffix == '.pdf':
-                content_type = 'application/pdf'
-            
-            # Read file synchronously
-            def read_file():
-                with open(resolved_path, 'rb') as f:
-                    return f.read()
-            
-            content = await asyncio.to_thread(read_file)
-            
-            # Return single file
-            response = web.Response(
-                body=content,
-                content_type=content_type,
-                headers={
-                    'Content-Disposition': f'attachment; filename="{resolved_path.name}"'
-                }
-            )
-            return response
-        
-        # Handle multiple files - create ZIP (including directories)
-        def create_zip():
-            buffer = io.BytesIO()
-            with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-                for file_path in file_paths:
-                    try:
-                        resolved_path = Path(file_path).resolve()
-                        if not resolved_path.exists():
-                            continue
-                        if resolved_path.is_dir():
-                            # Add entire directory
-                            for root, dirs, files in os.walk(resolved_path):
-                                for file in files:
-                                    full_path = os.path.join(root, file)
-                                    arcname = os.path.relpath(full_path, resolved_path.parent)
-                                    zf.write(full_path, arcname)
-                        elif resolved_path.is_file():
-                            zf.write(resolved_path, resolved_path.name)
-                    except Exception:
-                        continue
-            return buffer.getvalue()
-        
-        content = await asyncio.to_thread(create_zip)
-        
-        # Return ZIP file
-        response = web.Response(
-            body=content,
-            content_type='application/zip',
-            headers={
-                'Content-Disposition': 'attachment; filename="files.zip"'
-            }
-        )
-        return response
-        
-    except Exception as e:
-        logger.error(f"Error downloading file: {e}")
-        return web.json_response({
-            'success': False,
-            'error': str(e)
-        }, status=500)
+    """Backward-compatible alias for legacy file download endpoint."""
+    return await api_server_files_download(request)
 
 
 async def api_files_delete(request: web.Request) -> web.Response:
@@ -3021,6 +3053,11 @@ def setup_webchat_routes(app: web.Application):
     app.router.add_get('/api/sessions/{session_id}/chatlog', api_session_chatlog)
     app.router.add_get('/api/files', api_browse_files)
     app.router.add_get('/api/files/read', api_read_file)
+    app.router.add_get('/api/server-files', api_server_files_browse)
+    app.router.add_get('/api/server-files/read', api_server_files_read)
+    app.router.add_get('/api/server-files/content', api_server_files_content)
+    app.router.add_post('/api/server-files/upload', api_server_files_upload)
+    app.router.add_get('/api/server-files/download', api_server_files_download)
     app.router.add_get('/api/usage', api_usage)
     app.router.add_post('/api/clear', api_clear)
     app.router.add_post('/api/sessions/{session_id}/messages/{message_id}/edit', api_edit_message)
@@ -3066,6 +3103,11 @@ def setup_webchat_routes(app: web.Application):
     logger.info("  GET  /api/sessions/{id} - Load session messages")
     logger.info("  GET  /api/files    - Browse files")
     logger.info("  GET  /api/files/read - Read file content")
+    logger.info("  GET  /api/server-files - Browse workspace files")
+    logger.info("  GET  /api/server-files/read - Read text file content")
+    logger.info("  GET  /api/server-files/content - Inline file content")
+    logger.info("  POST /api/server-files/upload - Upload/extract files into workspace")
+    logger.info("  GET  /api/server-files/download - Download file(s) from workspace")
     logger.info("  GET  /api/usage   - Get usage stats")
     logger.info("  POST /api/clear   - Clear session")
     logger.info("  GET  /api/skills  - Get available skills")

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -113,6 +113,13 @@ class TestGatewayInit:
         assert hasattr(gateway, 'host')
         assert hasattr(gateway, 'port')
 
+    def test_runtime_workspace_root_uses_home_directory(self, monkeypatch, tmp_path):
+        """Workspace root helper should derive from the runtime user's home path."""
+        from src.gateway import server as gateway_server
+
+        monkeypatch.setattr(gateway_server.Path, "home", classmethod(lambda cls: tmp_path))
+        assert gateway_server._runtime_workspace_root() == (tmp_path / ".efp" / "workspace").resolve()
+
 
 class TestGatewayRoutes:
     """Gateway route tests."""

--- a/tests/test_webchat_server_files.py
+++ b/tests/test_webchat_server_files.py
@@ -1,0 +1,199 @@
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from multidict import MultiDict, MultiDictProxy
+
+from src.gateway import webchat
+
+
+def test_server_files_routes_registered():
+    app = web.Application()
+    webchat.setup_webchat_routes(app)
+    routes = [r.resource.canonical for r in app.router.routes() if r.resource]
+    assert "/api/server-files" in routes
+    assert "/api/server-files/read" in routes
+    assert "/api/server-files/content" in routes
+    assert "/api/server-files/upload" in routes
+    assert "/api/server-files/download" in routes
+
+
+class _Request:
+    def __init__(self, query=None, multipart_reader=None):
+        self.query = MultiDictProxy(MultiDict(query or {}))
+        self._multipart_reader = multipart_reader
+
+    async def multipart(self):
+        return self._multipart_reader
+
+
+class _Field:
+    def __init__(self, name, value=None, filename=None, data=None):
+        self.name = name
+        self._value = value
+        self.filename = filename
+        self._data = data or b""
+
+    async def text(self):
+        return self._value or ""
+
+    async def read(self, decode=False):
+        return self._data
+
+
+class _Multipart:
+    def __init__(self, fields):
+        self._fields = list(fields)
+        self._idx = 0
+
+    async def next(self):
+        if self._idx >= len(self._fields):
+            return None
+        field = self._fields[self._idx]
+        self._idx += 1
+        return field
+
+
+def _patch_workspace_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(webchat.Path, "home", classmethod(lambda cls: tmp_path))
+    workspace_root = tmp_path / ".efp" / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    return workspace_root
+
+
+@pytest.mark.asyncio
+async def test_server_files_browse_defaults_to_workspace_root(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    (workspace_root / "a.txt").write_text("hello", encoding="utf-8")
+
+    response = await webchat.api_server_files_browse(_Request())
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body["root_path"] == str(workspace_root.resolve())
+    assert body["path"] == str(workspace_root.resolve())
+    assert body["items"][0]["name"] == "a.txt"
+
+
+@pytest.mark.asyncio
+async def test_server_files_rejects_outside_root_path(monkeypatch, tmp_path):
+    _patch_workspace_home(monkeypatch, tmp_path)
+    outside = tmp_path.parent
+
+    response = await webchat.api_server_files_browse(_Request({"path": str(outside)}))
+    body = json.loads(response.body)
+
+    assert response.status == 400
+    assert "within workspace root" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_server_files_read_text_utf8(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    text_file = workspace_root / "notes.md"
+    text_file.write_text("hello world", encoding="utf-8")
+
+    response = await webchat.api_server_files_read(_Request({"path": str(text_file)}))
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body["content"] == "hello world"
+    assert body["language"] == "markdown"
+    assert body["content_type"] == "text/markdown"
+
+
+@pytest.mark.asyncio
+async def test_server_files_binary_read_fails_but_content_works(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    binary_file = workspace_root / "image.bin"
+    binary_file.write_bytes(b"\xff\xd8\xff")
+
+    read_response = await webchat.api_server_files_read(_Request({"path": str(binary_file)}))
+    read_body = json.loads(read_response.body)
+    assert read_response.status == 400
+    assert "Cannot read binary file" in read_body["error"]
+
+    content_response = await webchat.api_server_files_content(_Request({"path": str(binary_file)}))
+    assert isinstance(content_response, web.FileResponse)
+    assert content_response.headers["Content-Disposition"] == 'inline; filename="image.bin"'
+
+
+@pytest.mark.asyncio
+async def test_server_files_upload_regular_file(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    target_dir = workspace_root / "uploads"
+    target_dir.mkdir(parents=True)
+
+    multipart = _Multipart([
+        _Field("path", value=str(target_dir)),
+        _Field("file", filename="hello.txt", data=b"hello"),
+    ])
+    response = await webchat.api_server_files_upload(_Request(multipart_reader=multipart))
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body["mode"] == "file_save"
+    assert (target_dir / "hello.txt").read_text(encoding="utf-8") == "hello"
+
+
+@pytest.mark.asyncio
+async def test_server_files_zip_upload_extracts_and_blocks_zip_slip(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    target_dir = workspace_root / "zips"
+    target_dir.mkdir(parents=True)
+
+    good_zip = io.BytesIO()
+    with zipfile.ZipFile(good_zip, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("nested/ok.txt", "ok")
+    multipart = _Multipart([
+        _Field("path", value=str(target_dir)),
+        _Field("file", filename="ok.zip", data=good_zip.getvalue()),
+    ])
+    ok_response = await webchat.api_server_files_upload(_Request(multipart_reader=multipart))
+    ok_body = json.loads(ok_response.body)
+    assert ok_response.status == 200
+    assert ok_body["mode"] == "zip_extract"
+    assert (target_dir / "nested" / "ok.txt").exists()
+
+    bad_zip = io.BytesIO()
+    with zipfile.ZipFile(bad_zip, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("../escape.txt", "escape")
+    bad_multipart = _Multipart([
+        _Field("path", value=str(target_dir)),
+        _Field("file", filename="bad.zip", data=bad_zip.getvalue()),
+    ])
+    bad_response = await webchat.api_server_files_upload(_Request(multipart_reader=bad_multipart))
+    bad_body = json.loads(bad_response.body)
+    assert bad_response.status == 400
+    assert "Unsafe ZIP entry" in bad_body["error"]
+
+
+@pytest.mark.asyncio
+async def test_server_files_download_single_file(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    file_path = workspace_root / "single.txt"
+    file_path.write_text("one", encoding="utf-8")
+
+    response = await webchat.api_server_files_download(_Request({"path": str(file_path)}))
+
+    assert isinstance(response, web.FileResponse)
+    assert response.headers["Content-Disposition"] == 'attachment; filename="single.txt"'
+
+
+@pytest.mark.asyncio
+async def test_server_files_download_directory_as_zip(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    dir_path = workspace_root / "bundle"
+    dir_path.mkdir(parents=True)
+    (dir_path / "a.txt").write_text("A", encoding="utf-8")
+
+    response = await webchat.api_server_files_download(_Request({"path": str(dir_path)}))
+
+    assert response.status == 200
+    assert response.content_type == "application/zip"
+    with zipfile.ZipFile(io.BytesIO(response.body), "r") as archive:
+        names = archive.namelist()
+    assert "bundle/a.txt" in names


### PR DESCRIPTION
### Motivation
- The runtime mixed attachment APIs and server-side workspace browsing under `/api/files/*`, causing incorrect behaviors (missing `/api/files/upload-zip`, JSON returned for image `<img src>` previews, inconsistent workspace boundary checks, and unsafe default `/root`).
- Introduce a clear, scoped API surface for server-side workspace operations so the portal can reliably preview, upload, extract, and download workspace files without changing attachment behavior.
- Enforce a single workspace root (`Path.home() / ".efp" / "workspace"`) and centralize path normalization/validation to eliminate traversal/outside-root access.

### Description
- Added a new server-files API namespace in `src/gateway/webchat.py` with handlers: `api_server_files_browse` (`GET /api/server-files`), `api_server_files_read` (`GET /api/server-files/read`), `api_server_files_content` (`GET /api/server-files/content`), `api_server_files_upload` (`POST /api/server-files/upload`), and `api_server_files_download` (`GET /api/server-files/download`).
- Implemented shared helpers: `_workspace_root`, `_resolve_server_file_path`, `_is_within_root`, `_server_file_language`, `_server_file_content_type`, and `_create_server_files_zip` to normalize/validate paths, enforce workspace boundary, derive language/content-type, and create zips.
- Uploads accept multipart `file` and optional `path`, save files (overwrite) or extract `.zip` archives with zip-slip protections, and return JSON summaries; `/read` is text-only with a clear binary-file error, while `/content` serves bytes via `web.FileResponse` for inline previews; `download` streams single files or returns ZIPs for directories / multiple paths.
- Kept legacy `/api/files/*` attachment endpoints unchanged and provided backward-compatible aliases for the old path-based browse/read/download to avoid breaking portal attachments; registered the new routes in `setup_webchat_routes(app)` and added concise logging for browse/upload/extract/content/download events.
- Files changed: modified `src/gateway/webchat.py` to add helpers and new handlers, and added new tests in `tests/test_webchat_server_files.py` to validate the server-files behavior.

### Testing
- Ran syntax validation with `python -m py_compile src/gateway/webchat.py tests/test_webchat_server_files.py` which succeeded.
- Ran the new focused test suite with `pytest -q tests/test_webchat_server_files.py` and all tests passed (`9 passed`).
- Ran a targeted existing route-registration check with `pytest -q tests/test_webchat.py -k "routes_registered"` which passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db0ad9f534832aa3930cc2fc026c96)