### PR TITLE
Add assistant display_blocks contract, persist it, and make WebChat prefer it

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -1739,7 +1739,7 @@ You have access to the following tools. When a user asks you to do something tha
         
         # Send completion event
         send_event("complete", {
-            "response": "Task completed (max iterations reached)",
+            "response": max_iterations_text,
             "total_iterations": max_tool_iterations,
             "note": "max_iterations"
         })
@@ -1752,7 +1752,7 @@ You have access to the following tools. When a user asks you to do something tha
         events = tracer_instance.get_events_for_ui(limit=10, session_id=session_id)
         
         return self._build_assistant_result_payload(
-            "Task completed (max iterations reached)",
+            max_iterations_text,
             usage=usage_data or {},
             events=events,
             user_message_id=user_message_id,

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -573,6 +573,55 @@ You have access to the following tools. When a user asks you to do something tha
         )
         return merged_extra
 
+    def _build_assistant_result_payload(
+        self,
+        content: str,
+        *,
+        usage: Optional[Dict[str, Any]] = None,
+        user_message_id: Optional[str] = None,
+        events: Optional[List[Dict[str, Any]]] = None,
+        reasoning: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
+        include_content_alias: bool = False,
+        include_role: bool = False,
+        **additional_fields: Any,
+    ) -> Dict[str, Any]:
+        assistant_extra = self._build_assistant_message_extra(content, extra)
+        payload: Dict[str, Any] = {
+            "response": content,
+            "display_blocks": assistant_extra.get("display_blocks", []),
+        }
+        if usage is not None:
+            payload["usage"] = usage
+        if user_message_id:
+            payload["user_message_id"] = user_message_id
+        if events:
+            payload["events"] = events
+        if reasoning:
+            payload["reasoning"] = reasoning
+        if include_content_alias:
+            payload["content"] = content
+        if include_role:
+            payload["role"] = "assistant"
+        payload.update(additional_fields)
+        return payload
+
+    async def _persist_assistant_message(
+        self,
+        session_id: str,
+        content: str,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        assistant_extra = self._build_assistant_message_extra(content, extra)
+        await session_manager.add_message(
+            session_id,
+            "assistant",
+            content,
+            extra=assistant_extra,
+        )
+        return assistant_extra
+
     async def process(
         self,
         message: str,
@@ -647,8 +696,12 @@ You have access to the following tools. When a user asks you to do something tha
         fastlane_response = await process_fastlane_command(message, self)
         if fastlane_response:
             # Fast lane command processed, return the response
-            await session_manager.add_message(session_id, "assistant", fastlane_response, extra=self._build_assistant_message_extra(fastlane_response))
-            return {"response": fastlane_response, "usage": usage_data, "user_message_id": user_message_id}
+            await self._persist_assistant_message(session_id, fastlane_response)
+            return self._build_assistant_result_payload(
+                fastlane_response,
+                usage=usage_data,
+                user_message_id=user_message_id,
+            )
         # ===== END FAST LANE =====
 
         # ===== SKILL MATCHING =====
@@ -1283,8 +1336,12 @@ You have access to the following tools. When a user asks you to do something tha
                     # If still empty, provide a default prompt
                     if not fallback_content.strip():
                         fallback_content = "Operation completed, but no detailed result was returned."
-                await session_manager.add_message(session_id, "assistant", fallback_content, extra=self._build_assistant_message_extra(fallback_content))
-                result = {"response": fallback_content, "usage": usage_data, "user_message_id": user_message_id}
+                await self._persist_assistant_message(session_id, fallback_content)
+                result = self._build_assistant_result_payload(
+                    fallback_content,
+                    usage=usage_data,
+                    user_message_id=user_message_id,
+                )
                 if enable_reasoning:
                     reasoning_content = llm_result.get("reasoning", "")
                     result["reasoning"] = reasoning_content
@@ -1392,12 +1449,15 @@ You have access to the following tools. When a user asks you to do something tha
                         })
                 
                 # Build final result
-                result = {
-                    "content": content,
-                    "role": "assistant",
-                    "events": events,
-                    "user_message_id": user_message_id,
-                }
+                await self._persist_assistant_message(session_id, content)
+                result = self._build_assistant_result_payload(
+                    content,
+                    usage=usage_data,
+                    events=events,
+                    user_message_id=user_message_id,
+                    include_content_alias=True,
+                    include_role=True,
+                )
                 
                 # Add complete thinking flow to debug info
                 if llm_result and "_llm_debug" in llm_result:
@@ -1650,7 +1710,7 @@ You have access to the following tools. When a user asks you to do something tha
                 )
                 if passthrough_recommended:
                     passthrough_content = str(single_tool_result.content)
-                    await session_manager.add_message(session_id, "assistant", passthrough_content, extra=self._build_assistant_message_extra(passthrough_content))
+                    await self._persist_assistant_message(session_id, passthrough_content)
                     send_event("complete", {
                         "response": truncate_with_count(passthrough_content, 500),
                         "total_iterations": iteration
@@ -1659,12 +1719,12 @@ You have access to the following tools. When a user asks you to do something tha
                     from src.skills import get_tracer
                     tracer_instance = get_tracer()
                     events = tracer_instance.get_events_for_ui(limit=10, session_id=session_id)
-                    return {
-                        "response": passthrough_content,
-                        "usage": usage_data,
-                        "events": events,
-                        "user_message_id": user_message_id,
-                    }
+                    return self._build_assistant_result_payload(
+                        passthrough_content,
+                        usage=usage_data,
+                        events=events,
+                        user_message_id=user_message_id,
+                    )
             
             # Send iteration complete event
             send_event("iteration_end", {"iteration": iteration})
@@ -1674,7 +1734,8 @@ You have access to the following tools. When a user asks you to do something tha
         
         # Safety: max iterations reached
         logger.warning(f"[Tool Loop] Max iterations ({max_tool_iterations}) reached")
-        await session_manager.add_message(session_id, "assistant", "Task completed after maximum iterations.", extra=self._build_assistant_message_extra("Task completed after maximum iterations."))
+        max_iterations_text = "Task completed after maximum iterations."
+        await self._persist_assistant_message(session_id, max_iterations_text)
         
         # Send completion event
         send_event("complete", {
@@ -1690,7 +1751,12 @@ You have access to the following tools. When a user asks you to do something tha
         tracer_instance = get_tracer()
         events = tracer_instance.get_events_for_ui(limit=10, session_id=session_id)
         
-        return {"response": "Task completed (max iterations reached)", "usage": usage_data or {}, "events": events, "user_message_id": user_message_id}
+        return self._build_assistant_result_payload(
+            "Task completed (max iterations reached)",
+            usage=usage_data or {},
+            events=events,
+            user_message_id=user_message_id,
+        )
 
     async def _start_skill_mode(
         self,
@@ -1856,9 +1922,14 @@ You have access to the following tools. When a user asks you to do something tha
         if not skill:
             await session_manager.set_active_skill_session(session_id, None)
             fallback = "Skill session was cleared because the skill definition is unavailable."
-            await session_manager.add_message(session_id, "assistant", fallback, extra=self._build_assistant_message_extra(fallback))
+            await self._persist_assistant_message(session_id, fallback)
             events = tracer.get_events_for_ui(limit=10, session_id=session_id)
-            return {"response": fallback, "usage": usage_data, "events": events, "user_message_id": user_message_id}
+            return self._build_assistant_result_payload(
+                fallback,
+                usage=usage_data,
+                events=events,
+                user_message_id=user_message_id,
+            )
 
         logger.debug(f"[SkillMode] skill={skill.name}, skill_session.status={skill_session.status}")
         logger.debug(f"[SkillMode] skill_session.completed_steps count={len(skill_session.completed_steps)}")
@@ -2241,13 +2312,18 @@ You have access to the following tools. When a user asks you to do something tha
             tracer.log_skill_mode_step("ASK_USER", "completed", f"Question: {question[:50]}...")
             send_skill_event("skill_step", {"step": "ASK_USER", "status": "completed", "detail": safe_preview(question, 200)})
             await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
-            await session_manager.add_message(session_id, "assistant", question, extra=self._build_assistant_message_extra(question))
+            await self._persist_assistant_message(session_id, question)
             # Get events for UI
             events = tracer.get_events_for_ui(limit=10, session_id=session_id)
             send_skill_event("skill_complete", {"reason": "ask_user", "question": safe_preview(question, 200)})
             logger.info("[SkillMode][Terminate] reason=%s", skill_session.termination_reason)
             logger.debug(f"[SkillMode] ===== _continue_skill_mode END (ASK_USER) =====")
-            return {"response": question, "usage": usage_data, "events": events, "user_message_id": user_message_id}
+            return self._build_assistant_result_payload(
+                question,
+                usage=usage_data,
+                events=events,
+                user_message_id=user_message_id,
+            )
 
         if action == "finish":
             final_text = body.strip() or "Skill task completed."
@@ -2291,13 +2367,9 @@ You have access to the following tools. When a user asks you to do something tha
             send_skill_event("skill_complete", {"reason": "finish", "result": safe_preview(final_text, 200)})
             await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
             await session_manager.set_active_skill_session(session_id, None)
-            finish_extra = self._build_assistant_message_extra(
-                final_text,
-                {"terminal_skill_session": terminal_snapshot},
-            )
-            await session_manager.add_message(
+            finish_extra = {"terminal_skill_session": terminal_snapshot}
+            await self._persist_assistant_message(
                 session_id,
-                "assistant",
                 final_text,
                 extra=finish_extra,
             )
@@ -2305,7 +2377,12 @@ You have access to the following tools. When a user asks you to do something tha
             events = tracer.get_events_for_ui(limit=10, session_id=session_id)
             logger.info("[SkillMode][Terminate] reason=%s", skill_session.termination_reason)
             logger.debug(f"[SkillMode] ===== _continue_skill_mode END (FINISH) =====")
-            return {"response": final_text, "usage": usage_data, "events": events, "user_message_id": user_message_id}
+            return self._build_assistant_result_payload(
+                final_text,
+                usage=usage_data,
+                events=events,
+                user_message_id=user_message_id,
+            )
 
         # default: execute
         was_waiting_user = skill_session.status == "waiting_user"
@@ -2339,10 +2416,15 @@ You have access to the following tools. When a user asks you to do something tha
         skill_session.memory_summary = _update_skill_memory_summary(skill_session, message, result_text)
 
         await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
-        await session_manager.add_message(session_id, "assistant", result_text, extra=self._build_assistant_message_extra(result_text))
+        await self._persist_assistant_message(session_id, result_text)
         # Get events for UI
         events = tracer.get_events_for_ui(limit=10, session_id=session_id)
-        return {"response": result_text, "usage": usage_data, "events": events, "user_message_id": user_message_id}
+        return self._build_assistant_result_payload(
+            result_text,
+            usage=usage_data,
+            events=events,
+            user_message_id=user_message_id,
+        )
 
     async def _execute_skill(
         self,

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -622,6 +622,18 @@ You have access to the following tools. When a user asks you to do something tha
         )
         return assistant_extra
 
+    def _assistant_extra_from_payload(
+        self,
+        payload: Optional[Dict[str, Any]],
+        content: str,
+    ) -> Dict[str, Any]:
+        assistant_extra: Dict[str, Any] = {}
+        if isinstance(payload, dict) and "display_blocks" in payload:
+            assistant_extra["display_blocks"] = payload.get("display_blocks")
+        elif payload is not None and hasattr(payload, "display_blocks"):
+            assistant_extra["display_blocks"] = getattr(payload, "display_blocks")
+        return self._build_assistant_message_extra(content, assistant_extra)
+
     async def process(
         self,
         message: str,
@@ -1336,11 +1348,17 @@ You have access to the following tools. When a user asks you to do something tha
                     # If still empty, provide a default prompt
                     if not fallback_content.strip():
                         fallback_content = "Operation completed, but no detailed result was returned."
-                await self._persist_assistant_message(session_id, fallback_content)
+                assistant_extra = self._assistant_extra_from_payload(llm_result, fallback_content)
+                await self._persist_assistant_message(
+                    session_id,
+                    fallback_content,
+                    extra=assistant_extra,
+                )
                 result = self._build_assistant_result_payload(
                     fallback_content,
                     usage=usage_data,
                     user_message_id=user_message_id,
+                    extra=assistant_extra,
                 )
                 if enable_reasoning:
                     reasoning_content = llm_result.get("reasoning", "")
@@ -1710,7 +1728,15 @@ You have access to the following tools. When a user asks you to do something tha
                 )
                 if passthrough_recommended:
                     passthrough_content = str(single_tool_result.content)
-                    await self._persist_assistant_message(session_id, passthrough_content)
+                    assistant_extra = self._assistant_extra_from_payload(
+                        single_tool_result,
+                        passthrough_content,
+                    )
+                    await self._persist_assistant_message(
+                        session_id,
+                        passthrough_content,
+                        extra=assistant_extra,
+                    )
                     send_event("complete", {
                         "response": truncate_with_count(passthrough_content, 500),
                         "total_iterations": iteration
@@ -1724,6 +1750,7 @@ You have access to the following tools. When a user asks you to do something tha
                         usage=usage_data,
                         events=events,
                         user_message_id=user_message_id,
+                        extra=assistant_extra,
                     )
             
             # Send iteration complete event

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -54,6 +54,7 @@ from src.agents.skill_runtime import (
 )
 from src.skills.runtime import SkillRuntimeConfig
 from src.runtime.chat_orchestration_adapter import execute_tool_or_task_orchestration
+from src.runtime.display_blocks import normalize_display_blocks
 
 logger = logging.getLogger(__name__)
 
@@ -556,6 +557,22 @@ You have access to the following tools. When a user asks you to do something tha
             extra["author_id"] = agent_id
         return extra
 
+    def _build_assistant_message_extra(
+        self,
+        content: str,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        merged_extra: Dict[str, Any] = self._build_agent_author_extra()
+        supplied_extra = dict(extra or {})
+        raw_display_blocks = supplied_extra.get("display_blocks")
+        merged_extra["display_blocks"] = normalize_display_blocks(raw_display_blocks, content)
+        merged_extra.update(supplied_extra)
+        merged_extra["display_blocks"] = normalize_display_blocks(
+            merged_extra.get("display_blocks"),
+            content,
+        )
+        return merged_extra
+
     async def process(
         self,
         message: str,
@@ -630,7 +647,7 @@ You have access to the following tools. When a user asks you to do something tha
         fastlane_response = await process_fastlane_command(message, self)
         if fastlane_response:
             # Fast lane command processed, return the response
-            await session_manager.add_message(session_id, "assistant", fastlane_response, extra=self._build_agent_author_extra())
+            await session_manager.add_message(session_id, "assistant", fastlane_response, extra=self._build_assistant_message_extra(fastlane_response))
             return {"response": fastlane_response, "usage": usage_data, "user_message_id": user_message_id}
         # ===== END FAST LANE =====
 
@@ -1266,7 +1283,7 @@ You have access to the following tools. When a user asks you to do something tha
                     # If still empty, provide a default prompt
                     if not fallback_content.strip():
                         fallback_content = "Operation completed, but no detailed result was returned."
-                await session_manager.add_message(session_id, "assistant", fallback_content, extra=self._build_agent_author_extra())
+                await session_manager.add_message(session_id, "assistant", fallback_content, extra=self._build_assistant_message_extra(fallback_content))
                 result = {"response": fallback_content, "usage": usage_data, "user_message_id": user_message_id}
                 if enable_reasoning:
                     reasoning_content = llm_result.get("reasoning", "")
@@ -1633,7 +1650,7 @@ You have access to the following tools. When a user asks you to do something tha
                 )
                 if passthrough_recommended:
                     passthrough_content = str(single_tool_result.content)
-                    await session_manager.add_message(session_id, "assistant", passthrough_content, extra=self._build_agent_author_extra())
+                    await session_manager.add_message(session_id, "assistant", passthrough_content, extra=self._build_assistant_message_extra(passthrough_content))
                     send_event("complete", {
                         "response": truncate_with_count(passthrough_content, 500),
                         "total_iterations": iteration
@@ -1657,7 +1674,7 @@ You have access to the following tools. When a user asks you to do something tha
         
         # Safety: max iterations reached
         logger.warning(f"[Tool Loop] Max iterations ({max_tool_iterations}) reached")
-        await session_manager.add_message(session_id, "assistant", "Task completed after maximum iterations.", extra=self._build_agent_author_extra())
+        await session_manager.add_message(session_id, "assistant", "Task completed after maximum iterations.", extra=self._build_assistant_message_extra("Task completed after maximum iterations."))
         
         # Send completion event
         send_event("complete", {
@@ -1839,7 +1856,7 @@ You have access to the following tools. When a user asks you to do something tha
         if not skill:
             await session_manager.set_active_skill_session(session_id, None)
             fallback = "Skill session was cleared because the skill definition is unavailable."
-            await session_manager.add_message(session_id, "assistant", fallback, extra=self._build_agent_author_extra())
+            await session_manager.add_message(session_id, "assistant", fallback, extra=self._build_assistant_message_extra(fallback))
             events = tracer.get_events_for_ui(limit=10, session_id=session_id)
             return {"response": fallback, "usage": usage_data, "events": events, "user_message_id": user_message_id}
 
@@ -2224,7 +2241,7 @@ You have access to the following tools. When a user asks you to do something tha
             tracer.log_skill_mode_step("ASK_USER", "completed", f"Question: {question[:50]}...")
             send_skill_event("skill_step", {"step": "ASK_USER", "status": "completed", "detail": safe_preview(question, 200)})
             await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
-            await session_manager.add_message(session_id, "assistant", question, extra=self._build_agent_author_extra())
+            await session_manager.add_message(session_id, "assistant", question, extra=self._build_assistant_message_extra(question))
             # Get events for UI
             events = tracer.get_events_for_ui(limit=10, session_id=session_id)
             send_skill_event("skill_complete", {"reason": "ask_user", "question": safe_preview(question, 200)})
@@ -2274,8 +2291,10 @@ You have access to the following tools. When a user asks you to do something tha
             send_skill_event("skill_complete", {"reason": "finish", "result": safe_preview(final_text, 200)})
             await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
             await session_manager.set_active_skill_session(session_id, None)
-            finish_extra = self._build_agent_author_extra()
-            finish_extra["terminal_skill_session"] = terminal_snapshot
+            finish_extra = self._build_assistant_message_extra(
+                final_text,
+                {"terminal_skill_session": terminal_snapshot},
+            )
             await session_manager.add_message(
                 session_id,
                 "assistant",
@@ -2320,7 +2339,7 @@ You have access to the following tools. When a user asks you to do something tha
         skill_session.memory_summary = _update_skill_memory_summary(skill_session, message, result_text)
 
         await session_manager.set_active_skill_session(session_id, skill_session.to_dict())
-        await session_manager.add_message(session_id, "assistant", result_text, extra=self._build_agent_author_extra())
+        await session_manager.add_message(session_id, "assistant", result_text, extra=self._build_assistant_message_extra(result_text))
         # Get events for UI
         events = tracer.get_events_for_ui(limit=10, session_id=session_id)
         return {"response": result_text, "usage": usage_data, "events": events, "user_message_id": user_message_id}

--- a/src/gateway/chat_payloads.py
+++ b/src/gateway/chat_payloads.py
@@ -2,9 +2,35 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import importlib.util
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
 
-from src.runtime.display_blocks import normalize_display_blocks
+_normalize_display_blocks_fn: Optional[Callable[[Optional[Any], str], list[dict[str, Any]]]] = None
+
+
+def _get_normalize_display_blocks() -> Callable[[Optional[Any], str], list[dict[str, Any]]]:
+    """Resolve ``normalize_display_blocks`` with an import-light fallback."""
+    global _normalize_display_blocks_fn
+    if _normalize_display_blocks_fn is not None:
+        return _normalize_display_blocks_fn
+
+    try:
+        from src.runtime.display_blocks import normalize_display_blocks as runtime_normalize_display_blocks
+        _normalize_display_blocks_fn = runtime_normalize_display_blocks
+        return _normalize_display_blocks_fn
+    except Exception:
+        module_path = Path(__file__).resolve().parent.parent / "runtime" / "display_blocks.py"
+        spec = importlib.util.spec_from_file_location("runtime_display_blocks_fallback", module_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Failed to load display_blocks module from {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        normalize_display_blocks = getattr(module, "normalize_display_blocks", None)
+        if normalize_display_blocks is None or not callable(normalize_display_blocks):
+            raise ImportError("normalize_display_blocks not found in fallback module")
+        _normalize_display_blocks_fn = normalize_display_blocks
+        return _normalize_display_blocks_fn
 
 
 def build_webchat_response_payload(result: Optional[Dict[str, Any]], session_id: str) -> Dict[str, Any]:
@@ -12,6 +38,7 @@ def build_webchat_response_payload(result: Optional[Dict[str, Any]], session_id:
     payload_result = result if isinstance(result, dict) else {}
     response_text = payload_result.get("response") or payload_result.get("content") or ""
     usage = payload_result.get("usage", {}) or {}
+    normalize_display_blocks = _get_normalize_display_blocks()
 
     response_payload: Dict[str, Any] = {
         "response": response_text,
@@ -32,6 +59,7 @@ def normalize_assistant_history_message(message: Dict[str, Any]) -> Dict[str, An
     normalized_message = dict(message)
     if normalized_message.get("role") != "assistant":
         return normalized_message
+    normalize_display_blocks = _get_normalize_display_blocks()
     normalized_message["display_blocks"] = normalize_display_blocks(
         message.get("display_blocks"),
         message.get("content", "") or "",

--- a/src/gateway/chat_payloads.py
+++ b/src/gateway/chat_payloads.py
@@ -33,10 +33,22 @@ def _get_normalize_display_blocks() -> Callable[[Optional[Any], str], list[dict[
         return _normalize_display_blocks_fn
 
 
+def _meaningful_text(value: Any) -> str:
+    """Return original text when meaningful; otherwise empty string."""
+    if value is None:
+        return ""
+    text = str(value)
+    if not text.strip():
+        return ""
+    return text
+
+
 def build_webchat_response_payload(result: Optional[Dict[str, Any]], session_id: str) -> Dict[str, Any]:
     """Build the stable JSON payload returned by ``/api/chat``."""
     payload_result = result if isinstance(result, dict) else {}
-    response_text = payload_result.get("response") or payload_result.get("content") or ""
+    response_value = _meaningful_text(payload_result.get("response"))
+    content_value = _meaningful_text(payload_result.get("content"))
+    response_text = response_value or content_value
     usage = payload_result.get("usage", {}) or {}
     normalize_display_blocks = _get_normalize_display_blocks()
 
@@ -60,8 +72,9 @@ def normalize_assistant_history_message(message: Dict[str, Any]) -> Dict[str, An
     if normalized_message.get("role") != "assistant":
         return normalized_message
     normalize_display_blocks = _get_normalize_display_blocks()
+    fallback_text = _meaningful_text(message.get("content"))
     normalized_message["display_blocks"] = normalize_display_blocks(
         message.get("display_blocks"),
-        message.get("content", "") or "",
+        fallback_text,
     )
     return normalized_message

--- a/src/gateway/chat_payloads.py
+++ b/src/gateway/chat_payloads.py
@@ -1,0 +1,39 @@
+"""Pure helpers for normalizing WebChat assistant payloads."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from src.runtime.display_blocks import normalize_display_blocks
+
+
+def build_webchat_response_payload(result: Optional[Dict[str, Any]], session_id: str) -> Dict[str, Any]:
+    """Build the stable JSON payload returned by ``/api/chat``."""
+    payload_result = result if isinstance(result, dict) else {}
+    response_text = payload_result.get("response") or payload_result.get("content") or ""
+    usage = payload_result.get("usage", {}) or {}
+
+    response_payload: Dict[str, Any] = {
+        "response": response_text,
+        "session_id": session_id,
+        "usage": usage,
+        "display_blocks": normalize_display_blocks(payload_result.get("display_blocks"), response_text),
+    }
+    for key in ("user_message_id", "events", "_llm_debug", "reasoning"):
+        if key in payload_result:
+            response_payload[key] = payload_result[key]
+    return response_payload
+
+
+def normalize_assistant_history_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a shallow-copied assistant message with normalized display blocks."""
+    if not isinstance(message, dict):
+        return message
+    normalized_message = dict(message)
+    if normalized_message.get("role") != "assistant":
+        return normalized_message
+    normalized_message["display_blocks"] = normalize_display_blocks(
+        message.get("display_blocks"),
+        message.get("content", "") or "",
+    )
+    return normalized_message

--- a/src/gateway/static/css/webchat.css
+++ b/src/gateway/static/css/webchat.css
@@ -457,6 +457,18 @@ body {
 }
 
 /* Markdown Content Styling */
+.message-block {
+    width: 100%;
+}
+
+.message-block + .message-block {
+    margin-top: var(--space-md);
+}
+
+.message-block table {
+    width: 100%;
+}
+
 .message-bubble h1,
 .message-bubble h2,
 .message-bubble h3,
@@ -476,6 +488,10 @@ body {
 
 .message-bubble p:last-child {
     margin-bottom: 0;
+}
+
+.message-bubble p + p {
+    margin-top: var(--space-sm);
 }
 
 .message-bubble code {
@@ -505,6 +521,55 @@ body {
     font-size: 13px;
     line-height: 1.6;
     color: #e4e4e7;
+}
+
+.message-codeblock {
+    background: #0d0d0f;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+}
+
+.message-codeblock pre {
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+}
+
+.message-codeblock-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--color-border);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.message-codeblock-lang {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+}
+
+.copy-code-button {
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-input);
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    padding: 4px 8px;
+    cursor: pointer;
+}
+
+.copy-code-button:hover {
+    color: var(--color-text);
+}
+
+.copy-code-button.copied {
+    color: var(--color-success);
 }
 
 .message-bubble ul,
@@ -588,6 +653,49 @@ body {
     height: 1px;
     background: var(--color-border);
     margin: var(--space-md) 0;
+}
+
+.message-bubble hr {
+    border: 0;
+    border-top: 1px solid var(--color-border);
+    margin: var(--space-md) 0;
+}
+
+.message-bubble img {
+    max-width: 100%;
+    border-radius: var(--radius-md);
+    margin: var(--space-sm) 0;
+}
+
+.message-bubble table {
+    border-collapse: collapse;
+    margin: var(--space-md) 0;
+    font-size: 13px;
+}
+
+.message-bubble th,
+.message-bubble td {
+    border: 1px solid var(--color-border);
+    padding: 8px 10px;
+    text-align: left;
+}
+
+.message-table-wrap {
+    overflow-x: auto;
+}
+
+.message-callout {
+    border-left: 3px solid var(--color-accent);
+    background: var(--color-bg-input);
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-sm);
+}
+
+.message-tool-result {
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-sm) var(--space-md);
+    background: rgba(255, 255, 255, 0.02);
 }
 
 /* Timestamp */

--- a/src/gateway/static/css/webchat.css
+++ b/src/gateway/static/css/webchat.css
@@ -691,11 +691,75 @@ body {
     border-radius: var(--radius-sm);
 }
 
+.message-callout-title {
+    font-weight: 600;
+    margin-bottom: 6px;
+    color: var(--color-text);
+}
+
+.message-callout-content {
+    color: var(--color-text-muted);
+}
+
+.message-callout.is-info {
+    border-left-color: #3b82f6;
+}
+
+.message-callout.is-success {
+    border-left-color: #22c55e;
+    background: rgba(34, 197, 94, 0.08);
+}
+
+.message-callout.is-warning {
+    border-left-color: #f59e0b;
+    background: rgba(245, 158, 11, 0.08);
+}
+
+.message-callout.is-error {
+    border-left-color: #ef4444;
+    background: rgba(239, 68, 68, 0.08);
+}
+
 .message-tool-result {
     border: 1px dashed var(--color-border);
     border-radius: var(--radius-sm);
     padding: var(--space-sm) var(--space-md);
     background: rgba(255, 255, 255, 0.02);
+}
+
+.message-tool-result-title {
+    font-weight: 600;
+    margin-bottom: 6px;
+    color: var(--color-text);
+}
+
+.message-tool-result-content {
+    color: var(--color-text-muted);
+}
+
+.message-tool-result.is-info {
+    border-color: #3b82f6;
+    background: rgba(59, 130, 246, 0.08);
+}
+
+.message-tool-result.is-success {
+    border-color: #22c55e;
+    background: rgba(34, 197, 94, 0.08);
+}
+
+.message-tool-result.is-warning {
+    border-color: #f59e0b;
+    background: rgba(245, 158, 11, 0.08);
+}
+
+.message-tool-result.is-error {
+    border-color: #ef4444;
+    background: rgba(239, 68, 68, 0.08);
+}
+
+.message-tool-result.is-running {
+    border-color: #8b5cf6;
+    background: rgba(139, 92, 246, 0.08);
 }
 
 /* Timestamp */

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1215,7 +1215,8 @@
         const blocks = raw
             .filter((block) => block && typeof block === 'object' && typeof block.type === 'string')
             .map((block) => ({ ...block, type: block.type.trim() }))
-            .filter((block) => block.type.length > 0);
+            .filter((block) => block.type.length > 0)
+            .filter((block) => hasRenderableDisplayBlock(block));
         return blocks.length > 0 ? blocks : null;
     }
 
@@ -1232,7 +1233,7 @@
             return '';
         }
         const textFields = preferCode
-            ? ['code', 'content', 'text', 'output', 'result', 'value']
+            ? ['code', 'content', 'text', 'message', 'output', 'result', 'value']
             : ['content', 'text', 'output', 'result', 'value', 'message'];
         for (const field of textFields) {
             const value = block[field];
@@ -1248,20 +1249,28 @@
         return '';
     }
 
+    function hasRenderableDisplayBlock(block) {
+        if (!block || typeof block !== 'object') {
+            return false;
+        }
+        const blockType = String(block.type || '').toLowerCase();
+        if (!blockType) {
+            return false;
+        }
+        if (blockType === 'table') {
+            const headers = Array.isArray(block.headers) ? block.headers : (Array.isArray(block.columns) ? block.columns : []);
+            const rows = Array.isArray(block.rows) ? block.rows : [];
+            return headers.length > 0 || rows.length > 0 || getBlockText(block).length > 0;
+        }
+        return getBlockText(block, blockType === 'code').length > 0;
+    }
+
     function hasMeaningfulDisplayBlocks(blocks) {
         const parsedBlocks = parseDisplayBlocks(blocks);
         if (!parsedBlocks) {
             return false;
         }
-        return parsedBlocks.some((block) => {
-            const blockType = String(block.type || '').toLowerCase();
-            if (blockType === 'table') {
-                const headers = Array.isArray(block.headers) ? block.headers : (Array.isArray(block.columns) ? block.columns : []);
-                const rows = Array.isArray(block.rows) ? block.rows : [];
-                return headers.length > 0 || rows.length > 0 || getBlockText(block, false).length > 0;
-            }
-            return getBlockText(block, blockType === 'code').length > 0;
-        });
+        return parsedBlocks.some((block) => hasRenderableDisplayBlock(block));
     }
 
     function renderSingleDisplayBlock(block) {

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -999,7 +999,7 @@
      * @param {string} [timestamp] - Optional timestamp
      * @param {Object} [toolCalls] - Optional tool calls array for assistant messages
      */
-    function addMessage(role, content, timestamp, toolCalls = null) {
+    function addMessage(role, content, timestamp, toolCalls = null, displayBlocks = null) {
         // Remove welcome message if present
         const welcome = messagesContainer.querySelector('.welcome-message');
         if (welcome) {
@@ -1050,7 +1050,7 @@
 
         // Render markdown only for non-user, non-error roles; user and error messages are escaped/plain text
         const contentHtml = (role === 'assistant' || role === 'tool')
-            ? renderMarkdown(processedContent)
+            ? renderDisplayBlocks(displayBlocks, processedContent)
             : escapeHtml(processedContent).replace(/\n/g, '<br>');
 
         div.innerHTML = `
@@ -1070,12 +1070,7 @@
             markPendingAssistant(div);
         }
 
-        // Apply syntax highlighting to code blocks
-        if (typeof hljs !== 'undefined') {
-            div.querySelectorAll('pre code').forEach((block) => {
-                hljs.highlightElement(block);
-            });
-        }
+        enhanceRenderedMessage(div);
 
         // Process file references for inline images
         processMessageImages();
@@ -1163,18 +1158,6 @@
             marked.setOptions({
                 breaks: true,        // Convert \n to <br>
                 gfm: true,          // GitHub Flavored Markdown
-                highlight: function(code, lang) {
-                    if (lang && hljs) {
-                        try {
-                            return hljs.highlight(code, { language: lang }).value;
-                        } catch (e) {
-                            // Fallback: escape code to avoid HTML injection
-                            return escapeHtml(code);
-                        }
-                    }
-                    // No language or hljs unavailable: escape code
-                    return escapeHtml(code);
-                }
             });
         } catch (e) {
             console.warn('Failed to configure marked:', e);
@@ -1223,6 +1206,134 @@
             console.warn('Markdown rendering failed:', e);
             return escapeHtml(text).replace(/\n/g, '<br>');
         }
+    }
+
+    function parseDisplayBlocks(raw) {
+        if (!Array.isArray(raw) || raw.length === 0) {
+            return null;
+        }
+        const blocks = raw
+            .filter((block) => block && typeof block === 'object' && typeof block.type === 'string')
+            .map((block) => ({ ...block, type: block.type.trim() }))
+            .filter((block) => block.type.length > 0);
+        return blocks.length > 0 ? blocks : null;
+    }
+
+    function renderDisplayBlocks(blocks, fallbackMarkdown = '') {
+        const parsedBlocks = parseDisplayBlocks(blocks);
+        if (!parsedBlocks) {
+            return renderMarkdown(fallbackMarkdown || '');
+        }
+        return parsedBlocks.map(renderSingleDisplayBlock).join('');
+    }
+
+    function renderSingleDisplayBlock(block) {
+        const blockType = String(block.type || '').toLowerCase();
+        if (blockType === 'code') {
+            return renderCodeBlock(block);
+        }
+        if (blockType === 'table') {
+            return renderTableBlock(block);
+        }
+        if (blockType === 'callout') {
+            return `<div class="message-block message-callout">${renderMarkdown(String(block.content || block.text || ''))}</div>`;
+        }
+        if (blockType === 'tool_result') {
+            return `<div class="message-block message-tool-result">${renderMarkdown(String(block.content || block.text || ''))}</div>`;
+        }
+        return `<div class="message-block">${renderMarkdown(String(block.content || ''))}</div>`;
+    }
+
+    function renderCodeBlock(block) {
+        const language = String(block.language || block.lang || '').trim();
+        const codeText = String(block.content || block.code || '');
+        const escapedLanguage = escapeHtml(language || 'text');
+        const escapedCode = escapeHtml(codeText);
+        const classLanguage = language.toLowerCase().replace(/[^a-z0-9_+-]/g, '');
+        return `
+            <div class="message-block message-codeblock">
+                <div class="message-codeblock-toolbar">
+                    <span class="message-codeblock-lang">${escapedLanguage}</span>
+                    <button type="button" class="copy-code-button">Copy</button>
+                </div>
+                <pre><code class="${classLanguage ? `language-${classLanguage}` : ''}">${escapedCode}</code></pre>
+            </div>
+        `;
+    }
+
+    function renderTableBlock(block) {
+        const headers = Array.isArray(block.headers) ? block.headers : [];
+        const rows = Array.isArray(block.rows) ? block.rows : [];
+        if (!headers.length && !rows.length) {
+            return `<div class="message-block message-table-wrap">${renderMarkdown(String(block.content || ''))}</div>`;
+        }
+        const headHtml = headers.length
+            ? `<thead><tr>${headers.map((h) => `<th>${escapeHtml(String(h ?? ''))}</th>`).join('')}</tr></thead>`
+            : '';
+        const bodyHtml = rows.length
+            ? `<tbody>${rows.map((row) => `<tr>${(Array.isArray(row) ? row : []).map((cell) => `<td>${escapeHtml(String(cell ?? ''))}</td>`).join('')}</tr>`).join('')}</tbody>`
+            : '';
+        return `<div class="message-block message-table-wrap"><table>${headHtml}${bodyHtml}</table></div>`;
+    }
+
+    async function copyText(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(text);
+            return;
+        }
+        const area = document.createElement('textarea');
+        area.value = text;
+        area.setAttribute('readonly', '');
+        area.style.position = 'absolute';
+        area.style.left = '-9999px';
+        document.body.appendChild(area);
+        area.select();
+        document.execCommand('copy');
+        document.body.removeChild(area);
+    }
+
+    function enhanceRenderedMessage(root) {
+        if (!root) return;
+        if (typeof hljs !== 'undefined') {
+            root.querySelectorAll('pre code').forEach((block) => {
+                if (!block.classList.contains('hljs')) {
+                    hljs.highlightElement(block);
+                }
+            });
+        }
+        root.querySelectorAll('pre').forEach((pre) => {
+            let toolbar = pre.previousElementSibling;
+            if (!toolbar || !toolbar.classList.contains('message-codeblock-toolbar')) {
+                toolbar = document.createElement('div');
+                toolbar.className = 'message-codeblock-toolbar';
+                toolbar.innerHTML = '<span class="message-codeblock-lang"></span><button type="button" class="copy-code-button">Copy</button>';
+                pre.parentNode.insertBefore(toolbar, pre);
+            }
+            const code = pre.querySelector('code');
+            const langEl = toolbar.querySelector('.message-codeblock-lang');
+            if (langEl && (!langEl.textContent || langEl.textContent === 'text')) {
+                const classMatch = code?.className.match(/language-([a-z0-9_+-]+)/i);
+                langEl.textContent = classMatch ? classMatch[1] : 'text';
+            }
+            const copyButton = toolbar.querySelector('.copy-code-button');
+            if (copyButton && !copyButton.dataset.bound) {
+                copyButton.dataset.bound = 'true';
+                copyButton.addEventListener('click', async function() {
+                    try {
+                        await copyText(code ? code.textContent || '' : pre.textContent || '');
+                        this.textContent = 'Copied!';
+                        this.classList.add('copied');
+                        setTimeout(() => {
+                            this.textContent = 'Copy';
+                            this.classList.remove('copied');
+                        }, 2000);
+                    } catch (error) {
+                        this.textContent = 'Copy failed';
+                        setTimeout(() => { this.textContent = 'Copy'; }, 2000);
+                    }
+                });
+            }
+        });
     }
 
     // Close skill and file selector when clicking outside
@@ -1300,12 +1411,7 @@
         timestamp.textContent = formatSmartDate(new Date());
         bubble.appendChild(timestamp);
 
-        // Apply syntax highlighting to finished message
-        if (typeof hljs !== 'undefined') {
-            div.querySelectorAll('pre code').forEach((block) => {
-                hljs.highlightElement(block);
-            });
-        }
+        enhanceRenderedMessage(div);
     }
 
     /**
@@ -1508,7 +1614,13 @@
                 }
             } else {
                 // Fallback to simple response display
-                addMessage('assistant', data.response || '[No reply received. Please try again later.]');
+                addMessage(
+                    'assistant',
+                    data.response || '[No reply received. Please try again later.]',
+                    null,
+                    null,
+                    data.display_blocks || null
+                );
             }
 
             if (data.usage) {
@@ -1776,7 +1888,13 @@
                     if (!isDebugEnabled() && isToolPlaceholder(msg.content, role)) {
                         return;
                     }
-                    addMessage(role, msg.content || '', msg.timestamp || msg.created_at, msg.tool_calls);
+                    addMessage(
+                        role,
+                        msg.content || '',
+                        msg.timestamp || msg.created_at,
+                        msg.tool_calls,
+                        msg.display_blocks || null
+                    );
                 });
             }
 
@@ -2702,41 +2820,6 @@
             settingsPanel.classList.remove('show');
         });
     }
-
-    // ========== Copy Code Button ==========
-
-    function addCopyButtons() {
-        document.querySelectorAll('pre code').forEach((block) => {
-            if (block.parentElement.querySelector('.copy-code-button')) return;
-
-            const button = document.createElement('button');
-            button.className = 'copy-code-button';
-            button.textContent = 'Copy';
-            button.addEventListener('click', function() {
-                navigator.clipboard.writeText(block.textContent).then(() => {
-                    this.textContent = 'Copied!';
-                    this.classList.add('copied');
-                    setTimeout(() => {
-                        this.textContent = 'Copy';
-                        this.classList.remove('copied');
-                    }, 2000);
-                });
-            });
-            block.parentElement.style.position = 'relative';
-            block.parentElement.appendChild(button);
-        });
-    }
-
-    // Add copy buttons when new messages are added
-    const originalAddMessage = window.webchatAddMessage;
-    window.webchatAddMessage = function(role, content, timestamp) {
-        const result = originalAddMessage(role, content, timestamp);
-        addCopyButtons();
-        return result;
-    };
-
-    // Add copy buttons to existing code blocks
-    addCopyButtons();
 
     // Debug: Expose session functions globally for testing
     window.webchatDebugSession = {

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1546,7 +1546,13 @@
                     }
                     const content = msg.content || '';
                     const timestamp = msg.timestamp || msg.created_at;
-                    addMessage(role, content, timestamp, msg.tool_calls);
+                    addMessage(
+                        role,
+                        content,
+                        timestamp,
+                        msg.tool_calls,
+                        msg.display_blocks || null
+                    );
                 });
                 scrollToBottom();
                 // Show thinking events from session metadata

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1227,6 +1227,13 @@
         return parsedBlocks.map(renderSingleDisplayBlock).join('');
     }
 
+    function getBlockText(block) {
+        if (!block || typeof block !== 'object') {
+            return '';
+        }
+        return String(block.content ?? block.text ?? '');
+    }
+
     function renderSingleDisplayBlock(block) {
         const blockType = String(block.type || '').toLowerCase();
         if (blockType === 'code') {
@@ -1236,12 +1243,32 @@
             return renderTableBlock(block);
         }
         if (blockType === 'callout') {
-            return `<div class="message-block message-callout">${renderMarkdown(String(block.content || block.text || ''))}</div>`;
+            const tone = String(block.tone || 'info').toLowerCase();
+            const title = String(block.title || '').trim();
+            const body = renderMarkdown(getBlockText(block));
+            return `
+                <div class="message-block">
+                    <div class="message-callout is-${escapeHtml(tone)}">
+                        ${title ? `<div class="message-callout-title">${escapeHtml(title)}</div>` : ''}
+                        <div class="message-callout-content">${body}</div>
+                    </div>
+                </div>
+            `;
         }
         if (blockType === 'tool_result') {
-            return `<div class="message-block message-tool-result">${renderMarkdown(String(block.content || block.text || ''))}</div>`;
+            const status = String(block.status || 'info').toLowerCase();
+            const title = String(block.title || 'Tool result').trim() || 'Tool result';
+            const body = renderMarkdown(getBlockText(block));
+            return `
+                <div class="message-block">
+                    <div class="message-tool-result is-${escapeHtml(status)}">
+                        <div class="message-tool-result-title">${escapeHtml(title)}</div>
+                        <div class="message-tool-result-content">${body}</div>
+                    </div>
+                </div>
+            `;
         }
-        return `<div class="message-block">${renderMarkdown(String(block.content || ''))}</div>`;
+        return `<div class="message-block">${renderMarkdown(getBlockText(block))}</div>`;
     }
 
     function renderCodeBlock(block) {
@@ -1262,10 +1289,12 @@
     }
 
     function renderTableBlock(block) {
-        const headers = Array.isArray(block.headers) ? block.headers : [];
+        const headers = Array.isArray(block.headers)
+            ? block.headers
+            : (Array.isArray(block.columns) ? block.columns : []);
         const rows = Array.isArray(block.rows) ? block.rows : [];
         if (!headers.length && !rows.length) {
-            return `<div class="message-block message-table-wrap">${renderMarkdown(String(block.content || ''))}</div>`;
+            return `<div class="message-block message-table-wrap">${renderMarkdown(getBlockText(block))}</div>`;
         }
         const headHtml = headers.length
             ? `<thead><tr>${headers.map((h) => `<th>${escapeHtml(String(h ?? ''))}</th>`).join('')}</tr></thead>`
@@ -1499,8 +1528,9 @@
                 // Find last assistant message
                 const lastMsg = [...sessionData.messages].reverse().find(m => m.role === 'assistant');
                 if (!lastMsg) return false;
-                // Consider non-empty content as final
-                return !!lastMsg.content && lastMsg.content.trim().length > 0;
+                const hasTextContent = typeof lastMsg.content === 'string' && lastMsg.content.trim().length > 0;
+                const hasDisplayBlocks = Array.isArray(lastMsg.display_blocks) && lastMsg.display_blocks.length > 0;
+                return hasTextContent || hasDisplayBlocks;
             }
 
             // Try to fetch session and poll if needed

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1231,7 +1231,15 @@
         if (!block || typeof block !== 'object') {
             return '';
         }
-        return String(block.content ?? block.text ?? '');
+        return String(
+            block.content
+            ?? block.text
+            ?? block.message
+            ?? block.output
+            ?? block.result
+            ?? block.value
+            ?? ''
+        );
     }
 
     function renderSingleDisplayBlock(block) {

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1273,7 +1273,7 @@
 
     function renderCodeBlock(block) {
         const language = String(block.language || block.lang || '').trim();
-        const codeText = String(block.content || block.code || '');
+        const codeText = String(block.code ?? getBlockText(block) ?? '');
         const escapedLanguage = escapeHtml(language || 'text');
         const escapedCode = escapeHtml(codeText);
         const classLanguage = language.toLowerCase().replace(/[^a-z0-9_+-]/g, '');

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1246,6 +1246,33 @@
         return '';
     }
 
+    function getMeaningfulScalar(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        const textValue = String(value);
+        return textValue.trim().length > 0 ? textValue : '';
+    }
+
+    function hasMeaningfulDisplayBlocks(blocks) {
+        const parsedBlocks = parseDisplayBlocks(blocks);
+        if (!parsedBlocks) {
+            return false;
+        }
+        return parsedBlocks.some((block) => {
+            const blockType = String(block.type || '').toLowerCase();
+            if (blockType === 'table') {
+                const headers = Array.isArray(block.headers) ? block.headers : (Array.isArray(block.columns) ? block.columns : []);
+                const rows = Array.isArray(block.rows) ? block.rows : [];
+                return headers.length > 0 || rows.length > 0 || getBlockText(block).length > 0;
+            }
+            if (blockType === 'code') {
+                return (getMeaningfulScalar(block.code) || getBlockText(block)).length > 0;
+            }
+            return getBlockText(block).length > 0;
+        });
+    }
+
     function renderSingleDisplayBlock(block) {
         const blockType = String(block.type || '').toLowerCase();
         if (blockType === 'code') {
@@ -1285,7 +1312,7 @@
 
     function renderCodeBlock(block) {
         const language = String(block.language || block.lang || '').trim();
-        const codeText = String(block.code ?? getBlockText(block) ?? '');
+        const codeText = getMeaningfulScalar(block.code) || getBlockText(block);
         const escapedLanguage = escapeHtml(language || 'text');
         const escapedCode = escapeHtml(codeText);
         const classLanguage = language.toLowerCase().replace(/[^a-z0-9_+-]/g, '');
@@ -1541,7 +1568,7 @@
                 const lastMsg = [...sessionData.messages].reverse().find(m => m.role === 'assistant');
                 if (!lastMsg) return false;
                 const hasTextContent = typeof lastMsg.content === 'string' && lastMsg.content.trim().length > 0;
-                const hasDisplayBlocks = Array.isArray(lastMsg.display_blocks) && lastMsg.display_blocks.length > 0;
+                const hasDisplayBlocks = hasMeaningfulDisplayBlocks(lastMsg.display_blocks);
                 return hasTextContent || hasDisplayBlocks;
             }
 

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1231,15 +1231,19 @@
         if (!block || typeof block !== 'object') {
             return '';
         }
-        return String(
-            block.content
-            ?? block.text
-            ?? block.message
-            ?? block.output
-            ?? block.result
-            ?? block.value
-            ?? ''
-        );
+        const textFields = ['content', 'text', 'message', 'output', 'result', 'value'];
+        for (const field of textFields) {
+            const value = block[field];
+            if (value === null || value === undefined) {
+                continue;
+            }
+            const textValue = String(value);
+            if (textValue.trim().length === 0) {
+                continue;
+            }
+            return textValue;
+        }
+        return '';
     }
 
     function renderSingleDisplayBlock(block) {

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1227,11 +1227,13 @@
         return parsedBlocks.map(renderSingleDisplayBlock).join('');
     }
 
-    function getBlockText(block) {
+    function getBlockText(block, preferCode = false) {
         if (!block || typeof block !== 'object') {
             return '';
         }
-        const textFields = ['content', 'text', 'message', 'output', 'result', 'value'];
+        const textFields = preferCode
+            ? ['code', 'content', 'text', 'output', 'result', 'value']
+            : ['content', 'text', 'output', 'result', 'value', 'message'];
         for (const field of textFields) {
             const value = block[field];
             if (value === null || value === undefined) {
@@ -1246,14 +1248,6 @@
         return '';
     }
 
-    function getMeaningfulScalar(value) {
-        if (value === null || value === undefined) {
-            return '';
-        }
-        const textValue = String(value);
-        return textValue.trim().length > 0 ? textValue : '';
-    }
-
     function hasMeaningfulDisplayBlocks(blocks) {
         const parsedBlocks = parseDisplayBlocks(blocks);
         if (!parsedBlocks) {
@@ -1264,12 +1258,9 @@
             if (blockType === 'table') {
                 const headers = Array.isArray(block.headers) ? block.headers : (Array.isArray(block.columns) ? block.columns : []);
                 const rows = Array.isArray(block.rows) ? block.rows : [];
-                return headers.length > 0 || rows.length > 0 || getBlockText(block).length > 0;
+                return headers.length > 0 || rows.length > 0 || getBlockText(block, false).length > 0;
             }
-            if (blockType === 'code') {
-                return (getMeaningfulScalar(block.code) || getBlockText(block)).length > 0;
-            }
-            return getBlockText(block).length > 0;
+            return getBlockText(block, blockType === 'code').length > 0;
         });
     }
 
@@ -1284,7 +1275,7 @@
         if (blockType === 'callout') {
             const tone = String(block.tone || 'info').toLowerCase();
             const title = String(block.title || '').trim();
-            const body = renderMarkdown(getBlockText(block));
+            const body = renderMarkdown(getBlockText(block, false));
             return `
                 <div class="message-block">
                     <div class="message-callout is-${escapeHtml(tone)}">
@@ -1297,7 +1288,7 @@
         if (blockType === 'tool_result') {
             const status = String(block.status || 'info').toLowerCase();
             const title = String(block.title || 'Tool result').trim() || 'Tool result';
-            const body = renderMarkdown(getBlockText(block));
+            const body = renderMarkdown(getBlockText(block, false));
             return `
                 <div class="message-block">
                     <div class="message-tool-result is-${escapeHtml(status)}">
@@ -1307,12 +1298,12 @@
                 </div>
             `;
         }
-        return `<div class="message-block">${renderMarkdown(getBlockText(block))}</div>`;
+        return `<div class="message-block">${renderMarkdown(getBlockText(block, false))}</div>`;
     }
 
     function renderCodeBlock(block) {
         const language = String(block.language || block.lang || '').trim();
-        const codeText = getMeaningfulScalar(block.code) || getBlockText(block);
+        const codeText = getBlockText(block, true);
         const escapedLanguage = escapeHtml(language || 'text');
         const escapedCode = escapeHtml(codeText);
         const classLanguage = language.toLowerCase().replace(/[^a-z0-9_+-]/g, '');

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -52,7 +52,10 @@ from src.runtime.portal_session_metadata_client import (
     extract_session_metadata_publish_fields,
     publish_session_metadata,
 )
-from src.runtime.display_blocks import normalize_display_blocks
+from src.gateway.chat_payloads import (
+    build_webchat_response_payload,
+    normalize_assistant_history_message,
+)
 from src.runtime.capability_registry import get_capability_registry
 from src.gateway.event_bus import emit_agent_event
 from src.sessions.manager import session_manager
@@ -385,16 +388,7 @@ def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str]
 
 def _message_with_display_blocks(message: Dict[str, Any]) -> Dict[str, Any]:
     """Return assistant messages with normalized display blocks."""
-    if not isinstance(message, dict):
-        return message
-    if message.get("role") != "assistant":
-        return dict(message)
-    normalized_message = dict(message)
-    normalized_message["display_blocks"] = normalize_display_blocks(
-        message.get("display_blocks"),
-        message.get("content", "") or "",
-    )
-    return normalized_message
+    return normalize_assistant_history_message(message)
 
 
 def load_template(filename: str) -> str:
@@ -679,13 +673,11 @@ async def api_chat(request: web.Request) -> web.Response:
         else:
             logger.warning(f"[api_chat] No session or empty history for {session_id}")
         
-        response = ""
-        usage = {}
-        reasoning = ""
-        if isinstance(result, dict):
-            response = result.get("response") or result.get("content") or ""
-            usage = result.get("usage", {}) or {}
-            reasoning = result.get("reasoning", "") or ""
+        response_data = build_webchat_response_payload(
+            result if isinstance(result, dict) else None,
+            session_id,
+        )
+        usage = response_data.get("usage", {}) or {}
         
         # Record usage if available
         if usage:
@@ -700,26 +692,9 @@ async def api_chat(request: web.Request) -> web.Response:
                 task_type="chat"
             )
         
-        response_data = {
-            'response': response,
-            'session_id': session_id,
-            'usage': usage
-        }
-        response_data["display_blocks"] = normalize_display_blocks(
-            result.get("display_blocks") if isinstance(result, dict) else None,
-            response,
-        )
-        
-        # Include user_message_id for frontend to update optimistic UI
-        if result and isinstance(result, dict):
-            user_msg_id = result.get("user_message_id")
-            if user_msg_id:
-                response_data['user_message_id'] = user_msg_id
-        
         # Include events for thinking process display
-        events = result.get("events", []) if result else []
+        events = response_data.get("events", [])
         if events:
-            response_data['events'] = events
             # Save events to session for persistence
             if 'metadata' not in session:
                 session['metadata'] = {}
@@ -727,9 +702,7 @@ async def api_chat(request: web.Request) -> web.Response:
             logger.info(f"[api_chat] Saved {len(events)} thinking events to session metadata")
         
         # Include LLM debug info for sidebar display
-        llm_debug = result.get("_llm_debug", {}) if result else {}
-        if llm_debug:
-            response_data['_llm_debug'] = llm_debug
+        llm_debug = response_data.get("_llm_debug", {}) or {}
         
         # Always save thinking events to chatlog (even without llm_debug)
         chatlog_dir = os.path.join(session_persistence.storage_dir, "chatlogs")
@@ -752,10 +725,6 @@ async def api_chat(request: web.Request) -> web.Response:
             logger.info(f"[api_chat] Saved chatlog with {len(events)} events to {chatlog_file}")
         except Exception as e:
             logger.warning(f"[api_chat] Failed to save chatlog: {e}")
-        
-        # Include reasoning if available
-        if reasoning:
-            response_data['reasoning'] = reasoning
         
         return web.json_response(response_data)
         

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -679,9 +679,13 @@ async def api_chat(request: web.Request) -> web.Response:
         else:
             logger.warning(f"[api_chat] No session or empty history for {session_id}")
         
-        response = result.get("response", "") if result else ""
-        usage = result.get("usage", {}) if result else {}
-        reasoning = result.get("reasoning", "") if result else ""
+        response = ""
+        usage = {}
+        reasoning = ""
+        if isinstance(result, dict):
+            response = result.get("response") or result.get("content") or ""
+            usage = result.get("usage", {}) or {}
+            reasoning = result.get("reasoning", "") or ""
         
         # Record usage if available
         if usage:

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -52,6 +52,7 @@ from src.runtime.portal_session_metadata_client import (
     extract_session_metadata_publish_fields,
     publish_session_metadata,
 )
+from src.runtime.display_blocks import normalize_display_blocks
 from src.runtime.capability_registry import get_capability_registry
 from src.gateway.event_bus import emit_agent_event
 from src.sessions.manager import session_manager
@@ -382,6 +383,20 @@ def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str]
     return runtime_agent_id, runtime_agent_name
 
 
+def _message_with_display_blocks(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Return assistant messages with normalized display blocks."""
+    if not isinstance(message, dict):
+        return message
+    if message.get("role") != "assistant":
+        return dict(message)
+    normalized_message = dict(message)
+    normalized_message["display_blocks"] = normalize_display_blocks(
+        message.get("display_blocks"),
+        message.get("content", "") or "",
+    )
+    return normalized_message
+
+
 def load_template(filename: str) -> str:
     """Load HTML template from file."""
     template_path = TEMPLATE_DIR / filename
@@ -686,6 +701,10 @@ async def api_chat(request: web.Request) -> web.Response:
             'session_id': session_id,
             'usage': usage
         }
+        response_data["display_blocks"] = normalize_display_blocks(
+            result.get("display_blocks") if isinstance(result, dict) else None,
+            response,
+        )
         
         # Include user_message_id for frontend to update optimistic UI
         if result and isinstance(result, dict):
@@ -1420,10 +1439,11 @@ async def api_load_session(request: web.Request) -> web.Response:
             return web.json_response({'error': 'Session not found'}, status=404)
         
         history = session_info.get('history', [])
+        normalized_history = [_message_with_display_blocks(msg) for msg in history]
         
         # Extract session name from first user message
         session_name = 'New Chat'
-        for msg in history:
+        for msg in normalized_history:
             if msg.get('role') == 'user':
                 content = msg.get('content', '') or 'New Chat'
                 session_name = truncate(content, 30)
@@ -1432,7 +1452,7 @@ async def api_load_session(request: web.Request) -> web.Response:
         return web.json_response({
             'session_id': session_id,
             'name': session_name,
-            'messages': history,
+            'messages': normalized_history,
             'metadata': session_info.get('metadata', {}),
         })
     except Exception as e:

--- a/src/runtime/display_blocks.py
+++ b/src/runtime/display_blocks.py
@@ -12,6 +12,54 @@ def build_markdown_display_blocks(text: str) -> List[Dict[str, Any]]:
     return [{"type": "markdown", "content": text}]
 
 
+def _text_value(block: Dict[str, Any]) -> str:
+    return str(block.get("content") if block.get("content") is not None else (block.get("text") or ""))
+
+
+def _normalize_display_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not isinstance(block, dict):
+        return None
+    block_type = block.get("type")
+    if not isinstance(block_type, str):
+        return None
+    normalized_type = block_type.strip().lower()
+    if not normalized_type:
+        return None
+
+    normalized_block: Dict[str, Any] = dict(block)
+    normalized_block["type"] = normalized_type
+
+    if normalized_type in {"markdown", "callout", "tool_result"}:
+        normalized_block["content"] = _text_value(block)
+        return normalized_block
+
+    if normalized_type == "code":
+        code_text = block.get("content")
+        if code_text is None:
+            code_text = block.get("code")
+        if code_text is None:
+            code_text = block.get("text")
+        normalized_block["content"] = "" if code_text is None else str(code_text)
+        language = block.get("lang")
+        if language is None:
+            language = block.get("language")
+        if language is not None:
+            normalized_block["lang"] = str(language)
+        return normalized_block
+
+    if normalized_type == "table":
+        headers = block.get("headers")
+        if not isinstance(headers, list):
+            headers = block.get("columns")
+        normalized_block["headers"] = headers if isinstance(headers, list) else []
+        rows = block.get("rows")
+        normalized_block["rows"] = rows if isinstance(rows, list) else []
+        normalized_block["content"] = _text_value(block)
+        return normalized_block
+
+    return normalized_block
+
+
 def normalize_display_blocks(raw_blocks: Optional[Any], fallback_text: str = "") -> List[Dict[str, Any]]:
     """Return normalized display blocks with markdown fallback.
 
@@ -20,14 +68,9 @@ def normalize_display_blocks(raw_blocks: Optional[Any], fallback_text: str = "")
     if isinstance(raw_blocks, list):
         normalized: List[Dict[str, Any]] = []
         for block in raw_blocks:
-            if not isinstance(block, dict):
-                continue
-            block_type = block.get("type")
-            if not isinstance(block_type, str) or not block_type.strip():
-                continue
-            normalized_block = dict(block)
-            normalized_block["type"] = block_type.strip()
-            normalized.append(normalized_block)
+            normalized_block = _normalize_display_block(block)
+            if normalized_block is not None:
+                normalized.append(normalized_block)
         if normalized:
             return normalized
 

--- a/src/runtime/display_blocks.py
+++ b/src/runtime/display_blocks.py
@@ -43,18 +43,46 @@ def _normalize_display_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if not normalized_type:
         return None
 
-    normalized_block: Dict[str, Any] = dict(block)
-    normalized_block["type"] = normalized_type
+    if normalized_type == "markdown":
+        content = _text_value(block)
+        if not content:
+            return None
+        return {"type": "markdown", "content": content}
 
-    if normalized_type in {"markdown", "callout", "tool_result"}:
-        normalized_block["content"] = _text_value(block)
+    if normalized_type == "callout":
+        content = _text_value(block)
+        if not content:
+            return None
+        normalized_block: Dict[str, Any] = {"type": "callout", "content": content}
+        title = _first_text_value(block, ("title",))
+        tone = _first_text_value(block, ("tone",))
+        if title:
+            normalized_block["title"] = title
+        if tone:
+            normalized_block["tone"] = tone
+        return normalized_block
+
+    if normalized_type == "tool_result":
+        content = _text_value(block)
+        if not content:
+            return None
+        normalized_block = {"type": "tool_result", "content": content}
+        title = _first_text_value(block, ("title",))
+        status = _first_text_value(block, ("status",))
+        if title:
+            normalized_block["title"] = title
+        if status:
+            normalized_block["status"] = status
         return normalized_block
 
     if normalized_type == "code":
-        normalized_block["content"] = _first_text_value(
+        content = _first_text_value(
             block,
             ("content", "code", "text", "value", "output"),
         )
+        if not content:
+            return None
+        normalized_block = {"type": "code", "content": content}
         language = block.get("lang")
         if language is None:
             language = block.get("language")
@@ -66,13 +94,25 @@ def _normalize_display_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         headers = block.get("headers")
         if not isinstance(headers, list):
             headers = block.get("columns")
-        normalized_block["headers"] = headers if isinstance(headers, list) else []
+        normalized_headers = headers if isinstance(headers, list) else []
         rows = block.get("rows")
-        normalized_block["rows"] = rows if isinstance(rows, list) else []
-        normalized_block["content"] = _text_value(block)
+        normalized_rows = rows if isinstance(rows, list) else []
+        content = _text_value(block)
+        if not normalized_headers and not normalized_rows and not content:
+            return None
+        normalized_block = {
+            "type": "table",
+            "headers": normalized_headers,
+            "rows": normalized_rows,
+        }
+        if content:
+            normalized_block["content"] = content
         return normalized_block
 
-    return normalized_block
+    content = _text_value(block)
+    if not content:
+        return None
+    return {"type": "markdown", "content": content}
 
 
 def normalize_display_blocks(raw_blocks: Optional[Any], fallback_text: str = "") -> List[Dict[str, Any]]:

--- a/src/runtime/display_blocks.py
+++ b/src/runtime/display_blocks.py
@@ -7,7 +7,9 @@ from typing import Any, Dict, List, Optional
 
 def build_markdown_display_blocks(text: str) -> List[Dict[str, Any]]:
     """Build a single markdown display block from plain text."""
-    if not isinstance(text, str) or not text:
+    if not isinstance(text, str):
+        return []
+    if not text.strip():
         return []
     return [{"type": "markdown", "content": text}]
 
@@ -15,8 +17,12 @@ def build_markdown_display_blocks(text: str) -> List[Dict[str, Any]]:
 def _first_text_value(block: Dict[str, Any], field_order: tuple[str, ...]) -> str:
     for field_name in field_order:
         value = block.get(field_name)
-        if value is not None:
-            return str(value)
+        if value is None:
+            continue
+        text = str(value)
+        if not text.strip():
+            continue
+        return text
     return ""
 
 

--- a/src/runtime/display_blocks.py
+++ b/src/runtime/display_blocks.py
@@ -14,16 +14,19 @@ def build_markdown_display_blocks(text: str) -> List[Dict[str, Any]]:
     return [{"type": "markdown", "content": text}]
 
 
+def _first_nonblank_str(block: Dict[str, Any], keys: List[str]) -> Optional[str]:
+    for key in keys:
+        value = block.get(key)
+        if not isinstance(value, str):
+            continue
+        if not value.strip():
+            continue
+        return value
+    return None
+
+
 def _first_text_value(block: Dict[str, Any], field_order: tuple[str, ...]) -> str:
-    for field_name in field_order:
-        value = block.get(field_name)
-        if value is None:
-            continue
-        text = str(value)
-        if not text.strip():
-            continue
-        return text
-    return ""
+    return _first_nonblank_str(block, list(field_order)) or ""
 
 
 def _text_value(block: Dict[str, Any]) -> str:
@@ -78,16 +81,16 @@ def _normalize_display_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if normalized_type == "code":
         content = _first_text_value(
             block,
-            ("content", "code", "text", "value", "output"),
+            ("content", "code", "text", "output", "result", "value"),
         )
         if not content:
             return None
         normalized_block = {"type": "code", "content": content}
-        language = block.get("lang")
+        language = block.get("language")
         if language is None:
-            language = block.get("language")
-        if language is not None:
-            normalized_block["lang"] = str(language)
+            language = block.get("lang")
+        if isinstance(language, str) and language.strip():
+            normalized_block["language"] = language
         return normalized_block
 
     if normalized_type == "table":
@@ -100,6 +103,8 @@ def _normalize_display_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         content = _text_value(block)
         if not normalized_headers and not normalized_rows and not content:
             return None
+        if not normalized_headers and not normalized_rows and content:
+            return {"type": "markdown", "content": content}
         normalized_block = {
             "type": "table",
             "headers": normalized_headers,
@@ -112,7 +117,7 @@ def _normalize_display_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     content = _text_value(block)
     if not content:
         return None
-    return {"type": "markdown", "content": content}
+    return {"type": normalized_type, "content": content}
 
 
 def normalize_display_blocks(raw_blocks: Optional[Any], fallback_text: str = "") -> List[Dict[str, Any]]:

--- a/src/runtime/display_blocks.py
+++ b/src/runtime/display_blocks.py
@@ -86,11 +86,11 @@ def _normalize_display_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         if not content:
             return None
         normalized_block = {"type": "code", "content": content}
-        language = block.get("language")
+        language = block.get("lang")
         if language is None:
-            language = block.get("lang")
+            language = block.get("language")
         if isinstance(language, str) and language.strip():
-            normalized_block["language"] = language
+            normalized_block["lang"] = language
         return normalized_block
 
     if normalized_type == "table":

--- a/src/runtime/display_blocks.py
+++ b/src/runtime/display_blocks.py
@@ -12,8 +12,19 @@ def build_markdown_display_blocks(text: str) -> List[Dict[str, Any]]:
     return [{"type": "markdown", "content": text}]
 
 
+def _first_text_value(block: Dict[str, Any], field_order: tuple[str, ...]) -> str:
+    for field_name in field_order:
+        value = block.get(field_name)
+        if value is not None:
+            return str(value)
+    return ""
+
+
 def _text_value(block: Dict[str, Any]) -> str:
-    return str(block.get("content") if block.get("content") is not None else (block.get("text") or ""))
+    return _first_text_value(
+        block,
+        ("content", "text", "message", "output", "result", "value"),
+    )
 
 
 def _normalize_display_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -34,12 +45,10 @@ def _normalize_display_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         return normalized_block
 
     if normalized_type == "code":
-        code_text = block.get("content")
-        if code_text is None:
-            code_text = block.get("code")
-        if code_text is None:
-            code_text = block.get("text")
-        normalized_block["content"] = "" if code_text is None else str(code_text)
+        normalized_block["content"] = _first_text_value(
+            block,
+            ("content", "code", "text", "value", "output"),
+        )
         language = block.get("lang")
         if language is None:
             language = block.get("language")

--- a/src/runtime/display_blocks.py
+++ b/src/runtime/display_blocks.py
@@ -1,0 +1,34 @@
+"""Utilities for normalizing assistant display blocks."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def build_markdown_display_blocks(text: str) -> List[Dict[str, Any]]:
+    """Build a single markdown display block from plain text."""
+    if not isinstance(text, str) or not text:
+        return []
+    return [{"type": "markdown", "content": text}]
+
+
+def normalize_display_blocks(raw_blocks: Optional[Any], fallback_text: str = "") -> List[Dict[str, Any]]:
+    """Return normalized display blocks with markdown fallback.
+
+    Valid blocks are non-empty dict items with a string ``type`` field.
+    """
+    if isinstance(raw_blocks, list):
+        normalized: List[Dict[str, Any]] = []
+        for block in raw_blocks:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if not isinstance(block_type, str) or not block_type.strip():
+                continue
+            normalized_block = dict(block)
+            normalized_block["type"] = block_type.strip()
+            normalized.append(normalized_block)
+        if normalized:
+            return normalized
+
+    return build_markdown_display_blocks(fallback_text)

--- a/tests/test_display_blocks_contract.py
+++ b/tests/test_display_blocks_contract.py
@@ -26,7 +26,7 @@ def test_normalize_code_aliases_to_canonical_fields():
     assert len(blocks) == 1
     assert blocks[0]["type"] == "code"
     assert blocks[0]["content"] == "print(1)"
-    assert blocks[0]["lang"] == "python"
+    assert blocks[0]["language"] == "python"
 
 
 def test_normalize_table_columns_to_headers():
@@ -61,7 +61,7 @@ def test_render_code_block_uses_block_text_fallback():
     assert start != -1
     chunk = js[start:start + 500]
 
-    assert "getBlockText(block)" in chunk or "block.text" in chunk
+    assert "getBlockText(block, true)" in chunk or "block.text" in chunk
 
 
 def test_normalize_tool_result_output_alias_to_content():
@@ -151,7 +151,7 @@ def test_normalize_code_prefers_non_blank_text_when_code_blank():
     assert len(blocks) == 1
     assert blocks[0]["type"] == "code"
     assert blocks[0]["content"] == "print(1)"
-    assert blocks[0]["lang"] == "python"
+    assert blocks[0]["language"] == "python"
 
 
 def test_normalize_fallback_markdown_preserves_leading_and_trailing_newlines():

--- a/tests/test_display_blocks_contract.py
+++ b/tests/test_display_blocks_contract.py
@@ -26,7 +26,7 @@ def test_normalize_code_aliases_to_canonical_fields():
     assert len(blocks) == 1
     assert blocks[0]["type"] == "code"
     assert blocks[0]["content"] == "print(1)"
-    assert blocks[0]["language"] == "python"
+    assert blocks[0]["lang"] == "python"
 
 
 def test_normalize_table_columns_to_headers():
@@ -86,6 +86,18 @@ def test_normalize_callout_message_alias_to_content():
     assert len(blocks) == 1
     assert blocks[0]["type"] == "callout"
     assert blocks[0]["content"] == "hello"
+
+
+def test_normalize_callout_message_alias_to_content_heads_up():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks([
+        {"type": "callout", "title": "Note", "message": "Heads up"}
+    ])
+
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "callout"
+    assert blocks[0]["content"] == "Heads up"
 
 
 def test_build_markdown_display_blocks_skips_whitespace_only_text():
@@ -151,7 +163,18 @@ def test_normalize_code_prefers_non_blank_text_when_code_blank():
     assert len(blocks) == 1
     assert blocks[0]["type"] == "code"
     assert blocks[0]["content"] == "print(1)"
-    assert blocks[0]["language"] == "python"
+    assert blocks[0]["lang"] == "python"
+
+
+def test_normalize_tool_result_bodyless_block_falls_back_to_markdown():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks(
+        [{"type": "tool_result", "title": "Bash", "content": "   "}],
+        fallback_text="hello",
+    )
+
+    assert blocks == [{"type": "markdown", "content": "hello"}]
 
 
 def test_normalize_fallback_markdown_preserves_leading_and_trailing_newlines():

--- a/tests/test_display_blocks_contract.py
+++ b/tests/test_display_blocks_contract.py
@@ -152,3 +152,21 @@ def test_normalize_code_prefers_non_blank_text_when_code_blank():
     assert blocks[0]["type"] == "code"
     assert blocks[0]["content"] == "print(1)"
     assert blocks[0]["lang"] == "python"
+
+
+def test_normalize_fallback_markdown_preserves_leading_and_trailing_newlines():
+    mod = _load_display_blocks_module()
+
+    raw_markdown = "\n# Title\n\nBody\n"
+    blocks = mod.normalize_display_blocks(None, raw_markdown)
+
+    assert blocks == [{"type": "markdown", "content": raw_markdown}]
+
+
+def test_normalize_fallback_markdown_preserves_indented_code_whitespace():
+    mod = _load_display_blocks_module()
+
+    raw_markdown = "    indented code line\n    second\n"
+    blocks = mod.normalize_display_blocks(None, raw_markdown)
+
+    assert blocks == [{"type": "markdown", "content": raw_markdown}]

--- a/tests/test_display_blocks_contract.py
+++ b/tests/test_display_blocks_contract.py
@@ -86,3 +86,34 @@ def test_normalize_callout_message_alias_to_content():
     assert len(blocks) == 1
     assert blocks[0]["type"] == "callout"
     assert blocks[0]["content"] == "hello"
+
+
+def test_build_markdown_display_blocks_skips_whitespace_only_text():
+    mod = _load_display_blocks_module()
+
+    assert mod.build_markdown_display_blocks("   ") == []
+    assert mod.build_markdown_display_blocks("\n\n") == []
+
+
+def test_normalize_tool_result_uses_non_blank_output_when_content_blank():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks([
+        {"type": "tool_result", "content": "   ", "output": "done"}
+    ])
+
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "tool_result"
+    assert blocks[0]["content"] == "done"
+
+
+def test_normalize_code_uses_non_blank_text_when_content_blank():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks([
+        {"type": "code", "content": "  ", "text": "print(1)"}
+    ])
+
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "code"
+    assert blocks[0]["content"] == "print(1)"

--- a/tests/test_display_blocks_contract.py
+++ b/tests/test_display_blocks_contract.py
@@ -1,0 +1,64 @@
+"""Focused display_blocks contract tests with minimal import surface."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_display_blocks_module():
+    repo_root = Path(__file__).parent.parent
+    module_path = repo_root / "src" / "runtime" / "display_blocks.py"
+    spec = importlib.util.spec_from_file_location("display_blocks_contract", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_code_aliases_to_canonical_fields():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks([
+        {"type": "code", "text": "print(1)", "language": "python"}
+    ])
+
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "code"
+    assert blocks[0]["content"] == "print(1)"
+    assert blocks[0]["lang"] == "python"
+
+
+def test_normalize_table_columns_to_headers():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks([
+        {"type": "table", "columns": ["A"], "rows": [["1"]]}
+    ])
+
+    assert len(blocks) == 1
+    assert blocks[0]["headers"] == ["A"]
+    assert blocks[0]["rows"] == [["1"]]
+
+
+def test_normalize_invalid_blocks_falls_back_to_markdown():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks(
+        [{"type": "   "}, "bad", None],
+        fallback_text="hello",
+    )
+
+    assert blocks == [{"type": "markdown", "content": "hello"}]
+
+
+def test_render_code_block_uses_block_text_fallback():
+    repo_root = Path(__file__).parent.parent
+    js = (repo_root / "src" / "gateway" / "static" / "js" / "webchat.js").read_text(encoding="utf-8")
+
+    anchor = "function renderCodeBlock(block)"
+    start = js.find(anchor)
+    assert start != -1
+    chunk = js[start:start + 500]
+
+    assert "getBlockText(block)" in chunk or "block.text" in chunk

--- a/tests/test_display_blocks_contract.py
+++ b/tests/test_display_blocks_contract.py
@@ -117,3 +117,38 @@ def test_normalize_code_uses_non_blank_text_when_content_blank():
     assert len(blocks) == 1
     assert blocks[0]["type"] == "code"
     assert blocks[0]["content"] == "print(1)"
+
+
+def test_normalize_whitespace_tool_result_is_dropped_without_fallback():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks(
+        [{"type": "tool_result", "title": "Bash", "content": "   "}],
+        fallback_text="",
+    )
+
+    assert blocks == []
+
+
+def test_normalize_whitespace_callout_uses_markdown_fallback():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks(
+        [{"type": "callout", "title": "Note", "content": "   "}],
+        fallback_text="fallback",
+    )
+
+    assert blocks == [{"type": "markdown", "content": "fallback"}]
+
+
+def test_normalize_code_prefers_non_blank_text_when_code_blank():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks(
+        [{"type": "code", "code": "   ", "text": "print(1)", "language": "python"}]
+    )
+
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "code"
+    assert blocks[0]["content"] == "print(1)"
+    assert blocks[0]["lang"] == "python"

--- a/tests/test_display_blocks_contract.py
+++ b/tests/test_display_blocks_contract.py
@@ -62,3 +62,27 @@ def test_render_code_block_uses_block_text_fallback():
     chunk = js[start:start + 500]
 
     assert "getBlockText(block)" in chunk or "block.text" in chunk
+
+
+def test_normalize_tool_result_output_alias_to_content():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks([
+        {"type": "tool_result", "title": "Bash", "status": "success", "output": "done"}
+    ])
+
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "tool_result"
+    assert blocks[0]["content"] == "done"
+
+
+def test_normalize_callout_message_alias_to_content():
+    mod = _load_display_blocks_module()
+
+    blocks = mod.normalize_display_blocks([
+        {"type": "callout", "title": "Note", "message": "hello"}
+    ])
+
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "callout"
+    assert blocks[0]["content"] == "hello"

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -85,6 +85,9 @@ class TestWebChatStaticFiles:
         assert 'escapeHtml(' in js
         assert 'renderDisplayBlocks(' in js
         assert 'enhanceRenderedMessage(' in js
+        assert 'function getBlockText(block, preferCode = false)' in js
+        assert 'hasMeaningfulDisplayBlocks(' in js
+        assert 'hasMeaningfulDisplayBlocks(lastMsg.display_blocks)' in js
 
 
 
@@ -2131,6 +2134,38 @@ async def test_api_chat_accepts_legacy_content_payload(monkeypatch):
     payload = json.loads(resp.text)
     assert payload["response"] == "hello from content"
     assert payload["display_blocks"][0]["content"] == "hello from content"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_treats_whitespace_response_as_empty_and_falls_back_to_content(monkeypatch):
+    from src.gateway import webchat
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {
+            "response": "   ",
+            "content": "hello from content",
+            "usage": {},
+            "_execution_result": object(),
+        }
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-whitespace-fallback"}
+
+    resp = await webchat.api_chat(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["response"] == "hello from content"
 
 
 @pytest.mark.asyncio

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import subprocess
 import pytest
 from pathlib import Path
 
@@ -2245,7 +2246,7 @@ def test_webchat_js_tool_result_richer_renderer_present():
     assert "message-tool-result" in chunk
     assert "message-tool-result-title" in chunk
     assert "is-${" in chunk
-    assert "block.content ?? block.text ?? ''" in js
+    assert "getBlockText(block)" in chunk or "block.output" in js
 
 
 def test_webchat_js_callout_richer_renderer_present():
@@ -2260,7 +2261,7 @@ def test_webchat_js_callout_richer_renderer_present():
     assert "message-callout" in chunk
     assert "message-callout-title" in chunk
     assert "is-${" in chunk
-    assert "block.content ?? block.text ?? ''" in js
+    assert "getBlockText(block)" in chunk or "block.message" in js
 
 
 def test_webchat_css_richer_block_variant_classes_present():
@@ -2274,3 +2275,90 @@ def test_webchat_css_richer_block_variant_classes_present():
     assert ".message-tool-result.is-warning" in css
     assert ".message-tool-result.is-error" in css
     assert ".message-tool-result.is-running" in css
+
+
+def test_webchat_js_renders_tool_result_output_and_callout_message():
+    repo_root = Path(__file__).parent.parent
+    js_path = repo_root / "src" / "gateway" / "static" / "js" / "webchat.js"
+    js = js_path.read_text(encoding="utf-8")
+
+    start_get = js.find("function getBlockText(block)")
+    start_single = js.find("function renderSingleDisplayBlock(block)")
+    start_code = js.find("function renderCodeBlock(block)")
+    start_table = js.find("function renderTableBlock(block)")
+    assert min(start_get, start_single, start_code, start_table) >= 0
+
+    snippet = "\n".join([
+        js[start_get:start_single],
+        js[start_single:start_code],
+        js[start_code:start_table],
+    ])
+
+    node_script = f"""
+{snippet}
+function renderMarkdown(text) {{
+  return String(text || '');
+}}
+function escapeHtml(text) {{
+  return String(text || '');
+}}
+const toolHtml = renderSingleDisplayBlock({{
+  type: 'tool_result',
+  title: 'Bash',
+  status: 'success',
+  output: 'done'
+}});
+const calloutHtml = renderSingleDisplayBlock({{
+  type: 'callout',
+  title: 'Note',
+  message: 'hello'
+}});
+if (!toolHtml.includes('done')) throw new Error('tool_result output not rendered');
+if (!calloutHtml.includes('hello')) throw new Error('callout message not rendered');
+console.log('ok');
+"""
+    result = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=str(repo_root),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.asyncio
+async def test_assistant_persist_and_result_payload_share_display_blocks(monkeypatch):
+    from src.agents.core import Agent
+    from src.agents import core as core_module
+
+    agent = Agent.__new__(Agent)
+    agent.agent_name = "Assistant"
+    agent.agent_id = "agent-1"
+    supplied_extra = {"display_blocks": [{"type": "code", "text": "print(1)", "language": "python"}]}
+
+    captured = {}
+
+    async def _fake_add_message(session_id, role, content, extra=None):
+        captured["session_id"] = session_id
+        captured["role"] = role
+        captured["content"] = content
+        captured["extra"] = extra or {}
+        return "m-1"
+
+    monkeypatch.setattr(core_module.session_manager, "add_message", _fake_add_message)
+
+    persisted_extra = await agent._persist_assistant_message(
+        "s1",
+        "print(1)",
+        extra=supplied_extra,
+    )
+    payload = agent._build_assistant_result_payload(
+        "print(1)",
+        usage={},
+        user_message_id="u1",
+        extra=supplied_extra,
+    )
+
+    assert captured["role"] == "assistant"
+    assert persisted_extra["display_blocks"] == payload["display_blocks"]

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -90,6 +90,47 @@ class TestWebChatStaticFiles:
         assert 'hasMeaningfulDisplayBlocks(lastMsg.display_blocks)' in js
 
 
+def test_webchat_js_final_assistant_detection_respects_renderable_blocks():
+    js_path = Path(__file__).parent.parent / "src" / "gateway" / "static" / "js" / "webchat.js"
+    js = js_path.read_text(encoding='utf-8')
+    parse_start = js.find("function parseDisplayBlocks(raw)")
+    get_block_text_start = js.find("function getBlockText(block, preferCode = false)")
+    has_renderable_start = js.find("function hasRenderableDisplayBlock(block)")
+    has_meaningful_start = js.find("function hasMeaningfulDisplayBlocks(blocks)")
+    render_single_start = js.find("function renderSingleDisplayBlock(block)")
+    has_final_start = js.find("function hasFinalAssistant(sessionData)")
+    poll_start = js.find("async function pollSessionUntilFinal()")
+
+    assert parse_start != -1
+    assert get_block_text_start != -1
+    assert has_renderable_start != -1
+    assert has_meaningful_start != -1
+    assert render_single_start != -1
+    assert has_final_start != -1
+    assert poll_start != -1
+
+    parse_fn = js[parse_start:get_block_text_start]
+    get_block_text_fn = js[get_block_text_start:has_renderable_start]
+    has_renderable_fn = js[has_renderable_start:has_meaningful_start]
+    has_meaningful_fn = js[has_meaningful_start:render_single_start]
+    has_final_fn = js[has_final_start:poll_start]
+
+    empty_payload = {"messages": [{"role": "assistant", "display_blocks": [{"type": "tool_result", "title": "Bash", "content": "   "}]}]}
+    filled_payload = {"messages": [{"role": "assistant", "display_blocks": [{"type": "tool_result", "title": "Bash", "output": "done"}]}]}
+    script = f"""
+{parse_fn}
+{get_block_text_fn}
+{has_renderable_fn}
+{has_meaningful_fn}
+{has_final_fn}
+console.log(String(hasFinalAssistant({json.dumps(empty_payload)})));
+console.log(String(hasFinalAssistant({json.dumps(filled_payload)})));
+"""
+    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    outputs = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    assert outputs == ["false", "true"]
+
+
 
 class TestWebChatRoutes:
     """Tests for WebChat route registration."""

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -2171,3 +2171,35 @@ def test_agent_assistant_display_helpers_minimal_payload():
     assert payload["response"] == "hello"
     assert payload["display_blocks"][0]["content"] == "hello"
     assert payload["user_message_id"] == "u1"
+
+
+def test_webchat_js_passes_display_blocks_in_both_session_render_paths():
+    repo_root = Path(__file__).parent.parent
+    js = (repo_root / "src" / "gateway" / "static" / "js" / "webchat.js").read_text(encoding="utf-8")
+
+    poll_render_anchor = "if (gotFinal && sessionData && sessionData.messages && sessionData.messages.length > 0)"
+    poll_start = js.find(poll_render_anchor)
+    assert poll_start != -1
+    poll_chunk = js[poll_start: poll_start + 1200]
+    assert "msg.display_blocks || null" in poll_chunk
+
+    load_session_anchor = "messages.forEach(msg => {"
+    load_start = js.rfind(load_session_anchor)
+    assert load_start != -1
+    load_chunk = js[load_start: load_start + 700]
+    assert "msg.display_blocks || null" in load_chunk
+
+
+def test_core_max_iterations_response_text_is_consistent():
+    repo_root = Path(__file__).parent.parent
+    core_py = (repo_root / "src" / "agents" / "core.py").read_text(encoding="utf-8")
+
+    max_iter_anchor = "max_iterations_text = \"Task completed after maximum iterations.\""
+    start = core_py.find(max_iter_anchor)
+    assert start != -1
+    chunk = core_py[start: start + 1100]
+
+    assert 'send_event("complete", {' in chunk
+    assert '"response": max_iterations_text' in chunk
+    assert '_build_assistant_result_payload(' in chunk
+    assert '"Task completed (max iterations reached)"' not in chunk

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -2063,3 +2063,111 @@ async def test_api_load_session_backfills_assistant_display_blocks(monkeypatch):
     assert assistant_msg["role"] == "assistant"
     assert assistant_msg["display_blocks"][0]["type"] == "markdown"
     assert assistant_msg["display_blocks"][0]["content"] == "hello from history"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_preserves_structured_display_blocks(monkeypatch):
+    from src.gateway import webchat
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {
+            "response": "fallback text",
+            "display_blocks": [
+                {"type": "code", "lang": "python", "content": "print('hi')"}
+            ],
+            "usage": {},
+            "_execution_result": object(),
+        }
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-structured"}
+
+    resp = await webchat.api_chat(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["display_blocks"][0]["type"] == "code"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_accepts_legacy_content_payload(monkeypatch):
+    from src.gateway import webchat
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {
+            "content": "hello from content",
+            "role": "assistant",
+            "usage": {},
+            "_execution_result": object(),
+        }
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-legacy"}
+
+    resp = await webchat.api_chat(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["response"] == "hello from content"
+    assert payload["display_blocks"][0]["content"] == "hello from content"
+
+
+@pytest.mark.asyncio
+async def test_api_load_session_keeps_existing_structured_display_blocks(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+
+    async def _fake_get_session(_session_id):
+        return {
+            "history": [
+                {"role": "assistant", "content": "fallback", "display_blocks": [{"type": "code", "lang": "python", "content": "print('x')"}]},
+            ],
+            "metadata": {},
+        }
+
+    monkeypatch.setattr(webchat.session_manager, "get_session", _fake_get_session)
+
+    class _Request:
+        match_info = {"session_id": "s-keep"}
+
+    resp = await webchat.api_load_session(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["messages"][0]["display_blocks"][0]["type"] == "code"
+
+
+def test_agent_assistant_display_helpers_minimal_payload():
+    from src.agents.core import Agent
+
+    agent = Agent.__new__(Agent)
+    agent.agent_name = "Assistant"
+    agent.agent_id = "agent-1"
+
+    message_extra = agent._build_assistant_message_extra("hello")
+    assert message_extra["display_blocks"][0]["type"] == "markdown"
+
+    payload = agent._build_assistant_result_payload("hello", usage={}, user_message_id="u1")
+    assert payload["response"] == "hello"
+    assert payload["display_blocks"][0]["content"] == "hello"
+    assert payload["user_message_id"] == "u1"

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -2203,3 +2203,74 @@ def test_core_max_iterations_response_text_is_consistent():
     assert '"response": max_iterations_text' in chunk
     assert '_build_assistant_result_payload(' in chunk
     assert '"Task completed (max iterations reached)"' not in chunk
+
+
+def test_webchat_js_block_only_final_assistant_detection_present():
+    repo_root = Path(__file__).parent.parent
+    js = (repo_root / "src" / "gateway" / "static" / "js" / "webchat.js").read_text(encoding="utf-8")
+
+    anchor = "function hasFinalAssistant(sessionData)"
+    start = js.find(anchor)
+    assert start != -1
+    chunk = js[start:start + 900]
+
+    assert "find(m => m.role === 'assistant')" in chunk
+    assert "lastMsg.display_blocks" in chunk
+    assert "lastMsg.content" in chunk
+    assert "hasTextContent || hasDisplayBlocks" in chunk
+
+
+def test_webchat_js_table_columns_compatibility_present():
+    repo_root = Path(__file__).parent.parent
+    js = (repo_root / "src" / "gateway" / "static" / "js" / "webchat.js").read_text(encoding="utf-8")
+
+    anchor = "function renderTableBlock(block)"
+    start = js.find(anchor)
+    assert start != -1
+    chunk = js[start:start + 700]
+
+    assert "block.headers" in chunk
+    assert "block.columns" in chunk
+
+
+def test_webchat_js_tool_result_richer_renderer_present():
+    repo_root = Path(__file__).parent.parent
+    js = (repo_root / "src" / "gateway" / "static" / "js" / "webchat.js").read_text(encoding="utf-8")
+
+    anchor = "if (blockType === 'tool_result')"
+    start = js.find(anchor)
+    assert start != -1
+    chunk = js[start:start + 700]
+
+    assert "message-tool-result" in chunk
+    assert "message-tool-result-title" in chunk
+    assert "is-${" in chunk
+    assert "block.content ?? block.text ?? ''" in js
+
+
+def test_webchat_js_callout_richer_renderer_present():
+    repo_root = Path(__file__).parent.parent
+    js = (repo_root / "src" / "gateway" / "static" / "js" / "webchat.js").read_text(encoding="utf-8")
+
+    anchor = "if (blockType === 'callout')"
+    start = js.find(anchor)
+    assert start != -1
+    chunk = js[start:start + 700]
+
+    assert "message-callout" in chunk
+    assert "message-callout-title" in chunk
+    assert "is-${" in chunk
+    assert "block.content ?? block.text ?? ''" in js
+
+
+def test_webchat_css_richer_block_variant_classes_present():
+    repo_root = Path(__file__).parent.parent
+    css = (repo_root / "src" / "gateway" / "static" / "css" / "webchat.css").read_text(encoding="utf-8")
+
+    assert ".message-callout.is-success" in css
+    assert ".message-callout.is-warning" in css
+    assert ".message-callout.is-error" in css
+    assert ".message-tool-result.is-success" in css
+    assert ".message-tool-result.is-warning" in css
+    assert ".message-tool-result.is-error" in css
+    assert ".message-tool-result.is-running" in css

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -66,6 +66,9 @@ class TestWebChatStaticFiles:
         assert '.message {' in css
         assert '.input-field {' in css
         assert '.send-button {' in css
+        assert '.copy-code-button' in css
+        assert '.message-codeblock-toolbar' in css
+        assert '.message-table-wrap' in css
     
     def test_js_file_exists(self):
         """Test JS file exists and has content."""
@@ -79,6 +82,8 @@ class TestWebChatStaticFiles:
         assert 'function sendMessage()' in js
         assert 'addMessage(' in js
         assert 'escapeHtml(' in js
+        assert 'renderDisplayBlocks(' in js
+        assert 'enhanceRenderedMessage(' in js
 
 
 
@@ -1995,3 +2000,66 @@ def test_runtime_task_tracker_prune_removes_terminal_records_even_if_oldest_is_r
     assert tracker.get("task-running") is not None
     remaining_terminal = [task_id for task_id in ("task-success", "task-error") if tracker.get(task_id) is not None]
     assert len(remaining_terminal) == 1
+
+
+@pytest.mark.asyncio
+async def test_api_chat_returns_display_blocks(monkeypatch):
+    from src.gateway import webchat
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {
+            "response": "## Hello\n\n```python\nprint('hi')\n```",
+            "usage": {},
+            "_execution_result": object(),
+        }
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-display"}
+
+    resp = await webchat.api_chat(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["response"] == "## Hello\n\n```python\nprint('hi')\n```"
+    assert "display_blocks" in payload
+    assert payload["display_blocks"][0]["type"] == "markdown"
+    assert payload["display_blocks"][0]["content"] == payload["response"]
+
+
+@pytest.mark.asyncio
+async def test_api_load_session_backfills_assistant_display_blocks(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+
+    async def _fake_get_session(_session_id):
+        return {
+            "history": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello from history"},
+            ],
+            "metadata": {},
+        }
+
+    monkeypatch.setattr(webchat.session_manager, "get_session", _fake_get_session)
+
+    class _Request:
+        match_info = {"session_id": "s-load"}
+
+    resp = await webchat.api_load_session(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assistant_msg = payload["messages"][1]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["display_blocks"][0]["type"] == "markdown"
+    assert assistant_msg["display_blocks"][0]["content"] == "hello from history"

--- a/tests/test_webchat_display_contract.py
+++ b/tests/test_webchat_display_contract.py
@@ -76,6 +76,15 @@ def test_normalize_assistant_history_message_leaves_non_assistant_shape():
     assert "display_blocks" not in message
 
 
+def test_webchat_source_includes_display_blocks_final_assistant_checks():
+    repo_root = Path(__file__).parent.parent
+    js_source = (repo_root / "src" / "gateway" / "static" / "js" / "webchat.js").read_text(encoding="utf-8")
+
+    assert "function getBlockText(block, preferCode = false)" in js_source
+    assert "lastMsg.display_blocks" in js_source
+    assert "hasMeaningfulDisplayBlocks(lastMsg.display_blocks)" in js_source
+
+
 def test_build_webchat_response_payload_treats_whitespace_response_as_empty():
     mod = _load_chat_payloads_module()
     payload = mod.build_webchat_response_payload(
@@ -119,7 +128,7 @@ def test_render_single_display_block_uses_non_blank_output_text():
     js_path = repo_root / "src" / "gateway" / "static" / "js" / "webchat.js"
     js_source = js_path.read_text(encoding="utf-8")
 
-    get_block_text_start = js_source.find("function getBlockText(block)")
+    get_block_text_start = js_source.find("function getBlockText(block, preferCode = false)")
     render_single_start = js_source.find("function renderSingleDisplayBlock(block)")
     render_code_start = js_source.find("function renderCodeBlock(block)")
     assert get_block_text_start != -1
@@ -146,24 +155,20 @@ def test_render_code_block_ignores_blank_code_and_uses_text_fallback():
     js_path = repo_root / "src" / "gateway" / "static" / "js" / "webchat.js"
     js_source = js_path.read_text(encoding="utf-8")
 
-    get_block_text_start = js_source.find("function getBlockText(block)")
-    get_meaningful_start = js_source.find("function getMeaningfulScalar(value)")
+    get_block_text_start = js_source.find("function getBlockText(block, preferCode = false)")
     render_single_start = js_source.find("function renderSingleDisplayBlock(block)")
     render_code_start = js_source.find("function renderCodeBlock(block)")
     render_table_start = js_source.find("function renderTableBlock(block)")
     assert get_block_text_start != -1
-    assert get_meaningful_start != -1
     assert render_single_start != -1
     assert render_code_start != -1
     assert render_table_start != -1
 
-    get_block_text_fn = js_source[get_block_text_start:get_meaningful_start]
-    get_meaningful_fn = js_source[get_meaningful_start:render_single_start]
+    get_block_text_fn = js_source[get_block_text_start:render_single_start]
     render_code_fn = js_source[render_code_start:render_table_start]
 
     script = f"""
 {get_block_text_fn}
-{get_meaningful_fn}
 function escapeHtml(v) {{ return String(v); }}
 {render_code_fn}
 const html = renderCodeBlock({json.dumps({"type": "code", "code": "   ", "text": "print(1)", "language": "python"})});
@@ -180,23 +185,20 @@ def test_has_final_assistant_ignores_shell_display_blocks():
     js_source = js_path.read_text(encoding="utf-8")
 
     parse_start = js_source.find("function parseDisplayBlocks(raw)")
-    get_block_text_start = js_source.find("function getBlockText(block)")
-    get_meaningful_start = js_source.find("function getMeaningfulScalar(value)")
+    get_block_text_start = js_source.find("function getBlockText(block, preferCode = false)")
     has_meaningful_start = js_source.find("function hasMeaningfulDisplayBlocks(blocks)")
     render_single_start = js_source.find("function renderSingleDisplayBlock(block)")
     has_final_start = js_source.find("function hasFinalAssistant(sessionData)")
     poll_start = js_source.find("async function pollSessionUntilFinal()")
     assert parse_start != -1
     assert get_block_text_start != -1
-    assert get_meaningful_start != -1
     assert has_meaningful_start != -1
     assert render_single_start != -1
     assert has_final_start != -1
     assert poll_start != -1
 
     parse_fn = js_source[parse_start:get_block_text_start]
-    get_block_text_fn = js_source[get_block_text_start:get_meaningful_start]
-    get_meaningful_fn = js_source[get_meaningful_start:has_meaningful_start]
+    get_block_text_fn = js_source[get_block_text_start:has_meaningful_start]
     has_meaningful_fn = js_source[has_meaningful_start:render_single_start]
     has_final_fn = js_source[has_final_start:poll_start]
 
@@ -208,7 +210,6 @@ def test_has_final_assistant_ignores_shell_display_blocks():
     script = f"""
 {parse_fn}
 {get_block_text_fn}
-{get_meaningful_fn}
 {has_meaningful_fn}
 {has_final_fn}
 const result = hasFinalAssistant({json.dumps(session_payload)});

--- a/tests/test_webchat_display_contract.py
+++ b/tests/test_webchat_display_contract.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
+import subprocess
 
 
 def _load_chat_payloads_module():
@@ -72,3 +74,50 @@ def test_normalize_assistant_history_message_leaves_non_assistant_shape():
     assert message["role"] == "user"
     assert message["content"] == "hello"
     assert "display_blocks" not in message
+
+
+def test_build_webchat_response_payload_treats_whitespace_response_as_empty():
+    mod = _load_chat_payloads_module()
+    payload = mod.build_webchat_response_payload(
+        {"response": "   ", "display_blocks": [None, {"type": "   "}]},
+        "s-4",
+    )
+
+    assert payload["response"] == ""
+    assert payload["display_blocks"] == []
+
+
+def test_normalize_assistant_history_message_treats_whitespace_content_as_empty():
+    mod = _load_chat_payloads_module()
+    message = mod.normalize_assistant_history_message(
+        {"role": "assistant", "content": "   ", "display_blocks": [None, {"type": "   "}]}
+    )
+
+    assert message["display_blocks"] == []
+
+
+def test_render_single_display_block_uses_non_blank_output_text():
+    repo_root = Path(__file__).parent.parent
+    js_path = repo_root / "src" / "gateway" / "static" / "js" / "webchat.js"
+    js_source = js_path.read_text(encoding="utf-8")
+
+    get_block_text_start = js_source.find("function getBlockText(block)")
+    render_single_start = js_source.find("function renderSingleDisplayBlock(block)")
+    render_code_start = js_source.find("function renderCodeBlock(block)")
+    assert get_block_text_start != -1
+    assert render_single_start != -1
+    assert render_code_start != -1
+
+    get_block_text_fn = js_source[get_block_text_start:render_single_start]
+    render_single_fn = js_source[render_single_start:render_code_start]
+
+    script = f"""
+{get_block_text_fn}
+function escapeHtml(v) {{ return String(v); }}
+function renderMarkdown(v) {{ return String(v); }}
+{render_single_fn}
+const html = renderSingleDisplayBlock({json.dumps({"type": "tool_result", "content": "   ", "output": "done"})});
+console.log(html);
+"""
+    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    assert "done" in result.stdout

--- a/tests/test_webchat_display_contract.py
+++ b/tests/test_webchat_display_contract.py
@@ -121,3 +121,79 @@ console.log(html);
 """
     result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
     assert "done" in result.stdout
+
+
+def test_render_code_block_ignores_blank_code_and_uses_text_fallback():
+    repo_root = Path(__file__).parent.parent
+    js_path = repo_root / "src" / "gateway" / "static" / "js" / "webchat.js"
+    js_source = js_path.read_text(encoding="utf-8")
+
+    get_block_text_start = js_source.find("function getBlockText(block)")
+    get_meaningful_start = js_source.find("function getMeaningfulScalar(value)")
+    render_single_start = js_source.find("function renderSingleDisplayBlock(block)")
+    render_code_start = js_source.find("function renderCodeBlock(block)")
+    render_table_start = js_source.find("function renderTableBlock(block)")
+    assert get_block_text_start != -1
+    assert get_meaningful_start != -1
+    assert render_single_start != -1
+    assert render_code_start != -1
+    assert render_table_start != -1
+
+    get_block_text_fn = js_source[get_block_text_start:get_meaningful_start]
+    get_meaningful_fn = js_source[get_meaningful_start:render_single_start]
+    render_code_fn = js_source[render_code_start:render_table_start]
+
+    script = f"""
+{get_block_text_fn}
+{get_meaningful_fn}
+function escapeHtml(v) {{ return String(v); }}
+{render_code_fn}
+const html = renderCodeBlock({json.dumps({"type": "code", "code": "   ", "text": "print(1)", "language": "python"})});
+console.log(html);
+"""
+    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    assert "print(1)" in result.stdout
+
+
+def test_has_final_assistant_ignores_shell_display_blocks():
+    repo_root = Path(__file__).parent.parent
+    js_path = repo_root / "src" / "gateway" / "static" / "js" / "webchat.js"
+    js_source = js_path.read_text(encoding="utf-8")
+
+    parse_start = js_source.find("function parseDisplayBlocks(raw)")
+    get_block_text_start = js_source.find("function getBlockText(block)")
+    get_meaningful_start = js_source.find("function getMeaningfulScalar(value)")
+    has_meaningful_start = js_source.find("function hasMeaningfulDisplayBlocks(blocks)")
+    render_single_start = js_source.find("function renderSingleDisplayBlock(block)")
+    has_final_start = js_source.find("function hasFinalAssistant(sessionData)")
+    poll_start = js_source.find("async function pollSessionUntilFinal()")
+    assert parse_start != -1
+    assert get_block_text_start != -1
+    assert get_meaningful_start != -1
+    assert has_meaningful_start != -1
+    assert render_single_start != -1
+    assert has_final_start != -1
+    assert poll_start != -1
+
+    parse_fn = js_source[parse_start:get_block_text_start]
+    get_block_text_fn = js_source[get_block_text_start:get_meaningful_start]
+    get_meaningful_fn = js_source[get_meaningful_start:has_meaningful_start]
+    has_meaningful_fn = js_source[has_meaningful_start:render_single_start]
+    has_final_fn = js_source[has_final_start:poll_start]
+
+    session_payload = {
+        "messages": [
+            {"role": "assistant", "content": "   ", "display_blocks": [{"type": "tool_result", "content": "   "}]}
+        ]
+    }
+    script = f"""
+{parse_fn}
+{get_block_text_fn}
+{get_meaningful_fn}
+{has_meaningful_fn}
+{has_final_fn}
+const result = hasFinalAssistant({json.dumps(session_payload)});
+console.log(String(result));
+"""
+    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    assert result.stdout.strip() == "false"

--- a/tests/test_webchat_display_contract.py
+++ b/tests/test_webchat_display_contract.py
@@ -1,0 +1,74 @@
+"""Import-light contract tests for WebChat payload normalization helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_chat_payloads_module():
+    repo_root = Path(__file__).parent.parent
+    module_path = repo_root / "src" / "gateway" / "chat_payloads.py"
+    spec = importlib.util.spec_from_file_location("webchat_payloads_contract", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_webchat_response_payload_falls_back_to_content():
+    mod = _load_chat_payloads_module()
+    payload = mod.build_webchat_response_payload({"content": "hello"}, "s-1")
+
+    assert payload["response"] == "hello"
+    assert payload["session_id"] == "s-1"
+    assert payload["display_blocks"] == [{"type": "markdown", "content": "hello"}]
+
+
+def test_build_webchat_response_payload_preserves_block_only_response():
+    mod = _load_chat_payloads_module()
+    payload = mod.build_webchat_response_payload(
+        {
+            "response": "",
+            "display_blocks": [
+                {"type": "tool_result", "title": "Bash", "status": "success", "output": "done"},
+            ],
+        },
+        "s-2",
+    )
+
+    assert payload["response"] == ""
+    assert payload["display_blocks"][0]["type"] == "tool_result"
+    assert payload["display_blocks"][0]["content"] == "done"
+
+
+def test_build_webchat_response_payload_falls_back_for_invalid_blocks():
+    mod = _load_chat_payloads_module()
+    payload = mod.build_webchat_response_payload(
+        {
+            "response": "hello",
+            "display_blocks": [None, "bad", {"type": "   "}],
+        },
+        "s-3",
+    )
+
+    assert payload["display_blocks"] == [{"type": "markdown", "content": "hello"}]
+
+
+def test_normalize_assistant_history_message_backfills_display_blocks():
+    mod = _load_chat_payloads_module()
+    message = mod.normalize_assistant_history_message({"role": "assistant", "content": "hello"})
+
+    assert message["role"] == "assistant"
+    assert message["content"] == "hello"
+    assert message["display_blocks"] == [{"type": "markdown", "content": "hello"}]
+
+
+def test_normalize_assistant_history_message_leaves_non_assistant_shape():
+    mod = _load_chat_payloads_module()
+    original = {"role": "user", "content": "hello"}
+    message = mod.normalize_assistant_history_message(original)
+
+    assert message["role"] == "user"
+    assert message["content"] == "hello"
+    assert "display_blocks" not in message

--- a/tests/test_webchat_display_contract.py
+++ b/tests/test_webchat_display_contract.py
@@ -87,6 +87,24 @@ def test_build_webchat_response_payload_treats_whitespace_response_as_empty():
     assert payload["display_blocks"] == []
 
 
+def test_build_webchat_response_payload_preserves_raw_markdown_newlines():
+    mod = _load_chat_payloads_module()
+    raw_markdown = "\n# Title\n\nBody\n"
+    payload = mod.build_webchat_response_payload({"response": raw_markdown}, "s-raw")
+
+    assert payload["response"] == raw_markdown
+    assert payload["display_blocks"] == [{"type": "markdown", "content": raw_markdown}]
+
+
+def test_build_webchat_response_payload_preserves_indented_markdown_whitespace():
+    mod = _load_chat_payloads_module()
+    raw_markdown = "    indented code line\n    second\n"
+    payload = mod.build_webchat_response_payload({"response": raw_markdown}, "s-indent")
+
+    assert payload["response"] == raw_markdown
+    assert payload["display_blocks"] == [{"type": "markdown", "content": raw_markdown}]
+
+
 def test_normalize_assistant_history_message_treats_whitespace_content_as_empty():
     mod = _load_chat_payloads_module()
     message = mod.normalize_assistant_history_message(

--- a/tests/test_webchat_display_contract.py
+++ b/tests/test_webchat_display_contract.py
@@ -171,6 +171,7 @@ console.log(html);
 """
     result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
     assert "print(1)" in result.stdout
+    assert "language-python" in result.stdout
 
 
 def test_has_final_assistant_ignores_shell_display_blocks():


### PR DESCRIPTION
### Motivation
- Provide a safe, backward-compatible assistant display contract so frontends can render structured presentation data instead of guessing from raw text.
- Persist and backfill the contract for session history so old sessions and new assistant writes expose `display_blocks` without changing existing API shape.
- Let the built-in standalone WebChat prefer structured blocks while falling back to existing markdown rendering to remain compatible with current behavior.

### Description
- Add `src/runtime/display_blocks.py` with `normalize_display_blocks(...)` and `build_markdown_display_blocks(...)` to normalize incoming blocks and produce a markdown fallback when needed.
- Centralize assistant message persistence in `Agent._build_assistant_message_extra(...)` and update assistant save sites to include normalized `display_blocks` (fast-lane, fallback, passthrough, max-iterations, skill-mode ASK_USER/FINISH/EXECUTE) while preserving `terminal_skill_session` on FINISH.
- Update `POST /api/chat` to always include an additive `display_blocks` entry (normalized from runtime `result` or falling back to `response`) while leaving `response`, `usage`, `events`, `reasoning`, and `user_message_id` unchanged.
- Update `GET /api/sessions/{session_id}` to return a normalized copy of session messages where assistant messages are backfilled with `display_blocks` on read (no storage migration, no in-place mutation of persisted history).
- Enhance the standalone WebChat (`src/gateway/static/js/webchat.js`) to accept optional `displayBlocks`, add helpers (`parseDisplayBlocks`, `renderDisplayBlocks`, `renderSingleDisplayBlock`, `renderCodeBlock`, `renderTableBlock`, `enhanceRenderedMessage`, `copyText`), prefer `display_blocks` over raw content, perform idempotent code-toolbar / copy UI insertion, and avoid double-highlighting by only highlighting unhighlighted code blocks.
- Add minimal CSS classes for structured rendering (`.message-block`, `.message-codeblock`, `.message-codeblock-toolbar`, `.message-codeblock-lang`, `.copy-code-button`, `.message-table-wrap`, `.message-callout`, `.message-tool-result`) and modest markdown improvements in `src/gateway/static/css/webchat.css`.
- Add/extend tests in `tests/test_webchat.py` to assert `/api/chat` now returns `display_blocks`, `/api/sessions/{id}` backfills assistant `display_blocks`, and static assets contain the new helper/function/class names.

### Testing
- Ran `pytest tests/test_webchat.py -q` and all tests passed: 77 passed, 1 warning.
- Ran `node --check src/gateway/static/js/webchat.js` and the JS file passed static syntax check.
- New tests added include assertions that `/api/chat` returns `display_blocks` with a markdown block, that `api_load_session` backfills assistant `display_blocks` for legacy messages, and static JS/CSS include the new helpers and classes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3eaecbb4832aa220c8c6adafc0d0)