### PR TITLE
Improve server-files ZIP upload diagnostics and add POST /api/server-files/delete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
-# Create workspace directory for memory files
+# Create the workspace directory for this container image's default runtime user (root).
+# Note: the canonical runtime workspace model is user-home-based (`~/.efp/workspace`);
+# in this image, `~` resolves to `/root`.
 RUN mkdir -p /root/.efp/workspace
 
 # Expose port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
       # Config file - required
       - ./config.yaml:/app/config.yaml:ro
       
-      # Workspace directory for memory files - persists across restarts
+      # Workspace directory for memory files - persists across restarts.
+      # This compose setup maps to the container's root-user home workspace path.
+      # It is a local dev-container default, not a universal cross-environment path contract.
       # Contains: SOUL.md, USER.md, AGENTS.md, TOOLS.md, MEMORY.md, memory/
       - ./workspace:/root/.efp/workspace
       

--- a/src/bash_tools/README.md
+++ b/src/bash_tools/README.md
@@ -63,7 +63,7 @@ Execute a shell command with security restrictions.
 await run_command(
     cmd="git",
     args=["status"],
-    cwd="/root/.efp/workspace",  # Must be in workspace
+    cwd="/home/<runtime-user>/.efp/workspace",  # Must be in the runtime user's workspace
     timeout_ms=15000,
 )
 ```

--- a/src/bash_tools/README.md
+++ b/src/bash_tools/README.md
@@ -21,7 +21,7 @@ Two tools for the agent:
 - `run_command` - Execute shell commands with security restrictions
 
 ### Security Features
-- Working directory limited to `~/.efp/workspace`
+- Working directory limited to the runtime user's home workspace path (`~/.efp/workspace`)
 - Dangerous commands blocked (rm, mkfs, dd, fdisk, etc.)
 - Absolute path execution blocked
 - Environment variable allowlist (no PATH override)
@@ -63,7 +63,7 @@ Execute a shell command with security restrictions.
 await run_command(
     cmd="git",
     args=["status"],
-    cwd="/home/<runtime-user>/.efp/workspace",  # Must be in the runtime user's workspace
+    cwd="/home/<runtime-user>/.efp/workspace",  # Example user-home workspace path (not always /root)
     timeout_ms=15000,
 )
 ```

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1943,6 +1943,98 @@
     const fileExplorerPanel = document.getElementById('fileExplorerPanel');
     const closeFileExplorer = document.getElementById('closeFileExplorer');
     const fileExplorerContent = document.getElementById('fileExplorerContent');
+    const serverFilesUploadInput = document.createElement('input');
+    serverFilesUploadInput.type = 'file';
+    serverFilesUploadInput.style.display = 'none';
+    document.body.appendChild(serverFilesUploadInput);
+    let serverFilesCurrentPath = '';
+    let selectedServerFilePaths = new Set();
+
+    async function parseJsonSafe(response) {
+        try {
+            return await response.json();
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function getServerFilesErrorMessage(payload, fallback = 'Request failed') {
+        if (!payload) return fallback;
+        if (payload.error) {
+            return payload.detail ? `${payload.error}: ${payload.detail}` : payload.error;
+        }
+        return fallback;
+    }
+
+    function updateServerFilesToolbarState() {
+        const deleteBtn = fileExplorerContent.querySelector('#serverFilesDeleteBtn');
+        if (!deleteBtn) return;
+        const count = selectedServerFilePaths.size;
+        deleteBtn.disabled = count === 0;
+        deleteBtn.textContent = count > 0 ? `Delete (${count})` : 'Delete';
+    }
+
+    async function uploadServerFile(file) {
+        if (!file) return;
+        setStatus(`Uploading ${file.name}...`, 'uploading');
+
+        const formData = new FormData();
+        formData.append('file', file);
+        formData.append('path', serverFilesCurrentPath || '');
+
+        try {
+            const response = await fetch('/api/server-files/upload', {
+                method: 'POST',
+                body: formData
+            });
+            const payload = await parseJsonSafe(response);
+
+            if (!response.ok || (payload && payload.success === false)) {
+                const errorMessage = getServerFilesErrorMessage(payload, `Failed to upload ${file.name}`);
+                setStatus(`Upload failed: ${errorMessage}`, 'error');
+                return;
+            }
+
+            const extractedCount = payload?.mode === 'zip_extract' ? payload.extracted_count || 0 : null;
+            const successMessage = extractedCount !== null
+                ? `Uploaded ${file.name} and extracted ${extractedCount} item(s)`
+                : `Uploaded ${file.name}`;
+            setStatus(successMessage, 'success');
+            await showFileExplorer(serverFilesCurrentPath);
+        } catch (error) {
+            console.error('Server file upload error:', error);
+            setStatus(`Upload failed: ${error.message}`, 'error');
+        }
+    }
+
+    async function deleteServerFiles(paths) {
+        if (!paths.length) return;
+        const confirmed = confirm(`Delete ${paths.length} selected item(s)? This cannot be undone.`);
+        if (!confirmed) return;
+
+        setStatus(`Deleting ${paths.length} item(s)...`, 'uploading');
+        try {
+            const response = await fetch('/api/server-files/delete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ paths })
+            });
+            const payload = await parseJsonSafe(response);
+
+            if (!response.ok || (payload && payload.success === false)) {
+                const errorMessage = getServerFilesErrorMessage(payload, 'Failed to delete selected items');
+                setStatus(`Delete failed: ${errorMessage}`, 'error');
+                return;
+            }
+
+            setStatus(`Deleted ${paths.length} item(s)`, 'success');
+            selectedServerFilePaths = new Set();
+            await showFileExplorer(serverFilesCurrentPath);
+        } catch (error) {
+            console.error('Server file delete error:', error);
+            setStatus(`Delete failed: ${error.message}`, 'error');
+        }
+    }
 
     // Show My Uploads (user's uploaded files)
     async function showMyUploads() {
@@ -1978,6 +2070,8 @@
 
             const rootPath = data.root_path || '';
             const activePath = data.path || rootPath;
+            serverFilesCurrentPath = activePath;
+            selectedServerFilePaths = new Set();
             let pathParts = [];
             if (rootPath && activePath.startsWith(rootPath)) {
                 const relativePath = activePath.slice(rootPath.length).replace(/^\/+/, '');
@@ -1995,9 +2089,22 @@
                 pathHtml += '<button data-path="' + currentPath + '">' + escapeHtml(part) + '</button>';
             });
             pathHtml += '</div>';
+            pathHtml += `
+                <div class="file-explorer-toolbar" style="display:flex;gap:8px;margin:8px 0 10px 0;">
+                    <button type="button" id="serverFilesUploadBtn">Upload</button>
+                    <button type="button" id="serverFilesDeleteBtn" disabled>Delete</button>
+                </div>
+            `;
 
             if (data.items.length === 0) {
                 fileExplorerContent.innerHTML = pathHtml + '<div class="file-explorer-empty">Empty directory</div>';
+                const uploadBtn = fileExplorerContent.querySelector('#serverFilesUploadBtn');
+                if (uploadBtn) {
+                    uploadBtn.addEventListener('click', () => {
+                        serverFilesUploadInput.value = '';
+                        serverFilesUploadInput.click();
+                    });
+                }
                 return;
             }
 
@@ -2005,6 +2112,7 @@
                 <div class="file-explorer-list">
                     ${data.items.map(item => `
                         <div class="file-explorer-item" data-path="${item.path}" data-is-dir="${item.is_dir}">
+                            <input type="checkbox" class="server-file-select" data-path="${item.path}" title="Select for delete" />
                             ${item.is_dir ?
                                 '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>' :
                                 '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>'
@@ -2014,6 +2122,33 @@
                     `).join('')}
                 </div>
             `;
+
+            const uploadBtn = fileExplorerContent.querySelector('#serverFilesUploadBtn');
+            if (uploadBtn) {
+                uploadBtn.addEventListener('click', () => {
+                    serverFilesUploadInput.value = '';
+                    serverFilesUploadInput.click();
+                });
+            }
+            const deleteBtn = fileExplorerContent.querySelector('#serverFilesDeleteBtn');
+            if (deleteBtn) {
+                deleteBtn.addEventListener('click', () => {
+                    deleteServerFiles(Array.from(selectedServerFilePaths));
+                });
+            }
+            fileExplorerContent.querySelectorAll('.server-file-select').forEach(checkbox => {
+                checkbox.addEventListener('click', e => e.stopPropagation());
+                checkbox.addEventListener('change', function() {
+                    const selectedPath = this.dataset.path;
+                    if (this.checked) {
+                        selectedServerFilePaths.add(selectedPath);
+                    } else {
+                        selectedServerFilePaths.delete(selectedPath);
+                    }
+                    updateServerFilesToolbarState();
+                });
+            });
+            updateServerFilesToolbarState();
 
             // Add click handlers
             fileExplorerContent.querySelectorAll('.file-explorer-path button').forEach(btn => {
@@ -2025,6 +2160,7 @@
 
             fileExplorerContent.querySelectorAll('.file-explorer-item').forEach(item => {
                 item.addEventListener('click', function(e) {
+                    if (e.target.closest('.server-file-select')) return;
                     e.stopPropagation();
                     const isDir = this.dataset.isDir === 'true';
                     const path = this.dataset.path;
@@ -2055,6 +2191,12 @@
             fileExplorerContent.innerHTML = '<div class="loading">Error loading files</div>';
         }
     }
+
+    serverFilesUploadInput.addEventListener('change', async function() {
+        const file = this.files && this.files[0];
+        if (!file) return;
+        await uploadServerFile(file);
+    });
 
     if (closeFileExplorer) {
         closeFileExplorer.addEventListener('click', function() {

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -1653,39 +1653,67 @@ async def api_server_files_upload(request: web.Request) -> web.Response:
         payload = await upload_field.read(decode=False)
 
         if filename.lower().endswith('.zip'):
+            payload_size = len(payload)
+            starts_with_zip_signature = payload.startswith(b'PK')
+            is_zip_payload = zipfile.is_zipfile(io.BytesIO(payload)) if payload else False
+            logger.info(
+                "[server-files] zip upload diagnostics target=%s filename=%s content_type=%s payload_size=%s starts_with_pk=%s is_zipfile=%s",
+                target_dir,
+                filename,
+                getattr(upload_field, 'content_type', None),
+                payload_size,
+                starts_with_zip_signature,
+                is_zip_payload,
+            )
+
+            if payload_size == 0:
+                return web.json_response({'success': False, 'error': 'Uploaded ZIP file is empty'}, status=400)
+            if not is_zip_payload:
+                return web.json_response({'success': False, 'error': 'Uploaded file is not a valid ZIP archive'}, status=400)
+
             try:
                 archive = zipfile.ZipFile(io.BytesIO(payload))
+                items: List[str] = []
+                extracted_count = 0
+                with archive:
+                    for member in archive.infolist():
+                        member_path = PurePosixPath(member.filename)
+                        if not member.filename or member.filename.endswith('/'):
+                            continue
+                        if member_path.is_absolute() or '..' in member_path.parts:
+                            return web.json_response({'success': False, 'error': f'Unsafe ZIP entry: {member.filename}'}, status=400)
+
+                        destination = (target_dir / Path(*member_path.parts)).resolve(strict=False)
+                        if not _is_within_root(destination, target_dir):
+                            return web.json_response({'success': False, 'error': f'Unsafe ZIP entry: {member.filename}'}, status=400)
+                        destination.parent.mkdir(parents=True, exist_ok=True)
+                        with archive.open(member, 'r') as source, open(destination, 'wb') as sink:
+                            shutil.copyfileobj(source, sink)
+                        items.append(str(destination))
+                        extracted_count += 1
+
+                logger.info(
+                    "[server-files] zip extract success target=%s filename=%s extracted_count=%s",
+                    target_dir,
+                    filename,
+                    extracted_count,
+                )
+                return web.json_response({
+                    'success': True,
+                    'mode': 'zip_extract',
+                    'target_path': str(target_dir),
+                    'uploaded_filename': filename,
+                    'extracted_count': extracted_count,
+                    'items': items,
+                })
             except zipfile.BadZipFile:
-                return web.json_response({'success': False, 'error': 'Invalid ZIP archive'}, status=400)
-
-            items: List[str] = []
-            extracted_count = 0
-            with archive:
-                for member in archive.infolist():
-                    member_path = PurePosixPath(member.filename)
-                    if not member.filename or member.filename.endswith('/'):
-                        continue
-                    if member_path.is_absolute() or '..' in member_path.parts:
-                        return web.json_response({'success': False, 'error': f'Unsafe ZIP entry: {member.filename}'}, status=400)
-
-                    destination = (target_dir / Path(*member_path.parts)).resolve(strict=False)
-                    if not _is_within_root(destination, target_dir):
-                        return web.json_response({'success': False, 'error': f'Unsafe ZIP entry: {member.filename}'}, status=400)
-                    destination.parent.mkdir(parents=True, exist_ok=True)
-                    with archive.open(member, 'r') as source, open(destination, 'wb') as sink:
-                        shutil.copyfileobj(source, sink)
-                    items.append(str(destination))
-                    extracted_count += 1
-
-            logger.info("[server-files] zip extract target=%s count=%s", target_dir, extracted_count)
-            return web.json_response({
-                'success': True,
-                'mode': 'zip_extract',
-                'target_path': str(target_dir),
-                'uploaded_filename': filename,
-                'extracted_count': extracted_count,
-                'items': items,
-            })
+                return web.json_response({'success': False, 'error': 'Uploaded ZIP archive is malformed'}, status=400)
+            except RuntimeError as exc:
+                return web.json_response({'success': False, 'error': 'Failed to extract ZIP archive', 'detail': str(exc)}, status=400)
+            except ValueError as exc:
+                return web.json_response({'success': False, 'error': 'Invalid ZIP archive parameters', 'detail': str(exc)}, status=400)
+            except NotImplementedError as exc:
+                return web.json_response({'success': False, 'error': 'ZIP archive uses an unsupported feature', 'detail': str(exc)}, status=400)
 
         destination = (target_dir / filename).resolve(strict=False)
         if not _is_within_root(destination, target_dir):
@@ -1704,6 +1732,47 @@ async def api_server_files_upload(request: web.Request) -> web.Response:
         return web.json_response({'success': False, **json.loads(exc.text)}, status=400)
     except Exception as e:
         logger.error(f"Error uploading server file: {e}")
+        return web.json_response({'success': False, 'error': str(e)}, status=500)
+
+
+async def api_server_files_delete(request: web.Request) -> web.Response:
+    """Delete one or more files/directories rooted under workspace."""
+    try:
+        body = await request.json()
+        raw_paths = body.get('paths')
+        if not isinstance(raw_paths, list) or len(raw_paths) == 0:
+            return web.json_response({'success': False, 'error': 'paths is required and must be a non-empty list'}, status=400)
+        if not all(isinstance(raw, str) for raw in raw_paths):
+            return web.json_response({'success': False, 'error': 'paths must be a list of strings'}, status=400)
+
+        root = _workspace_root()
+        resolved_paths = [_resolve_server_file_path(raw) for raw in raw_paths]
+        for resolved in resolved_paths:
+            if resolved == root:
+                return web.json_response({'success': False, 'error': 'Deleting workspace root is not allowed'}, status=400)
+
+        deleted = []
+        for resolved in resolved_paths:
+            if not resolved.exists() and not resolved.is_symlink():
+                return web.json_response({'success': False, 'error': 'Path not found', 'path': str(resolved)}, status=404)
+
+            if resolved.is_symlink() or resolved.is_file():
+                resolved.unlink()
+                deleted.append({'path': str(resolved), 'type': 'file'})
+            elif resolved.is_dir():
+                shutil.rmtree(resolved)
+                deleted.append({'path': str(resolved), 'type': 'directory'})
+            else:
+                return web.json_response({'success': False, 'error': 'Unsupported path type', 'path': str(resolved)}, status=400)
+
+        logger.info("[server-files] delete count=%s", len(deleted))
+        return web.json_response({'success': True, 'deleted': deleted})
+    except web.HTTPBadRequest as exc:
+        return web.json_response({'success': False, **json.loads(exc.text)}, status=400)
+    except json.JSONDecodeError:
+        return web.json_response({'success': False, 'error': 'Invalid JSON body'}, status=400)
+    except Exception as e:
+        logger.error(f"Error deleting server files: {e}")
         return web.json_response({'success': False, 'error': str(e)}, status=500)
 
 
@@ -3058,6 +3127,7 @@ def setup_webchat_routes(app: web.Application):
     app.router.add_get('/api/server-files/read', api_server_files_read)
     app.router.add_get('/api/server-files/content', api_server_files_content)
     app.router.add_post('/api/server-files/upload', api_server_files_upload)
+    app.router.add_post('/api/server-files/delete', api_server_files_delete)
     app.router.add_get('/api/server-files/download', api_server_files_download)
 
     # Legacy compatibility aliases for older clients (path-based)
@@ -3110,6 +3180,7 @@ def setup_webchat_routes(app: web.Application):
     logger.info("  GET  /api/server-files/read - Read text file content")
     logger.info("  GET  /api/server-files/content - Inline file content")
     logger.info("  POST /api/server-files/upload - Upload/extract files into workspace")
+    logger.info("  POST /api/server-files/delete - Delete files/directories from workspace")
     logger.info("  GET  /api/server-files/download - Download file(s) from workspace")
     logger.info("  GET  /api/files (legacy alias) - Compatibility browse route")
     logger.info("  GET  /api/files/read (legacy alias) - Compatibility text-read route")

--- a/tests/test_webchat_server_files.py
+++ b/tests/test_webchat_server_files.py
@@ -18,24 +18,32 @@ def test_server_files_routes_registered():
     assert "/api/server-files/read" in routes
     assert "/api/server-files/content" in routes
     assert "/api/server-files/upload" in routes
+    assert "/api/server-files/delete" in routes
     assert "/api/server-files/download" in routes
 
 
 class _Request:
-    def __init__(self, query=None, multipart_reader=None):
+    def __init__(self, query=None, multipart_reader=None, json_body=None):
         self.query = MultiDictProxy(MultiDict(query or {}))
         self._multipart_reader = multipart_reader
+        self._json_body = json_body
 
     async def multipart(self):
         return self._multipart_reader
 
+    async def json(self):
+        if self._json_body is None:
+            raise json.JSONDecodeError("missing", "", 0)
+        return self._json_body
+
 
 class _Field:
-    def __init__(self, name, value=None, filename=None, data=None):
+    def __init__(self, name, value=None, filename=None, data=None, content_type=None):
         self.name = name
         self._value = value
         self.filename = filename
         self._data = data or b""
+        self.content_type = content_type
 
     async def text(self):
         return self._value or ""
@@ -140,7 +148,7 @@ async def test_server_files_upload_regular_file(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_server_files_zip_upload_extracts_and_blocks_zip_slip(monkeypatch, tmp_path):
+async def test_server_files_zip_upload_extracts(monkeypatch, tmp_path):
     workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
     target_dir = workspace_root / "zips"
     target_dir.mkdir(parents=True)
@@ -158,6 +166,48 @@ async def test_server_files_zip_upload_extracts_and_blocks_zip_slip(monkeypatch,
     assert ok_body["mode"] == "zip_extract"
     assert (target_dir / "nested" / "ok.txt").exists()
 
+@pytest.mark.asyncio
+async def test_server_files_zip_upload_rejects_empty_payload(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    target_dir = workspace_root / "zips"
+    target_dir.mkdir(parents=True)
+
+    multipart = _Multipart([
+        _Field("path", value=str(target_dir)),
+        _Field("file", filename="empty.zip", data=b""),
+    ])
+
+    response = await webchat.api_server_files_upload(_Request(multipart_reader=multipart))
+    body = json.loads(response.body)
+
+    assert response.status == 400
+    assert body["error"] == "Uploaded ZIP file is empty"
+
+
+@pytest.mark.asyncio
+async def test_server_files_zip_upload_rejects_non_zip_payload(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    target_dir = workspace_root / "zips"
+    target_dir.mkdir(parents=True)
+
+    multipart = _Multipart([
+        _Field("path", value=str(target_dir)),
+        _Field("file", filename="invalid.zip", data=b"not-a-zip"),
+    ])
+
+    response = await webchat.api_server_files_upload(_Request(multipart_reader=multipart))
+    body = json.loads(response.body)
+
+    assert response.status == 400
+    assert body["error"] == "Uploaded file is not a valid ZIP archive"
+
+
+@pytest.mark.asyncio
+async def test_server_files_zip_upload_blocks_zip_slip(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    target_dir = workspace_root / "zips"
+    target_dir.mkdir(parents=True)
+
     bad_zip = io.BytesIO()
     with zipfile.ZipFile(bad_zip, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr("../escape.txt", "escape")
@@ -165,10 +215,85 @@ async def test_server_files_zip_upload_extracts_and_blocks_zip_slip(monkeypatch,
         _Field("path", value=str(target_dir)),
         _Field("file", filename="bad.zip", data=bad_zip.getvalue()),
     ])
+
     bad_response = await webchat.api_server_files_upload(_Request(multipart_reader=bad_multipart))
     bad_body = json.loads(bad_response.body)
+
     assert bad_response.status == 400
     assert "Unsafe ZIP entry" in bad_body["error"]
+
+
+@pytest.mark.asyncio
+async def test_server_files_delete_single_file(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    file_path = workspace_root / "delete-me.txt"
+    file_path.write_text("bye", encoding="utf-8")
+
+    response = await webchat.api_server_files_delete(_Request(json_body={"paths": [str(file_path)]}))
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body["success"] is True
+    assert body["deleted"][0]["type"] == "file"
+    assert not file_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_server_files_delete_directory_recursively(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    dir_path = workspace_root / "delete-dir"
+    (dir_path / "nested").mkdir(parents=True)
+    (dir_path / "nested" / "a.txt").write_text("a", encoding="utf-8")
+
+    response = await webchat.api_server_files_delete(_Request(json_body={"paths": [str(dir_path)]}))
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body["deleted"][0]["type"] == "directory"
+    assert not dir_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_server_files_delete_rejects_workspace_root(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+
+    response = await webchat.api_server_files_delete(_Request(json_body={"paths": [str(workspace_root)]}))
+    body = json.loads(response.body)
+
+    assert response.status == 400
+    assert body["error"] == "Deleting workspace root is not allowed"
+
+
+@pytest.mark.asyncio
+async def test_server_files_delete_rejects_outside_root(monkeypatch, tmp_path):
+    _patch_workspace_home(monkeypatch, tmp_path)
+    outside_path = tmp_path.parent / "outside.txt"
+
+    response = await webchat.api_server_files_delete(_Request(json_body={"paths": [str(outside_path)]}))
+    body = json.loads(response.body)
+
+    assert response.status == 400
+    assert "within workspace root" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_server_files_delete_multiple_paths(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    file_path = workspace_root / "a.txt"
+    file_path.write_text("a", encoding="utf-8")
+    dir_path = workspace_root / "d"
+    (dir_path / "nested").mkdir(parents=True)
+    (dir_path / "nested" / "b.txt").write_text("b", encoding="utf-8")
+
+    response = await webchat.api_server_files_delete(
+        _Request(json_body={"paths": [str(file_path), str(dir_path)]})
+    )
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert len(body["deleted"]) == 2
+    assert not file_path.exists()
+    assert not dir_path.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Make ZIP uploads diagnosable and robust by surfacing metadata and clear errors instead of opaque "Invalid ZIP archive" responses.
- Preserve the existing path-based Server Files behavior while adding a safe, workspace-root-restricted delete API for files and directories.

### Description
- Added lightweight ZIP diagnostics and pre-checks in `api_server_files_upload`, logging `filename`, `content_type`, payload size, whether the payload begins with `PK`, and `zipfile.is_zipfile(...)`, and rejecting empty uploads or non-ZIP payloads with clear 400 errors (`Uploaded ZIP file is empty`, `Uploaded file is not a valid ZIP archive`).
- Kept existing ZIP extraction flow and zip-slip protections, and expanded exception handling to map `zipfile.BadZipFile`, `RuntimeError`, `ValueError`, and `NotImplementedError` to clearer JSON errors while preserving the success response shape (`success`, `mode`, `target_path`, `uploaded_filename`, `extracted_count`, `items`).
- Added a new endpoint `api_server_files_delete` registered at `POST /api/server-files/delete` which validates a required non-empty `paths` list, enforces workspace-root resolution via `_resolve_server_file_path`, forbids deleting the workspace root, deletes files/symlinks with `unlink()` and directories recursively with `shutil.rmtree()`, and returns a structured `deleted` list.
- Registered the new route in `setup_webchat_routes` and updated route-summary logging; tests were expanded in `tests/test_webchat_server_files.py` to cover ZIP robustness and delete behavior.

### Testing
- Compiled the modified modules with `python -m compileall src/gateway/webchat.py tests/test_webchat_server_files.py` without syntax errors.
- Ran unit tests with `pytest -q tests/test_webchat_server_files.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4f3385c8832ab719af34d8a13e85)