### PR TITLE
Fix server-files multipart upload draining regression

### DIFF
--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1979,8 +1979,8 @@
         setStatus(`Uploading ${file.name}...`, 'uploading');
 
         const formData = new FormData();
-        formData.append('file', file);
         formData.append('path', serverFilesCurrentPath || '');
+        formData.append('file', file);
 
         try {
             const response = await fetch('/api/server-files/upload', {

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -1627,8 +1627,10 @@ async def api_server_files_upload(request: web.Request) -> web.Response:
     """Upload files to workspace root (with optional ZIP extraction)."""
     try:
         reader = await request.multipart()
-        upload_field = None
         target_path_raw: Optional[str] = None
+        upload_filename: Optional[str] = None
+        upload_content_type: Optional[str] = None
+        upload_payload: Optional[bytes] = None
 
         while True:
             field = await reader.next()
@@ -1636,10 +1638,14 @@ async def api_server_files_upload(request: web.Request) -> web.Response:
                 break
             if field.name == 'path':
                 target_path_raw = await field.text()
-            elif field.name == 'file' and upload_field is None:
-                upload_field = field
+            elif field.name == 'file' and upload_payload is None:
+                upload_filename = Path(field.filename or 'upload.bin').name
+                upload_content_type = getattr(field, 'content_type', None)
+                # Consume upload bytes immediately so multipart iteration cannot
+                # drain/discard the file payload before we process it.
+                upload_payload = await field.read(decode=False)
 
-        if upload_field is None:
+        if upload_payload is None:
             return web.json_response({'success': False, 'error': 'file is required'}, status=400)
 
         target_dir = _resolve_server_file_path(target_path_raw)
@@ -1648,9 +1654,9 @@ async def api_server_files_upload(request: web.Request) -> web.Response:
         if not target_dir.is_dir():
             return web.json_response({'success': False, 'error': 'Target path must be a directory'}, status=400)
 
-        filename = Path(upload_field.filename or 'upload.bin').name
+        filename = upload_filename or 'upload.bin'
         logger.info("[server-files] upload target=%s filename=%s", target_dir, filename)
-        payload = await upload_field.read(decode=False)
+        payload = upload_payload
 
         if filename.lower().endswith('.zip'):
             payload_size = len(payload)
@@ -1660,7 +1666,7 @@ async def api_server_files_upload(request: web.Request) -> web.Response:
                 "[server-files] zip upload diagnostics target=%s filename=%s content_type=%s payload_size=%s starts_with_pk=%s is_zipfile=%s",
                 target_dir,
                 filename,
-                getattr(upload_field, 'content_type', None),
+                upload_content_type,
                 payload_size,
                 starts_with_zip_signature,
                 is_zip_payload,
@@ -1718,6 +1724,7 @@ async def api_server_files_upload(request: web.Request) -> web.Response:
         destination = (target_dir / filename).resolve(strict=False)
         if not _is_within_root(destination, target_dir):
             return web.json_response({'success': False, 'error': 'Invalid target filename'}, status=400)
+        # Intentionally allow explicit zero-byte regular file uploads.
         with open(destination, 'wb') as output:
             output.write(payload)
 

--- a/tests/test_webchat_server_files.py
+++ b/tests/test_webchat_server_files.py
@@ -44,11 +44,16 @@ class _Field:
         self.filename = filename
         self._data = data or b""
         self.content_type = content_type
+        self._was_read = False
+        self._drained = False
 
     async def text(self):
         return self._value or ""
 
     async def read(self, decode=False):
+        self._was_read = True
+        if self._drained:
+            return b""
         return self._data
 
 
@@ -56,12 +61,20 @@ class _Multipart:
     def __init__(self, fields):
         self._fields = list(fields)
         self._idx = 0
+        self._previous_field = None
 
     async def next(self):
+        if (
+            self._previous_field is not None
+            and self._previous_field.name == "file"
+            and not self._previous_field._was_read
+        ):
+            self._previous_field._drained = True
         if self._idx >= len(self._fields):
             return None
         field = self._fields[self._idx]
         self._idx += 1
+        self._previous_field = field
         return field
 
 
@@ -136,8 +149,8 @@ async def test_server_files_upload_regular_file(monkeypatch, tmp_path):
     target_dir.mkdir(parents=True)
 
     multipart = _Multipart([
-        _Field("path", value=str(target_dir)),
         _Field("file", filename="hello.txt", data=b"hello"),
+        _Field("path", value=str(target_dir)),
     ])
     response = await webchat.api_server_files_upload(_Request(multipart_reader=multipart))
     body = json.loads(response.body)
@@ -157,8 +170,8 @@ async def test_server_files_zip_upload_extracts(monkeypatch, tmp_path):
     with zipfile.ZipFile(good_zip, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr("nested/ok.txt", "ok")
     multipart = _Multipart([
-        _Field("path", value=str(target_dir)),
         _Field("file", filename="ok.zip", data=good_zip.getvalue()),
+        _Field("path", value=str(target_dir)),
     ])
     ok_response = await webchat.api_server_files_upload(_Request(multipart_reader=multipart))
     ok_body = json.loads(ok_response.body)
@@ -173,8 +186,8 @@ async def test_server_files_zip_upload_rejects_empty_payload(monkeypatch, tmp_pa
     target_dir.mkdir(parents=True)
 
     multipart = _Multipart([
-        _Field("path", value=str(target_dir)),
         _Field("file", filename="empty.zip", data=b""),
+        _Field("path", value=str(target_dir)),
     ])
 
     response = await webchat.api_server_files_upload(_Request(multipart_reader=multipart))
@@ -191,8 +204,8 @@ async def test_server_files_zip_upload_rejects_non_zip_payload(monkeypatch, tmp_
     target_dir.mkdir(parents=True)
 
     multipart = _Multipart([
-        _Field("path", value=str(target_dir)),
         _Field("file", filename="invalid.zip", data=b"not-a-zip"),
+        _Field("path", value=str(target_dir)),
     ])
 
     response = await webchat.api_server_files_upload(_Request(multipart_reader=multipart))
@@ -212,8 +225,8 @@ async def test_server_files_zip_upload_blocks_zip_slip(monkeypatch, tmp_path):
     with zipfile.ZipFile(bad_zip, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr("../escape.txt", "escape")
     bad_multipart = _Multipart([
-        _Field("path", value=str(target_dir)),
         _Field("file", filename="bad.zip", data=bad_zip.getvalue()),
+        _Field("path", value=str(target_dir)),
     ])
 
     bad_response = await webchat.api_server_files_upload(_Request(multipart_reader=bad_multipart))


### PR DESCRIPTION
### Motivation
- A multipart handling bug caused the runtime to store the `file` part object and continue iterating, which allowed aiohttp multipart iteration to drain unread file bodies and produce empty payloads for ZIP uploads. 
- The change fixes the root cause in the EFP runtime without redesigning the server-files API or altering delete/preview/browse behavior.

### Description
- Rewrote the multipart consumption in `api_server_files_upload` to immediately read and buffer `upload_payload`, `upload_filename`, and `upload_content_type` when the `file` part is encountered, replacing the prior pattern of storing the field for later reading (file: `src/gateway/webchat.py`, function: `api_server_files_upload`).
- Kept ZIP diagnostics and validation intact but wired them to the buffered metadata and payload instead of the unread `field` object. (`src/gateway/webchat.py`).
- Strengthened tests in `tests/test_webchat_server_files.py` to use the real frontend multipart ordering (file first, then path) and improved the `_Multipart`/_Field test stub to simulate unread file-part draining so the old broken behavior would be caught by tests. (`tests/test_webchat_server_files.py`).
- Added a low-risk defense-in-depth frontend ordering change in the built-in webchat so `path` is appended before `file` in `FormData`, aligning the request ordering and reducing fragility without changing other UI behavior (`src/gateway/static/js/webchat.js`).
- Did not change API surface, delete logic, ZIP validation messages, or server-files routes; Portal-side file `app/static/js/chat_ui.js` could not be modified because that repository path was not available in this environment.

### Testing
- Ran syntax checks with `python -m py_compile src/gateway/webchat.py tests/test_webchat_server_files.py` which completed successfully. 
- Ran the focused upload/delete test suite with `pytest tests/test_webchat_server_files.py -k 'upload or delete'` and all selected tests passed (10 passed, 7 deselected). 
- The updated multipart stub and file-first ordering tests now reproduce the draining behavior and guard against regressions where the server would previously receive empty payloads when advancing parts before reading the file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db66175d9c832a877f5aa33ea0e742)