### PR TITLE
feat(runtime): add bundle_action_task and trusted bundle template registry

### DIFF
--- a/skills/collect_research_notes_to_bundle/skill.py
+++ b/skills/collect_research_notes_to_bundle/skill.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List
+
+from src.agents.executor import SkillResult, skill
+from src.agents.llm import LLMClient
+from src.github import github_channel
+from src.runtime.requirement_bundle_assets import (
+    RequirementBundleError,
+    load_bundle_manifest,
+    resolve_bundle_artifacts,
+    resolve_target_bundle_ref,
+    write_bundle_yaml,
+)
+from src.utils.redaction import sanitize_exception_message
+
+from skills.collect_requirements_to_bundle.skill import (
+    _extract_json_dict,
+    _load_confluence_sources,
+    _load_github_doc_sources,
+    _load_jira_sources,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@skill(
+    name="collect_research_notes_to_bundle",
+    description="Collect research notes from sources and write research-notes.yaml in bundle.",
+)
+async def collect_research_notes_to_bundle(
+    bundle_ref: Dict[str, Any],
+    sources: Dict[str, Any] | None = None,
+    manifest_ref: Dict[str, Any] | None = None,
+) -> SkillResult:
+    try:
+        if not github_channel.is_configured():
+            return SkillResult(success=False, error="GitHub integration is not configured")
+
+        normalized_sources = dict(sources or {})
+        jira_ids = [str(item).strip() for item in normalized_sources.get("jira", []) if str(item).strip()]
+        confluence_ids = [str(item).strip() for item in normalized_sources.get("confluence", []) if str(item).strip()]
+        github_docs = [str(item).strip() for item in normalized_sources.get("github_docs", []) if str(item).strip()]
+        figma_refs = [str(item).strip() for item in normalized_sources.get("figma", []) if str(item).strip()]
+
+        manifest_source_ref, manifest = await load_bundle_manifest(bundle_ref, manifest_ref=manifest_ref)
+        target_ref = resolve_target_bundle_ref(manifest_source_ref, manifest)
+        artifacts = resolve_bundle_artifacts(manifest)
+        research_notes_file = str(artifacts.get("research_notes") or "").strip().strip("/")
+        if not research_notes_file:
+            raise RequirementBundleError("bundle.yaml field 'artifacts.research_notes' must be a non-empty string")
+
+        supported_source_count = len(jira_ids) + len(confluence_ids) + len(github_docs)
+        if supported_source_count <= 0:
+            error = "At least one supported source is required"
+            if figma_refs:
+                error = f"{error}; figma is ignored in MVP"
+            return SkillResult(success=False, error=error)
+
+        jira_payload = await _load_jira_sources(jira_ids) if jira_ids else []
+        confluence_payload = await _load_confluence_sources(confluence_ids) if confluence_ids else []
+        github_payload = (
+            await _load_github_doc_sources(
+                {
+                    "repo": target_ref.repo_full_name,
+                    "path": target_ref.path,
+                    "branch": target_ref.branch,
+                },
+                github_docs,
+            )
+            if github_docs
+            else []
+        )
+
+        prompt_context = {
+            "bundle": {
+                "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
+                "template_id": manifest.get("template_id"),
+                "title": manifest.get("title"),
+                "scope": manifest.get("scope", {}),
+                "metadata": manifest.get("metadata", {}),
+            },
+            "sources": {
+                "jira": jira_payload,
+                "confluence": confluence_payload,
+                "github_docs": github_payload,
+            },
+        }
+
+        llm = LLMClient()
+        llm_response = await llm.chat(
+            system_prompt=(
+                "You are a research analyst. Return STRICT JSON only (no markdown, no prose) with top-level keys: "
+                "summary, findings, open_questions, references."
+            ),
+            messages=[{"role": "user", "content": json.dumps(prompt_context, ensure_ascii=False)}],
+            temperature=0.1,
+        )
+        structured = _extract_json_dict(str(llm_response.get("content") or ""))
+
+        research_doc = {
+            "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
+            "sources": {
+                "jira": jira_ids,
+                "confluence": confluence_ids,
+                "github_docs": github_docs,
+                "figma": figma_refs,
+            },
+            "summary": structured.get("summary", {}),
+            "findings": structured.get("findings", []),
+            "open_questions": structured.get("open_questions", []),
+            "references": structured.get("references", []),
+        }
+
+        write_result = await write_bundle_yaml(
+            target_ref,
+            research_notes_file,
+            research_doc,
+            f"chore(bundle): update {research_notes_file} for {target_ref.path}",
+        )
+        commit_sha = ((write_result.get("commit") or {}).get("sha")) if isinstance(write_result, dict) else None
+        warnings: List[str] = []
+        if figma_refs:
+            warnings.append("figma sources are ignored in MVP")
+
+        data = {
+            "bundle_ref": {
+                "repo": target_ref.repo_full_name,
+                "path": target_ref.path,
+                "branch": target_ref.branch,
+            },
+            "updated_files": [f"{target_ref.path}/{research_notes_file}"],
+            "commit_sha": commit_sha,
+            "summary": "Collected research notes from configured sources",
+        }
+        if warnings:
+            data["warnings"] = warnings
+
+        return SkillResult(success=True, output="research-notes.yaml updated", data=data)
+    except RequirementBundleError as exc:
+        logger.warning(
+            "Collect research notes skill failed | action=collect_research_notes_to_bundle error_class=%s error=%s",
+            exc.__class__.__name__,
+            sanitize_exception_message(exc),
+        )
+        return SkillResult(success=False, error=str(exc))
+    except Exception as exc:
+        logger.warning(
+            "Collect research notes skill failed | action=collect_research_notes_to_bundle error_class=%s error=%s",
+            exc.__class__.__name__,
+            sanitize_exception_message(exc),
+        )
+        return SkillResult(success=False, error=f"collect_research_notes_to_bundle failed: {exc}")

--- a/skills/generate_implementation_plan_from_bundle/skill.py
+++ b/skills/generate_implementation_plan_from_bundle/skill.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from src.agents.executor import SkillResult, skill
+from src.agents.llm import LLMClient
+from src.runtime.requirement_bundle_assets import (
+    RequirementBundleError,
+    load_bundle_manifest,
+    read_bundle_yaml,
+    resolve_bundle_artifacts,
+    resolve_target_bundle_ref,
+    write_bundle_yaml,
+)
+
+from skills.collect_requirements_to_bundle.skill import _extract_json_dict
+
+
+@skill(
+    name="generate_implementation_plan_from_bundle",
+    description="Generate implementation plan artifact from bundle context.",
+)
+async def generate_implementation_plan_from_bundle(
+    bundle_ref: Dict[str, Any],
+    manifest_ref: Dict[str, Any] | None = None,
+) -> SkillResult:
+    try:
+        manifest_source_ref, manifest = await load_bundle_manifest(bundle_ref, manifest_ref=manifest_ref)
+        target_ref = resolve_target_bundle_ref(manifest_source_ref, manifest)
+        artifacts = resolve_bundle_artifacts(manifest)
+
+        implementation_plan_file = str(artifacts.get("implementation_plan") or "").strip().strip("/")
+        if not implementation_plan_file:
+            raise RequirementBundleError("bundle.yaml field 'artifacts.implementation_plan' must be a non-empty string")
+
+        requirements_doc: Dict[str, Any] | None = None
+        requirements_file = str(artifacts.get("requirements") or "").strip().strip("/")
+        if requirements_file:
+            try:
+                requirements_doc = await read_bundle_yaml(target_ref, requirements_file)
+            except RequirementBundleError:
+                requirements_doc = None
+
+        prompt_context = {
+            "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
+            "template_id": manifest.get("template_id"),
+            "title": manifest.get("title"),
+            "scope": manifest.get("scope", {}),
+            "metadata": manifest.get("metadata", {}),
+            "artifacts": artifacts,
+            "requirements": requirements_doc,
+        }
+
+        llm = LLMClient()
+        llm_response = await llm.chat(
+            system_prompt=(
+                "You are an implementation planner. Return STRICT JSON only with top-level keys: "
+                "summary, workstreams, tasks, risks, validation_checks."
+            ),
+            messages=[{"role": "user", "content": json.dumps(prompt_context, ensure_ascii=False)}],
+            temperature=0.1,
+        )
+        structured = _extract_json_dict(str(llm_response.get("content") or ""))
+
+        payload = {
+            "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
+            "generated_from_bundle_commit": "",
+            "summary": structured.get("summary", {}),
+            "workstreams": structured.get("workstreams", []),
+            "tasks": structured.get("tasks", []),
+            "risks": structured.get("risks", []),
+            "validation_checks": structured.get("validation_checks", []),
+        }
+
+        write_result = await write_bundle_yaml(
+            target_ref,
+            implementation_plan_file,
+            payload,
+            f"chore(bundle): update {implementation_plan_file} for {target_ref.path}",
+        )
+        commit_sha = ((write_result.get("commit") or {}).get("sha")) if isinstance(write_result, dict) else None
+
+        return SkillResult(
+            success=True,
+            output="implementation-plan.yaml updated",
+            data={
+                "bundle_ref": {
+                    "repo": target_ref.repo_full_name,
+                    "path": target_ref.path,
+                    "branch": target_ref.branch,
+                },
+                "updated_files": [f"{target_ref.path}/{implementation_plan_file}"],
+                "commit_sha": commit_sha,
+                "summary": "Generated implementation plan from bundle context",
+            },
+        )
+    except RequirementBundleError as exc:
+        return SkillResult(success=False, error=str(exc))
+    except Exception as exc:
+        return SkillResult(success=False, error=f"generate_implementation_plan_from_bundle failed: {exc}")

--- a/skills/generate_runbook_from_bundle/skill.py
+++ b/skills/generate_runbook_from_bundle/skill.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from src.agents.executor import SkillResult, skill
+from src.agents.llm import LLMClient
+from src.runtime.requirement_bundle_assets import (
+    RequirementBundleError,
+    load_bundle_manifest,
+    read_bundle_yaml,
+    resolve_bundle_artifacts,
+    resolve_target_bundle_ref,
+    write_bundle_yaml,
+)
+
+from skills.collect_requirements_to_bundle.skill import _extract_json_dict
+
+
+@skill(
+    name="generate_runbook_from_bundle",
+    description="Generate runbook artifact from bundle context.",
+)
+async def generate_runbook_from_bundle(
+    bundle_ref: Dict[str, Any],
+    manifest_ref: Dict[str, Any] | None = None,
+) -> SkillResult:
+    try:
+        manifest_source_ref, manifest = await load_bundle_manifest(bundle_ref, manifest_ref=manifest_ref)
+        target_ref = resolve_target_bundle_ref(manifest_source_ref, manifest)
+        artifacts = resolve_bundle_artifacts(manifest)
+
+        runbook_file = str(artifacts.get("runbook") or "").strip().strip("/")
+        if not runbook_file:
+            raise RequirementBundleError("bundle.yaml field 'artifacts.runbook' must be a non-empty string")
+
+        requirements_doc: Dict[str, Any] | None = None
+        requirements_file = str(artifacts.get("requirements") or "").strip().strip("/")
+        if requirements_file:
+            try:
+                requirements_doc = await read_bundle_yaml(target_ref, requirements_file)
+            except RequirementBundleError:
+                requirements_doc = None
+
+        prompt_context = {
+            "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
+            "template_id": manifest.get("template_id"),
+            "title": manifest.get("title"),
+            "scope": manifest.get("scope", {}),
+            "metadata": manifest.get("metadata", {}),
+            "artifacts": artifacts,
+            "requirements": requirements_doc,
+        }
+
+        llm = LLMClient()
+        llm_response = await llm.chat(
+            system_prompt=(
+                "You are an operations planner. Return STRICT JSON only with top-level keys: "
+                "service_summary, rollout_steps, rollback_steps, monitoring_checks, alerts, operational_risks."
+            ),
+            messages=[{"role": "user", "content": json.dumps(prompt_context, ensure_ascii=False)}],
+            temperature=0.1,
+        )
+        structured = _extract_json_dict(str(llm_response.get("content") or ""))
+
+        payload = {
+            "bundle_id": manifest.get("bundle_id") or manifest.get("id") or target_ref.path,
+            "generated_from_bundle_commit": "",
+            "service_summary": structured.get("service_summary", {}),
+            "rollout_steps": structured.get("rollout_steps", []),
+            "rollback_steps": structured.get("rollback_steps", []),
+            "monitoring_checks": structured.get("monitoring_checks", []),
+            "alerts": structured.get("alerts", []),
+            "operational_risks": structured.get("operational_risks", []),
+        }
+
+        write_result = await write_bundle_yaml(
+            target_ref,
+            runbook_file,
+            payload,
+            f"chore(bundle): update {runbook_file} for {target_ref.path}",
+        )
+        commit_sha = ((write_result.get("commit") or {}).get("sha")) if isinstance(write_result, dict) else None
+
+        return SkillResult(
+            success=True,
+            output="runbook.yaml updated",
+            data={
+                "bundle_ref": {
+                    "repo": target_ref.repo_full_name,
+                    "path": target_ref.path,
+                    "branch": target_ref.branch,
+                },
+                "updated_files": [f"{target_ref.path}/{runbook_file}"],
+                "commit_sha": commit_sha,
+                "summary": "Generated runbook from bundle context",
+            },
+        )
+    except RequirementBundleError as exc:
+        return SkillResult(success=False, error=str(exc))
+    except Exception as exc:
+        return SkillResult(success=False, error=f"generate_runbook_from_bundle failed: {exc}")

--- a/src/runtime/bundle_template_registry.py
+++ b/src/runtime/bundle_template_registry.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class BundleActionDefinition:
+    action_id: str
+    skill_name: str
+    requires_sources: bool = False
+    required_artifacts: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BundleTemplateDefinition:
+    template_id: str
+    display_name: str
+    artifact_files: dict[str, str]
+    actions: dict[str, BundleActionDefinition]
+
+
+_BUNDLE_TEMPLATE_REGISTRY: Dict[str, BundleTemplateDefinition] = {
+    "requirement.v1": BundleTemplateDefinition(
+        template_id="requirement.v1",
+        display_name="Requirement Bundle",
+        artifact_files={
+            "requirements": "requirements.yaml",
+            "test_cases": "test-cases.yaml",
+        },
+        actions={
+            "collect_requirements": BundleActionDefinition(
+                action_id="collect_requirements",
+                skill_name="collect_requirements_to_bundle",
+                requires_sources=True,
+            ),
+            "design_test_cases": BundleActionDefinition(
+                action_id="design_test_cases",
+                skill_name="design_test_cases_from_bundle",
+                required_artifacts=("requirements",),
+            ),
+        },
+    ),
+    "research.v1": BundleTemplateDefinition(
+        template_id="research.v1",
+        display_name="Research Bundle",
+        artifact_files={
+            "research_notes": "research-notes.yaml",
+        },
+        actions={
+            "collect_research_notes": BundleActionDefinition(
+                action_id="collect_research_notes",
+                skill_name="collect_research_notes_to_bundle",
+                requires_sources=True,
+            ),
+        },
+    ),
+    "development.v1": BundleTemplateDefinition(
+        template_id="development.v1",
+        display_name="Development Bundle",
+        artifact_files={
+            "implementation_plan": "implementation-plan.yaml",
+        },
+        actions={
+            "generate_implementation_plan": BundleActionDefinition(
+                action_id="generate_implementation_plan",
+                skill_name="generate_implementation_plan_from_bundle",
+            ),
+        },
+    ),
+    "operations.v1": BundleTemplateDefinition(
+        template_id="operations.v1",
+        display_name="Operations Bundle",
+        artifact_files={
+            "runbook": "runbook.yaml",
+        },
+        actions={
+            "generate_runbook": BundleActionDefinition(
+                action_id="generate_runbook",
+                skill_name="generate_runbook_from_bundle",
+            ),
+        },
+    ),
+}
+
+
+def _bundle_error(message: str) -> Exception:
+    from src.runtime.requirement_bundle_assets import RequirementBundleError
+
+    return RequirementBundleError(message)
+
+
+def get_bundle_template(template_id: str) -> BundleTemplateDefinition | None:
+    normalized = str(template_id or "").strip().lower()
+    if not normalized:
+        return None
+    return _BUNDLE_TEMPLATE_REGISTRY.get(normalized)
+
+
+def require_bundle_template(template_id: str) -> BundleTemplateDefinition:
+    resolved = get_bundle_template(template_id)
+    if resolved is None:
+        raise _bundle_error(f"Unsupported bundle template_id: {template_id}")
+    return resolved
+
+
+def get_bundle_action(template_id: str, action_id: str) -> BundleActionDefinition | None:
+    template = get_bundle_template(template_id)
+    if template is None:
+        return None
+    normalized_action_id = str(action_id or "").strip().lower()
+    if not normalized_action_id:
+        return None
+    return template.actions.get(normalized_action_id)
+
+
+def require_bundle_action(template_id: str, action_id: str) -> BundleActionDefinition:
+    action = get_bundle_action(template_id, action_id)
+    if action is None:
+        raise _bundle_error(f"Unsupported bundle action '{action_id}' for template '{template_id}'")
+    return action
+
+
+def resolve_bundle_template_id_from_manifest(manifest: Dict[str, Any]) -> str:
+    template_id = str((manifest or {}).get("template_id") or "").strip().lower()
+    if template_id:
+        return template_id
+
+    links = (manifest or {}).get("links")
+    if isinstance(links, dict) and bool(links):
+        return "requirement.v1"
+
+    raise _bundle_error("bundle.yaml requires 'template_id' or legacy 'links'")

--- a/src/runtime/bundle_template_registry.py
+++ b/src/runtime/bundle_template_registry.py
@@ -124,7 +124,7 @@ def require_bundle_action(template_id: str, action_id: str) -> BundleActionDefin
 def resolve_bundle_template_id_from_manifest(manifest: Dict[str, Any]) -> str:
     template_id = str((manifest or {}).get("template_id") or "").strip().lower()
     if template_id:
-        return template_id
+        return require_bundle_template(template_id).template_id
 
     links = (manifest or {}).get("links")
     if isinstance(links, dict) and bool(links):

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -10,6 +10,7 @@ from src.agents.executor import SkillResult, ToolResult, execute_tool_by_name, r
 from src.agents.subagent import run_subagent_execution
 from src.agents.tasks import task_manager
 from src.runtime.adapter_executor import execute_adapter_action
+from src.runtime.bundle_template_registry import get_bundle_action
 from src.runtime.capability_registry import get_capability_registry
 from src.runtime.contracts import (
     DelegationResult,
@@ -1114,9 +1115,11 @@ def build_default_execution_bus(
         task_type: str,
         default_skill_name: str,
         event_prefix: str,
+        allow_payload_skill_name: bool = True,
     ) -> ExecutionResult:
         capability = resolve_task_capability_plan(task_type, request.input_payload)
-        skill_name = str(request.input_payload.get("skill_name") or default_skill_name).strip() or default_skill_name
+        payload_skill_name = request.input_payload.get("skill_name") if allow_payload_skill_name else None
+        skill_name = str(payload_skill_name or default_skill_name).strip() or default_skill_name
         skill_kwargs = dict(request.input_payload.get("skill_kwargs") or {})
         logger.debug(
             "Skill-backed task resolved | task_id=%s task_type=%s skill_name=%s capability_id=%s capability_type=%s",
@@ -2085,6 +2088,32 @@ def build_default_execution_bus(
                 task_type=task_type,
                 default_skill_name="design_test_cases_from_bundle",
                 event_prefix="task.requirement_bundle_design_test_cases",
+            )
+
+        if task_type == "bundle_action_task":
+            template_id = str(request.input_payload.get("template_id") or "").strip().lower()
+            action_id = str(request.input_payload.get("action_id") or "").strip().lower()
+            action = get_bundle_action(template_id, action_id)
+            if action is None:
+                return make_execution_result(
+                    request_id=request.request_id,
+                    status="blocked",
+                    output_payload={
+                        "task_type": task_type,
+                        "template_id": template_id,
+                        "action_id": action_id,
+                        "success": False,
+                        "error": f"Unsupported bundle action '{action_id}' for template '{template_id}'",
+                        "task_boundary": True,
+                    },
+                )
+            return await _execute_skill_backed_task(
+                request,
+                task_id=task_id,
+                task_type=task_type,
+                default_skill_name=action.skill_name,
+                event_prefix="task.bundle_action",
+                allow_payload_skill_name=False,
             )
 
         if task_type != "tool_task":

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 from ruamel.yaml import YAML
 
 from src.github import github_channel
-from src.runtime.bundle_template_registry import resolve_bundle_template_id_from_manifest
+from src.runtime.bundle_template_registry import require_bundle_template, resolve_bundle_template_id_from_manifest
 from src.utils.redaction import safe_preview, sanitize_exception_message
 
 _yaml = YAML()
@@ -490,6 +490,9 @@ def validate_bundle_manifest(manifest: Dict[str, Any]) -> None:
     has_template_id = isinstance(template_id, str) and bool(template_id.strip())
     if template_id is not None and not has_template_id:
         raise RequirementBundleError("bundle.yaml field 'template_id' must be a non-empty string")
+    if has_template_id:
+        normalized_template_id = str(template_id).strip().lower()
+        require_bundle_template(normalized_template_id)
 
     template_version = manifest.get("template_version")
     if template_version is not None and (not isinstance(template_version, int) or template_version < 1):

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 from ruamel.yaml import YAML
 
 from src.github import github_channel
+from src.runtime.bundle_template_registry import resolve_bundle_template_id_from_manifest
 from src.utils.redaction import safe_preview, sanitize_exception_message
 
 _yaml = YAML()
@@ -258,15 +259,14 @@ async def load_bundle_manifest(
 def resolve_bundle_links(manifest: Dict[str, Any]) -> tuple[str, str]:
     logger.debug("Resolve bundle links start")
     try:
-        links = manifest.get("links")
-        if not isinstance(links, dict):
-            raise RequirementBundleError("bundle.yaml field 'links' must be an object")
-
-        requirements_file = str(links.get("requirements_file") or "").strip().strip("/")
-        test_cases_file = str(links.get("test_cases_file") or "").strip().strip("/")
+        artifacts = resolve_bundle_artifacts(manifest)
+        requirements_file = str(artifacts.get("requirements") or "").strip().strip("/")
+        test_cases_file = str(artifacts.get("test_cases") or "").strip().strip("/")
 
         if not requirements_file:
-            raise RequirementBundleError("bundle.yaml field 'links.requirements_file' must be a non-empty string")
+            raise RequirementBundleError(
+                "bundle.yaml field 'links.requirements_file' must be a non-empty string"
+            )
         if not test_cases_file:
             raise RequirementBundleError("bundle.yaml field 'links.test_cases_file' must be a non-empty string")
 
@@ -275,6 +275,39 @@ def resolve_bundle_links(manifest: Dict[str, Any]) -> tuple[str, str]:
     except RequirementBundleError as exc:
         _log_bundle_asset_failure("resolve_bundle_links", exc)
         raise
+
+
+def resolve_bundle_artifacts(manifest: Dict[str, Any]) -> dict[str, str]:
+    artifacts = manifest.get("artifacts")
+    if isinstance(artifacts, dict) and artifacts:
+        normalized: dict[str, str] = {}
+        for key, value in artifacts.items():
+            artifact_key = str(key or "").strip()
+            artifact_path = str(value or "").strip().strip("/")
+            if not artifact_key or not artifact_path:
+                raise RequirementBundleError("bundle.yaml field 'artifacts' values must be non-empty strings")
+            normalized[artifact_key] = artifact_path
+        if normalized:
+            return normalized
+
+    links = manifest.get("links")
+    if not isinstance(links, dict):
+        raise RequirementBundleError("bundle.yaml field 'artifacts' or legacy 'links' must be an object")
+
+    requirements_file = str(links.get("requirements_file") or "").strip().strip("/")
+    test_cases_file = str(links.get("test_cases_file") or "").strip().strip("/")
+    resolved: dict[str, str] = {}
+    if requirements_file:
+        resolved["requirements"] = requirements_file
+    if test_cases_file:
+        resolved["test_cases"] = test_cases_file
+    if not resolved:
+        raise RequirementBundleError("bundle.yaml requires non-empty 'artifacts' or legacy 'links' file entries")
+    return resolved
+
+
+def resolve_bundle_template_id(manifest: Dict[str, Any]) -> str:
+    return resolve_bundle_template_id_from_manifest(manifest)
 
 
 def resolve_target_bundle_ref(input_ref: BundleRef, manifest: Dict[str, Any]) -> BundleRef:
@@ -418,7 +451,7 @@ def validate_bundle_manifest(manifest: Dict[str, Any]) -> None:
     if not isinstance(manifest, dict):
         raise RequirementBundleError("bundle.yaml must be an object")
 
-    required_top_level = ("bundle_id", "title", "status", "scope", "storage", "links")
+    required_top_level = ("bundle_id", "title", "status", "scope", "storage")
     for key in required_top_level:
         if key not in manifest:
             raise RequirementBundleError(f"bundle.yaml missing required field: {key}")
@@ -453,15 +486,47 @@ def validate_bundle_manifest(manifest: Dict[str, Any]) -> None:
     if not owner or not repo:
         raise RequirementBundleError("bundle.yaml field 'storage.repo' must be in 'owner/repo' format")
 
+    template_id = manifest.get("template_id")
+    has_template_id = isinstance(template_id, str) and bool(template_id.strip())
+    if template_id is not None and not has_template_id:
+        raise RequirementBundleError("bundle.yaml field 'template_id' must be a non-empty string")
+
+    template_version = manifest.get("template_version")
+    if template_version is not None and (not isinstance(template_version, int) or template_version < 1):
+        raise RequirementBundleError("bundle.yaml field 'template_version' must be an integer >= 1")
+
+    artifacts = manifest.get("artifacts")
     links = manifest.get("links")
-    if not isinstance(links, dict):
-        raise RequirementBundleError("bundle.yaml field 'links' must be an object")
-    for key in ("requirements_file", "test_cases_file"):
-        if key not in links:
-            raise RequirementBundleError(f"bundle.yaml missing required field: links.{key}")
-        value = links.get(key)
-        if not isinstance(value, str) or not value.strip():
-            raise RequirementBundleError(f"bundle.yaml field 'links.{key}' must be a non-empty string")
+
+    if artifacts is None and links is None:
+        raise RequirementBundleError("bundle.yaml requires 'artifacts' or legacy 'links'")
+
+    if artifacts is not None:
+        if not isinstance(artifacts, dict):
+            raise RequirementBundleError("bundle.yaml field 'artifacts' must be an object")
+        if not artifacts:
+            raise RequirementBundleError("bundle.yaml field 'artifacts' must include at least one artifact")
+        for key, value in artifacts.items():
+            if not isinstance(key, str) or not key.strip():
+                raise RequirementBundleError("bundle.yaml field 'artifacts' keys must be non-empty strings")
+            normalized_value = str(value or "").strip().strip("/")
+            if not normalized_value:
+                raise RequirementBundleError(
+                    f"bundle.yaml field 'artifacts.{key}' must be a non-empty string"
+                )
+
+    if links is not None:
+        if not isinstance(links, dict):
+            raise RequirementBundleError("bundle.yaml field 'links' must be an object")
+        for key in ("requirements_file", "test_cases_file"):
+            value = links.get(key)
+            if value is None:
+                continue
+            if not isinstance(value, str) or not value.strip().strip("/"):
+                raise RequirementBundleError(f"bundle.yaml field 'links.{key}' must be a non-empty string")
+
+    if has_template_id and artifacts is None:
+        raise RequirementBundleError("bundle.yaml field 'artifacts' is required when 'template_id' is set")
 
 
 def validate_requirements_doc(requirements_doc: Dict[str, Any]) -> None:

--- a/src/runtime/task_capability_contracts.py
+++ b/src/runtime/task_capability_contracts.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
+from src.runtime.bundle_template_registry import get_bundle_action
 from src.runtime.capability_registry import get_capability_registry
 
 
@@ -89,6 +90,36 @@ def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) ->
         primary_capability_id = f"skill:{skill_name}"
         descriptor = registry.get(primary_capability_id)
         involved = _resolve_involved_capability_ids_for_task(normalized_task_type, normalized_payload)
+        if descriptor is None:
+            return {
+                **fallback,
+                "primary_capability_id": primary_capability_id,
+                "capability_id": primary_capability_id,
+                "action_id": primary_capability_id,
+                "capability_type": "skill",
+                "involved_capability_ids": involved,
+            }
+        return {
+            **fallback,
+            "primary_capability_id": descriptor.capability_id,
+            "capability_id": descriptor.capability_id,
+            "capability_type": descriptor.type,
+            "action_id": descriptor.capability_id,
+            "involved_capability_ids": involved,
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": bool(descriptor.requires_identity_binding),
+            "capability_resolution": "resolved",
+        }
+
+    if normalized_task_type == "bundle_action_task":
+        template_id = str(normalized_payload.get("template_id") or "").strip().lower()
+        action_id = str(normalized_payload.get("action_id") or "").strip().lower()
+        action = get_bundle_action(template_id, action_id)
+        if action is None:
+            return fallback
+        primary_capability_id = f"skill:{action.skill_name}"
+        descriptor = registry.get(primary_capability_id)
+        involved = [primary_capability_id]
         if descriptor is None:
             return {
                 **fallback,

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -3427,3 +3427,61 @@ async def test_requirement_bundle_collect_task_skill_failure_keeps_task_boundary
     assert result.status == "error"
     assert result.output_payload["task_boundary"] is True
     assert result.output_payload["success"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("template_id", "action_id", "expected_skill"),
+    [
+        ("requirement.v1", "collect_requirements", "collect_requirements_to_bundle"),
+        ("requirement.v1", "design_test_cases", "design_test_cases_from_bundle"),
+        ("research.v1", "collect_research_notes", "collect_research_notes_to_bundle"),
+        ("development.v1", "generate_implementation_plan", "generate_implementation_plan_from_bundle"),
+        ("operations.v1", "generate_runbook", "generate_runbook_from_bundle"),
+    ],
+)
+async def test_bundle_action_task_routes_to_registry_skill(monkeypatch, template_id, action_id, expected_skill):
+    observed = {}
+
+    async def _fake_run_skill_execution(skill_name, **kwargs):
+        observed["skill_name"] = skill_name
+        observed["kwargs"] = kwargs
+        return SkillResult(success=True, output="ok", data={"bundle_ref": kwargs.get("bundle_ref"), "updated_files": []})
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_skill_execution", _fake_run_skill_execution)
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "bundle_action_task",
+            "template_id": template_id,
+            "action_id": action_id,
+            "bundle_ref": {"repo": "acme/demo", "path": "bundles/a", "branch": "feat/a"},
+            "skill_name": "should_not_override",
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert observed["skill_name"] == expected_skill
+    assert result.status == "success"
+    assert result.output_payload["task_boundary"] is True
+    assert result.output_payload["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_bundle_action_task_unknown_template_action_blocked(monkeypatch):
+    called = {"value": False}
+
+    async def _fake_run_skill_execution(_skill_name, **_kwargs):
+        called["value"] = True
+        return SkillResult(success=True)
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_skill_execution", _fake_run_skill_execution)
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={"task_type": "bundle_action_task", "template_id": "unknown.v1", "action_id": "x"},
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "blocked"
+    assert result.output_payload["task_boundary"] is True
+    assert called["value"] is False

--- a/tests/test_requirement_bundle_tasks.py
+++ b/tests/test_requirement_bundle_tasks.py
@@ -1021,6 +1021,31 @@ def test_resolve_bundle_template_id_legacy_defaults_requirement_v1():
     assert resolve_bundle_template_id(manifest) == "requirement.v1"
 
 
+def test_validate_bundle_manifest_rejects_unknown_template_id():
+    manifest = {
+        "bundle_id": "rb-unknown-template",
+        "template_id": "foo.v1",
+        "template_version": 1,
+        "title": "Unknown Template",
+        "status": "draft",
+        "scope": {"domain": "payments", "summary": "unknown template"},
+        "storage": {
+            "repo": "acme/assets",
+            "path": "requirement-bundles/payments/unknown",
+            "base_branch": "main",
+            "working_branch": "bundle/unknown",
+        },
+        "artifacts": {"requirements": "requirements.yaml"},
+    }
+    with pytest.raises(RequirementBundleError, match="Unsupported bundle template_id"):
+        validate_bundle_manifest(manifest)
+
+
+def test_resolve_bundle_template_id_unknown_template_raises():
+    with pytest.raises(RequirementBundleError, match="Unsupported bundle template_id"):
+        resolve_bundle_template_id({"template_id": "foo.v1"})
+
+
 def test_build_test_design_context_is_trimmed():
     context = build_test_design_context(
         {"bundle_id": "rb-9", "title": "T", "scope": {"a": 1}, "other": "x"},

--- a/tests/test_requirement_bundle_tasks.py
+++ b/tests/test_requirement_bundle_tasks.py
@@ -4,16 +4,23 @@ import json
 import pytest
 
 from skills.collect_requirements_to_bundle.skill import collect_requirements_to_bundle as collect_requirements_skill
+from skills.collect_research_notes_to_bundle.skill import collect_research_notes_to_bundle as collect_research_notes_skill
 from skills.design_test_cases_from_bundle.skill import design_test_cases_from_bundle as design_test_cases_skill
+from skills.generate_implementation_plan_from_bundle.skill import (
+    generate_implementation_plan_from_bundle as generate_implementation_plan_skill,
+)
+from skills.generate_runbook_from_bundle.skill import generate_runbook_from_bundle as generate_runbook_skill
 from src.runtime.requirement_bundle_assets import (
     RequirementBundleError,
     BundleRef,
     build_test_design_context,
     load_bundle_manifest,
+    resolve_bundle_artifacts,
     parse_github_doc_ref,
     parse_bundle_ref,
     read_github_doc_text,
     resolve_bundle_links,
+    resolve_bundle_template_id,
     resolve_target_bundle_ref,
     validate_bundle_manifest,
     write_requirements_doc_for_ref,
@@ -42,6 +49,31 @@ def _valid_manifest_yaml(
         "links:\n"
         f"  requirements_file: {requirements_file}\n"
         f"  test_cases_file: {test_cases_file}\n"
+    )
+
+
+def _valid_template_manifest_yaml(
+    template_id: str = "requirement.v1",
+    artifacts_yaml: str = "  requirements: requirements.yaml\n  test_cases: test-cases.yaml\n",
+    bundle_id: str = "rb-template-1",
+) -> str:
+    return (
+        f"bundle_id: {bundle_id}\n"
+        f"template_id: {template_id}\n"
+        "template_version: 1\n"
+        "title: Maker Checker\n"
+        "status: draft\n"
+        "scope:\n"
+        "  domain: payments\n"
+        "  summary: maker checker\n"
+        "storage:\n"
+        "  repo: acme/assets\n"
+        "  path: requirement-bundles/payments/maker\n"
+        "  base_branch: main\n"
+        "  working_branch: bundle/1\n"
+        "artifacts:\n"
+        f"{artifacts_yaml}"
+        "metadata: {}\n"
     )
 
 
@@ -415,6 +447,44 @@ async def test_collect_skill_writes_custom_requirements_file_from_manifest_links
 
 
 @pytest.mark.asyncio
+async def test_collect_requirements_skill_reads_template_artifacts_manifest(monkeypatch):
+    writes = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        if path.endswith("bundle.yaml"):
+            return {
+                "content": _b64(
+                    _valid_template_manifest_yaml(
+                        template_id="requirement.v1",
+                        artifacts_yaml="  requirements: docs/reqs.yaml\n  test_cases: outputs/tc.yaml\n",
+                        bundle_id="rb-template-collect",
+                    )
+                )
+            }
+        if path == "docs/spec.md":
+            return {"content": _b64("# Spec")}
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append(path)
+        return {"commit": {"sha": "sha-template-collect"}}
+
+    async def _fake_chat(self, **kwargs):
+        return {"content": "{\"summary\":{},\"functional_requirements\":[\"a\"],\"business_rules\":[],\"acceptance_criteria\":[],\"edge_cases\":[],\"quality_flags\":{\"ambiguities\":[],\"conflicts\":[],\"missing_information\":[]}}"}
+
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.github_channel.is_configured", lambda: True)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+    result = await collect_requirements_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"},
+        sources={"github_docs": ["docs/spec.md"]},
+    )
+    assert result.success is True
+    assert writes == ["requirement-bundles/payments/maker/docs/reqs.yaml"]
+
+
+@pytest.mark.asyncio
 async def test_design_skill_reads_requirements_and_writes_test_cases(monkeypatch):
     writes = []
 
@@ -449,6 +519,117 @@ async def test_design_skill_reads_requirements_and_writes_test_cases(monkeypatch
     assert result.success is True
     assert writes and writes[0]["path"].endswith("test-cases.yaml")
     assert writes[0]["branch"] == "bundle/1"
+
+
+@pytest.mark.asyncio
+async def test_collect_research_notes_skill_writes_research_notes_yaml(monkeypatch):
+    writes = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        if path.endswith("bundle.yaml"):
+            return {
+                "content": _b64(
+                    _valid_template_manifest_yaml(
+                        template_id="research.v1",
+                        artifacts_yaml="  research_notes: research-notes.yaml\n",
+                        bundle_id="rb-research",
+                    )
+                )
+            }
+        if path == "docs/spec.md":
+            return {"content": _b64("# Spec")}
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append(path)
+        return {"commit": {"sha": "sha-research"}}
+
+    async def _fake_chat(self, **_kwargs):
+        return {"content": "{\"summary\":{},\"findings\":[],\"open_questions\":[],\"references\":[]}"}
+
+    monkeypatch.setattr("skills.collect_research_notes_to_bundle.skill.github_channel.is_configured", lambda: True)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await collect_research_notes_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"},
+        sources={"github_docs": ["docs/spec.md"]},
+    )
+    assert result.success is True
+    assert writes == ["requirement-bundles/payments/maker/research-notes.yaml"]
+
+
+@pytest.mark.asyncio
+async def test_generate_implementation_plan_skill_writes_implementation_plan_yaml(monkeypatch):
+    writes = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        if path.endswith("bundle.yaml"):
+            return {
+                "content": _b64(
+                    _valid_template_manifest_yaml(
+                        template_id="development.v1",
+                        artifacts_yaml="  implementation_plan: implementation-plan.yaml\n",
+                        bundle_id="rb-dev",
+                    )
+                )
+            }
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append(path)
+        return {"commit": {"sha": "sha-dev"}}
+
+    async def _fake_chat(self, **_kwargs):
+        return {"content": "{\"summary\":{},\"workstreams\":[],\"tasks\":[],\"risks\":[],\"validation_checks\":[]}"}
+
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await generate_implementation_plan_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"}
+    )
+    assert result.success is True
+    assert writes == ["requirement-bundles/payments/maker/implementation-plan.yaml"]
+
+
+@pytest.mark.asyncio
+async def test_generate_runbook_skill_writes_runbook_yaml(monkeypatch):
+    writes = []
+
+    async def _fake_get_file(owner, repo, path, ref=""):
+        if path.endswith("bundle.yaml"):
+            return {
+                "content": _b64(
+                    _valid_template_manifest_yaml(
+                        template_id="operations.v1",
+                        artifacts_yaml="  runbook: runbook.yaml\n",
+                        bundle_id="rb-ops",
+                    )
+                )
+            }
+        raise AssertionError((owner, repo, path, ref))
+
+    async def _fake_put_file(owner, repo, path, content, message, sha=None, branch=""):
+        writes.append(path)
+        return {"commit": {"sha": "sha-ops"}}
+
+    async def _fake_chat(self, **_kwargs):
+        return {
+            "content": "{\"service_summary\":{},\"rollout_steps\":[],\"rollback_steps\":[],\"monitoring_checks\":[],\"alerts\":[],\"operational_risks\":[]}"
+        }
+
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.create_or_update_file", _fake_put_file)
+    monkeypatch.setattr("src.agents.llm.LLMClient.chat", _fake_chat)
+
+    result = await generate_runbook_skill.execute(
+        bundle_ref={"repo": "acme/assets", "path": "requirement-bundles/payments/maker", "branch": "bundle/1"}
+    )
+    assert result.success is True
+    assert writes == ["requirement-bundles/payments/maker/runbook.yaml"]
 
 
 @pytest.mark.asyncio
@@ -821,6 +1002,23 @@ def test_resolve_bundle_links_uses_manifest_links():
 
     assert requirements_file == "docs/reqs.yaml"
     assert test_cases_file == "outputs/tc.yaml"
+
+
+def test_resolve_bundle_artifacts_supports_template_artifacts():
+    manifest = {
+        "artifacts": {
+            "requirements": " requirements.yaml ",
+            "test_cases": "/test-cases.yaml/",
+        }
+    }
+    artifacts = resolve_bundle_artifacts(manifest)
+    assert artifacts["requirements"] == "requirements.yaml"
+    assert artifacts["test_cases"] == "test-cases.yaml"
+
+
+def test_resolve_bundle_template_id_legacy_defaults_requirement_v1():
+    manifest = {"links": {"requirements_file": "requirements.yaml", "test_cases_file": "test-cases.yaml"}}
+    assert resolve_bundle_template_id(manifest) == "requirement.v1"
 
 
 def test_build_test_design_context_is_trimmed():

--- a/tests/test_task_capability_contracts.py
+++ b/tests/test_task_capability_contracts.py
@@ -194,3 +194,57 @@ def test_resolve_task_capability_contract_requirement_bundle_design_test_cases_t
     assert plan["capability_id"] == "skill:design_test_cases_from_bundle"
     assert plan["capability_type"] == "skill"
     assert plan["involved_capability_ids"] == ["skill:design_test_cases_from_bundle"]
+
+
+def test_resolve_task_capability_contract_bundle_action_task_requirement_collect():
+    plan = resolve_task_capability_contract(
+        "bundle_action_task",
+        {"template_id": "requirement.v1", "action_id": "collect_requirements"},
+    )
+    assert plan["primary_capability_id"] == "skill:collect_requirements_to_bundle"
+    assert plan["capability_id"] == "skill:collect_requirements_to_bundle"
+
+
+def test_resolve_task_capability_contract_bundle_action_task_requirement_design():
+    plan = resolve_task_capability_contract(
+        "bundle_action_task",
+        {"template_id": "requirement.v1", "action_id": "design_test_cases"},
+    )
+    assert plan["primary_capability_id"] == "skill:design_test_cases_from_bundle"
+    assert plan["capability_id"] == "skill:design_test_cases_from_bundle"
+
+
+def test_resolve_task_capability_contract_bundle_action_task_research_collect():
+    plan = resolve_task_capability_contract(
+        "bundle_action_task",
+        {"template_id": "research.v1", "action_id": "collect_research_notes"},
+    )
+    assert plan["primary_capability_id"] == "skill:collect_research_notes_to_bundle"
+    assert plan["capability_id"] == "skill:collect_research_notes_to_bundle"
+
+
+def test_resolve_task_capability_contract_bundle_action_task_development_generate():
+    plan = resolve_task_capability_contract(
+        "bundle_action_task",
+        {"template_id": "development.v1", "action_id": "generate_implementation_plan"},
+    )
+    assert plan["primary_capability_id"] == "skill:generate_implementation_plan_from_bundle"
+    assert plan["capability_id"] == "skill:generate_implementation_plan_from_bundle"
+
+
+def test_resolve_task_capability_contract_bundle_action_task_operations_generate():
+    plan = resolve_task_capability_contract(
+        "bundle_action_task",
+        {"template_id": "operations.v1", "action_id": "generate_runbook"},
+    )
+    assert plan["primary_capability_id"] == "skill:generate_runbook_from_bundle"
+    assert plan["capability_id"] == "skill:generate_runbook_from_bundle"
+
+
+def test_resolve_task_capability_contract_bundle_action_task_unknown_is_unresolved():
+    plan = resolve_task_capability_contract(
+        "bundle_action_task",
+        {"template_id": "unknown.v1", "action_id": "does_not_exist"},
+    )
+    assert plan["capability_resolution"] == "unresolved"
+    assert plan["primary_capability_id"] is None


### PR DESCRIPTION
### Motivation
- Introduce a runtime-trusted, static bundle template registry so `template_id + action_id` from portal map to known skills without trusting payload or manifest `skill_name` fields.
- Generalize bundle manifest handling to support a new `template_id + artifacts` protocol while preserving legacy `links` compatibility so existing requirement flows keep working.
- Reuse the existing skill-backed task execution path so new `bundle_action_task` integrates with the current runtime events/auditing model and governance.

### Description
- Added a static registry `src/runtime/bundle_template_registry.py` that defines `requirement.v1`, `research.v1`, `development.v1`, and `operations.v1` templates with action->skill and artifact mappings and helper resolvers.
- Generalized manifest handling in `src/runtime/requirement_bundle_assets.py` by adding `resolve_bundle_artifacts()` and `resolve_bundle_template_id()`, updating `resolve_bundle_links()` to be a compatibility wrapper, and updating `validate_bundle_manifest()` to accept the new `template_id + artifacts` schema while keeping legacy `links` valid.
- Extended capability resolution in `src/runtime/task_capability_contracts.py` with a `bundle_action_task` branch that maps `template_id+action_id` -> `skill:{skill_name}` via the registry and returns a resolved/unresolved structure consistent with existing contract style.
- Routed execution in `src/runtime/execution_bus.py` to handle `bundle_action_task` by resolving the bundle action via the registry and invoking the existing `_execute_skill_backed_task()` helper (with payload `skill_name` override disabled for `bundle_action_task`), and returning a blocked `ExecutionResult` when template/action resolution fails.
- Added three new skills under `skills/`: `collect_research_notes_to_bundle`, `generate_implementation_plan_from_bundle`, and `generate_runbook_from_bundle`, implemented in the same style as existing requirement skills and writing their respective artifact files declared by templates.
- Extended tests to cover the new contract, routing behavior, manifest/artifact parsing, and the three new skills, while preserving all legacy requirement tests; modified test helpers and added `_valid_template_manifest_yaml()` to exercise new manifest shapes.

### Testing
- Ran the focused test set: `pytest -q tests/test_task_capability_contracts.py tests/test_execution_bus.py tests/test_requirement_bundle_tasks.py` and all selected tests passed (181 passed, 1 warning).
- New unit tests assert `bundle_action_task` capability resolution and execution routing for all templates and actions, and verify unknown template/action returns unresolved (capability) or `blocked` (execution).
- Requirement-path tests were preserved and additionally verify that new manifest `artifacts` are parsed and that new skills write expected artifact files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbbf1bcbb4832a95f49e1632d25625)