### PR TITLE
Expose trusted request_id and publish chat.started metadata for /api/chat and /api/chat/stream

### DIFF
--- a/src/gateway/chat_payloads.py
+++ b/src/gateway/chat_payloads.py
@@ -58,6 +58,12 @@ def build_webchat_response_payload(result: Optional[Dict[str, Any]], session_id:
         "usage": usage,
         "display_blocks": normalize_display_blocks(payload_result.get("display_blocks"), response_text),
     }
+    request_id = payload_result.get("request_id")
+    if not request_id:
+        execution_result = payload_result.get("_execution_result")
+        request_id = getattr(execution_result, "request_id", None) if execution_result is not None else None
+    if request_id:
+        response_payload["request_id"] = request_id
     for key in ("user_message_id", "events", "_llm_debug", "reasoning"):
         if key in payload_result:
             response_payload[key] = payload_result[key]

--- a/src/gateway/event_bus.py
+++ b/src/gateway/event_bus.py
@@ -17,6 +17,7 @@ _SUPPORTED_FILTER_KEYS = {
     "task_id",
     "group_id",
     "coordination_run_id",
+    "request_id",
 }
 
 
@@ -65,6 +66,8 @@ class EventBus:
                     data.get("current_coordination_run_id"),
                     data.get("portal_coordination_run_id"),
                 ]
+            elif key == "request_id":
+                candidates = [data.get("request_id"), data.get("execution_id")]
             else:
                 return False
 

--- a/src/gateway/events.py
+++ b/src/gateway/events.py
@@ -24,7 +24,7 @@ async def handle_websocket(request: web.Request) -> WebSocketResponse:
     queue = asyncio.Queue()
 
     query = request.rel_url.query
-    filter_keys = ("session_id", "task_id", "group_id", "coordination_run_id", "agent_id")
+    filter_keys = ("session_id", "task_id", "group_id", "coordination_run_id", "agent_id", "request_id")
     filters = {key: str(query.get(key, "")).strip() for key in filter_keys if str(query.get(key, "")).strip()}
 
     # Register this connection as a listener

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -57,6 +57,10 @@ from src.gateway.chat_payloads import (
     build_webchat_response_payload,
     normalize_assistant_history_message,
 )
+from src.gateway.webchat_request_contracts import (
+    build_stream_start_event_payload,
+    extract_trusted_client_request_id,
+)
 from src.runtime.capability_registry import get_capability_registry
 from src.gateway.event_bus import emit_agent_event
 from src.sessions.manager import session_manager
@@ -151,19 +155,7 @@ def _extract_trusted_control_plane_metadata(request: web.Request, data: Dict[str
 
 
 def _extract_trusted_client_request_id(request: web.Request, data: Dict[str, Any]) -> Optional[str]:
-    if not _is_trusted_portal_request(request):
-        return None
-    candidate = data.get("client_request_id")
-    if candidate is None:
-        candidate = data.get("request_id")
-    if not isinstance(candidate, str):
-        return None
-    cleaned = candidate.strip()
-    if not cleaned or len(cleaned) > 128:
-        return None
-    if not re.fullmatch(r"[A-Za-z0-9_:-]+", cleaned):
-        return None
-    return cleaned
+    return extract_trusted_client_request_id(_is_trusted_portal_request(request), data)
 
 
 def _require_non_empty_string(data: Dict[str, Any], key: str) -> str:
@@ -847,7 +839,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
 
         # Send start event
         await response.write(
-            f"event: start\ndata: {json.dumps({'session_id': session_id, 'request_id': request_id})}\n\n".encode()
+            f"event: start\ndata: {json.dumps(build_stream_start_event_payload(session_id, request_id))}\n\n".encode()
         )
 
         event_queue = asyncio.Queue()

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -150,6 +150,22 @@ def _extract_trusted_control_plane_metadata(request: web.Request, data: Dict[str
     return trusted_metadata
 
 
+def _extract_trusted_client_request_id(request: web.Request, data: Dict[str, Any]) -> Optional[str]:
+    if not _is_trusted_portal_request(request):
+        return None
+    candidate = data.get("client_request_id")
+    if candidate is None:
+        candidate = data.get("request_id")
+    if not isinstance(candidate, str):
+        return None
+    cleaned = candidate.strip()
+    if not cleaned or len(cleaned) > 128:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9_:-]+", cleaned):
+        return None
+    return cleaned
+
+
 def _require_non_empty_string(data: Dict[str, Any], key: str) -> str:
     value = data.get(key)
     if not isinstance(value, str) or not value.strip():
@@ -261,6 +277,7 @@ async def _run_chat_via_execution_bus(
     request_path: str = "/api/chat",
     execution_metadata: Optional[Dict[str, Any]] = None,
     agent_id: Optional[str] = None,
+    request_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     async def _chat_handler(execution_request):
         payload = execution_request.input_payload
@@ -280,8 +297,9 @@ async def _run_chat_via_execution_bus(
 
     merged_metadata = dict(execution_metadata or {})
     merged_metadata.pop("path", None)
+    resolved_request_id = request_id or f"chat-{uuid.uuid4()}"
     execution_result = await execute_chat_orchestration(
-        request_id=f"chat-{uuid.uuid4()}",
+        request_id=resolved_request_id,
         session_id=session_id,
         source_ref="webchat",
         agent_id=agent_id,
@@ -305,6 +323,7 @@ async def _run_chat_via_execution_bus(
     )
     original_output_payload = execution_result.output_payload
     output_payload = dict(original_output_payload) if isinstance(original_output_payload, dict) else {}
+    output_payload["request_id"] = getattr(execution_result, "request_id", resolved_request_id)
     output_payload["_execution_result"] = execution_result
     if execution_result.status == "error" or output_payload.get("error"):
         error_value = output_payload.get("error", "Execution bus error")
@@ -489,6 +508,8 @@ async def api_chat(request: web.Request) -> web.Response:
         attachments = data.get('attachments', [])
         portal_user_id, portal_user_name = _extract_portal_identity(request, data)
         execution_metadata = _extract_trusted_control_plane_metadata(request, data)
+        client_request_id = _extract_trusted_client_request_id(request, data)
+        request_id = client_request_id or f"chat-{uuid.uuid4()}"
         effective_user_name = _resolve_chat_display_user_name(data, portal_user_name)
         logger.debug(
             "[api_chat] Request summary: session_id=%s, has_message=%s, attachment_count=%d, portal_user_id_present=%s",
@@ -629,6 +650,20 @@ async def api_chat(request: web.Request) -> web.Response:
             agent_id=runtime_agent_id,
             agent_name=runtime_agent_name,
         )
+        if runtime_agent_id and session_id:
+            try:
+                await publish_session_metadata(
+                    agent_id=runtime_agent_id,
+                    session_id=session_id,
+                    last_execution_id=request_id,
+                    latest_event_type="chat.started",
+                    latest_event_state="running",
+                    snapshot_version=None,
+                    runtime_events=[],
+                    metadata=execution_metadata,
+                )
+            except Exception:
+                logger.warning("Best-effort session metadata publish failed for chat.started", exc_info=True)
         result = await _run_chat_via_execution_bus(
             agent=agent,
             message=message,
@@ -642,6 +677,7 @@ async def api_chat(request: web.Request) -> web.Response:
             request_path="/api/chat",
             execution_metadata=execution_metadata,
             agent_id=runtime_agent_id,
+            request_id=request_id,
         )
         execution_result = result.get("_execution_result")
         if runtime_agent_id and execution_result is not None:
@@ -788,6 +824,8 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         session_id = data.get('session_id', f'webchat_{datetime.utcnow().strftime("%Y%m%d_%H%M%S")}')
         portal_user_id, portal_user_name = _extract_portal_identity(request, data)
         execution_metadata = _extract_trusted_control_plane_metadata(request, data)
+        client_request_id = _extract_trusted_client_request_id(request, data)
+        request_id = client_request_id or f"chat-{uuid.uuid4()}"
         effective_user_name = _resolve_chat_display_user_name(data, portal_user_name)
 
         if not message:
@@ -808,7 +846,9 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         await response.prepare(request)
 
         # Send start event
-        await response.write(f"event: start\ndata: {json.dumps({'session_id': session_id})}\n\n".encode())
+        await response.write(
+            f"event: start\ndata: {json.dumps({'session_id': session_id, 'request_id': request_id})}\n\n".encode()
+        )
 
         event_queue = asyncio.Queue()
 
@@ -823,6 +863,20 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             agent_id=runtime_agent_id,
             agent_name=runtime_agent_name,
         )
+        if runtime_agent_id and session_id:
+            try:
+                await publish_session_metadata(
+                    agent_id=runtime_agent_id,
+                    session_id=session_id,
+                    last_execution_id=request_id,
+                    latest_event_type="chat.started",
+                    latest_event_state="running",
+                    snapshot_version=None,
+                    runtime_events=[],
+                    metadata=execution_metadata,
+                )
+            except Exception:
+                logger.warning("Best-effort session metadata publish failed for streaming chat.started", exc_info=True)
 
         run_task = asyncio.create_task(
             _run_chat_via_execution_bus(
@@ -836,6 +890,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
                 request_path="/api/chat/stream",
                 execution_metadata=execution_metadata,
                 agent_id=runtime_agent_id,
+                request_id=request_id,
             )
         )
 

--- a/src/gateway/webchat_request_contracts.py
+++ b/src/gateway/webchat_request_contracts.py
@@ -1,0 +1,34 @@
+"""Lightweight request-id contracts shared by WebChat handlers and tests."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Mapping, Optional
+
+
+def extract_trusted_client_request_id(
+    is_trusted_portal_request: bool,
+    data: Mapping[str, Any],
+) -> Optional[str]:
+    """Return accepted client request id for trusted portal requests only."""
+    if not is_trusted_portal_request:
+        return None
+    candidate = data.get("client_request_id")
+    if candidate is None:
+        candidate = data.get("request_id")
+    if not isinstance(candidate, str):
+        return None
+    cleaned = candidate.strip()
+    if not cleaned or len(cleaned) > 128:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9_:-]+", cleaned):
+        return None
+    return cleaned
+
+
+def build_stream_start_event_payload(session_id: str, request_id: str) -> Dict[str, str]:
+    """Return the stable start-event payload for stream chat responses."""
+    return {
+        "session_id": session_id,
+        "request_id": request_id,
+    }

--- a/tests/_import_helpers.py
+++ b/tests/_import_helpers.py
@@ -1,0 +1,39 @@
+"""Helpers for import-light test module loading from repository paths."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _ensure_package(package_name: str) -> None:
+    if package_name in sys.modules:
+        return
+    module = types.ModuleType(package_name)
+    module.__path__ = []  # type: ignore[attr-defined]
+    sys.modules[package_name] = module
+
+
+def load_module_from_repo_path(module_name: str, relative_path: str):
+    """Load and execute a module from ``relative_path`` under repo root.
+
+    Supports package-qualified names (for example ``src.gateway.events``) so
+    relative imports inside the loaded module continue to resolve.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    module_path = repo_root / relative_path
+
+    package_parts = module_name.split(".")[:-1]
+    for idx in range(1, len(package_parts) + 1):
+        _ensure_package(".".join(package_parts[:idx]))
+
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Failed to create module spec for {module_name} at {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -116,3 +116,18 @@ async def test_event_bus_request_id_and_session_id_combined_filter():
     assert event["data"]["session_id"] == "s-1"
     assert event["data"]["request_id"] == "req-1"
     assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_event_bus_request_id_filter_does_not_match_parent_request_id():
+    bus = EventBus()
+    queue = asyncio.Queue()
+    await bus.add_listener(queue, filters={"request_id": "req-1"})
+
+    await bus.emit("execution.progress", {"parent_request_id": "req-1"})
+    await bus.emit("execution.progress", {"request_id": "req-1"})
+
+    event = json.loads(await queue.get())
+    assert "parent_request_id" not in event["data"]
+    assert event["data"]["request_id"] == "req-1"
+    assert queue.empty()

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -3,7 +3,10 @@ import json
 
 import pytest
 
-from src.gateway.event_bus import EventBus
+from tests._import_helpers import load_module_from_repo_path
+
+_event_bus_module = load_module_from_repo_path("src.gateway.event_bus", "src/gateway/event_bus.py")
+EventBus = _event_bus_module.EventBus
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -70,3 +70,46 @@ async def test_event_bus_group_and_coordination_filters():
     assert event["data"]["portal_group_id"] == "group-1"
     assert event["data"]["current_coordination_run_id"] == "coord-1"
     assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_event_bus_request_id_filter_exact_match():
+    bus = EventBus()
+    queue = asyncio.Queue()
+    await bus.add_listener(queue, filters={"request_id": "req-1"})
+
+    await bus.emit("execution.progress", {"request_id": "req-2"})
+    await bus.emit("execution.progress", {"request_id": "req-1"})
+
+    event = json.loads(await queue.get())
+    assert event["data"]["request_id"] == "req-1"
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_event_bus_request_id_filter_matches_execution_id_alias():
+    bus = EventBus()
+    queue = asyncio.Queue()
+    await bus.add_listener(queue, filters={"request_id": "req-exec-1"})
+
+    await bus.emit("execution.progress", {"execution_id": "req-exec-1"})
+
+    event = json.loads(await queue.get())
+    assert event["data"]["execution_id"] == "req-exec-1"
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_event_bus_request_id_and_session_id_combined_filter():
+    bus = EventBus()
+    queue = asyncio.Queue()
+    await bus.add_listener(queue, filters={"session_id": "s-1", "request_id": "req-1"})
+
+    await bus.emit("execution.progress", {"session_id": "s-1", "request_id": "req-x"})
+    await bus.emit("execution.progress", {"session_id": "s-x", "request_id": "req-1"})
+    await bus.emit("execution.progress", {"session_id": "s-1", "request_id": "req-1"})
+
+    event = json.loads(await queue.get())
+    assert event["data"]["session_id"] == "s-1"
+    assert event["data"]["request_id"] == "req-1"
+    assert queue.empty()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -49,6 +49,7 @@ async def test_handle_websocket_passes_query_filters_to_event_bus(monkeypatch):
                 "group_id": "",
                 "coordination_run_id": "coord-1",
                 "agent_id": "agent-1",
+                "request_id": " req-1 ",
             }
         )
     )
@@ -61,5 +62,6 @@ async def test_handle_websocket_passes_query_filters_to_event_bus(monkeypatch):
         "task_id": "t-1",
         "coordination_run_id": "coord-1",
         "agent_id": "agent-1",
+        "request_id": "req-1",
     }
     assert captured.get("removed") is True

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,7 +2,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.gateway import events
+from tests._import_helpers import load_module_from_repo_path
+
+load_module_from_repo_path("src.gateway.event_bus", "src/gateway/event_bus.py")
+events = load_module_from_repo_path("src.gateway.events", "src/gateway/events.py")
 
 
 class _FakeWS:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -68,3 +68,39 @@ async def test_handle_websocket_passes_query_filters_to_event_bus(monkeypatch):
         "request_id": "req-1",
     }
     assert captured.get("removed") is True
+
+
+@pytest.mark.asyncio
+async def test_handle_websocket_passes_combined_session_and_request_filters_and_omits_blank_values(monkeypatch):
+    captured = {}
+
+    async def _fake_add_listener(queue, filters=None):
+        captured["queue"] = queue
+        captured["filters"] = filters
+
+    async def _fake_remove_listener(_queue):
+        captured["removed"] = True
+
+    monkeypatch.setattr(events.web, "WebSocketResponse", _FakeWS)
+    monkeypatch.setattr(events.event_bus, "add_listener", _fake_add_listener)
+    monkeypatch.setattr(events.event_bus, "remove_listener", _fake_remove_listener)
+    monkeypatch.setattr(events.event_bus, "_listeners", [])
+
+    request = SimpleNamespace(
+        rel_url=SimpleNamespace(
+            query={
+                "session_id": " s-keep ",
+                "request_id": " req-keep ",
+                "task_id": " ",
+            }
+        )
+    )
+
+    ws = await events.handle_websocket(request)
+
+    assert isinstance(ws, _FakeWS)
+    assert captured["filters"] == {
+        "session_id": "s-keep",
+        "request_id": "req-keep",
+    }
+    assert captured.get("removed") is True

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -1053,6 +1053,77 @@ async def test_api_chat_stream_start_event_contains_request_id_and_forwards_same
 
 
 @pytest.mark.asyncio
+async def test_api_chat_stream_first_start_event_request_id_matches_execution_request_id(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data.decode())
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-stream-contract", "client_request_id": "portal-stream-req-1"}
+
+    resp = await webchat.api_chat_stream(_Request())
+    assert resp.status == 200
+    assert resp.writes
+    assert resp.writes[0].startswith("event: start")
+    start_data = json.loads(resp.writes[0].split("data: ", 1)[1].strip())
+    assert start_data["session_id"] == "s-stream-contract"
+    assert start_data["request_id"] == "portal-stream-req-1"
+    assert captured["request_id"] == "portal-stream-req-1"
+
+
+def test_build_webchat_response_payload_prefers_top_level_request_id_over_execution_result():
+    from src.gateway.chat_payloads import build_webchat_response_payload
+
+    payload = build_webchat_response_payload(
+        {
+            "response": "ok",
+            "request_id": "top-1",
+            "_execution_result": type("ExecutionResult", (), {"request_id": "exec-1"})(),
+        },
+        "s-payload-priority",
+    )
+
+    assert payload["request_id"] == "top-1"
+
+
+def test_build_webchat_response_payload_backfills_request_id_from_execution_result_when_missing_top_level():
+    from src.gateway.chat_payloads import build_webchat_response_payload
+
+    payload = build_webchat_response_payload(
+        {
+            "response": "ok",
+            "_execution_result": type("ExecutionResult", (), {"request_id": "exec-1"})(),
+        },
+        "s-payload-fallback",
+    )
+
+    assert payload["request_id"] == "exec-1"
+
+
+@pytest.mark.asyncio
 async def test_api_chat_rejects_non_object_metadata(monkeypatch):
     from src.gateway import webchat
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -1094,35 +1094,6 @@ async def test_api_chat_stream_first_start_event_request_id_matches_execution_re
     assert captured["request_id"] == "portal-stream-req-1"
 
 
-def test_build_webchat_response_payload_prefers_top_level_request_id_over_execution_result():
-    from src.gateway.chat_payloads import build_webchat_response_payload
-
-    payload = build_webchat_response_payload(
-        {
-            "response": "ok",
-            "request_id": "top-1",
-            "_execution_result": type("ExecutionResult", (), {"request_id": "exec-1"})(),
-        },
-        "s-payload-priority",
-    )
-
-    assert payload["request_id"] == "top-1"
-
-
-def test_build_webchat_response_payload_backfills_request_id_from_execution_result_when_missing_top_level():
-    from src.gateway.chat_payloads import build_webchat_response_payload
-
-    payload = build_webchat_response_payload(
-        {
-            "response": "ok",
-            "_execution_result": type("ExecutionResult", (), {"request_id": "exec-1"})(),
-        },
-        "s-payload-fallback",
-    )
-
-    assert payload["request_id"] == "exec-1"
-
-
 @pytest.mark.asyncio
 async def test_api_chat_rejects_non_object_metadata(monkeypatch):
     from src.gateway import webchat

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -785,6 +785,87 @@ async def test_api_chat_best_effort_publishes_session_metadata(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_api_chat_trusted_client_request_id_forwarded_and_started_metadata_published(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+    publish_calls = []
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {
+            "response": "ok",
+            "usage": {},
+            "request_id": kwargs["request_id"],
+            "_execution_result": type(
+                "R",
+                (),
+                {"request_id": kwargs["request_id"], "status": "success", "runtime_events": [], "artifacts": {}, "output_payload": {}},
+            )(),
+        }
+
+    async def _fake_publish_session_metadata(**kwargs):
+        publish_calls.append(kwargs)
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "publish_session_metadata", _fake_publish_session_metadata)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat, "_resolve_runtime_agent_identity", lambda _request: ("agent-1", "Agent One"))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-trusted-id", "client_request_id": "portal-chat-req-1"}
+
+    resp = await webchat.api_chat(_Request())
+    payload = json.loads(resp.text)
+    assert resp.status == 200
+    assert captured["request_id"] == "portal-chat-req-1"
+    assert len(publish_calls) >= 2
+    assert publish_calls[0]["latest_event_type"] == "chat.started"
+    assert publish_calls[0]["latest_event_state"] == "running"
+    assert publish_calls[0]["last_execution_id"] == "portal-chat-req-1"
+    assert publish_calls[1]["last_execution_id"] == "portal-chat-req-1"
+    assert payload["request_id"] == "portal-chat-req-1"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_untrusted_client_request_id_not_accepted(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-untrusted-id", "client_request_id": "attacker-id"}
+
+    resp = await webchat.api_chat(_Request())
+    assert resp.status == 200
+    assert captured["request_id"] != "attacker-id"
+    assert captured["request_id"].startswith("chat-")
+
+
+@pytest.mark.asyncio
 async def test_api_chat_publish_failure_does_not_break_response(monkeypatch):
     from src.gateway import webchat
 
@@ -911,6 +992,64 @@ async def test_api_chat_stream_trusted_portal_metadata_passed_to_execution_bus(m
     resp = await webchat.api_chat_stream(_Request())
     assert resp.status == 200
     assert captured["execution_metadata"]["allowed_actions"] == ["adapter:portal:get_group_task_board"]
+
+
+@pytest.mark.asyncio
+async def test_api_chat_stream_start_event_contains_request_id_and_forwards_same_id(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+    publish_calls = []
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {
+            "response": "ok",
+            "usage": {},
+            "_execution_result": type(
+                "R",
+                (),
+                {"request_id": kwargs["request_id"], "status": "success", "runtime_events": [], "artifacts": {}, "output_payload": {}},
+            )(),
+        }
+
+    async def _fake_publish_session_metadata(**kwargs):
+        publish_calls.append(kwargs)
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data.decode())
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "publish_session_metadata", _fake_publish_session_metadata)
+    monkeypatch.setattr(webchat, "_resolve_runtime_agent_identity", lambda _request: ("agent-stream", "Agent Stream"))
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-stream-req", "client_request_id": "portal-stream-req-1"}
+
+    resp = await webchat.api_chat_stream(_Request())
+    assert resp.status == 200
+    start_chunk = next(chunk for chunk in resp.writes if "event: start" in chunk)
+    start_data = json.loads(start_chunk.split("data: ", 1)[1].strip())
+    assert start_data["session_id"] == "s-stream-req"
+    assert start_data["request_id"] == "portal-stream-req-1"
+    assert captured["request_id"] == "portal-stream-req-1"
+    assert len(publish_calls) >= 2
+    assert publish_calls[0]["latest_event_type"] == "chat.started"
+    assert publish_calls[0]["latest_event_state"] == "running"
 
 
 @pytest.mark.asyncio

--- a/tests/test_webchat_display_contract.py
+++ b/tests/test_webchat_display_contract.py
@@ -114,6 +114,17 @@ def test_build_webchat_response_payload_preserves_indented_markdown_whitespace()
     assert payload["display_blocks"] == [{"type": "markdown", "content": raw_markdown}]
 
 
+def test_build_webchat_response_payload_backfills_request_id_from_execution_result():
+    mod = _load_chat_payloads_module()
+    execution_result = type("ExecutionResult", (), {"request_id": "exec-123"})()
+    payload = mod.build_webchat_response_payload(
+        {"response": "hello", "_execution_result": execution_result},
+        "s-request-id",
+    )
+
+    assert payload["request_id"] == "exec-123"
+
+
 def test_normalize_assistant_history_message_treats_whitespace_content_as_empty():
     mod = _load_chat_payloads_module()
     message = mod.normalize_assistant_history_message(

--- a/tests/test_webchat_request_id_contract.py
+++ b/tests/test_webchat_request_id_contract.py
@@ -1,0 +1,94 @@
+"""Import-light contract tests for webchat request-id behavior."""
+
+from __future__ import annotations
+
+from tests._import_helpers import load_module_from_repo_path
+
+
+def _load_contracts_module():
+    return load_module_from_repo_path(
+        "src.gateway.webchat_request_contracts",
+        "src/gateway/webchat_request_contracts.py",
+    )
+
+
+def _load_chat_payloads_module():
+    return load_module_from_repo_path(
+        "src.gateway.chat_payloads",
+        "src/gateway/chat_payloads.py",
+    )
+
+
+def test_extract_trusted_client_request_id_accepts_trusted_client_request_id():
+    mod = _load_contracts_module()
+    request_id = mod.extract_trusted_client_request_id(
+        is_trusted_portal_request=True,
+        data={"client_request_id": "portal-chat-req-1"},
+    )
+    assert request_id == "portal-chat-req-1"
+
+
+def test_extract_trusted_client_request_id_rejects_untrusted_client_request_id():
+    mod = _load_contracts_module()
+    request_id = mod.extract_trusted_client_request_id(
+        is_trusted_portal_request=False,
+        data={"client_request_id": "attacker-id"},
+    )
+    assert request_id is None
+
+
+def test_extract_trusted_client_request_id_prefers_client_request_id_then_request_id():
+    mod = _load_contracts_module()
+    preferred = mod.extract_trusted_client_request_id(
+        is_trusted_portal_request=True,
+        data={"client_request_id": "client-1", "request_id": "fallback-1"},
+    )
+    fallback = mod.extract_trusted_client_request_id(
+        is_trusted_portal_request=True,
+        data={"request_id": "fallback-2"},
+    )
+    assert preferred == "client-1"
+    assert fallback == "fallback-2"
+
+
+def test_extract_trusted_client_request_id_rejects_invalid_values():
+    mod = _load_contracts_module()
+    too_long = "a" * 129
+    assert mod.extract_trusted_client_request_id(True, {"client_request_id": ""}) is None
+    assert mod.extract_trusted_client_request_id(True, {"client_request_id": "   "}) is None
+    assert mod.extract_trusted_client_request_id(True, {"client_request_id": 123}) is None
+    assert mod.extract_trusted_client_request_id(True, {"client_request_id": too_long}) is None
+    assert mod.extract_trusted_client_request_id(True, {"client_request_id": "bad/id"}) is None
+    assert mod.extract_trusted_client_request_id(True, {"client_request_id": "bad id"}) is None
+    assert mod.extract_trusted_client_request_id(True, {"client_request_id": "bad?id"}) is None
+
+
+def test_build_stream_start_event_payload_contract():
+    mod = _load_contracts_module()
+    payload = mod.build_stream_start_event_payload("s-1", "req-1")
+    assert payload == {"session_id": "s-1", "request_id": "req-1"}
+
+
+def test_build_webchat_response_payload_request_id_priority_prefers_top_level():
+    mod = _load_chat_payloads_module()
+    payload = mod.build_webchat_response_payload(
+        {
+            "response": "ok",
+            "request_id": "top-1",
+            "_execution_result": type("ExecutionResult", (), {"request_id": "exec-1"})(),
+        },
+        "s-priority",
+    )
+    assert payload["request_id"] == "top-1"
+
+
+def test_build_webchat_response_payload_request_id_backfills_from_execution_result():
+    mod = _load_chat_payloads_module()
+    payload = mod.build_webchat_response_payload(
+        {
+            "response": "ok",
+            "_execution_result": type("ExecutionResult", (), {"request_id": "exec-1"})(),
+        },
+        "s-backfill",
+    )
+    assert payload["request_id"] == "exec-1"


### PR DESCRIPTION
### Motivation
- Portal needs a stable request identifier and early "running" status for multi-agent concurrent chats so Portal can correlate events reliably instead of guessing from global state.
- The runtime must only accept client-provided request ids from trusted Portal requests while preserving current untrusted behavior and not mutating execution results.

### Description
- Added `_extract_trusted_client_request_id(request, data)` in `src/gateway/webchat.py` to accept `client_request_id` (or `request_id`) only for trusted Portal requests with strict validation (whitelist chars `[A-Za-z0-9_:-]`, trimmed, max length 128), otherwise returns `None`.
- Extended `_run_chat_via_execution_bus(..., request_id: Optional[str] = None)` to resolve `resolved_request_id = request_id or f"chat-{uuid.uuid4()}"`, pass it into `execute_chat_orchestration(...)`, and inject `request_id` into the copied `output_payload` without modifying the original `execution_result.output_payload`.
- In `api_chat()` and `api_chat_stream()` parsed the trusted client request id and resolved a stable `request_id`, performed a best-effort `publish_session_metadata(..., latest_event_type="chat.started", latest_event_state="running", last_execution_id=request_id, ...)` before invoking the execution bus, and forwarded the same `request_id` to `_run_chat_via_execution_bus(...)`.
- For streaming, the SSE `start` event now includes `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd05c642c8832a93d193f466ccf853)