### PR TITLE
Remove legacy Runtime→Portal auth token flow; add portal_internal_api helper and clean tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ For complete control-plane contract details, see `docs/control_plane_contract.md
 
 3. **EFP adapter -> Portal internal APIs** (`adapter:portal:*`)  
    Requires `PORTAL_INTERNAL_BASE_URL` (env) or `server.portal_internal_base_url`.  
-   Optional legacy token: `PORTAL_INTERNAL_AUTH_TOKEN` (env) or `server.portal_internal_auth_token`.
 
 ### Sessions
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -163,7 +163,6 @@ server:
   host: "0.0.0.0"  # Listen on all interfaces
   port: 8000       # Default port
   portal_internal_base_url: "https://portal.internal"  # Runtime -> Portal internal API base URL (adapter:portal:*)
-  portal_internal_auth_token: ""  # Optional legacy Runtime -> Portal bearer token; env/config supported, env takes precedence
   jira_reconciliation_enabled: false  # Enable scheduled Jira reconciliation -> Portal external event ingest
   jira_reconciliation_interval_seconds: 300  # Reconciliation polling interval
 

--- a/docs/control_plane_contract.md
+++ b/docs/control_plane_contract.md
@@ -28,7 +28,7 @@ This document defines the Portal ↔ EFP runtime trust boundaries.
 |---|---|---|
 | Portal → EFP `/api/tasks/execute`, `/api/capabilities` | none | none required (currently permissive) |
 | Portal → EFP trusted chat metadata/identity | `X-Portal-Author-Source: portal` | `X-Portal-User-Id`, `X-Portal-User-Name` (optional) |
-| Runtime adapter (`adapter:portal:*`) → Portal internal API | `server.portal_internal_base_url` / `PORTAL_INTERNAL_BASE_URL` | no additional bearer/internal key |
+| Runtime adapter (`adapter:portal:*`) → Portal internal API | `server.portal_internal_base_url` / `PORTAL_INTERNAL_BASE_URL` | internal route available at configured base URL |
 
 ## 5) Jira Reconciliation Contract (Runtime Fallback)
 

--- a/docs/control_plane_contract.md
+++ b/docs/control_plane_contract.md
@@ -21,7 +21,6 @@ This document defines the Portal ↔ EFP runtime trust boundaries.
 
 - `adapter:portal:*` actions call Portal internal APIs with:
   - base URL from `PORTAL_INTERNAL_BASE_URL` env, fallback `server.portal_internal_base_url`
-  - optional `Authorization: Bearer <PORTAL_INTERNAL_AUTH_TOKEN>` (legacy compatibility; env first, fallback `server.portal_internal_auth_token`)
 
 ## 4) Trust Matrix
 
@@ -29,7 +28,7 @@ This document defines the Portal ↔ EFP runtime trust boundaries.
 |---|---|---|
 | Portal → EFP `/api/tasks/execute`, `/api/capabilities` | none | none required (currently permissive) |
 | Portal → EFP trusted chat metadata/identity | `X-Portal-Author-Source: portal` | `X-Portal-User-Id`, `X-Portal-User-Name` (optional) |
-| Runtime adapter (`adapter:portal:*`) → Portal internal API | `server.portal_internal_base_url` / `PORTAL_INTERNAL_BASE_URL`; optional `server.portal_internal_auth_token` / `PORTAL_INTERNAL_AUTH_TOKEN` | optional `Authorization` |
+| Runtime adapter (`adapter:portal:*`) → Portal internal API | `server.portal_internal_base_url` / `PORTAL_INTERNAL_BASE_URL` | no additional bearer/internal key |
 
 ## 5) Jira Reconciliation Contract (Runtime Fallback)
 

--- a/src/cron/jira_reconciliation.py
+++ b/src/cron/jira_reconciliation.py
@@ -11,7 +11,7 @@ from aiohttp import ClientSession
 
 from src.channels.jira import jira_channel
 from src.config import config
-from src.utils.internal_api_keys import build_portal_internal_api_headers, get_portal_internal_base_url
+from src.utils.portal_internal_api import build_portal_internal_api_headers, get_portal_internal_base_url
 
 logger = logging.getLogger(__name__)
 

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -210,10 +210,6 @@ def _parse_task_execute_request(data: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _build_internal_auth_error_response(status_code: int, message: str) -> web.Response:
-    return web.json_response({"error": message}, status=status_code)
-
-
 def _sanitize_trace_value(value: Any, max_len: int = 128) -> Optional[str]:
     if value is None:
         return None
@@ -237,14 +233,6 @@ def _extract_task_trace_headers(request: web.Request) -> Dict[str, Optional[str]
     if not trace["span_id"]:
         trace["span_id"] = uuid.uuid4().hex[:16]
     return trace
-
-
-def _authorize_internal_runtime_request(request: web.Request) -> Optional[web.Response]:
-    # This helper is intentionally a no-op.
-    # Keep it as a compatibility seam so existing internal routes
-    # can continue calling it without branching changes.
-    _ = request
-    return None
 
 
 def _json_compatible(value: Any) -> Any:
@@ -977,9 +965,6 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
         path="/api/tasks/execute",
     )
     try:
-        auth_error = _authorize_internal_runtime_request(request)
-        if auth_error is not None:
-            return auth_error
         data = await request.json()
         parsed = _parse_task_execute_request(data)
         set_log_context(
@@ -1278,9 +1263,6 @@ async def api_task_status(request: web.Request) -> web.Response:
         path="/api/tasks/{task_id}",
     )
     try:
-        auth_error = _authorize_internal_runtime_request(request)
-        if auth_error is not None:
-            return auth_error
         task_id = str(request.match_info.get("task_id") or "").strip()
         if not task_id:
             return web.json_response({"error": "task_id is required"}, status=400)
@@ -1327,9 +1309,6 @@ async def api_capabilities(request: web.Request) -> web.Response:
     GET /api/capabilities?type=...&enabled=true|false&capability_id=...
     """
     try:
-        auth_error = _authorize_internal_runtime_request(request)
-        if auth_error is not None:
-            return auth_error
         registry = get_capability_registry()
         snapshot = (
             registry.export_catalog_snapshot()
@@ -2142,11 +2121,8 @@ async def api_get_config(request: web.Request) -> web.Response:
 
 async def api_apply_runtime_profile(request: web.Request) -> web.Response:
     """Apply runtime managed profile overlay from trusted Portal control-plane request."""
-    auth_error = _authorize_internal_runtime_request(request)
-    if auth_error is not None:
-        return auth_error
     if not _is_trusted_portal_request(request):
-        return _build_internal_auth_error_response(403, "Forbidden")
+        return web.json_response({"error": "Forbidden"}, status=403)
 
     try:
         data = await request.json()

--- a/src/runtime/adapter_executor.py
+++ b/src/runtime/adapter_executor.py
@@ -12,7 +12,7 @@ from src.runtime.capability_adapters import (
     build_jira_adapter_capabilities,
     build_portal_adapter_capabilities,
 )
-from src.utils.internal_api_keys import build_portal_internal_api_headers, get_portal_internal_base_url
+from src.utils.portal_internal_api import build_portal_internal_api_headers, get_portal_internal_base_url
 
 
 def _event(event_type: str, state: str, detail_payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/runtime/portal_session_metadata_client.py
+++ b/src/runtime/portal_session_metadata_client.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 from aiohttp import ClientSession
 
 from src.runtime.contracts import ExecutionResult
-from src.utils.internal_api_keys import build_portal_internal_api_headers, get_portal_internal_base_url
+from src.utils.portal_internal_api import build_portal_internal_api_headers, get_portal_internal_base_url
 
 logger = logging.getLogger(__name__)
 

--- a/src/runtime/runtime_profile_client.py
+++ b/src/runtime/runtime_profile_client.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 from aiohttp import ClientSession
 
 from src.config import Config, config
-from src.utils.internal_api_keys import (
+from src.utils.portal_internal_api import (
     build_portal_internal_api_headers,
     get_portal_agent_id,
     get_portal_internal_base_url,

--- a/src/utils/portal_internal_api.py
+++ b/src/utils/portal_internal_api.py
@@ -1,7 +1,4 @@
-"""Portal internal request header helpers.
-
-Uses the optional legacy bearer auth token fallback when configured.
-"""
+"""Portal internal API request helpers."""
 
 from __future__ import annotations
 
@@ -27,19 +24,7 @@ def get_portal_agent_id() -> str:
     return str(config_value or "").strip()
 
 
-def get_portal_internal_auth_token() -> str:
-    env_value = str(os.getenv("PORTAL_INTERNAL_AUTH_TOKEN") or "").strip()
-    if env_value:
-        return env_value
-    config_value = global_config.get("server.portal_internal_auth_token", "")
-    return str(config_value or "").strip()
-
-
 def build_portal_internal_api_headers(include_content_type: bool = True) -> Dict[str, str]:
-    headers: Dict[str, str] = {}
     if include_content_type:
-        headers["Content-Type"] = "application/json"
-    token = get_portal_internal_auth_token()
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
+        return {"Content-Type": "application/json"}
+    return {}

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -8,7 +8,7 @@ from src.runtime.adapter_executor import (
     validate_enabled_adapter_actions_have_executors,
 )
 from src.runtime.leader_delegation_adapter import create_portal_delegation_from_runtime
-from src.utils.internal_api_keys import build_portal_internal_api_headers
+from src.utils.portal_internal_api import build_portal_internal_api_headers
 
 
 @pytest.mark.asyncio
@@ -307,20 +307,10 @@ async def test_execute_adapter_action_portal_delete_task_agent_uses_delete(monke
     assert captured["headers"] == {"Content-Type": "application/json"}
 
 
-def test_build_portal_headers_without_auth_token(monkeypatch):
-    monkeypatch.delenv("PORTAL_INTERNAL_AUTH_TOKEN", raising=False)
-
+def test_build_portal_headers_default_contract():
     headers = _build_portal_headers()
 
     assert headers == {"Content-Type": "application/json"}
-
-
-def test_build_portal_headers_with_auth_token(monkeypatch):
-    monkeypatch.setenv("PORTAL_INTERNAL_AUTH_TOKEN", "legacy-token")
-
-    headers = _build_portal_headers()
-
-    assert headers == {"Content-Type": "application/json", "Authorization": "Bearer legacy-token"}
 
 
 @pytest.mark.asyncio
@@ -334,7 +324,7 @@ async def test_execute_portal_action_uses_config_fallback_base_url(monkeypatch):
 
     monkeypatch.delenv("PORTAL_INTERNAL_BASE_URL", raising=False)
     monkeypatch.setattr(
-        "src.utils.internal_api_keys.global_config.get",
+        "src.utils.portal_internal_api.global_config.get",
         lambda key, default=None: (
             "https://portal.cfg"
             if key == "server.portal_internal_base_url"
@@ -359,7 +349,7 @@ async def test_execute_portal_action_base_url_env_precedence_over_config(monkeyp
 
     monkeypatch.setenv("PORTAL_INTERNAL_BASE_URL", "https://portal.env")
     monkeypatch.setattr(
-        "src.utils.internal_api_keys.global_config.get",
+        "src.utils.portal_internal_api.global_config.get",
         lambda key, default=None: (
             "https://portal.cfg"
             if key == "server.portal_internal_base_url"
@@ -373,39 +363,9 @@ async def test_execute_portal_action_base_url_env_precedence_over_config(monkeyp
     assert captured["url"].startswith("https://portal.env/")
 
 
-def test_build_portal_internal_api_headers_auth_token_config_fallback(monkeypatch):
-    monkeypatch.delenv("PORTAL_INTERNAL_AUTH_TOKEN", raising=False)
-    monkeypatch.setattr(
-        "src.utils.internal_api_keys.global_config.get",
-        lambda key, default=None: "tok-cfg" if key == "server.portal_internal_auth_token" else default,
-    )
-
-    headers = build_portal_internal_api_headers()
-
-    assert headers["Authorization"] == "Bearer tok-cfg"
-
-
-def test_build_portal_internal_api_headers_auth_token_env_precedence(monkeypatch):
-    monkeypatch.setenv("PORTAL_INTERNAL_AUTH_TOKEN", "tok-env")
-    monkeypatch.setattr(
-        "src.utils.internal_api_keys.global_config.get",
-        lambda key, default=None: "tok-cfg" if key == "server.portal_internal_auth_token" else default,
-    )
-
-    headers = build_portal_internal_api_headers()
-
-    assert headers["Authorization"] == "Bearer tok-env"
-
-
-def test_build_portal_internal_api_headers_contract_with_and_without_auth_token(monkeypatch):
-    monkeypatch.delenv("PORTAL_INTERNAL_AUTH_TOKEN", raising=False)
-
-    headers_without_token = build_portal_internal_api_headers(include_content_type=True)
-    assert headers_without_token == {"Content-Type": "application/json"}
-
-    monkeypatch.setenv("PORTAL_INTERNAL_AUTH_TOKEN", "token-123")
-    headers_with_token = build_portal_internal_api_headers(include_content_type=True)
-    assert headers_with_token == {"Content-Type": "application/json", "Authorization": "Bearer token-123"}
+def test_build_portal_internal_api_headers_content_type_contract():
+    assert build_portal_internal_api_headers(include_content_type=True) == {"Content-Type": "application/json"}
+    assert build_portal_internal_api_headers(include_content_type=False) == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -220,24 +220,6 @@ class _HeaderOnlyRequest:
         self.headers = headers or {}
 
 
-def test_authorize_runtime_request_returns_none_without_extra_headers():
-    from src.gateway import webchat
-
-    assert webchat._authorize_internal_runtime_request(_HeaderOnlyRequest()) is None
-
-
-def test_authorize_runtime_request_returns_none_with_unrelated_header():
-    from src.gateway import webchat
-
-    assert webchat._authorize_internal_runtime_request(_HeaderOnlyRequest({"X-Unused-Sideband": "wrong"})) is None
-
-
-def test_authorize_runtime_request_returns_none_with_any_unrelated_header():
-    from src.gateway import webchat
-
-    assert webchat._authorize_internal_runtime_request(_HeaderOnlyRequest({"X-Unused-Sideband": "anything"})) is None
-
-
 def test_is_trusted_portal_request_true_for_portal_source():
     from src.gateway import webchat
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -13,7 +13,6 @@ except ImportError:
     pytest.skip("WebChat module not available", allow_module_level=True)
 
 
-INTERNAL_API_KEY = "runtime-internal-key"
 INTERNAL_HEADERS = {}
 
 
@@ -230,7 +229,7 @@ def test_authorize_runtime_request_returns_none_without_extra_headers():
 def test_authorize_runtime_request_returns_none_with_unrelated_header():
     from src.gateway import webchat
 
-    assert webchat._authorize_internal_runtime_request(_HeaderOnlyRequest({"X-Debug-Bypass": "wrong"})) is None
+    assert webchat._authorize_internal_runtime_request(_HeaderOnlyRequest({"X-Unused-Sideband": "wrong"})) is None
 
 
 def test_authorize_runtime_request_returns_none_with_any_unrelated_header():
@@ -261,10 +260,10 @@ def test_is_trusted_portal_request_ignores_unrelated_internal_like_headers():
     from src.gateway import webchat
 
     trusted = webchat._is_trusted_portal_request(
-        _HeaderOnlyRequest({"X-Portal-Author-Source": "portal", "X-Debug-Bypass": "wrong"})
+        _HeaderOnlyRequest({"X-Portal-Author-Source": "portal", "X-Unused-Sideband": "wrong"})
     )
     untrusted = webchat._is_trusted_portal_request(
-        _HeaderOnlyRequest({"X-Portal-Author-Source": "runtime", "X-Debug-Bypass": "portal-secret"})
+        _HeaderOnlyRequest({"X-Portal-Author-Source": "runtime", "X-Unused-Sideband": "unused-value"})
     )
     assert trusted is True
     assert untrusted is False
@@ -1455,7 +1454,7 @@ async def test_api_capabilities_ignores_unrelated_header(monkeypatch):
     monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
 
     class _Request:
-        headers = {"X-Debug-Bypass": "bad-key"}
+        headers = {"X-Unused-Sideband": "bad-key"}
         query = {}
 
     response = await webchat.api_capabilities(_Request())
@@ -1581,7 +1580,7 @@ async def test_api_tasks_execute_ignores_unrelated_header(monkeypatch):
     webchat.runtime_task_tracker.reset()
 
     class _Request:
-        headers = {"X-Debug-Bypass": "wrong"}
+        headers = {"X-Unused-Sideband": "wrong"}
 
         async def json(self):
             return {"task_id": "task-key-wrong-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
@@ -2042,7 +2041,7 @@ async def test_api_tasks_execute_accepts_without_waiting_for_terminal_result(mon
 
 
 @pytest.mark.asyncio
-async def test_api_task_status_pending_and_auth(monkeypatch):
+async def test_api_task_status_pending_ignores_unrelated_header(monkeypatch):
     from src.gateway import webchat
     webchat.runtime_task_tracker.reset()
 
@@ -2064,7 +2063,7 @@ async def test_api_task_status_pending_and_auth(monkeypatch):
     await webchat.api_tasks_execute(_ExecuteRequest())
 
     class _StatusBadAuth:
-        headers = {"X-Debug-Bypass": "bad"}
+        headers = {"X-Unused-Sideband": "bad"}
         match_info = {"task_id": "task-pending-1"}
 
     bad_auth_response = await webchat.api_task_status(_StatusBadAuth())

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -238,11 +238,11 @@ def test_is_trusted_portal_request_false_for_non_portal_source():
     assert webchat._is_trusted_portal_request(_HeaderOnlyRequest({"X-Portal-Author-Source": "runtime"})) is False
 
 
-def test_is_trusted_portal_request_ignores_unrelated_internal_like_headers():
+def test_is_trusted_portal_request_depends_only_on_portal_source_marker():
     from src.gateway import webchat
 
     trusted = webchat._is_trusted_portal_request(
-        _HeaderOnlyRequest({"X-Portal-Author-Source": "portal", "X-Unused-Sideband": "wrong"})
+        _HeaderOnlyRequest({"X-Portal-Author-Source": "portal", "X-Unused-Sideband": "ignored"})
     )
     untrusted = webchat._is_trusted_portal_request(
         _HeaderOnlyRequest({"X-Portal-Author-Source": "runtime", "X-Unused-Sideband": "unused-value"})
@@ -1407,7 +1407,7 @@ async def test_api_capabilities_filters_by_capability_id_and_type(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_api_capabilities_does_not_depend_on_unrelated_headers(monkeypatch):
+async def test_api_capabilities_accepts_default_request_headers(monkeypatch):
     from src.gateway import webchat
 
     class _Registry:
@@ -1425,7 +1425,7 @@ async def test_api_capabilities_does_not_depend_on_unrelated_headers(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_api_capabilities_ignores_unrelated_header(monkeypatch):
+async def test_api_capabilities_ignores_arbitrary_sideband_header(monkeypatch):
     from src.gateway import webchat
 
 
@@ -1436,7 +1436,7 @@ async def test_api_capabilities_ignores_unrelated_header(monkeypatch):
     monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
 
     class _Request:
-        headers = {"X-Unused-Sideband": "bad-key"}
+        headers = {"X-Unused-Sideband": "ignored"}
         query = {}
 
     response = await webchat.api_capabilities(_Request())
@@ -1444,7 +1444,7 @@ async def test_api_capabilities_ignores_unrelated_header(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_does_not_require_unrelated_header(monkeypatch):
+async def test_api_tasks_execute_accepts_default_request_headers(monkeypatch):
     from src.gateway import webchat
 
     webchat.runtime_task_tracker.reset()
@@ -1453,7 +1453,7 @@ async def test_api_tasks_execute_does_not_require_unrelated_header(monkeypatch):
         headers = {}
 
         async def json(self):
-            return {"task_id": "task-no-key-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
+            return {"task_id": "task-open-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
 
     async def _fake_execute_runtime_task_request(**kwargs):
         return type(
@@ -1480,7 +1480,7 @@ async def test_api_tasks_execute_does_not_require_unrelated_header(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_not_configured_does_not_log_auth_rejection(monkeypatch, caplog):
+async def test_api_tasks_execute_not_configured_still_accepts_request(monkeypatch):
     from src.gateway import webchat
 
     monkeypatch.setattr(webchat.global_config, "get", lambda *_args, **_kwargs: "")
@@ -1490,7 +1490,7 @@ async def test_api_tasks_execute_not_configured_does_not_log_auth_rejection(monk
         headers = {"X-Trace-Id": "trace-auth-503", "X-Portal-Dispatch-Id": "dispatch-1"}
 
         async def json(self):
-            return {"task_id": "task-no-key-2", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
+            return {"task_id": "task-open-2", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
 
     async def _fake_execute_runtime_task_request(**kwargs):
         return type(
@@ -1511,16 +1511,14 @@ async def test_api_tasks_execute_not_configured_does_not_log_auth_rejection(monk
     monkeypatch.setattr(webchat, "execute_runtime_task_request", _fake_execute_runtime_task_request)
     monkeypatch.setattr(webchat, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
-    with caplog.at_level("WARNING"):
-        response = await webchat.api_tasks_execute(_Request())
+    response = await webchat.api_tasks_execute(_Request())
 
     assert response.status == 202
-    assert "auth rejected" not in caplog.text.lower()
     await spawned[0]
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_ignores_missing_unrelated_header(monkeypatch):
+async def test_api_tasks_execute_accepts_request_without_sideband_headers(monkeypatch):
     from src.gateway import webchat
 
     webchat.runtime_task_tracker.reset()
@@ -1529,7 +1527,7 @@ async def test_api_tasks_execute_ignores_missing_unrelated_header(monkeypatch):
         headers = {}
 
         async def json(self):
-            return {"task_id": "task-key-missing-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
+            return {"task_id": "task-default-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
 
     async def _fake_execute_runtime_task_request(**kwargs):
         return type(
@@ -1556,16 +1554,16 @@ async def test_api_tasks_execute_ignores_missing_unrelated_header(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_ignores_unrelated_header(monkeypatch):
+async def test_api_tasks_execute_ignores_arbitrary_sideband_header(monkeypatch):
     from src.gateway import webchat
 
     webchat.runtime_task_tracker.reset()
 
     class _Request:
-        headers = {"X-Unused-Sideband": "wrong"}
+        headers = {"X-Unused-Sideband": "ignored"}
 
         async def json(self):
-            return {"task_id": "task-key-wrong-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
+            return {"task_id": "task-sideband-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
 
     async def _fake_execute_runtime_task_request(**kwargs):
         return type(
@@ -2023,7 +2021,7 @@ async def test_api_tasks_execute_accepts_without_waiting_for_terminal_result(mon
 
 
 @pytest.mark.asyncio
-async def test_api_task_status_pending_ignores_unrelated_header(monkeypatch):
+async def test_api_task_status_pending_accepts_arbitrary_sideband_header(monkeypatch):
     from src.gateway import webchat
     webchat.runtime_task_tracker.reset()
 
@@ -2045,7 +2043,7 @@ async def test_api_task_status_pending_ignores_unrelated_header(monkeypatch):
     await webchat.api_tasks_execute(_ExecuteRequest())
 
     class _StatusBadAuth:
-        headers = {"X-Unused-Sideband": "bad"}
+        headers = {"X-Unused-Sideband": "ignored"}
         match_info = {"task_id": "task-pending-1"}
 
     bad_auth_response = await webchat.api_task_status(_StatusBadAuth())

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -242,10 +242,10 @@ def test_is_trusted_portal_request_depends_only_on_portal_source_marker():
     from src.gateway import webchat
 
     trusted = webchat._is_trusted_portal_request(
-        _HeaderOnlyRequest({"X-Portal-Author-Source": "portal", "X-Unused-Sideband": "ignored"})
+        _HeaderOnlyRequest({"X-Portal-Author-Source": "portal", "X-Arbitrary-Header": "ignored"})
     )
     untrusted = webchat._is_trusted_portal_request(
-        _HeaderOnlyRequest({"X-Portal-Author-Source": "runtime", "X-Unused-Sideband": "unused-value"})
+        _HeaderOnlyRequest({"X-Portal-Author-Source": "runtime", "X-Arbitrary-Header": "unused-value"})
     )
     assert trusted is True
     assert untrusted is False
@@ -1425,7 +1425,7 @@ async def test_api_capabilities_accepts_default_request_headers(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_api_capabilities_ignores_arbitrary_sideband_header(monkeypatch):
+async def test_api_capabilities_ignores_unrecognized_header(monkeypatch):
     from src.gateway import webchat
 
 
@@ -1436,7 +1436,7 @@ async def test_api_capabilities_ignores_arbitrary_sideband_header(monkeypatch):
     monkeypatch.setattr(webchat, "get_capability_registry", lambda: _Registry())
 
     class _Request:
-        headers = {"X-Unused-Sideband": "ignored"}
+        headers = {"X-Arbitrary-Header": "ignored"}
         query = {}
 
     response = await webchat.api_capabilities(_Request())
@@ -1518,7 +1518,7 @@ async def test_api_tasks_execute_not_configured_still_accepts_request(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_accepts_request_without_sideband_headers(monkeypatch):
+async def test_api_tasks_execute_accepts_empty_headers(monkeypatch):
     from src.gateway import webchat
 
     webchat.runtime_task_tracker.reset()
@@ -1554,13 +1554,13 @@ async def test_api_tasks_execute_accepts_request_without_sideband_headers(monkey
 
 
 @pytest.mark.asyncio
-async def test_api_tasks_execute_ignores_arbitrary_sideband_header(monkeypatch):
+async def test_api_tasks_execute_ignores_unrecognized_header(monkeypatch):
     from src.gateway import webchat
 
     webchat.runtime_task_tracker.reset()
 
     class _Request:
-        headers = {"X-Unused-Sideband": "ignored"}
+        headers = {"X-Arbitrary-Header": "ignored"}
 
         async def json(self):
             return {"task_id": "task-sideband-1", "task_type": "adapter_action_task", "input_payload": {"action_id": "jira.transition"}}
@@ -2021,7 +2021,7 @@ async def test_api_tasks_execute_accepts_without_waiting_for_terminal_result(mon
 
 
 @pytest.mark.asyncio
-async def test_api_task_status_pending_accepts_arbitrary_sideband_header(monkeypatch):
+async def test_api_task_status_pending_accepts_unrecognized_header(monkeypatch):
     from src.gateway import webchat
     webchat.runtime_task_tracker.reset()
 
@@ -2043,7 +2043,7 @@ async def test_api_task_status_pending_accepts_arbitrary_sideband_header(monkeyp
     await webchat.api_tasks_execute(_ExecuteRequest())
 
     class _StatusBadAuth:
-        headers = {"X-Unused-Sideband": "ignored"}
+        headers = {"X-Arbitrary-Header": "ignored"}
         match_info = {"task_id": "task-pending-1"}
 
     bad_auth_response = await webchat.api_task_status(_StatusBadAuth())

--- a/tests/test_webchat_runtime_profile.py
+++ b/tests/test_webchat_runtime_profile.py
@@ -85,7 +85,7 @@ async def test_internal_apply_runtime_profile_trusted_ignores_unrelated_header(m
     monkeypatch.setattr(webchat.global_config, "set_managed_overlay", lambda *_args, **_kwargs: ["jira"])
     req = _Req(
         payload={"runtime_profile_id": "rp_x", "revision": 1, "config": {"jira": {"enabled": True}}},
-        headers={"X-Portal-Author-Source": "portal", "X-Debug-Bypass": "wrong"},
+        headers={"X-Portal-Author-Source": "portal", "X-Unused-Sideband": "wrong"},
     )
     resp = await webchat.api_apply_runtime_profile(req)
     assert resp.status == 200

--- a/tests/test_webchat_runtime_profile.py
+++ b/tests/test_webchat_runtime_profile.py
@@ -81,22 +81,22 @@ async def test_internal_apply_runtime_profile_trusted_succeeds_with_portal_sourc
 
 
 @pytest.mark.asyncio
-async def test_internal_apply_runtime_profile_trusted_accepts_arbitrary_sideband_header(monkeypatch):
+async def test_internal_apply_runtime_profile_trusted_ignores_unrecognized_header(monkeypatch):
     monkeypatch.setattr(webchat.global_config, "set_managed_overlay", lambda *_args, **_kwargs: ["jira"])
     req = _Req(
         payload={"runtime_profile_id": "rp_x", "revision": 1, "config": {"jira": {"enabled": True}}},
-        headers={"X-Portal-Author-Source": "portal", "X-Unused-Sideband": "wrong"},
+        headers={"X-Portal-Author-Source": "portal", "X-Arbitrary-Header": "wrong"},
     )
     resp = await webchat.api_apply_runtime_profile(req)
     assert resp.status == 200
 
 
 @pytest.mark.asyncio
-async def test_internal_apply_runtime_profile_trusted_remains_valid_with_extra_sideband_header(monkeypatch):
+async def test_internal_apply_runtime_profile_trusted_remains_valid_with_extra_header(monkeypatch):
     monkeypatch.setattr(webchat.global_config, "set_managed_overlay", lambda *_args, **_kwargs: ["jira"])
     req = _Req(
         payload={"runtime_profile_id": "rp_x", "revision": 1, "config": {"jira": {"enabled": True}}},
-        headers={"X-Portal-Author-Source": "portal", "X-Unused-Sideband": "anything"},
+        headers={"X-Portal-Author-Source": "portal", "X-Arbitrary-Header": "anything"},
     )
     resp = await webchat.api_apply_runtime_profile(req)
     assert resp.status == 200

--- a/tests/test_webchat_runtime_profile.py
+++ b/tests/test_webchat_runtime_profile.py
@@ -70,7 +70,7 @@ async def test_internal_apply_runtime_profile_untrusted_rejected():
 
 
 @pytest.mark.asyncio
-async def test_internal_apply_runtime_profile_trusted_succeeds_without_unrelated_header(monkeypatch):
+async def test_internal_apply_runtime_profile_trusted_succeeds_with_portal_source_marker(monkeypatch):
     monkeypatch.setattr(webchat.global_config, "set_managed_overlay", lambda *_args, **_kwargs: ["jira"])
     req = _Req(
         payload={"runtime_profile_id": "rp_x", "revision": 1, "config": {"jira": {"enabled": True}}},
@@ -81,7 +81,7 @@ async def test_internal_apply_runtime_profile_trusted_succeeds_without_unrelated
 
 
 @pytest.mark.asyncio
-async def test_internal_apply_runtime_profile_trusted_ignores_unrelated_header(monkeypatch):
+async def test_internal_apply_runtime_profile_trusted_accepts_arbitrary_sideband_header(monkeypatch):
     monkeypatch.setattr(webchat.global_config, "set_managed_overlay", lambda *_args, **_kwargs: ["jira"])
     req = _Req(
         payload={"runtime_profile_id": "rp_x", "revision": 1, "config": {"jira": {"enabled": True}}},
@@ -92,7 +92,7 @@ async def test_internal_apply_runtime_profile_trusted_ignores_unrelated_header(m
 
 
 @pytest.mark.asyncio
-async def test_internal_apply_runtime_profile_allows_trusted_portal_with_any_unrelated_header(monkeypatch):
+async def test_internal_apply_runtime_profile_trusted_remains_valid_with_extra_sideband_header(monkeypatch):
     monkeypatch.setattr(webchat.global_config, "set_managed_overlay", lambda *_args, **_kwargs: ["jira"])
     req = _Req(
         payload={"runtime_profile_id": "rp_x", "revision": 1, "config": {"jira": {"enabled": True}}},


### PR DESCRIPTION
### Motivation
- Remove the legacy Runtime→Portal bearer token compatibility chain and eliminate related terminology pollution across the repo while preserving existing Runtime→Portal request behavior.
- Minimize surface changes by keeping header contract function name (`build_portal_internal_api_headers`) but move it into a new module without any auth/token logic so adapters keep original method/payload semantics.

### Description
- Added `src/utils/portal_internal_api.py` with `get_portal_internal_base_url()`, `get_portal_agent_id()`, and `build_portal_internal_api_headers(include_content_type: bool = True)` that returns `{"Content-Type": "application/json"}` when requested and `{}` otherwise, and does not read or inject any auth token.
- Removed `src/utils/internal_api_keys.py` and updated callers to import from `src.utils.portal_internal_api` in `src/runtime/adapter_executor.py`, `src/runtime/runtime_profile_client.py`, `src/runtime/portal_session_metadata_client.py`, and `src/cron/jira_reconciliation.py` without changing request URLs/methods/payloads.
- Cleaned configuration and docs by removing `server.portal_internal_auth_token` from `config.yaml.example`, removing the optional legacy token note from `README.md`, and updating `docs/control_plane_contract.md` to state that adapter→Portal calls rely on base URL only and not an additional bearer key.
- Updated tests: replaced imports in `tests/test_adapter_executor.py`, removed token-specific test cases and replaced them with header-contract tests, and sanitized legacy bypass/key terminology in `tests/test_webchat.py` and `tests/test_webchat_runtime_profile.py` (removed `runtime-internal-key`, replaced `X-Debug-Bypass`/`portal-secret` with `X-Unused-Sideband`, and renamed the pending-status test for clarity).
- Did not change inbound Portal→EFP trusted-header logic (e.g., `X-Portal-Author-Source`) nor any other modules that legitimately use `Authorization` headers (Jira/GitHub/etc.).

### Testing
- Ran the repository search `rg -n "PORTAL_INTERNAL_AUTH_TOKEN|portal_internal_auth_token|get_portal_internal_auth_token|internal_api_keys|X-Debug-Bypass|runtime-internal-key|portal-secret" src tests README.md docs config.yaml.example` and it returned no matches (zero results).
- Executed `pytest` for the requested suites: `tests/test_adapter_executor.py`, `tests/test_runtime_profile_client.py`, `tests/test_portal_session_metadata_client.py`, `tests/test_webchat.py`, and `tests/test_webchat_runtime_profile.py`; overall the modified tests produced 141 passed and 3 failed, where the 3 failures are existing WebChat JS renderer assertions unrelated to the auth-token cleanup and were not introduced by these changes.
- Also ran `pytest tests/test_jira_reconciliation.py` which passed (6 tests passed).
- Note: the failing WebChat JS renderer assertions appear to be pre-existing frontend JS expectations and are outside the scope of this token-removal change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd07f6f1c832a8b024abcc2ca3195)