### PR TITLE
test: lock runtime-profile control-plane metadata compatibility

### DIFF
--- a/src/runtime/runtime_profile_client.py
+++ b/src/runtime/runtime_profile_client.py
@@ -28,9 +28,15 @@ def _extract_runtime_profile_overlay(
       "runtime_profile_context": {
         "runtime_profile_id": "...",
         "revision": 3,
-        "config": {...}
+        "config": {...},
+        "...": "portal control-plane metadata (ignored by runtime)"
       }
     }
+
+    Runtime only consumes ``runtime_profile_context.config`` (overlay body)
+    and ``runtime_profile_context.revision``. Extra Portal-side ownership /
+    default metadata (for example ``owner_user_id`` or ``is_default``)
+    remains control-plane-only and is ignored here.
 
     Returns: (runtime_profile_id, revision, overlay_config, clear_flag)
     """

--- a/tests/test_runtime_profile_client.py
+++ b/tests/test_runtime_profile_client.py
@@ -114,6 +114,33 @@ def test_extract_runtime_profile_overlay_prefers_nested_revision_over_top_level(
     assert clear_flag is False
 
 
+def test_extract_runtime_profile_overlay_ignores_control_plane_only_fields():
+    payload = {
+        "runtime_profile_id": "rp_1",
+        "runtime_profile_context": {
+            "runtime_profile_id": "rp_1",
+            "name": "Default",
+            "description": "Per-user runtime profile",
+            "owner_user_id": 42,
+            "is_default": True,
+            "bound_agent_count": 3,
+            "revision": 7,
+            "managed_sections": ["llm", "proxy", "jira", "confluence", "github", "git", "debug"],
+            "config": {"llm": {"provider": "openai", "model": "gpt-4.1"}},
+            "source": "portal.runtime_profile",
+        },
+    }
+
+    runtime_profile_id, revision, overlay_config, clear_flag = runtime_profile_client._extract_runtime_profile_overlay(payload)
+    assert runtime_profile_id == "rp_1"
+    assert revision == 7
+    assert clear_flag is False
+    assert overlay_config == {"llm": {"provider": "openai", "model": "gpt-4.1"}}
+    assert "owner_user_id" not in overlay_config
+    assert "is_default" not in overlay_config
+    assert "name" not in overlay_config
+
+
 @pytest.mark.asyncio
 async def test_bootstrap_runtime_profile_apply(monkeypatch):
     monkeypatch.setattr(runtime_profile_client, "get_portal_internal_base_url", lambda: "http://portal")


### PR DESCRIPTION
### Motivation
- Prevent misunderstandings about Portal-side ownership/default metadata leaking into runtime overlay by making the contract explicit in code and tests.
- Provide a regression test that proves EFP runtime continues to only consume the nested `runtime_profile_context.config` and `revision`, while ignoring Portal control-plane fields like `owner_user_id`/`is_default`.

### Description
- Updated the docstring of `_extract_runtime_profile_overlay` in `src/runtime/runtime_profile_client.py` to explicitly state that runtime only consumes `runtime_profile_context.config` and `runtime_profile_context.revision` and ignores Portal control-plane metadata such as `owner_user_id` and `is_default`.
- Added a helper-level regression test `test_extract_runtime_profile_overlay_ignores_control_plane_only_fields` in `tests/test_runtime_profile_client.py` which supplies Portal payload with ownership/default fields and asserts only the nested `config` is extracted as the overlay.
- No production logic branches were changed; overlay extraction/legacy compatibility logic remains untouched.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_runtime_profile_client.py tests/test_runtime_profile_overlay.py tests/test_webchat_runtime_profile.py` and all tests passed (`23 passed, 1 warning`).
- The new test `test_extract_runtime_profile_overlay_ignores_control_plane_only_fields` passed along with the existing bootstrap/apply tests, confirming no behavioral regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddef07bf5c832a801eae8c22682c13)