### PR TITLE
Add Portal-driven subscription watchers for external-event ingress

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,11 @@ from src.gateway.server import gateway
 from src.sessions.persistence import session_persistence
 from src.sessions.manager import session_manager
 from src.sessions.usage import usage_tracker
-from src.cron.mention_poller import start_polling, stop_polling, is_enabled
+from src.cron.subscription_watchers import (
+    start_subscription_watchers,
+    stop_subscription_watchers,
+    is_enabled as are_subscription_watchers_enabled,
+)
 from src.cron.jira_reconciliation import start_reconciliation, stop_reconciliation, is_enabled as is_jira_reconciliation_enabled
 from src.git.api import setup_git_user
 from src.utils.logger import setup_logging, get_logger
@@ -165,7 +169,7 @@ async def main() -> None:
     except Exception as e:
         logger.warning(f"Failed to setup git user | error={e}", exc_info=True)
 
-    # Initialize polling_task before gateway start
+    # Initialize watcher task before gateway start
     polling_task = None
     jira_reconciliation_task = None
     
@@ -173,13 +177,13 @@ async def main() -> None:
         await gateway.start()
         logger.info("Gateway server started")
         
-        # Start mention polling if enabled
-        if is_enabled():
-            logger.info("Starting mention polling...")
-            polling_task = asyncio.create_task(start_polling())
-            logger.info("Mention polling started")
+        # Start subscription watchers if enabled
+        if are_subscription_watchers_enabled():
+            logger.info("Starting subscription watchers...")
+            polling_task = asyncio.create_task(start_subscription_watchers())
+            logger.info("Subscription watchers started")
         else:
-            logger.debug("Mention polling is disabled")
+            logger.debug("Subscription watchers are disabled")
 
         if is_jira_reconciliation_enabled():
             logger.info("Starting Jira reconciliation...")
@@ -202,12 +206,12 @@ async def main() -> None:
     except Exception as e:
         logger.error(f"Unexpected error in main loop | error={e}", exc_info=True)
     finally:
-        # Stop mention polling
+        # Stop subscription watchers
         if polling_task and not polling_task.done():
-            logger.info("Stopping mention polling...")
-            await stop_polling()
+            logger.info("Stopping subscription watchers...")
+            await stop_subscription_watchers()
             await polling_task
-            logger.info("Mention polling stopped")
+            logger.info("Subscription watchers stopped")
 
         await _shutdown_jira_reconciliation_task(jira_reconciliation_task, logger)
         

--- a/src/cron/README.md
+++ b/src/cron/README.md
@@ -12,6 +12,7 @@ cron/
 
 ### Subscription Watchers (Primary)
 Pulls enabled subscriptions/bindings from Portal internal export, discovers external signals, and posts normalized ingress events back to Portal.
+Poll ingress metadata includes subscription/binding provenance plus lookup-alias fields for Portal-side debugging.
 
 ### Mention Poller (Legacy)
 Kept for backward compatibility and tests. Not used as the main runtime entrypoint.

--- a/src/cron/README.md
+++ b/src/cron/README.md
@@ -4,18 +4,25 @@
 
 ```
 cron/
-└── mention_poller.py  # Monitor @mentions across platforms
+├── subscription_watchers.py  # Main Portal-driven ingress watchers (poll/hybrid subscriptions)
+└── mention_poller.py         # Legacy mention poller (tests compatibility / old direct-execute path)
 ```
 
 ## Components
 
-### Mention Poller
-Monitors GitHub, Jira, and Confluence for @mentions and processes commands.
+### Subscription Watchers (Primary)
+Pulls enabled subscriptions/bindings from Portal internal export, discovers external signals, and posts normalized ingress events back to Portal.
+
+### Mention Poller (Legacy)
+Kept for backward compatibility and tests. Not used as the main runtime entrypoint.
 
 ## Usage
 
 ```python
-from src.cron.mention_poller import start_polling, stop_polling
+from src.cron.subscription_watchers import (
+    start_subscription_watchers,
+    stop_subscription_watchers,
+)
 
-start_polling()
+start_subscription_watchers()
 ```

--- a/src/cron/README.md
+++ b/src/cron/README.md
@@ -19,10 +19,15 @@ Kept for backward compatibility and tests. Not used as the main runtime entrypoi
 ## Usage
 
 ```python
+import asyncio
 from src.cron.subscription_watchers import (
     start_subscription_watchers,
     stop_subscription_watchers,
 )
 
-start_subscription_watchers()
+async def main():
+    watcher_task = asyncio.create_task(start_subscription_watchers())
+    ...
+    await stop_subscription_watchers()
+    await watcher_task
 ```

--- a/src/cron/mention_poller.py
+++ b/src/cron/mention_poller.py
@@ -24,6 +24,8 @@ from src.channels.jira import jira_channel
 from src.channels.confluence import confluence_channel
 from src.agents.executor import execute_tool
 
+logger = logging.getLogger(__name__)
+
 # Import memory module for tracking processed issues
 try:
     from src.memory import get_memory_store
@@ -31,8 +33,6 @@ try:
 except ImportError:
     MEMORY_AVAILABLE = False
     logger.warning("Memory module not available, using in-memory tracking only")
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -68,6 +68,7 @@ class MentionPoller:
         
         # Load monitored usernames
         self.monitored_users: Set[str] = set()
+        self._processed: Set[str] = set()
         self._load_config()
     
     def _load_config(self):
@@ -188,7 +189,7 @@ class MentionPoller:
         
         try:
             for space in spaces:
-                pages = await confluence.search_pages(
+                pages = await confluence_channel.search_pages(
                     f'space = "{space}" AND type = page',
                     limit=20
                 )
@@ -471,9 +472,6 @@ class MentionPoller:
             if page_id:
                 await confluence_channel.add_comment(page_id, reply_body)
     
-    # Track processed comments to avoid duplicates
-    _processed: Set[str] = set()
-
 
 # Lazy-loaded instance
 _mention_poller: Optional[MentionPoller] = None

--- a/src/cron/subscription_watchers.py
+++ b/src/cron/subscription_watchers.py
@@ -1,0 +1,612 @@
+"""Portal-driven subscription watchers for external-event ingress."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from aiohttp import ClientSession
+
+from src.channels.confluence import confluence_channel
+from src.channels.github import github_channel
+from src.channels.jira import jira_channel
+from src.config import config
+from src.cron.mention_poller import MentionPoller
+from src.utils.portal_internal_api import (
+    build_portal_internal_api_headers,
+    build_portal_internal_url,
+    get_portal_agent_id,
+    get_portal_internal_base_url,
+    is_portal_internal_configured,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_DEDUPE_KEYS_PER_SUBSCRIPTION = 1000
+
+
+@dataclass
+class WatchSubscription:
+    id: str
+    agent_id: str
+    source_type: str
+    event_type: str
+    mode: str
+    source_kind: str
+    target_ref: Optional[str]
+    binding_id: Optional[str]
+    enabled: bool
+    config: Dict[str, Any]
+    scope: Dict[str, Any]
+    matcher: Dict[str, Any]
+    routing: Dict[str, Any]
+    poll_profile: Dict[str, Any]
+    raw_config_json: Optional[str] = None
+    raw_scope_json: Optional[str] = None
+    dedupe_key_template: Optional[str] = None
+
+
+class SubscriptionWatcherManager:
+    def __init__(self) -> None:
+        self._running = False
+        self._lock = asyncio.Lock()
+        self._last_check_by_subscription: dict[str, datetime] = {}
+        self._seen_event_keys: dict[str, set[str]] = {}
+        self._seen_event_order: dict[str, deque[str]] = {}
+
+    def _base_url(self) -> str:
+        return get_portal_internal_base_url()
+
+    def _agent_id(self) -> str:
+        return get_portal_agent_id()
+
+    def _headers(self) -> Dict[str, str]:
+        return build_portal_internal_api_headers(include_content_type=True)
+
+    async def _get_json(self, path: str, *, session: ClientSession | None = None) -> Dict[str, Any]:
+        url = build_portal_internal_url(path)
+        if session is not None:
+            async with session.get(url) as response:
+                data = await response.json(content_type=None)
+                if response.status >= 400:
+                    raise RuntimeError(f"HTTP {response.status}: {data}")
+                return data if isinstance(data, dict) else {"items": data}
+        async with ClientSession(headers=self._headers()) as temp_session:
+            async with temp_session.get(url) as response:
+                data = await response.json(content_type=None)
+                if response.status >= 400:
+                    raise RuntimeError(f"HTTP {response.status}: {data}")
+                return data if isinstance(data, dict) else {"items": data}
+
+    async def _post_json(self, path: str, payload: Dict[str, Any], *, session: ClientSession | None = None) -> None:
+        url = build_portal_internal_url(path)
+        if session is not None:
+            async with session.post(url, json=payload) as response:
+                if response.status >= 400:
+                    body = await response.text()
+                    raise RuntimeError(f"HTTP {response.status}: {body}")
+            return
+        async with ClientSession(headers=self._headers()) as temp_session:
+            async with temp_session.post(url, json=payload) as response:
+                if response.status >= 400:
+                    body = await response.text()
+                    raise RuntimeError(f"HTTP {response.status}: {body}")
+
+    @staticmethod
+    def _parse_json_field(raw: Any) -> Dict[str, Any]:
+        if isinstance(raw, dict):
+            return dict(raw)
+        if isinstance(raw, str) and raw.strip():
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, dict):
+                    return parsed
+            except Exception:
+                return {}
+        return {}
+
+    @classmethod
+    def _normalize_subscription(cls, raw: Dict[str, Any]) -> Optional[WatchSubscription]:
+        if not isinstance(raw, dict):
+            return None
+        source_kind = str(raw.get("source_kind") or "").strip()
+        mode = str(raw.get("mode") or "").strip().lower()
+        if mode not in {"poll", "hybrid"} or not source_kind:
+            return None
+
+        config_dict = cls._parse_json_field(raw.get("config"))
+        if not config_dict:
+            config_dict = cls._parse_json_field(raw.get("config_json"))
+
+        scope_dict = cls._parse_json_field(raw.get("scope"))
+        if not scope_dict:
+            scope_dict = cls._parse_json_field(raw.get("scope_json"))
+
+        matcher_dict = cls._parse_json_field(raw.get("matcher"))
+        if not matcher_dict:
+            matcher_dict = cls._parse_json_field(raw.get("matcher_json"))
+
+        routing_dict = cls._parse_json_field(raw.get("routing"))
+        if not routing_dict:
+            routing_dict = cls._parse_json_field(raw.get("routing_json"))
+
+        poll_profile_dict = cls._parse_json_field(raw.get("poll_profile"))
+        if not poll_profile_dict:
+            poll_profile_dict = cls._parse_json_field(raw.get("poll_profile_json"))
+
+        return WatchSubscription(
+            id=str(raw.get("id") or "").strip(),
+            agent_id=str(raw.get("agent_id") or "").strip(),
+            source_type=str(raw.get("source_type") or raw.get("provider_type") or "").strip().lower(),
+            event_type=str(raw.get("event_type") or "").strip(),
+            mode=mode,
+            source_kind=source_kind,
+            target_ref=(str(raw.get("target_ref") or "").strip() or None),
+            binding_id=(str(raw.get("binding_id") or "").strip() or None),
+            enabled=bool(raw.get("enabled", True)),
+            config=config_dict,
+            scope=scope_dict,
+            matcher=matcher_dict,
+            routing=routing_dict,
+            poll_profile=poll_profile_dict,
+            raw_config_json=raw.get("config_json") if isinstance(raw.get("config_json"), str) else None,
+            raw_scope_json=raw.get("scope_json") if isinstance(raw.get("scope_json"), str) else None,
+            dedupe_key_template=(str(raw.get("dedupe_key_template") or "").strip() or None),
+        )
+
+    async def fetch_subscriptions(self, *, session: ClientSession | None = None) -> List[WatchSubscription]:
+        path = f"/api/internal/external-event-subscriptions?agent_id={self._agent_id()}&enabled=true"
+        data = await self._get_json(path, session=session)
+        items = data.get("items") if isinstance(data.get("items"), list) else data
+        raw_items = items if isinstance(items, list) else []
+        normalized: List[WatchSubscription] = []
+        for item in raw_items:
+            sub = self._normalize_subscription(item) if isinstance(item, dict) else None
+            if sub and sub.enabled and sub.id and sub.source_kind:
+                normalized.append(sub)
+        return normalized
+
+    async def fetch_identity_bindings(self, *, session: ClientSession | None = None) -> List[Dict[str, Any]]:
+        data = await self._get_json("/api/internal/agent-identity-bindings?enabled=true", session=session)
+        items = data.get("items") if isinstance(data.get("items"), list) else []
+        return [item for item in items if isinstance(item, dict)]
+
+    @staticmethod
+    def _resolve_binding_scope(raw_scope: Any) -> Dict[str, Any]:
+        if isinstance(raw_scope, dict):
+            return raw_scope
+        if isinstance(raw_scope, str) and raw_scope.strip():
+            try:
+                parsed = json.loads(raw_scope)
+                if isinstance(parsed, dict):
+                    return parsed
+            except Exception:
+                return {}
+        return {}
+
+    def _select_bindings(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        selected: List[Dict[str, Any]] = []
+        for binding in bindings:
+            system_type = str(binding.get("system_type") or binding.get("provider_type") or "").strip().lower()
+            agent_id = str(binding.get("agent_id") or "").strip()
+            if system_type != subscription.source_type:
+                continue
+            if agent_id != subscription.agent_id:
+                continue
+            if subscription.binding_id:
+                if str(binding.get("id") or "").strip() != subscription.binding_id:
+                    continue
+            selected.append(binding)
+        return selected
+
+    def _is_seen(self, subscription_id: str, dedupe_key: str) -> bool:
+        return dedupe_key in self._seen_event_keys.get(subscription_id, set())
+
+    def _mark_seen(self, subscription_id: str, dedupe_key: str) -> None:
+        if subscription_id not in self._seen_event_keys:
+            self._seen_event_keys[subscription_id] = set()
+            self._seen_event_order[subscription_id] = deque()
+
+        seen_set = self._seen_event_keys[subscription_id]
+        order = self._seen_event_order[subscription_id]
+        if dedupe_key in seen_set:
+            return
+
+        seen_set.add(dedupe_key)
+        order.append(dedupe_key)
+        while len(order) > _MAX_DEDUPE_KEYS_PER_SUBSCRIPTION:
+            old_key = order.popleft()
+            seen_set.discard(old_key)
+
+    @staticmethod
+    def _normalize_list(value: Any) -> List[str]:
+        if isinstance(value, list):
+            return [str(x).strip() for x in value if str(x).strip()]
+        if isinstance(value, str) and value.strip():
+            return [value.strip()]
+        return []
+
+    def _resolve_repo_list(self, subscription: WatchSubscription) -> List[str]:
+        repos = self._normalize_list(subscription.scope.get("repos"))
+        if repos:
+            return repos
+        repos = self._normalize_list(subscription.config.get("allowed_repos"))
+        if repos:
+            return repos
+        target_ref = str(subscription.target_ref or "").strip()
+        if re.match(r"^[^/\s]+/[^/\s]+$", target_ref):
+            return [target_ref]
+        return []
+
+    def _resolve_projects(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]]) -> List[str]:
+        projects = set(self._normalize_list(subscription.scope.get("projects")))
+        target_ref = str(subscription.target_ref or "").strip()
+        if re.match(r"^[A-Za-z][A-Za-z0-9_\-]+$", target_ref):
+            projects.add(target_ref)
+        for binding in bindings:
+            scope = self._resolve_binding_scope(binding.get("scope") or binding.get("scope_json"))
+            for project in self._normalize_list(scope.get("projects")):
+                projects.add(project)
+        return sorted(projects)
+
+    def _resolve_spaces(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]]) -> List[str]:
+        spaces = set(self._normalize_list(subscription.scope.get("spaces")))
+        target_ref = str(subscription.target_ref or "").strip()
+        if target_ref:
+            spaces.add(target_ref)
+        for binding in bindings:
+            scope = self._resolve_binding_scope(binding.get("scope") or binding.get("scope_json"))
+            for space in self._normalize_list(scope.get("spaces")):
+                spaces.add(space)
+        return sorted([x for x in spaces if x])
+
+    @staticmethod
+    def _extract_mentions(text: str) -> set[str]:
+        return {m.lower() for m in MentionPoller.extract_mentions(text or "")}
+
+    @staticmethod
+    def _binding_reviewers(bindings: List[Dict[str, Any]]) -> List[str]:
+        reviewers: List[str] = []
+        for binding in bindings:
+            reviewer = str(binding.get("username") or "").strip()
+            if not reviewer:
+                reviewer = str(binding.get("external_account_id") or "").strip()
+            if reviewer:
+                reviewers.append(reviewer)
+        return reviewers
+
+    async def _poll_github_review_requests(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]], *, session: ClientSession | None = None) -> None:
+        repos = self._resolve_repo_list(subscription)
+        if not repos:
+            logger.warning("Subscription %s has no repos to scan for GitHub review polling", subscription.id)
+            return
+
+        for reviewer_login in self._binding_reviewers(bindings):
+            for repo_ref in repos:
+                if "/" not in repo_ref:
+                    continue
+                owner, repo_name = repo_ref.split("/", 1)
+                query = f"repo:{owner}/{repo_name} is:pr is:open review-requested:{reviewer_login}"
+                try:
+                    result = await github_channel.search_issues(query, max_results=50)
+                except Exception as exc:
+                    logger.warning("GitHub review polling search failed for sub=%s repo=%s reviewer=%s: %s", subscription.id, repo_ref, reviewer_login, exc)
+                    continue
+
+                items = result.get("items") if isinstance(result, dict) and isinstance(result.get("items"), list) else []
+                for item in items:
+                    pull_number = item.get("number") if isinstance(item, dict) else None
+                    if not isinstance(pull_number, int):
+                        continue
+                    try:
+                        pr = await github_channel.get_pull_request(owner, repo_name, pull_number)
+                        head_sha = str((pr.get("head") or {}).get("sha") or "").strip()
+                        if not head_sha:
+                            continue
+                        dedupe_key = f"github:review:{owner}/{repo_name}:{pull_number}:{reviewer_login}:{head_sha}"
+                        if self._is_seen(subscription.id, dedupe_key):
+                            continue
+                        payload = {
+                            "source_type": "github",
+                            "event_type": "pull_request_review_requested",
+                            "external_account_id": reviewer_login,
+                            "target_ref": f"{owner}/{repo_name}",
+                            "dedupe_key": dedupe_key,
+                            "payload_json": json.dumps({
+                                "owner": owner,
+                                "repo": repo_name,
+                                "pull_number": pull_number,
+                                "reviewer": reviewer_login,
+                                "head_sha": head_sha,
+                            }, ensure_ascii=False),
+                            "metadata_json": json.dumps({
+                                "trigger_mode": "poll",
+                                "source_kind": "github.pull_request_review_requested",
+                            }, ensure_ascii=False),
+                        }
+                        await self._post_json("/api/internal/external-events/ingest", payload, session=session)
+                        self._mark_seen(subscription.id, dedupe_key)
+                    except Exception as exc:
+                        logger.warning("GitHub review polling ingest failed for sub=%s repo=%s pr=%s: %s", subscription.id, repo_ref, pull_number, exc)
+
+    @staticmethod
+    def _extract_github_comment_context(repo_ref: str, comment: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = repo_ref.split("/", 1)
+        issue_number = comment.get("issue_number")
+        extra = comment.get("extra") if isinstance(comment.get("extra"), dict) else {}
+        if not issue_number:
+            issue_number = extra.get("issue_number")
+        url = str(comment.get("url") or "")
+        if (not issue_number) and url:
+            match = re.search(r"/issues/(\d+)", url)
+            if match:
+                issue_number = int(match.group(1))
+        return {
+            "owner": str(extra.get("owner") or owner),
+            "repo": str(extra.get("repo") or repo),
+            "issue_number": issue_number,
+            "url": url,
+        }
+
+    @staticmethod
+    def _resolve_matched_account(bindings: List[Dict[str, Any]], mentions: set[str]) -> Optional[str]:
+        for binding in bindings:
+            username = str(binding.get("username") or "").strip()
+            external = str(binding.get("external_account_id") or "").strip()
+            if username and username.lower() in mentions:
+                return username
+            if external and external.lower() in mentions:
+                return external
+        return None
+
+    async def _poll_github_mentions(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]], *, session: ClientSession | None = None) -> None:
+        repos = self._resolve_repo_list(subscription)
+        if not repos:
+            logger.warning("Subscription %s has no repos to scan for GitHub mentions", subscription.id)
+            return
+
+        last_check = self._last_check_by_subscription.get(subscription.id)
+        for repo_ref in repos:
+            try:
+                comments = await github_channel.get_recent_issue_comments(repo_ref, since=last_check)
+            except Exception as exc:
+                logger.warning("GitHub mention polling failed for sub=%s repo=%s: %s", subscription.id, repo_ref, exc)
+                continue
+            for comment in comments:
+                comment_id = str(comment.get("id") or "").strip()
+                if not comment_id:
+                    continue
+                mentions = self._extract_mentions(str(comment.get("body") or ""))
+                matched_account = self._resolve_matched_account(bindings, mentions)
+                if not matched_account:
+                    continue
+                context = self._extract_github_comment_context(repo_ref, comment)
+                target_ref = f"{context['owner']}/{context['repo']}"
+                dedupe_key = f"github:mention:{target_ref}:{comment_id}"
+                if self._is_seen(subscription.id, dedupe_key):
+                    continue
+                payload = {
+                    "source_type": "github",
+                    "event_type": "mention",
+                    "external_account_id": matched_account,
+                    "target_ref": target_ref,
+                    "dedupe_key": dedupe_key,
+                    "payload_json": json.dumps({
+                        "owner": context["owner"],
+                        "repo": context["repo"],
+                        "comment_id": comment_id,
+                        "author": comment.get("author"),
+                        "body": comment.get("body"),
+                        "url": context["url"],
+                        "issue_number": context["issue_number"],
+                    }, ensure_ascii=False),
+                    "metadata_json": json.dumps({
+                        "trigger_mode": "poll",
+                        "source_kind": "github.mention",
+                    }, ensure_ascii=False),
+                }
+                try:
+                    await self._post_json("/api/internal/external-events/ingest", payload, session=session)
+                    self._mark_seen(subscription.id, dedupe_key)
+                except Exception as exc:
+                    logger.warning("GitHub mention ingest failed for sub=%s repo=%s comment=%s: %s", subscription.id, repo_ref, comment_id, exc)
+
+    async def _poll_jira_mentions(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]], *, session: ClientSession | None = None) -> None:
+        projects = self._resolve_projects(subscription, bindings)
+        if not projects:
+            logger.warning("Subscription %s has no projects to scan for Jira mentions", subscription.id)
+            return
+
+        quoted = ",".join(projects)
+        jql = f'project IN ({quoted}) AND updated >= "-1h"'
+        try:
+            result = await jira_channel.search_issues(jql, max_results=50)
+        except Exception as exc:
+            logger.warning("Jira mention polling search failed for sub=%s: %s", subscription.id, exc)
+            return
+
+        issues = result.get("issues") if isinstance(result, dict) and isinstance(result.get("issues"), list) else []
+        for issue in issues:
+            issue_key = str(issue.get("key") or "").strip()
+            if not issue_key:
+                continue
+            project_key = str(((issue.get("fields") or {}).get("project") or {}).get("key") or "").strip()
+            if not project_key:
+                project_key = issue_key.split("-", 1)[0] if "-" in issue_key else (projects[0] if projects else "")
+            try:
+                comments = await jira_channel.get_comments(issue_key)
+            except Exception as exc:
+                logger.warning("Jira mention polling comments failed for sub=%s issue=%s: %s", subscription.id, issue_key, exc)
+                continue
+
+            for comment in comments:
+                comment_id = str(comment.get("id") or "").strip()
+                if not comment_id:
+                    continue
+                mentions = self._extract_mentions(str(comment.get("body") or ""))
+                matched_account = self._resolve_matched_account(bindings, mentions)
+                if not matched_account:
+                    continue
+                dedupe_key = f"jira:mention:{issue_key}:{comment_id}"
+                if self._is_seen(subscription.id, dedupe_key):
+                    continue
+                payload = {
+                    "source_type": "jira",
+                    "event_type": "mention",
+                    "external_account_id": matched_account,
+                    "target_ref": project_key,
+                    "dedupe_key": dedupe_key,
+                    "payload_json": json.dumps({
+                        "issue_key": issue_key,
+                        "project_key": project_key,
+                        "comment_id": comment_id,
+                        "author": comment.get("author"),
+                        "body": comment.get("body"),
+                    }, ensure_ascii=False),
+                    "metadata_json": json.dumps({
+                        "trigger_mode": "poll",
+                        "source_kind": "jira.mention",
+                    }, ensure_ascii=False),
+                }
+                try:
+                    await self._post_json("/api/internal/external-events/ingest", payload, session=session)
+                    self._mark_seen(subscription.id, dedupe_key)
+                except Exception as exc:
+                    logger.warning("Jira mention ingest failed for sub=%s issue=%s comment=%s: %s", subscription.id, issue_key, comment_id, exc)
+
+    async def _poll_confluence_mentions(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]], *, session: ClientSession | None = None) -> None:
+        spaces = self._resolve_spaces(subscription, bindings)
+        if not spaces:
+            logger.warning("Subscription %s has no spaces to scan for Confluence mentions", subscription.id)
+            return
+
+        for space in spaces:
+            try:
+                pages_result = await confluence_channel.search_pages(f'space = "{space}" AND type = page', limit=20)
+            except Exception as exc:
+                logger.warning("Confluence mention polling search failed for sub=%s space=%s: %s", subscription.id, space, exc)
+                continue
+
+            pages = pages_result.get("results") if isinstance(pages_result, dict) and isinstance(pages_result.get("results"), list) else []
+            for page in pages:
+                page_id = str(page.get("id") or "").strip()
+                if not page_id:
+                    continue
+                space_key = str(((page.get("space") or {}).get("key") or space)).strip()
+                try:
+                    comments = await confluence_channel.get_comments(page_id)
+                except Exception as exc:
+                    logger.warning("Confluence mention polling comments failed for sub=%s page=%s: %s", subscription.id, page_id, exc)
+                    continue
+
+                for comment in comments:
+                    comment_id = str(comment.get("id") or "").strip()
+                    if not comment_id:
+                        continue
+                    body = str(((comment.get("body") or {}).get("storage") or {}).get("value") or comment.get("body") or "")
+                    mentions = self._extract_mentions(body)
+                    matched_account = self._resolve_matched_account(bindings, mentions)
+                    if not matched_account:
+                        continue
+                    dedupe_key = f"confluence:mention:{page_id}:{comment_id}"
+                    if self._is_seen(subscription.id, dedupe_key):
+                        continue
+                    payload = {
+                        "source_type": "confluence",
+                        "event_type": "mention",
+                        "external_account_id": matched_account,
+                        "target_ref": space_key,
+                        "dedupe_key": dedupe_key,
+                        "payload_json": json.dumps({
+                            "space_key": space_key,
+                            "page_id": page_id,
+                            "comment_id": comment_id,
+                            "author": (comment.get("version") or {}).get("by", {}).get("displayName") or comment.get("author"),
+                            "body": body,
+                            "title": page.get("title"),
+                        }, ensure_ascii=False),
+                        "metadata_json": json.dumps({
+                            "trigger_mode": "poll",
+                            "source_kind": "confluence.mention",
+                        }, ensure_ascii=False),
+                    }
+                    try:
+                        await self._post_json("/api/internal/external-events/ingest", payload, session=session)
+                        self._mark_seen(subscription.id, dedupe_key)
+                    except Exception as exc:
+                        logger.warning("Confluence mention ingest failed for sub=%s page=%s comment=%s: %s", subscription.id, page_id, comment_id, exc)
+
+    async def _poll_subscription(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]], *, session: ClientSession | None = None) -> None:
+        kind = subscription.source_kind
+        if kind == "github.pull_request_review_requested":
+            await self._poll_github_review_requests(subscription, bindings, session=session)
+        elif kind == "github.mention":
+            await self._poll_github_mentions(subscription, bindings, session=session)
+        elif kind == "jira.mention":
+            await self._poll_jira_mentions(subscription, bindings, session=session)
+        elif kind == "confluence.mention":
+            await self._poll_confluence_mentions(subscription, bindings, session=session)
+        else:
+            logger.debug("Unsupported source_kind=%s for subscription=%s", kind, subscription.id)
+
+    async def run_once(self) -> None:
+        if not is_portal_internal_configured():
+            logger.debug("Subscription watchers skipped: Portal internal config incomplete")
+            return
+
+        try:
+            async with ClientSession(headers=self._headers()) as session:
+                subscriptions = await self.fetch_subscriptions(session=session)
+                bindings = await self.fetch_identity_bindings(session=session)
+
+                for subscription in subscriptions:
+                    sub_bindings = self._select_bindings(subscription, bindings)
+                    if not sub_bindings:
+                        logger.debug("Skipping subscription=%s due to no matching bindings", subscription.id)
+                        continue
+                    try:
+                        await self._poll_subscription(subscription, sub_bindings, session=session)
+                    except Exception as exc:
+                        logger.warning("Subscription watcher failed for subscription=%s source_kind=%s: %s", subscription.id, subscription.source_kind, exc)
+                    finally:
+                        self._last_check_by_subscription[subscription.id] = datetime.now(timezone.utc)
+        except Exception as exc:
+            logger.warning("Subscription watchers failed to load Portal control-plane exports: %s", exc)
+
+    async def start(self) -> None:
+        self._running = True
+        while self._running:
+            await self.run_once()
+            await asyncio.sleep(get_interval_seconds())
+
+    async def stop(self) -> None:
+        async with self._lock:
+            self._running = False
+
+
+_runner = SubscriptionWatcherManager()
+
+
+def get_interval_seconds() -> int:
+    value = int(config.get("server.subscription_watchers_interval_seconds", 60) or 60)
+    return max(15, value)
+
+
+def is_enabled() -> bool:
+    if not bool(config.get("server.subscription_watchers_enabled", True)):
+        return False
+    return is_portal_internal_configured()
+
+
+async def start_subscription_watchers() -> None:
+    await _runner.start()
+
+
+async def stop_subscription_watchers() -> None:
+    await _runner.stop()

--- a/src/cron/subscription_watchers.py
+++ b/src/cron/subscription_watchers.py
@@ -326,6 +326,9 @@ class SubscriptionWatcherManager:
             "watcher_agent_id": subscription.agent_id,
             "binding_id": (binding or {}).get("id"),
         }
+        lookup_name = SubscriptionWatcherManager._binding_lookup_name(binding) if binding else None
+        if lookup_name:
+            metadata["binding_lookup_username"] = lookup_name
         if isinstance(extra, dict):
             metadata.update(extra)
         return json.dumps(metadata, ensure_ascii=False)
@@ -374,7 +377,11 @@ class SubscriptionWatcherManager:
                                 "reviewer": reviewer_login,
                                 "head_sha": head_sha,
                             }, ensure_ascii=False),
-                            "metadata_json": self._build_poll_metadata(subscription, binding=binding),
+                            "metadata_json": self._build_poll_metadata(
+                                subscription,
+                                binding=binding,
+                                extra={"reviewer_login": reviewer_login},
+                            ),
                         }
                         await self._post_json("/api/internal/external-events/ingest", payload, session=session)
                         self._mark_seen(subscription.id, dedupe_key)

--- a/src/cron/subscription_watchers.py
+++ b/src/cron/subscription_watchers.py
@@ -615,8 +615,12 @@ class SubscriptionWatcherManager:
             logger.warning("Subscription watchers failed to load Portal control-plane exports: %s", exc)
 
     async def start(self) -> None:
-        self._running = True
-        self._stop_event.clear()
+        async with self._lock:
+            if self._running:
+                logger.debug("Subscription watchers already running; start() is a no-op")
+                return
+            self._running = True
+            self._stop_event.clear()
         while self._running:
             await self.run_once()
             if not self._running:
@@ -631,6 +635,10 @@ class SubscriptionWatcherManager:
 
     async def stop(self) -> None:
         async with self._lock:
+            if not self._running:
+                logger.debug("Subscription watchers already stopped; stop() is a no-op")
+                self._stop_event.set()
+                return
             self._running = False
             self._stop_event.set()
 

--- a/src/cron/subscription_watchers.py
+++ b/src/cron/subscription_watchers.py
@@ -8,7 +8,7 @@ import logging
 import re
 from collections import deque
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from aiohttp import ClientSession
@@ -56,6 +56,7 @@ class SubscriptionWatcherManager:
     def __init__(self) -> None:
         self._running = False
         self._lock = asyncio.Lock()
+        self._stop_event = asyncio.Event()
         self._last_check_by_subscription: dict[str, datetime] = {}
         self._seen_event_keys: dict[str, set[str]] = {}
         self._seen_event_order: dict[str, deque[str]] = {}
@@ -271,15 +272,63 @@ class SubscriptionWatcherManager:
         return {m.lower() for m in MentionPoller.extract_mentions(text or "")}
 
     @staticmethod
-    def _binding_reviewers(bindings: List[Dict[str, Any]]) -> List[str]:
-        reviewers: List[str] = []
+    def _binding_external_id(binding: Dict[str, Any]) -> Optional[str]:
+        external_id = str(binding.get("external_account_id") or "").strip()
+        if external_id:
+            return external_id
+        username = str(binding.get("username") or "").strip()
+        return username or None
+
+    @staticmethod
+    def _binding_lookup_name(binding: Dict[str, Any]) -> Optional[str]:
+        username = str(binding.get("username") or "").strip()
+        if username:
+            return username
+        external_id = str(binding.get("external_account_id") or "").strip()
+        return external_id or None
+
+    @classmethod
+    def _iter_binding_reviewers(cls, bindings: List[Dict[str, Any]]) -> List[tuple[Dict[str, Any], str, str]]:
+        reviewers: List[tuple[Dict[str, Any], str, str]] = []
         for binding in bindings:
-            reviewer = str(binding.get("username") or "").strip()
-            if not reviewer:
-                reviewer = str(binding.get("external_account_id") or "").strip()
-            if reviewer:
-                reviewers.append(reviewer)
+            reviewer_login = cls._binding_lookup_name(binding)
+            canonical_external_account_id = cls._binding_external_id(binding)
+            if reviewer_login and canonical_external_account_id:
+                reviewers.append((binding, reviewer_login, canonical_external_account_id))
         return reviewers
+
+    @classmethod
+    def _resolve_matched_binding(
+        cls,
+        bindings: List[Dict[str, Any]],
+        mentions: set[str],
+    ) -> Optional[Dict[str, Any]]:
+        for binding in bindings:
+            username = str(binding.get("username") or "").strip()
+            external_id = str(binding.get("external_account_id") or "").strip()
+            if username and username.lower() in mentions:
+                return binding
+            if external_id and external_id.lower() in mentions:
+                return binding
+        return None
+
+    @staticmethod
+    def _build_poll_metadata(
+        subscription: WatchSubscription,
+        binding: Dict[str, Any] | None = None,
+        extra: Dict[str, Any] | None = None,
+    ) -> str:
+        metadata: Dict[str, Any] = {
+            "trigger_mode": "poll",
+            "source_kind": subscription.source_kind,
+            "subscription_id": subscription.id,
+            "subscription_mode": subscription.mode,
+            "watcher_agent_id": subscription.agent_id,
+            "binding_id": (binding or {}).get("id"),
+        }
+        if isinstance(extra, dict):
+            metadata.update(extra)
+        return json.dumps(metadata, ensure_ascii=False)
 
     async def _poll_github_review_requests(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]], *, session: ClientSession | None = None) -> None:
         repos = self._resolve_repo_list(subscription)
@@ -287,7 +336,7 @@ class SubscriptionWatcherManager:
             logger.warning("Subscription %s has no repos to scan for GitHub review polling", subscription.id)
             return
 
-        for reviewer_login in self._binding_reviewers(bindings):
+        for binding, reviewer_login, canonical_external_account_id in self._iter_binding_reviewers(bindings):
             for repo_ref in repos:
                 if "/" not in repo_ref:
                     continue
@@ -315,7 +364,7 @@ class SubscriptionWatcherManager:
                         payload = {
                             "source_type": "github",
                             "event_type": "pull_request_review_requested",
-                            "external_account_id": reviewer_login,
+                            "external_account_id": canonical_external_account_id,
                             "target_ref": f"{owner}/{repo_name}",
                             "dedupe_key": dedupe_key,
                             "payload_json": json.dumps({
@@ -325,10 +374,7 @@ class SubscriptionWatcherManager:
                                 "reviewer": reviewer_login,
                                 "head_sha": head_sha,
                             }, ensure_ascii=False),
-                            "metadata_json": json.dumps({
-                                "trigger_mode": "poll",
-                                "source_kind": "github.pull_request_review_requested",
-                            }, ensure_ascii=False),
+                            "metadata_json": self._build_poll_metadata(subscription, binding=binding),
                         }
                         await self._post_json("/api/internal/external-events/ingest", payload, session=session)
                         self._mark_seen(subscription.id, dedupe_key)
@@ -354,17 +400,6 @@ class SubscriptionWatcherManager:
             "url": url,
         }
 
-    @staticmethod
-    def _resolve_matched_account(bindings: List[Dict[str, Any]], mentions: set[str]) -> Optional[str]:
-        for binding in bindings:
-            username = str(binding.get("username") or "").strip()
-            external = str(binding.get("external_account_id") or "").strip()
-            if username and username.lower() in mentions:
-                return username
-            if external and external.lower() in mentions:
-                return external
-        return None
-
     async def _poll_github_mentions(self, subscription: WatchSubscription, bindings: List[Dict[str, Any]], *, session: ClientSession | None = None) -> None:
         repos = self._resolve_repo_list(subscription)
         if not repos:
@@ -383,8 +418,11 @@ class SubscriptionWatcherManager:
                 if not comment_id:
                     continue
                 mentions = self._extract_mentions(str(comment.get("body") or ""))
-                matched_account = self._resolve_matched_account(bindings, mentions)
-                if not matched_account:
+                matched_binding = self._resolve_matched_binding(bindings, mentions)
+                if not matched_binding:
+                    continue
+                canonical_external_account_id = self._binding_external_id(matched_binding)
+                if not canonical_external_account_id:
                     continue
                 context = self._extract_github_comment_context(repo_ref, comment)
                 target_ref = f"{context['owner']}/{context['repo']}"
@@ -394,7 +432,7 @@ class SubscriptionWatcherManager:
                 payload = {
                     "source_type": "github",
                     "event_type": "mention",
-                    "external_account_id": matched_account,
+                    "external_account_id": canonical_external_account_id,
                     "target_ref": target_ref,
                     "dedupe_key": dedupe_key,
                     "payload_json": json.dumps({
@@ -406,10 +444,7 @@ class SubscriptionWatcherManager:
                         "url": context["url"],
                         "issue_number": context["issue_number"],
                     }, ensure_ascii=False),
-                    "metadata_json": json.dumps({
-                        "trigger_mode": "poll",
-                        "source_kind": "github.mention",
-                    }, ensure_ascii=False),
+                    "metadata_json": self._build_poll_metadata(subscription, binding=matched_binding),
                 }
                 try:
                     await self._post_json("/api/internal/external-events/ingest", payload, session=session)
@@ -450,8 +485,11 @@ class SubscriptionWatcherManager:
                 if not comment_id:
                     continue
                 mentions = self._extract_mentions(str(comment.get("body") or ""))
-                matched_account = self._resolve_matched_account(bindings, mentions)
-                if not matched_account:
+                matched_binding = self._resolve_matched_binding(bindings, mentions)
+                if not matched_binding:
+                    continue
+                canonical_external_account_id = self._binding_external_id(matched_binding)
+                if not canonical_external_account_id:
                     continue
                 dedupe_key = f"jira:mention:{issue_key}:{comment_id}"
                 if self._is_seen(subscription.id, dedupe_key):
@@ -459,7 +497,7 @@ class SubscriptionWatcherManager:
                 payload = {
                     "source_type": "jira",
                     "event_type": "mention",
-                    "external_account_id": matched_account,
+                    "external_account_id": canonical_external_account_id,
                     "target_ref": project_key,
                     "dedupe_key": dedupe_key,
                     "payload_json": json.dumps({
@@ -469,10 +507,7 @@ class SubscriptionWatcherManager:
                         "author": comment.get("author"),
                         "body": comment.get("body"),
                     }, ensure_ascii=False),
-                    "metadata_json": json.dumps({
-                        "trigger_mode": "poll",
-                        "source_kind": "jira.mention",
-                    }, ensure_ascii=False),
+                    "metadata_json": self._build_poll_metadata(subscription, binding=matched_binding),
                 }
                 try:
                     await self._post_json("/api/internal/external-events/ingest", payload, session=session)
@@ -511,8 +546,11 @@ class SubscriptionWatcherManager:
                         continue
                     body = str(((comment.get("body") or {}).get("storage") or {}).get("value") or comment.get("body") or "")
                     mentions = self._extract_mentions(body)
-                    matched_account = self._resolve_matched_account(bindings, mentions)
-                    if not matched_account:
+                    matched_binding = self._resolve_matched_binding(bindings, mentions)
+                    if not matched_binding:
+                        continue
+                    canonical_external_account_id = self._binding_external_id(matched_binding)
+                    if not canonical_external_account_id:
                         continue
                     dedupe_key = f"confluence:mention:{page_id}:{comment_id}"
                     if self._is_seen(subscription.id, dedupe_key):
@@ -520,7 +558,7 @@ class SubscriptionWatcherManager:
                     payload = {
                         "source_type": "confluence",
                         "event_type": "mention",
-                        "external_account_id": matched_account,
+                        "external_account_id": canonical_external_account_id,
                         "target_ref": space_key,
                         "dedupe_key": dedupe_key,
                         "payload_json": json.dumps({
@@ -531,10 +569,7 @@ class SubscriptionWatcherManager:
                             "body": body,
                             "title": page.get("title"),
                         }, ensure_ascii=False),
-                        "metadata_json": json.dumps({
-                            "trigger_mode": "poll",
-                            "source_kind": "confluence.mention",
-                        }, ensure_ascii=False),
+                        "metadata_json": self._build_poll_metadata(subscription, binding=matched_binding),
                     }
                     try:
                         await self._post_json("/api/internal/external-events/ingest", payload, session=session)
@@ -581,13 +616,23 @@ class SubscriptionWatcherManager:
 
     async def start(self) -> None:
         self._running = True
+        self._stop_event.clear()
         while self._running:
             await self.run_once()
-            await asyncio.sleep(get_interval_seconds())
+            if not self._running:
+                break
+            timeout = get_interval_seconds()
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                pass
+            if self._stop_event.is_set():
+                break
 
     async def stop(self) -> None:
         async with self._lock:
             self._running = False
+            self._stop_event.set()
 
 
 _runner = SubscriptionWatcherManager()

--- a/src/utils/portal_internal_api.py
+++ b/src/utils/portal_internal_api.py
@@ -24,6 +24,15 @@ def get_portal_agent_id() -> str:
     return str(config_value or "").strip()
 
 
+def is_portal_internal_configured() -> bool:
+    return bool(get_portal_internal_base_url() and get_portal_agent_id())
+
+
+def build_portal_internal_url(path: str) -> str:
+    normalized_path = f"/{str(path or '').lstrip('/')}"
+    return f"{get_portal_internal_base_url()}{normalized_path}"
+
+
 def build_portal_internal_api_headers(include_content_type: bool = True) -> Dict[str, str]:
     if include_content_type:
         return {"Content-Type": "application/json"}

--- a/tests/test_subscription_watchers.py
+++ b/tests/test_subscription_watchers.py
@@ -1,0 +1,288 @@
+import json
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_run_once_fetches_subscriptions_and_bindings_with_poll_filter(monkeypatch):
+    from src.cron.subscription_watchers import SubscriptionWatcherManager
+
+    manager = SubscriptionWatcherManager()
+    calls = []
+
+    async def _fake_get_json(path, *, session=None):
+        calls.append(path)
+        if path.startswith("/api/internal/external-event-subscriptions"):
+            return {
+                "items": [
+                    {
+                        "id": "s-1",
+                        "agent_id": "agent-1",
+                        "source_type": "github",
+                        "event_type": "pull_request_review_requested",
+                        "mode": "poll",
+                        "source_kind": "github.pull_request_review_requested",
+                        "enabled": True,
+                        "scope": {"repos": ["o/r"]},
+                    },
+                    {
+                        "id": "s-2",
+                        "agent_id": "agent-1",
+                        "source_type": "github",
+                        "event_type": "mention",
+                        "mode": "push",
+                        "source_kind": "github.mention",
+                        "enabled": True,
+                    },
+                ]
+            }
+        if path == "/api/internal/agent-identity-bindings?enabled=true":
+            return {
+                "items": [
+                    {
+                        "id": "b-1",
+                        "agent_id": "agent-1",
+                        "system_type": "github",
+                        "username": "reviewer1",
+                    }
+                ]
+            }
+        raise AssertionError("unexpected path")
+
+    polled = []
+
+    async def _fake_poll_subscription(subscription, bindings, *, session=None):
+        polled.append((subscription, bindings, session))
+
+    monkeypatch.setattr("src.cron.subscription_watchers.is_portal_internal_configured", lambda: True)
+    monkeypatch.setattr(manager, "_get_json", _fake_get_json)
+    monkeypatch.setattr(manager, "_agent_id", lambda: "agent-1")
+    monkeypatch.setattr(manager, "_poll_subscription", _fake_poll_subscription)
+
+    await manager.run_once()
+
+    assert any(path.startswith("/api/internal/external-event-subscriptions") for path in calls)
+    assert "/api/internal/agent-identity-bindings?enabled=true" in calls
+    assert len(polled) == 1
+    assert polled[0][0].id == "s-1"
+    assert polled[0][1][0]["id"] == "b-1"
+
+
+@pytest.mark.asyncio
+async def test_poll_github_review_requests_posts_normalized_ingress(monkeypatch):
+    from src.cron.subscription_watchers import SubscriptionWatcherManager, WatchSubscription
+
+    manager = SubscriptionWatcherManager()
+    posts = []
+
+    async def _fake_search_issues(query, max_results=50):
+        assert query == "repo:octo/portal is:pr is:open review-requested:reviewer1"
+        assert max_results == 50
+        return {"items": [{"number": 123}]}
+
+    async def _fake_get_pr(owner, repo, pull_number):
+        assert owner == "octo"
+        assert repo == "portal"
+        assert pull_number == 123
+        return {"head": {"sha": "abc123"}}
+
+    async def _fake_post_json(path, payload, *, session=None):
+        posts.append((path, payload))
+
+    monkeypatch.setattr("src.cron.subscription_watchers.github_channel.search_issues", _fake_search_issues)
+    monkeypatch.setattr("src.cron.subscription_watchers.github_channel.get_pull_request", _fake_get_pr)
+    monkeypatch.setattr(manager, "_post_json", _fake_post_json)
+
+    subscription = WatchSubscription(
+        id="sub-1",
+        agent_id="agent-1",
+        source_type="github",
+        event_type="pull_request_review_requested",
+        mode="poll",
+        source_kind="github.pull_request_review_requested",
+        target_ref="octo/portal",
+        binding_id=None,
+        enabled=True,
+        config={},
+        scope={},
+        matcher={},
+        routing={},
+        poll_profile={},
+    )
+    bindings = [{"id": "b-1", "username": "reviewer1", "external_account_id": "ext-1"}]
+
+    await manager._poll_github_review_requests(subscription, bindings)
+
+    assert posts
+    path, payload = posts[0]
+    assert path == "/api/internal/external-events/ingest"
+    assert payload["source_type"] == "github"
+    assert payload["event_type"] == "pull_request_review_requested"
+    assert payload["external_account_id"] == "reviewer1"
+    assert payload["target_ref"] == "octo/portal"
+    assert payload["dedupe_key"] == "github:review:octo/portal:123:reviewer1:abc123"
+    parsed = json.loads(payload["payload_json"])
+    assert parsed == {
+        "owner": "octo",
+        "repo": "portal",
+        "pull_number": 123,
+        "reviewer": "reviewer1",
+        "head_sha": "abc123",
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_mention_ingress_payloads_for_github_jira_confluence(monkeypatch):
+    from src.cron.subscription_watchers import SubscriptionWatcherManager, WatchSubscription
+
+    manager = SubscriptionWatcherManager()
+    posts = []
+
+    async def _fake_post_json(path, payload, *, session=None):
+        posts.append(payload)
+
+    monkeypatch.setattr(manager, "_post_json", _fake_post_json)
+
+    bindings = [{"id": "b-1", "username": "reviewer1", "external_account_id": "reviewer1"}]
+
+    github_sub = WatchSubscription(
+        id="gh-sub",
+        agent_id="agent-1",
+        source_type="github",
+        event_type="mention",
+        mode="poll",
+        source_kind="github.mention",
+        target_ref="octo/portal",
+        binding_id=None,
+        enabled=True,
+        config={},
+        scope={},
+        matcher={},
+        routing={},
+        poll_profile={},
+    )
+    jira_sub = WatchSubscription(
+        id="jira-sub",
+        agent_id="agent-1",
+        source_type="jira",
+        event_type="mention",
+        mode="poll",
+        source_kind="jira.mention",
+        target_ref="ENG",
+        binding_id=None,
+        enabled=True,
+        config={},
+        scope={},
+        matcher={},
+        routing={},
+        poll_profile={},
+    )
+    confluence_sub = WatchSubscription(
+        id="conf-sub",
+        agent_id="agent-1",
+        source_type="confluence",
+        event_type="mention",
+        mode="poll",
+        source_kind="confluence.mention",
+        target_ref="DEV",
+        binding_id=None,
+        enabled=True,
+        config={},
+        scope={},
+        matcher={},
+        routing={},
+        poll_profile={},
+    )
+
+    async def _fake_get_recent_issue_comments(repo, since=None):
+        return [{"id": "c1", "body": "hi @reviewer1", "author": "alice", "url": "https://github.com/octo/portal/issues/5#issuecomment-1", "issue_number": 5}]
+
+    async def _fake_search_issues(jql, max_results=50):
+        return {"issues": [{"key": "ENG-1", "fields": {"project": {"key": "ENG"}}}]}
+
+    async def _fake_get_jira_comments(issue_key):
+        return [{"id": "jc1", "body": "ping @reviewer1", "author": "bob"}]
+
+    async def _fake_search_pages(cql, limit=20):
+        return {"results": [{"id": "p1", "title": "Doc", "space": {"key": "DEV"}}]}
+
+    async def _fake_get_conf_comments(page_id):
+        return [{"id": "cc1", "body": {"storage": {"value": "<p>@reviewer1 please check</p>"}}, "version": {"by": {"displayName": "carol"}}}]
+
+    monkeypatch.setattr("src.cron.subscription_watchers.github_channel.get_recent_issue_comments", _fake_get_recent_issue_comments)
+    monkeypatch.setattr("src.cron.subscription_watchers.jira_channel.search_issues", _fake_search_issues)
+    monkeypatch.setattr("src.cron.subscription_watchers.jira_channel.get_comments", _fake_get_jira_comments)
+    monkeypatch.setattr("src.cron.subscription_watchers.confluence_channel.search_pages", _fake_search_pages)
+    monkeypatch.setattr("src.cron.subscription_watchers.confluence_channel.get_comments", _fake_get_conf_comments)
+
+    await manager._poll_github_mentions(github_sub, bindings)
+    await manager._poll_jira_mentions(jira_sub, bindings)
+    await manager._poll_confluence_mentions(confluence_sub, bindings)
+
+    assert any(p["dedupe_key"] == "github:mention:octo/portal:c1" for p in posts)
+    assert any(p["dedupe_key"] == "jira:mention:ENG-1:jc1" for p in posts)
+    assert any(p["dedupe_key"] == "confluence:mention:p1:cc1" for p in posts)
+
+
+@pytest.mark.asyncio
+async def test_run_once_reuses_single_client_session_per_run(monkeypatch):
+    from src.cron.subscription_watchers import SubscriptionWatcherManager
+
+    manager = SubscriptionWatcherManager()
+    session_constructors = []
+    sessions_seen = []
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def _fake_client_session(*args, **kwargs):
+        session = _FakeSession()
+        session_constructors.append(session)
+        return session
+
+    async def _fake_get_json(path, *, session=None):
+        sessions_seen.append(session)
+        if path.startswith("/api/internal/external-event-subscriptions"):
+            return {
+                "items": [
+                    {
+                        "id": "s-1",
+                        "agent_id": "agent-1",
+                        "source_type": "github",
+                        "event_type": "pull_request_review_requested",
+                        "mode": "poll",
+                        "source_kind": "github.pull_request_review_requested",
+                        "enabled": True,
+                        "scope": {"repos": ["o/r"]},
+                    }
+                ]
+            }
+        return {
+            "items": [
+                {
+                    "id": "b-1",
+                    "agent_id": "agent-1",
+                    "system_type": "github",
+                    "username": "reviewer1",
+                }
+            ]
+        }
+
+    async def _fake_poll_subscription(subscription, bindings, *, session=None):
+        sessions_seen.append(session)
+
+    monkeypatch.setattr("src.cron.subscription_watchers.is_portal_internal_configured", lambda: True)
+    monkeypatch.setattr("src.cron.subscription_watchers.ClientSession", _fake_client_session)
+    monkeypatch.setattr(manager, "_get_json", _fake_get_json)
+    monkeypatch.setattr(manager, "_poll_subscription", _fake_poll_subscription)
+    monkeypatch.setattr(manager, "_agent_id", lambda: "agent-1")
+
+    await manager.run_once()
+
+    assert len(session_constructors) == 1
+    assert sessions_seen
+    assert all(session is session_constructors[0] for session in sessions_seen)

--- a/tests/test_subscription_watchers.py
+++ b/tests/test_subscription_watchers.py
@@ -342,3 +342,44 @@ async def test_stop_sets_event_and_allows_start_loop_to_exit_promptly(monkeypatc
     await asyncio.wait_for(start_task, timeout=1.0)
 
     assert start_task.done()
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent_when_already_running(monkeypatch):
+    from src.cron.subscription_watchers import SubscriptionWatcherManager
+
+    manager = SubscriptionWatcherManager()
+    run_once_calls = 0
+    first_run_entered = asyncio.Event()
+
+    async def _fake_run_once():
+        nonlocal run_once_calls
+        run_once_calls += 1
+        first_run_entered.set()
+
+    monkeypatch.setattr(manager, "run_once", _fake_run_once)
+    monkeypatch.setattr("src.cron.subscription_watchers.get_interval_seconds", lambda: 999)
+
+    first_start_task = asyncio.create_task(manager.start())
+    await asyncio.wait_for(first_run_entered.wait(), timeout=1.0)
+    calls_after_first_start = run_once_calls
+
+    await asyncio.wait_for(manager.start(), timeout=1.0)
+    await asyncio.sleep(0)
+
+    assert run_once_calls == calls_after_first_start
+
+    await manager.stop()
+    await asyncio.wait_for(first_start_task, timeout=1.0)
+    assert first_start_task.done()
+
+
+@pytest.mark.asyncio
+async def test_stop_is_safe_when_not_running():
+    from src.cron.subscription_watchers import SubscriptionWatcherManager
+
+    manager = SubscriptionWatcherManager()
+
+    await manager.stop()
+
+    assert manager._stop_event.is_set() is True

--- a/tests/test_subscription_watchers.py
+++ b/tests/test_subscription_watchers.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+import asyncio
 
 
 @pytest.mark.asyncio
@@ -109,7 +110,7 @@ async def test_poll_github_review_requests_posts_normalized_ingress(monkeypatch)
         routing={},
         poll_profile={},
     )
-    bindings = [{"id": "b-1", "username": "reviewer1", "external_account_id": "ext-1"}]
+    bindings = [{"id": "b-1", "username": "reviewer1", "external_account_id": "github-reviewer-123"}]
 
     await manager._poll_github_review_requests(subscription, bindings)
 
@@ -118,7 +119,7 @@ async def test_poll_github_review_requests_posts_normalized_ingress(monkeypatch)
     assert path == "/api/internal/external-events/ingest"
     assert payload["source_type"] == "github"
     assert payload["event_type"] == "pull_request_review_requested"
-    assert payload["external_account_id"] == "reviewer1"
+    assert payload["external_account_id"] == "github-reviewer-123"
     assert payload["target_ref"] == "octo/portal"
     assert payload["dedupe_key"] == "github:review:octo/portal:123:reviewer1:abc123"
     parsed = json.loads(payload["payload_json"])
@@ -129,6 +130,12 @@ async def test_poll_github_review_requests_posts_normalized_ingress(monkeypatch)
         "reviewer": "reviewer1",
         "head_sha": "abc123",
     }
+    metadata = json.loads(payload["metadata_json"])
+    assert metadata["trigger_mode"] == "poll"
+    assert metadata["source_kind"] == "github.pull_request_review_requested"
+    assert metadata["subscription_id"] == "sub-1"
+    assert metadata["subscription_mode"] == "poll"
+    assert metadata["binding_id"] == "b-1"
 
 
 @pytest.mark.asyncio
@@ -143,7 +150,9 @@ async def test_build_mention_ingress_payloads_for_github_jira_confluence(monkeyp
 
     monkeypatch.setattr(manager, "_post_json", _fake_post_json)
 
-    bindings = [{"id": "b-1", "username": "reviewer1", "external_account_id": "reviewer1"}]
+    github_bindings = [{"id": "gh-bind-1", "username": "reviewer1", "external_account_id": "gh-user-1"}]
+    jira_bindings = [{"id": "jira-bind-1", "username": "reviewer1", "external_account_id": "jira-account-1"}]
+    confluence_bindings = [{"id": "conf-bind-1", "username": "reviewer1", "external_account_id": "conf-user-1"}]
 
     github_sub = WatchSubscription(
         id="gh-sub",
@@ -215,13 +224,38 @@ async def test_build_mention_ingress_payloads_for_github_jira_confluence(monkeyp
     monkeypatch.setattr("src.cron.subscription_watchers.confluence_channel.search_pages", _fake_search_pages)
     monkeypatch.setattr("src.cron.subscription_watchers.confluence_channel.get_comments", _fake_get_conf_comments)
 
-    await manager._poll_github_mentions(github_sub, bindings)
-    await manager._poll_jira_mentions(jira_sub, bindings)
-    await manager._poll_confluence_mentions(confluence_sub, bindings)
+    await manager._poll_github_mentions(github_sub, github_bindings)
+    await manager._poll_jira_mentions(jira_sub, jira_bindings)
+    await manager._poll_confluence_mentions(confluence_sub, confluence_bindings)
 
-    assert any(p["dedupe_key"] == "github:mention:octo/portal:c1" for p in posts)
-    assert any(p["dedupe_key"] == "jira:mention:ENG-1:jc1" for p in posts)
-    assert any(p["dedupe_key"] == "confluence:mention:p1:cc1" for p in posts)
+    github_payload = next(p for p in posts if p["dedupe_key"] == "github:mention:octo/portal:c1")
+    jira_payload = next(p for p in posts if p["dedupe_key"] == "jira:mention:ENG-1:jc1")
+    confluence_payload = next(p for p in posts if p["dedupe_key"] == "confluence:mention:p1:cc1")
+
+    assert github_payload["external_account_id"] == "gh-user-1"
+    assert jira_payload["external_account_id"] == "jira-account-1"
+    assert confluence_payload["external_account_id"] == "conf-user-1"
+
+    github_metadata = json.loads(github_payload["metadata_json"])
+    assert github_metadata["trigger_mode"] == "poll"
+    assert github_metadata["source_kind"] == "github.mention"
+    assert github_metadata["subscription_id"] == "gh-sub"
+    assert github_metadata["subscription_mode"] == "poll"
+    assert github_metadata["binding_id"] == "gh-bind-1"
+
+    jira_metadata = json.loads(jira_payload["metadata_json"])
+    assert jira_metadata["trigger_mode"] == "poll"
+    assert jira_metadata["source_kind"] == "jira.mention"
+    assert jira_metadata["subscription_id"] == "jira-sub"
+    assert jira_metadata["subscription_mode"] == "poll"
+    assert jira_metadata["binding_id"] == "jira-bind-1"
+
+    confluence_metadata = json.loads(confluence_payload["metadata_json"])
+    assert confluence_metadata["trigger_mode"] == "poll"
+    assert confluence_metadata["source_kind"] == "confluence.mention"
+    assert confluence_metadata["subscription_id"] == "conf-sub"
+    assert confluence_metadata["subscription_mode"] == "poll"
+    assert confluence_metadata["binding_id"] == "conf-bind-1"
 
 
 @pytest.mark.asyncio
@@ -286,3 +320,25 @@ async def test_run_once_reuses_single_client_session_per_run(monkeypatch):
     assert len(session_constructors) == 1
     assert sessions_seen
     assert all(session is session_constructors[0] for session in sessions_seen)
+
+
+@pytest.mark.asyncio
+async def test_stop_sets_event_and_allows_start_loop_to_exit_promptly(monkeypatch):
+    from src.cron.subscription_watchers import SubscriptionWatcherManager
+
+    manager = SubscriptionWatcherManager()
+    run_once_started = asyncio.Event()
+
+    async def _fake_run_once():
+        run_once_started.set()
+
+    monkeypatch.setattr(manager, "run_once", _fake_run_once)
+    monkeypatch.setattr("src.cron.subscription_watchers.get_interval_seconds", lambda: 999)
+
+    start_task = asyncio.create_task(manager.start())
+    await asyncio.wait_for(run_once_started.wait(), timeout=1.0)
+
+    await manager.stop()
+    await asyncio.wait_for(start_task, timeout=1.0)
+
+    assert start_task.done()

--- a/tests/test_subscription_watchers.py
+++ b/tests/test_subscription_watchers.py
@@ -136,6 +136,8 @@ async def test_poll_github_review_requests_posts_normalized_ingress(monkeypatch)
     assert metadata["subscription_id"] == "sub-1"
     assert metadata["subscription_mode"] == "poll"
     assert metadata["binding_id"] == "b-1"
+    assert metadata["binding_lookup_username"] == "reviewer1"
+    assert metadata["reviewer_login"] == "reviewer1"
 
 
 @pytest.mark.asyncio
@@ -242,6 +244,7 @@ async def test_build_mention_ingress_payloads_for_github_jira_confluence(monkeyp
     assert github_metadata["subscription_id"] == "gh-sub"
     assert github_metadata["subscription_mode"] == "poll"
     assert github_metadata["binding_id"] == "gh-bind-1"
+    assert github_metadata["binding_lookup_username"] == "reviewer1"
 
     jira_metadata = json.loads(jira_payload["metadata_json"])
     assert jira_metadata["trigger_mode"] == "poll"
@@ -249,6 +252,7 @@ async def test_build_mention_ingress_payloads_for_github_jira_confluence(monkeyp
     assert jira_metadata["subscription_id"] == "jira-sub"
     assert jira_metadata["subscription_mode"] == "poll"
     assert jira_metadata["binding_id"] == "jira-bind-1"
+    assert jira_metadata["binding_lookup_username"] == "reviewer1"
 
     confluence_metadata = json.loads(confluence_payload["metadata_json"])
     assert confluence_metadata["trigger_mode"] == "poll"
@@ -256,6 +260,7 @@ async def test_build_mention_ingress_payloads_for_github_jira_confluence(monkeyp
     assert confluence_metadata["subscription_id"] == "conf-sub"
     assert confluence_metadata["subscription_mode"] == "poll"
     assert confluence_metadata["binding_id"] == "conf-bind-1"
+    assert confluence_metadata["binding_lookup_username"] == "reviewer1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_subscription_watchers.py
+++ b/tests/test_subscription_watchers.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 import asyncio
+from pathlib import Path
 
 
 @pytest.mark.asyncio
@@ -388,3 +389,8 @@ async def test_stop_is_safe_when_not_running():
     await manager.stop()
 
     assert manager._stop_event.is_set() is True
+
+
+def test_subscription_watchers_does_not_call_execute_tool_directly():
+    source = Path("src/cron/subscription_watchers.py").read_text(encoding="utf-8")
+    assert "execute_tool(" not in source


### PR DESCRIPTION
### Motivation
- Provide a Portal-driven, ingress-only watcher that pulls enabled poll/hybrid subscriptions and identity bindings from Portal and forwards normalized external events to Portal ingress instead of directly executing tools.
- Ensure github.pull_request_review_requested polling is fully supported and unify mention ingress for GitHub/Jira/Confluence so Portal can create queued tasks and drive execution control-plane.
- Keep existing runtime execution paths, `/api/tasks/execute`, and `jira_reconciliation` behavior unchanged while fixing obvious bugs in the legacy mention poller used by tests.

### Description
- Added `src/cron/subscription_watchers.py` implementing `WatchSubscription` and `SubscriptionWatcherManager` that:
  - Pulls subscriptions from `/api/internal/external-event-subscriptions?agent_id=<PORTAL_AGENT_ID>&enabled=true` and identity bindings from `/api/internal/agent-identity-bindings?enabled=true`.
  - Filters to `mode in {"poll","hybrid"}` and non-empty `source_kind`, selects bindings per rules, reuses one `ClientSession` per `run_once`, and bounds in-process dedupe cache (max 1000 keys per subscription).
  - Implements complete `github.pull_request_review_requested` polling: resolves reviewer from bindings, determines repo list, calls `github_channel.search_issues()` and `github_channel.get_pull_request()`, builds `dedupe_key` and POSTs normalized ingress to `/api/internal/external-events/ingest` with `payload_json` and `metadata_json` strings.
  - Implements mention ingress (discovery + Portal POST only) for `github.mention`, `jira.mention`, and `confluence.mention` using `MentionPoller.extract_mentions` for mention extraction and existing channel APIs, without calling `execute_tool()` or replying to external comments.
- Extended `src/utils/portal_internal_api.py` with `is_portal_internal_configured()` and `build_portal_internal_url()` so watchers can be gracefully disabled when Portal config is incomplete.
- Switched `main.py` startup/shutdown wiring to start/stop the new subscription watchers (log messaging updated to "subscription watchers"); left `jira_reconciliation` startup unchanged.
- Kept `src/cron/mention_poller.py` file for compatibility with existing tests and fixed three defects: moved `logger` init before memory import fallback, corrected Confluence call to `confluence_channel.search_pages`, and converted `_processed` from a class attribute to an instance attribute to avoid cross-instance/test contamination.
- Added `tests/test_subscription_watchers.py` that verifies subscription/binding fetch/filtering, GitHub review polling ingress payload, mention ingress payload generation for GitHub/Jira/Confluence, and single `ClientSession` reuse within a `run_once`.

### Testing
- Ran unit tests: `tests/test_subscription_watchers.py`, `tests/test_mention_poller.py`, and `tests/test_jira_reconciliation.py` with `pytest`; all tests passed.
- Test summary: 42 tests passed, 1 warning (existing file-parser model warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de456d85f0832aaf8817847351c347)