### PR TITLE
Support capped multi-image attachments (llm.max_prompt_images) for /api/chat and /api/chat/stream

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -38,6 +38,10 @@ llm:
   # model: "claude-sonnet-4-20250514"  # or claude-haiku-4-20250514, claude-opus-4-20250514
   
   max_tokens: 1000
+  # Local EFP cap for how many image blocks can be sent in one prompt.
+  # Keep this <= the actual capability of your upstream model/runtime.
+  # Default behavior is 1 for backward compatibility.
+  max_prompt_images: 1
   temperature: 0.7
   max_retries: 3
   retry_delay: 1

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -148,6 +148,51 @@ def _format_content(content: str, prefix: str = "", max_length: int = 500) -> st
     return f"{prefix}(content hidden)"
 
 
+def _inject_attached_images_into_last_user_message(
+    messages: List[Dict[str, Any]],
+    attached_images: Optional[List[str]],
+    max_prompt_images: int,
+) -> int:
+    if not attached_images or not messages:
+        return 0
+
+    for i in range(len(messages) - 1, -1, -1):
+        if messages[i].get("role") != "user":
+            continue
+
+        user_content = messages[i].get("content", "")
+        if isinstance(user_content, list):
+            msg_content = []
+            for item in user_content:
+                if isinstance(item, dict):
+                    if item.get("type") == "text":
+                        msg_content.append({"type": "input_text", "text": item.get("text", "")})
+                    elif item.get("type") == "image_url":
+                        img_url = item.get("image_url", {}).get("url") if isinstance(item.get("image_url"), dict) else str(item.get("image_url", ""))
+                        if img_url:
+                            msg_content.append({"type": "input_image", "image_url": img_url})
+                    else:
+                        msg_content.append(item)
+        else:
+            msg_content = [{"type": "input_text", "text": str(user_content)}]
+
+        existing_images = sum(
+            1 for block in msg_content
+            if isinstance(block, dict) and block.get("type") == "input_image"
+        )
+        remaining_slots = max_prompt_images - existing_images
+        added_count = 0
+        if remaining_slots > 0:
+            for img in attached_images[:remaining_slots]:
+                msg_content.append({"type": "input_image", "image_url": img})
+                added_count += 1
+
+        messages[i] = {"role": "user", "content": msg_content}
+        return added_count
+
+    return 0
+
+
 def _hash_text(value: Any, max_len: int = 800) -> str:
     text = str(value or "")
     if len(text) > max_len:
@@ -975,34 +1020,18 @@ You have access to the following tools. When a user asks you to do something tha
                 ),
             )
         
-        # ===== INJECT ATTACHED IMAGES =====
-        if attached_images and len(messages) > 0:
-            # Find the last user message and add images to it
-            for i in range(len(messages) - 1, -1, -1):
-                if messages[i].get("role") == "user":
-                    user_content = messages[i].get("content", "")
-                    # Build vision content for Responses API (input_image format)
-                    if isinstance(user_content, list):
-                        msg_content = []
-                        for item in user_content:
-                            if isinstance(item, dict):
-                                if item.get("type") == "text":
-                                    msg_content.append({"type": "input_text", "text": item.get("text", "")})
-                                elif item.get("type") == "image_url":
-                                    img_url = item.get("image_url", {}).get("url") if isinstance(item.get("image_url"), dict) else str(item.get("image_url", ""))
-                                    if img_url:
-                                        msg_content.append({"type": "input_image", "image_url": img_url})
-                                else:
-                                    msg_content.append(item)
-                    else:
-                        msg_content = [{"type": "input_text", "text": str(user_content)}]
-                    
-                    for img in attached_images[:1]:
-                        msg_content.append({"type": "input_image", "image_url": img})
-                    messages[i] = {"role": "user", "content": msg_content}
-                    logger.info(f"[Agent] Attached {min(len(attached_images), 1)} image(s) to user message (Responses format)")
-                    break
-        # ===== END IMAGE INJECTION =====
+        max_prompt_images = config.get_max_prompt_images()
+        added_images = _inject_attached_images_into_last_user_message(
+            messages,
+            attached_images,
+            max_prompt_images,
+        )
+        if added_images:
+            logger.info(
+                "[Agent] Attached %s image(s) to user message (Responses format, max_prompt_images=%s)",
+                added_images,
+                max_prompt_images,
+            )
 
         # Convert messages to input_items for Responses API
         def _to_input_items(msgs):

--- a/src/config.py
+++ b/src/config.py
@@ -414,6 +414,19 @@ class Config:
         """Get LLM configuration."""
         return self._config.get("llm", {})
 
+    def get_max_prompt_images(self) -> int:
+        """Return the local EFP cap for image blocks per prompt.
+
+        This is NOT automatic provider capability discovery.
+        It is an operator-configured transport cap. Default: 1.
+        """
+        raw = self.llm.get("max_prompt_images", 1)
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return 1
+        return value if value > 0 else 1
+
     @property
     def session(self) -> Dict[str, Any]:
         """Get session configuration."""

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -19,7 +19,7 @@ import zipfile
 from datetime import datetime
 from pathlib import Path
 from pathlib import PurePosixPath
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 from aiohttp import web, ContentTypeError
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -217,6 +217,74 @@ def _sanitize_trace_value(value: Any, max_len: int = 128) -> Optional[str]:
     if not cleaned:
         return None
     return cleaned[:max_len]
+
+
+async def _collect_attached_images(
+    *,
+    session_id: str,
+    message: str,
+    attachments: Optional[List[str]],
+) -> List[str]:
+    max_prompt_images = global_config.get_max_prompt_images()
+    attached_images: List[str] = []
+    processed_file_ids: Set[str] = set()
+
+    async def process_file(file_id: str) -> bool:
+        if len(attached_images) >= max_prompt_images:
+            return False
+        if not isinstance(file_id, str) or not file_id:
+            return False
+        if file_id in processed_file_ids:
+            return False
+        try:
+            from src.utils.file_parser.storage import get_file_path
+            metadata = get_metadata(file_id)
+            if metadata.session_id and metadata.session_id != session_id:
+                logger.warning(f"[api_chat] File {file_id} belongs to different session")
+                return False
+            if metadata.content_type and metadata.content_type.startswith('image/'):
+                file_path = get_file_path(file_id)
+                if file_path.exists():
+                    import base64
+                    img_data = await asyncio.to_thread(
+                        lambda: base64.b64encode(file_path.read_bytes()).decode('utf-8')
+                    )
+                    ext = metadata.content_type.split('/')[-1]
+                    attached_images.append(f'data:image/{ext};base64,{img_data}')
+                    processed_file_ids.add(file_id)
+                    return True
+        except StoredFileNotFoundError:
+            logger.warning(f"[api_chat] File {file_id} not found")
+        except Exception as e:
+            logger.warning(f"[api_chat] Failed to process file {safe_preview(file_id, 80)}: {sanitize_exception_message(e)}")
+        return False
+
+    try:
+        refs = re.findall(r'@file_([a-zA-Z0-9]+)', message)
+        for short_id in dict.fromkeys(refs):
+            try:
+                metadata = get_metadata(short_id)
+                await process_file(metadata.file_id)
+            except (StoredFileNotFoundError, ValueError):
+                from src.utils.file_parser.storage import find_file_by_prefix
+                try:
+                    fid = find_file_by_prefix(short_id)
+                    if fid:
+                        await process_file(fid)
+                except ValueError as ve:
+                    logger.warning(f"[api_chat] Prefix lookup failed: {sanitize_exception_message(ve)}")
+            if len(attached_images) >= max_prompt_images:
+                break
+    except Exception as e:
+        logger.warning(f"[api_chat] @file_ parse error: {sanitize_exception_message(e)}")
+
+    if attachments and isinstance(attachments, list):
+        for file_id in attachments:
+            await process_file(file_id)
+            if len(attached_images) >= max_prompt_images:
+                break
+
+    return attached_images
 
 
 def _extract_task_trace_headers(request: web.Request) -> Dict[str, Optional[str]]:
@@ -514,66 +582,11 @@ async def api_chat(request: web.Request) -> web.Response:
         
         logger.info(f"[api_chat] Processing message for session: {session_id}")
         
-        # Process attachments from both @file_ references (backward compat) and attachments field
-        attached_images = []
-        
-        # Helper to process a single file_id
-        async def process_file(file_id: str) -> bool:
-            """Process a file_id and add to attached_images if valid. Returns True if processed."""
-            nonlocal attached_images
-            # Only process first image to avoid large payloads
-            if attached_images:
-                return True
-            try:
-                from src.utils.file_parser.storage import get_metadata, get_file_path, StoredFileNotFoundError
-                metadata = get_metadata(file_id)
-                # Validate session ownership
-                if metadata.session_id and metadata.session_id != session_id:
-                    logger.warning(f"[api_chat] File {file_id} belongs to different session")
-                    return False
-                # Check if it's an image
-                if metadata.content_type and metadata.content_type.startswith('image/'):
-                    file_path = get_file_path(file_id)
-                    if file_path.exists():
-                        import base64
-                        img_data = await asyncio.to_thread(
-                            lambda: base64.b64encode(file_path.read_bytes()).decode('utf-8')
-                        )
-                        ext = metadata.content_type.split('/')[-1]
-                        attached_images.append(f'data:image/{ext};base64,{img_data}')
-                        return True
-            except StoredFileNotFoundError:
-                logger.warning(f"[api_chat] File {file_id} not found")
-            except Exception as e:
-                logger.warning(f"[api_chat] Failed to process file {safe_preview(file_id, 80)}: {sanitize_exception_message(e)}")
-            return False
-        
-        # 1. Parse @file_ references from message (backward compatibility)
-        try:
-            refs = re.findall(r'@file_([a-zA-Z0-9]+)', message)
-            for short_id in set(refs):
-                # Try exact match first, then prefix match
-                try:
-                    from src.utils.file_parser.storage import get_metadata
-                    metadata = get_metadata(short_id)
-                    if await process_file(metadata.file_id):
-                        break  # Stop after first image
-                except (StoredFileNotFoundError, ValueError):
-                    # Try prefix match using public helper (handles short/ambiguous prefixes)
-                    from src.utils.file_parser.storage import find_file_by_prefix
-                    try:
-                        fid = find_file_by_prefix(short_id)
-                        if fid:
-                            await process_file(fid)
-                    except ValueError as ve:
-                        logger.warning(f"[api_chat] Prefix lookup failed: {sanitize_exception_message(ve)}")
-        except Exception as e:
-            logger.warning(f"[api_chat] @file_ parse error: {sanitize_exception_message(e)}")
-        
-        # 2. Process attachments from new attachments field
-        if attachments and isinstance(attachments, list):
-            for file_id in attachments:
-                await process_file(file_id)
+        attached_images = await _collect_attached_images(
+            session_id=session_id,
+            message=message,
+            attachments=attachments if isinstance(attachments, list) else None,
+        )
         
         # Set placeholder message if only images
         if attached_images and not message.strip():
@@ -803,13 +816,22 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         data = await request.json()
         message = (data.get('message') or '').strip()
         session_id = data.get('session_id', f'webchat_{datetime.utcnow().strftime("%Y%m%d_%H%M%S")}')
+        attachments = data.get('attachments')
         portal_user_id, portal_user_name = _extract_portal_identity(request, data)
         execution_metadata = _extract_trusted_control_plane_metadata(request, data)
         client_request_id = _extract_trusted_client_request_id(request, data)
         request_id = client_request_id or f"chat-{uuid.uuid4()}"
         effective_user_name = _resolve_chat_display_user_name(data, portal_user_name)
 
-        if not message:
+        attached_images = await _collect_attached_images(
+            session_id=session_id,
+            message=message,
+            attachments=attachments if isinstance(attachments, list) else None,
+        )
+        if attached_images and not message.strip():
+            message = "[image]"
+
+        if not message.strip() and not attached_images:
             response = web.json_response({'error': 'Empty message'}, status=400)
             return response
 
@@ -868,6 +890,8 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
                 portal_user_id=portal_user_id,
                 portal_user_name=portal_user_name,
                 stream_callback=event_queue,
+                attached_images=attached_images if attached_images else None,
+                attachments=attachments if attachments else None,
                 request_path="/api/chat/stream",
                 execution_metadata=execution_metadata,
                 agent_id=runtime_agent_id,

--- a/tests/test_agent_multiple_images.py
+++ b/tests/test_agent_multiple_images.py
@@ -1,0 +1,45 @@
+from src.agents.core import _inject_attached_images_into_last_user_message
+
+
+def test_inject_attached_images_into_last_user_message_adds_two_images():
+    messages = [{"role": "user", "content": "compare these"}]
+    attached_images = ["data:image/png;base64,AAA", "data:image/png;base64,BBB"]
+
+    added_count = _inject_attached_images_into_last_user_message(
+        messages=messages,
+        attached_images=attached_images,
+        max_prompt_images=2,
+    )
+
+    assert added_count == 2
+    assert isinstance(messages[0]["content"], list)
+
+    text_blocks = [b for b in messages[0]["content"] if isinstance(b, dict) and b.get("type") == "input_text"]
+    image_blocks = [b for b in messages[0]["content"] if isinstance(b, dict) and b.get("type") == "input_image"]
+
+    assert len(text_blocks) == 1
+    assert len(image_blocks) == 2
+    assert image_blocks[0]["image_url"] == "data:image/png;base64,AAA"
+    assert image_blocks[1]["image_url"] == "data:image/png;base64,BBB"
+
+
+def test_inject_attached_images_respects_existing_image_blocks_and_remaining_capacity():
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "input_text", "text": "compare"},
+            {"type": "input_image", "image_url": "data:image/png;base64,EXISTING"},
+        ],
+    }]
+    attached_images = ["data:image/png;base64,AAA", "data:image/png;base64,BBB"]
+
+    added_count = _inject_attached_images_into_last_user_message(
+        messages=messages,
+        attached_images=attached_images,
+        max_prompt_images=2,
+    )
+
+    assert added_count == 1
+    image_blocks = [b for b in messages[0]["content"] if isinstance(b, dict) and b.get("type") == "input_image"]
+    assert len(image_blocks) == 2
+    assert image_blocks[1]["image_url"] == "data:image/png;base64,AAA"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,43 @@ import pytest
 from src.config import Config
 
 
+def test_get_max_prompt_images_defaults_to_one(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "llm:\n"
+        "  api_key: test\n"
+        "  model: gpt-5-mini\n"
+    )
+    config = Config(str(config_path))
+
+    assert config.get_max_prompt_images() == 1
+
+
+def test_get_max_prompt_images_parses_and_clamps_values(tmp_path):
+    config_path = tmp_path / "config.yaml"
+
+    config_path.write_text(
+        "llm:\n"
+        "  max_prompt_images: \"2\"\n"
+    )
+    config = Config(str(config_path))
+    assert config.get_max_prompt_images() == 2
+
+    config_path.write_text(
+        "llm:\n"
+        "  max_prompt_images: 0\n"
+    )
+    config.load()
+    assert config.get_max_prompt_images() == 1
+
+    config_path.write_text(
+        "llm:\n"
+        "  max_prompt_images: abc\n"
+    )
+    config.load()
+    assert config.get_max_prompt_images() == 1
+
+
 class TestConfigBasic:
     """Basic configuration tests."""
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -595,6 +595,157 @@ async def test_api_chat_stream_resolves_portal_identity_from_headers(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_api_chat_forwards_two_attached_images_when_max_prompt_images_is_two(monkeypatch, tmp_path):
+    from src.gateway import webchat
+    from src.utils.file_parser import storage
+
+    captured = {}
+    one = tmp_path / "one.png"
+    two = tmp_path / "two.png"
+    one.write_bytes(b"one")
+    two.write_bytes(b"two")
+
+    class _Meta:
+        def __init__(self, file_id: str, session_id: str):
+            self.file_id = file_id
+            self.session_id = session_id
+            self.content_type = "image/png"
+
+    metadata_map = {"f1": _Meta("f1", "s1"), "f2": _Meta("f2", "s1")}
+    file_map = {"f1": one, "f2": two}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai", "max_prompt_images": 2}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+    monkeypatch.setattr(webchat, "get_metadata", lambda file_id: metadata_map[file_id])
+    monkeypatch.setattr(storage, "get_file_path", lambda file_id: file_map[file_id])
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "compare", "session_id": "s1", "attachments": ["f1", "f2"]}
+
+    response = await webchat.api_chat(_Request())
+    assert response.status == 200
+    assert len(captured["attached_images"]) == 2
+    assert captured["attached_images"][0].startswith("data:image/png;base64,")
+    assert captured["attached_images"][1].startswith("data:image/png;base64,")
+    assert captured["attached_images"][0].endswith("b25l")
+    assert captured["attached_images"][1].endswith("dHdv")
+
+
+@pytest.mark.asyncio
+async def test_api_chat_stream_forwards_two_attached_images_when_max_prompt_images_is_two(monkeypatch, tmp_path):
+    from src.gateway import webchat
+    from src.utils.file_parser import storage
+
+    captured = {}
+    one = tmp_path / "one.png"
+    two = tmp_path / "two.png"
+    one.write_bytes(b"one")
+    two.write_bytes(b"two")
+
+    class _Meta:
+        def __init__(self, file_id: str, session_id: str):
+            self.file_id = file_id
+            self.session_id = session_id
+            self.content_type = "image/png"
+
+    metadata_map = {"f1": _Meta("f1", "s2"), "f2": _Meta("f2", "s2")}
+    file_map = {"f1": one, "f2": two}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data)
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai", "max_prompt_images": 2}}, raising=False)
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+    monkeypatch.setattr(webchat, "get_metadata", lambda file_id: metadata_map[file_id])
+    monkeypatch.setattr(storage, "get_file_path", lambda file_id: file_map[file_id])
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "compare", "session_id": "s2", "attachments": ["f1", "f2"]}
+
+    response = await webchat.api_chat_stream(_Request())
+    assert response.status == 200
+    assert len(captured["attached_images"]) == 2
+    assert captured["attached_images"][0].endswith("b25l")
+    assert captured["attached_images"][1].endswith("dHdv")
+    assert captured["attachments"] == ["f1", "f2"]
+
+
+@pytest.mark.asyncio
+async def test_api_chat_defaults_to_one_image_when_max_prompt_images_is_unset(monkeypatch, tmp_path):
+    from src.gateway import webchat
+    from src.utils.file_parser import storage
+
+    captured = {}
+    one = tmp_path / "one.png"
+    two = tmp_path / "two.png"
+    one.write_bytes(b"one")
+    two.write_bytes(b"two")
+
+    class _Meta:
+        def __init__(self, file_id: str, session_id: str):
+            self.file_id = file_id
+            self.session_id = session_id
+            self.content_type = "image/png"
+
+    metadata_map = {"f1": _Meta("f1", "s1"), "f2": _Meta("f2", "s1")}
+    file_map = {"f1": one, "f2": two}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+    monkeypatch.setattr(webchat, "get_metadata", lambda file_id: metadata_map[file_id])
+    monkeypatch.setattr(storage, "get_file_path", lambda file_id: file_map[file_id])
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "compare", "session_id": "s1", "attachments": ["f1", "f2"]}
+
+    response = await webchat.api_chat(_Request())
+    assert response.status == 200
+    assert len(captured["attached_images"]) == 1
+
+
+@pytest.mark.asyncio
 async def test_api_chat_trusted_portal_metadata_passed_to_execution_bus(monkeypatch):
     from src.gateway import webchat
 


### PR DESCRIPTION
### Motivation
- Current chat endpoints only forwarded a single attached image into the user prompt, breaking multi-image workflows and losing user order; operators need a local cap to control how many images are sent per prompt.
- Introduce a single, safe operator-configured cap `llm.max_prompt_images` with default `1` to preserve backward compatibility while allowing multi-image prompts when explicitly enabled.

### Description
- Added `Config.get_max_prompt_images()` in `src/config.py` to parse `llm.max_prompt_images` with safe int parsing and fallback to `1` for invalid/non-positive values.
- Added `max_prompt_images: 1` and operator-facing comments to `config.yaml.example` to document the new local cap.
- Implemented `_collect_attached_images(...)` in `src/gateway/webchat.py` to unify extraction of images from `@file_...` and `attachments`, preserve user order (no `set(refs)`), deduplicate file IDs, enforce `max_prompt_images`, and return data-URL strings; both `api_chat()` and `api_chat_stream()` now call this helper and forward `attached_images`/`attachments` to the execution bus while retaining the `"[image]"` placeholder behavior.
- Refactored agents injection in `src/agents/core.py` by extracting `_inject_attached_images_into_last_user_message(...)` and replacing the previous `attached_images[:1]` logic so the last user message can receive up to `max_prompt_images` `input_image` blocks while respecting existing image blocks and preserving order.
- Changes affect only: `src/config.py`, `config.yaml.example`, `src/gateway/webchat.py`, `src/agents/core.py`, plus tests `tests/test_config.py`, `tests/test_webchat.py`, and new `tests/test_agent_multiple_images.py`.
- Scope note: provider/confluence/jira/tool-result/provider conversion layers were intentionally not modified because the goal is only to fix the transport/assembly path from user attachments into `input_image` blocks.

### Testing
- Added unit tests in `tests/test_config.py` covering default (`test_get_max_prompt_images_defaults_to_one`) and parsing/clamping behavior (`test_get_max_prompt_images_parses_and_clamps_values`).
- Added `tests/test_agent_multiple_images.py` to exercise `_inject_attached_images_into_last_user_message` for multi-image injection and respecting existing images.
- Extended `tests/test_webchat.py` with async tests: `test_api_chat_forwards_two_attached_images_when_max_prompt_images_is_two`, `test_api_chat_stream_forwards_two_attached_images_when_max_prompt_images_is_two`, and `test_api_chat_defaults_to_one_image_when_max_prompt_images_is_unset` to validate sync and stream endpoints and default behavior.
- Ran targeted test selection: `pytest -q tests/test_config.py tests/test_agent_multiple_images.py tests/test_webchat.py -k "max_prompt_images or attached_images or inject_attached_images"` and all selected tests passed (7 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6f1711b4832ab957e3888129ed5f)