### PR TITLE
Honor trusted X-Portal-Agent-Name and surface author_* consistently in chat + history

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -636,6 +636,9 @@ You have access to the following tools. When a user asks you to do something tha
             "response": content,
             "display_blocks": assistant_extra.get("display_blocks", []),
         }
+        for key in ("author_type", "author_id", "author_name", "author_source"):
+            if key in assistant_extra:
+                payload[key] = assistant_extra[key]
         if usage is not None:
             payload["usage"] = usage
         if user_message_id:

--- a/src/gateway/chat_payloads.py
+++ b/src/gateway/chat_payloads.py
@@ -64,7 +64,16 @@ def build_webchat_response_payload(result: Optional[Dict[str, Any]], session_id:
         request_id = getattr(execution_result, "request_id", None) if execution_result is not None else None
     if request_id:
         response_payload["request_id"] = request_id
-    for key in ("user_message_id", "events", "_llm_debug", "reasoning"):
+    for key in (
+        "user_message_id",
+        "events",
+        "_llm_debug",
+        "reasoning",
+        "author_type",
+        "author_id",
+        "author_name",
+        "author_source",
+    ):
         if key in payload_result:
             response_payload[key] = payload_result[key]
     return response_payload

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -119,6 +119,14 @@ def _extract_portal_identity(request: web.Request, data: Dict[str, Any]) -> tupl
     return resolved_user_id, resolved_user_name
 
 
+def _extract_trusted_portal_agent_name(request: web.Request) -> Optional[str]:
+    if not _is_trusted_portal_request(request):
+        return None
+    headers = getattr(request, "headers", {}) or {}
+    agent_name = _sanitize_portal_identity_value(headers.get("X-Portal-Agent-Name"))
+    return agent_name or None
+
+
 def _is_trusted_portal_request(request: web.Request) -> bool:
     headers = getattr(request, "headers", {}) or {}
     portal_source = str(headers.get("X-Portal-Author-Source") or "").strip().lower()
@@ -414,11 +422,15 @@ def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str]
                 return ""
         return str(value).strip()
 
+    trusted_portal_agent_name = _extract_trusted_portal_agent_name(request)
+
     raw_agent_id = app.get("agent_id") if hasattr(app, "get") else None
     raw_agent_name = app.get("agent_name") if hasattr(app, "get") else None
     if raw_agent_id:
         runtime_agent_id = str(raw_agent_id).strip() or None
-    if raw_agent_name:
+    if trusted_portal_agent_name:
+        runtime_agent_name = trusted_portal_agent_name
+    elif raw_agent_name:
         runtime_agent_name = str(raw_agent_name).strip() or None
 
     raw_agent = app.get("agent") if hasattr(app, "get") else None
@@ -455,9 +467,49 @@ def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str]
     return runtime_agent_id, runtime_agent_name
 
 
-def _message_with_display_blocks(message: Dict[str, Any]) -> Dict[str, Any]:
-    """Return assistant messages with normalized display blocks."""
-    return normalize_assistant_history_message(message)
+def _normalize_chat_history_message(
+    message: Dict[str, Any],
+    *,
+    portal_user_id: Optional[str],
+    portal_user_name: Optional[str],
+    runtime_agent_id: Optional[str],
+    runtime_agent_name: Optional[str],
+    trusted_portal_agent_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Normalize history message fields for display blocks and author metadata."""
+    if not isinstance(message, dict):
+        return message
+
+    normalized_message = dict(message)
+    role = normalized_message.get("role")
+
+    if role == "assistant":
+        normalized_message = normalize_assistant_history_message(normalized_message)
+        normalized_message.setdefault("author_type", "agent")
+        normalized_message.setdefault("author_source", "runtime")
+        if runtime_agent_id and not normalized_message.get("author_id"):
+            normalized_message["author_id"] = runtime_agent_id
+        if runtime_agent_name and not normalized_message.get("author_name"):
+            normalized_message["author_name"] = runtime_agent_name
+
+        if trusted_portal_agent_name and runtime_agent_name == trusted_portal_agent_name:
+            author_type = normalized_message.get("author_type")
+            author_id = normalized_message.get("author_id")
+            if (author_type in (None, "agent")) and (
+                not author_id or (runtime_agent_id and author_id == runtime_agent_id)
+            ):
+                normalized_message["author_name"] = runtime_agent_name
+        return normalized_message
+
+    if role == "user":
+        normalized_message.setdefault("author_type", "human")
+        if portal_user_id and not normalized_message.get("author_id"):
+            normalized_message["author_id"] = portal_user_id
+        if portal_user_name and not normalized_message.get("author_name"):
+            normalized_message["author_name"] = portal_user_name
+        if not normalized_message.get("author_source"):
+            normalized_message["author_source"] = "portal" if (portal_user_id or portal_user_name) else "runtime"
+    return normalized_message
 
 
 def load_template(filename: str) -> str:
@@ -1463,8 +1515,22 @@ async def api_load_session(request: web.Request) -> web.Response:
         if not session_info:
             return web.json_response({'error': 'Session not found'}, status=404)
         
+        portal_user_id, portal_user_name = _extract_portal_identity(request, {})
+        runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
+        trusted_portal_agent_name = _extract_trusted_portal_agent_name(request)
+
         history = session_info.get('history', [])
-        normalized_history = [_message_with_display_blocks(msg) for msg in history]
+        normalized_history = [
+            _normalize_chat_history_message(
+                msg,
+                portal_user_id=portal_user_id,
+                portal_user_name=portal_user_name,
+                runtime_agent_id=runtime_agent_id,
+                runtime_agent_name=runtime_agent_name,
+                trusted_portal_agent_name=trusted_portal_agent_name,
+            )
+            for msg in history
+        ]
         
         # Extract session name from first user message
         session_name = 'New Chat'

--- a/tests/test_author_metadata_persistence.py
+++ b/tests/test_author_metadata_persistence.py
@@ -111,6 +111,42 @@ async def test_process_normal_path_persists_user_and_assistant_author_metadata(m
 
 
 @pytest.mark.asyncio
+async def test_process_normal_path_persists_trusted_portal_assistant_display_name(monkeypatch):
+    from src.agents.core import Agent
+    from src.agents import core as core_mod
+
+    calls = []
+    monkeypatch.setattr(core_mod, "session_manager", _mk_session_manager(calls))
+
+    async def fake_fastlane(*args, **kwargs):
+        return None
+
+    async def fake_responses(**kwargs):
+        return {"content": "assistant reply", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.fastlane.process_fastlane_command", fake_fastlane)
+    monkeypatch.setattr(core_mod, "llm_client", SimpleNamespace(responses=fake_responses))
+    monkeypatch.setattr("src.skills.get_tracer", lambda: FakeTracer())
+    monkeypatch.setattr("src.skills.skill_registry._initialized", True)
+    monkeypatch.setattr("src.skills.skill_registry.match_skill", lambda message: [])
+
+    agent = Agent(agent_id="agent-1", agent_name="Portal Agent")
+    await agent.process(
+        message="hello",
+        session_id="s1",
+        user_name="Runtime User",
+        portal_user_id="portal-user-1",
+        portal_user_name="Alice",
+    )
+
+    assistant_call = next(c for c in calls if c["role"] == "assistant")
+    assert assistant_call["author_name"] == "Portal Agent"
+    assert assistant_call["author_id"] == "agent-1"
+    assert assistant_call["author_type"] == "agent"
+    assert assistant_call["author_source"] == "runtime"
+
+
+@pytest.mark.asyncio
 async def test_process_fastlane_path_persists_assistant_author_metadata(monkeypatch):
     from src.agents.core import Agent
     from src.agents import core as core_mod

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -556,6 +556,46 @@ async def test_api_chat_resolves_portal_identity_from_headers(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_api_chat_uses_trusted_portal_agent_name_for_assistant_author(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {
+            "response": "ok",
+            "usage": {},
+            "author_name": kwargs["agent"].agent_name,
+            "author_id": kwargs["agent"].agent_id,
+            "author_type": "agent",
+            "author_source": "runtime",
+            "_execution_result": object(),
+        }
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal", "X-Portal-Agent-Name": "Portal Agent"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-portal-agent-name"}
+
+    resp = await webchat.api_chat(_Request())
+    payload = json.loads(resp.text)
+    assert resp.status == 200
+    assert captured["agent"].agent_name == "Portal Agent"
+    assert payload["author_name"] == "Portal Agent"
+    assert payload["author_id"] == captured["agent"].agent_id
+
+
+@pytest.mark.asyncio
 async def test_api_chat_stream_resolves_portal_identity_from_headers(monkeypatch):
     from src.gateway import webchat
 
@@ -2385,6 +2425,75 @@ async def test_api_load_session_backfills_assistant_display_blocks(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_api_load_session_normalizes_assistant_name_from_trusted_portal_header(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat, "_resolve_runtime_agent_identity", lambda _request: ("agent-1", "Portal Agent"))
+
+    async def _fake_get_session(_session_id):
+        return {
+            "history": [
+                {
+                    "role": "assistant",
+                    "content": "hello from history",
+                    "author_id": "agent-1",
+                    "author_name": "Runtime Alias",
+                    "author_type": "agent",
+                    "author_source": "runtime",
+                },
+            ],
+            "metadata": {},
+        }
+
+    monkeypatch.setattr(webchat.session_manager, "get_session", _fake_get_session)
+
+    class _Request:
+        match_info = {"session_id": "s-load-agent-name"}
+        headers = {"X-Portal-Author-Source": "portal", "X-Portal-Agent-Name": "Portal Agent"}
+        app = {}
+
+    resp = await webchat.api_load_session(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["messages"][0]["author_name"] == "Portal Agent"
+
+
+@pytest.mark.asyncio
+async def test_api_load_session_backfills_user_author_from_trusted_portal_headers(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+
+    async def _fake_get_session(_session_id):
+        return {
+            "history": [
+                {"role": "user", "content": "hello from history"},
+            ],
+            "metadata": {},
+        }
+
+    monkeypatch.setattr(webchat.session_manager, "get_session", _fake_get_session)
+
+    class _Request:
+        match_info = {"session_id": "s-load-user"}
+        headers = {
+            "X-Portal-Author-Source": "portal",
+            "X-Portal-User-Id": "user-1",
+            "X-Portal-User-Name": "Alice",
+        }
+        app = {}
+
+    resp = await webchat.api_load_session(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    user_msg = payload["messages"][0]
+    assert user_msg["author_name"] == "Alice"
+    assert user_msg["author_id"] == "user-1"
+    assert user_msg["author_type"] == "human"
+
+
+@pytest.mark.asyncio
 async def test_api_chat_preserves_structured_display_blocks(monkeypatch):
     from src.gateway import webchat
 
@@ -2522,6 +2631,10 @@ def test_agent_assistant_display_helpers_minimal_payload():
     assert payload["response"] == "hello"
     assert payload["display_blocks"][0]["content"] == "hello"
     assert payload["user_message_id"] == "u1"
+    assert payload["author_name"] == "Assistant"
+    assert payload["author_id"] == "agent-1"
+    assert payload["author_type"] == "agent"
+    assert payload["author_source"] == "runtime"
 
 
 def test_webchat_js_passes_display_blocks_in_both_session_render_paths():

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -635,6 +635,49 @@ async def test_api_chat_stream_resolves_portal_identity_from_headers(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_api_chat_stream_uses_trusted_portal_agent_name_for_agent_identity(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data)
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(
+        webchat.global_config,
+        "_config",
+        {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}},
+        raising=False,
+    )
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal", "X-Portal-Agent-Name": "Portal Agent"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-stream-agent-name"}
+
+    response = await webchat.api_chat_stream(_Request())
+    assert response.status == 200
+    assert captured["agent"].agent_name == "Portal Agent"
+
+
+@pytest.mark.asyncio
 async def test_api_chat_forwards_two_attached_images_when_max_prompt_images_is_two(monkeypatch, tmp_path):
     from src.gateway import webchat
     from src.utils.file_parser import storage

--- a/tests/test_webchat_display_contract.py
+++ b/tests/test_webchat_display_contract.py
@@ -125,6 +125,25 @@ def test_build_webchat_response_payload_backfills_request_id_from_execution_resu
     assert payload["request_id"] == "exec-123"
 
 
+def test_build_webchat_response_payload_forwards_author_metadata():
+    mod = _load_chat_payloads_module()
+    payload = mod.build_webchat_response_payload(
+        {
+            "response": "hello",
+            "author_name": "Portal Agent",
+            "author_id": "agent-1",
+            "author_type": "agent",
+            "author_source": "runtime",
+        },
+        "s-author",
+    )
+
+    assert payload["author_name"] == "Portal Agent"
+    assert payload["author_id"] == "agent-1"
+    assert payload["author_type"] == "agent"
+    assert payload["author_source"] == "runtime"
+
+
 def test_normalize_assistant_history_message_treats_whitespace_content_as_empty():
     mod = _load_chat_payloads_module()
     message = mod.normalize_assistant_history_message(


### PR DESCRIPTION
### Motivation
- Ensure Portal-provided assistant display name (`X-Portal-Agent-Name`) is trusted only for portal requests and produces a consistent `author_name` across optimistic/send (`/api/chat`), response payloads, and history loads (`GET /api/sessions/{id}`).
- Keep existing runtimes and persistence schema unchanged while preventing metadata drift between runtime alias and Portal display name for the main agent.

### Description
- Added trusted header extraction for Portal agent name with `_extract_trusted_portal_agent_name(request)` and only trust it when `_is_trusted_portal_request(request)` is true. (`src/gateway/webchat.py`)
- Updated `_resolve_runtime_agent_identity(request)` to prefer the trusted `X-Portal-Agent-Name` for `runtime_agent_name` while preserving existing `agent_id` resolution paths. (`src/gateway/webchat.py`)
- Implemented request-aware history normalization `_normalize_chat_history_message(...)` and wired it into `api_load_session()` so history messages are normalized for both `display_blocks` and `author_*` fields (with conservative rules that only rename assistant messages when they belong to the current main agent). (`src/gateway/webchat.py`)
- Made `_build_assistant_result_payload()` reuse the same merged assistant extra used for persistence and include `author_type`, `author_id`, `author_name`, and `author_source` in the chat result payload when present. (`src/agents/core.py`)
- Extended `build_webchat_response_payload()` to forward `author_type`, `author_id`, `author_name`, and `author_source` into the final `/api/chat` JSON when they exist in the result. (`src/gateway/chat_payloads.py`)
- Added/expanded unit tests to cover the new contracts and behaviors: import-light contract for payload passthrough and API-level tests validating trusted Portal agent name resolution and history/user backfill. (`tests/test_webchat_display_contract.py`, `tests/test_webchat.py`)

### Testing
- Ran the focused test subset including new and related tests with `pytest -q tests/test_webchat_display_contract.py::test_build_webchat_response_payload_forwards_author_metadata tests/test_webchat.py::test_agent_assistant_display_helpers_minimal_payload tests/test_webchat.py::test_api_chat_resolves_portal_identity_from_headers tests/test_webchat.py::test_api_chat_uses_trusted_portal_agent_name_for_assistant_author tests/test_webchat.py::test_api_load_session_backfills_assistant_display_blocks tests/test_webchat.py::test_api_load_session_normalizes_assistant_name_from_trusted_portal_header tests/test_webchat.py::test_api_load_session_backfills_user_author_from_trusted_portal_headers tests/test_webchat.py::test_assistant_persist_and_result_payload_share_display_blocks tests/test_author_metadata_persistence.py` and all those tests passed.
- Ran a broader run `pytest -q tests/test_webchat_display_contract.py tests/test_webchat.py tests/test_author_metadata_persistence.py`; it failed 3 tests that exercise `src/gateway/static/js/webchat.js` content (JS renderer text/anchor checks), which are unrelated to the backend author metadata logic introduced here; the backend tests (including the newly added ones) passed in focused runs.
- New/modified tests added: `test_build_webchat_response_payload_forwards_author_metadata`, `test_api_chat_uses_trusted_portal_agent_name_for_assistant_author`, `test_api_load_session_normalizes_assistant_name_from_trusted_portal_header`, `test_api_load_session_backfills_user_author_from_trusted_portal_headers`, and expanded `test_agent_assistant_display_helpers_minimal_payload` to assert `author_*` fields.
- Known uncovered edge: there is not a dedicated unit test that exercises the case where a historical assistant message has `author_type` explicitly set to a non-`agent` value and should therefore not be renamed by Portal headers; code contains guards for this but a targeted test for that negative case was not added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df00b500bc832aa21e6e0e55445d1e)