### PR TITLE
Constrain Confluence image attachments to metadata-only output

### DIFF
--- a/src/confluence/__init__.py
+++ b/src/confluence/__init__.py
@@ -52,6 +52,43 @@ def _get_adapter() -> ConfluenceFormatAdapter:
 # ========== Tool Functions ==========
 
 
+def _infer_attachment_media_type(att: dict, filename: str) -> str:
+    """Infer attachment media type from metadata and filename."""
+    media_type = att.get("metadata", {}).get("mediaType")
+    if media_type:
+        return media_type
+
+    media_type = att.get("extensions", {}).get("mediaType")
+    if media_type:
+        return media_type
+
+    extension_to_media_type = {
+        "png": "image/png",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "gif": "image/gif",
+        "webp": "image/webp",
+        "bmp": "image/bmp",
+        "svg": "image/svg+xml",
+        "txt": "text/plain",
+        "md": "text/markdown",
+        "json": "application/json",
+        "csv": "text/csv",
+        "pdf": "application/pdf",
+    }
+
+    if "." in filename:
+        extension = filename.rsplit(".", 1)[-1].lower()
+        return extension_to_media_type.get(extension, "application/octet-stream")
+
+    return "application/octet-stream"
+
+
+def _is_image_attachment(att: dict, filename: str) -> bool:
+    """Check whether an attachment is an image."""
+    media_type = _infer_attachment_media_type(att, filename)
+    return media_type.startswith("image/")
+
 
 async def _process_confluence_attachments(
     page_id: str,
@@ -64,23 +101,36 @@ async def _process_confluence_attachments(
     except Exception as e:
         logger.debug(f"No attachments for page {page_id}: {e}")
         return ""
-    
+
     if not attachments:
         return ""
-    
+
     logger.info(f"Processing {len(attachments)} attachments for page {page_id}")
-    
+
+    shown_attachments = attachments[:5]
+    omitted_count = max(len(attachments) - len(shown_attachments), 0)
+
     results = []
-    for att in attachments[:5]:  # Max 5
+    for att in shown_attachments:
         filename = att.get("title", "unknown")
         size = att.get("extensions", {}).get("fileSize", 0)
-        
         link = att.get("_links", {}).get("download", "")
+        media_type = _infer_attachment_media_type(att, filename)
+
+        if _is_image_attachment(att, filename):
+            if size:
+                results.append(
+                    f"- **{filename}** (image, {size} bytes) [image attachment not auto-expanded]"
+                )
+            else:
+                results.append(f"- **{filename}** (image) [image attachment not auto-expanded]")
+            continue
+
         if link:
             base_url = channel.base_url.rstrip("/")
             auth_header = channel._auth_header if channel.is_configured() else None
             download_url = f"{base_url}{link}"
-            
+
             try:
                 result = await download_and_process_attachment(
                     url=download_url,
@@ -92,30 +142,44 @@ async def _process_confluence_attachments(
                     },
                     auth_header=auth_header,
                 )
-                
-                is_image = result.content_type.startswith("image/")
-                if is_image:
-                    results.append(f"- **{filename}** (image, {size} bytes)")
-                    if result.content_format == "text" and result.content:
-                        preview = result.content[:500]
-                        results.append("  Extracted text:")
-                        results.append(f"  {preview}")
-                    else:
-                        results.append("  [image retrieved, but no text could be extracted]")
-                elif result.content_format == "text" and result.content:
+
+                if result.content_format == "text" and result.content:
                     preview = result.content[:500]
-                    results.append(f"- **{filename}** (text, {size} bytes)")
+                    if size:
+                        results.append(f"- **{filename}** ({media_type}, {size} bytes)")
+                    else:
+                        results.append(f"- **{filename}** ({media_type})")
                     results.append(f"  {preview}")
+                elif result.content_format == "base64":
+                    if size:
+                        results.append(
+                            f"- **{filename}** ({media_type}, {size} bytes) [binary attachment omitted]"
+                        )
+                    else:
+                        results.append(f"- **{filename}** ({media_type}) [binary attachment omitted]")
                 else:
-                    results.append(f"- **{filename}** ({size} bytes)")
+                    if size:
+                        results.append(f"- **{filename}** ({media_type}, {size} bytes)")
+                    else:
+                        results.append(f"- **{filename}** ({media_type})")
             except Exception as e:
                 logger.warning(f"Failed to process {filename}: {e}")
-                results.append(f"- **{filename}** ({size} bytes) - [processing failed]")
+                if size:
+                    results.append(f"- **{filename}** ({media_type}, {size} bytes) - [processing failed]")
+                else:
+                    results.append(f"- **{filename}** ({media_type}) - [processing failed]")
         else:
-            results.append(f"- **{filename}** ({size} bytes)")
-    
+            if size:
+                results.append(f"- **{filename}** ({media_type}, {size} bytes)")
+            else:
+                results.append(f"- **{filename}** ({media_type})")
+
     if results:
-        return "**Attachments:**\n" + "\n".join(results) + "\n"
+        header = f"**Attachments:** (showing first {len(shown_attachments)} of {len(attachments)})"
+        if omitted_count > 0:
+            results.append(f"- ... and {omitted_count} more attachment(s) omitted")
+        return header + "\n" + "\n".join(results) + "\n"
+
     return ""
 
 

--- a/tests/test_confluence_attachment_policy.py
+++ b/tests/test_confluence_attachment_policy.py
@@ -1,0 +1,142 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.utils.attachment import AttachmentResult
+
+
+@pytest.mark.asyncio
+async def test_confluence_image_attachments_are_metadata_only_and_not_downloaded(monkeypatch):
+    import src.confluence as confluence
+
+    monkeypatch.setattr(
+        confluence.confluence_channel,
+        "get_attachments",
+        AsyncMock(
+            return_value=[
+                {
+                    "title": "step-01.png",
+                    "extensions": {"fileSize": 187622},
+                    "_links": {"download": "/download/attachments/123/step-01.png"},
+                    "metadata": {"mediaType": "image/png"},
+                }
+            ]
+        ),
+    )
+
+    mock_download = AsyncMock()
+    monkeypatch.setattr(confluence, "download_and_process_attachment", mock_download)
+
+    result = await confluence._process_confluence_attachments("123")
+
+    assert mock_download.await_count == 0
+    assert "step-01.png" in result
+    assert "image attachment not auto-expanded" in result
+    assert "Extracted text" not in result
+    assert "data:image" not in result
+    assert "base64" not in result
+
+
+@pytest.mark.asyncio
+async def test_confluence_text_attachment_still_uses_existing_preview_flow(monkeypatch):
+    import src.confluence as confluence
+
+    monkeypatch.setattr(
+        confluence.confluence_channel,
+        "get_attachments",
+        AsyncMock(
+            return_value=[
+                {
+                    "title": "notes.txt",
+                    "extensions": {"fileSize": 120},
+                    "_links": {"download": "/download/attachments/123/notes.txt"},
+                    "metadata": {"mediaType": "text/plain"},
+                }
+            ]
+        ),
+    )
+
+    mock_download = AsyncMock(
+        return_value=AttachmentResult(
+            file_id="file-1",
+            content_type="text/plain",
+            content="hello from attachment",
+            content_format="text",
+            filename="notes.txt",
+            metadata={},
+        )
+    )
+    monkeypatch.setattr(confluence, "download_and_process_attachment", mock_download)
+
+    result = await confluence._process_confluence_attachments("123")
+
+    assert mock_download.await_count == 1
+    assert "notes.txt" in result
+    assert "hello from attachment" in result
+
+
+@pytest.mark.asyncio
+async def test_confluence_attachment_output_is_bounded_and_reports_omitted_count(monkeypatch):
+    import src.confluence as confluence
+
+    attachments = [
+        {
+            "title": f"step-{idx}.png",
+            "extensions": {"fileSize": 100 + idx},
+            "_links": {"download": f"/download/attachments/123/step-{idx}.png"},
+            "metadata": {"mediaType": "image/png"},
+        }
+        for idx in range(1, 7)
+    ]
+
+    monkeypatch.setattr(
+        confluence.confluence_channel,
+        "get_attachments",
+        AsyncMock(return_value=attachments),
+    )
+
+    mock_download = AsyncMock()
+    monkeypatch.setattr(confluence, "download_and_process_attachment", mock_download)
+
+    result = await confluence._process_confluence_attachments("123")
+
+    assert "showing first 5 of 6" in result
+    assert "... and 1 more attachment(s) omitted" in result
+    assert mock_download.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_unexpected_base64_result_is_not_inlined(monkeypatch):
+    import src.confluence as confluence
+
+    monkeypatch.setattr(
+        confluence.confluence_channel,
+        "get_attachments",
+        AsyncMock(
+            return_value=[
+                {
+                    "title": "artifact.bin",
+                    "extensions": {"fileSize": 999},
+                    "_links": {"download": "/download/attachments/123/artifact.bin"},
+                    "metadata": {"mediaType": "application/octet-stream"},
+                }
+            ]
+        ),
+    )
+
+    mock_download = AsyncMock(
+        return_value=AttachmentResult(
+            file_id="file-2",
+            content_type="application/octet-stream",
+            content="AAAABBBBCCCCDDDDEEEE",
+            content_format="base64",
+            filename="artifact.bin",
+            metadata={},
+        )
+    )
+    monkeypatch.setattr(confluence, "download_and_process_attachment", mock_download)
+
+    result = await confluence._process_confluence_attachments("123")
+
+    assert "AAAABBBBCCCCDDDDEEEE" not in result
+    assert "[binary attachment omitted]" in result

--- a/tests/test_confluence_image_handling.py
+++ b/tests/test_confluence_image_handling.py
@@ -42,16 +42,13 @@ async def test_confluence_get_page_by_url_processes_attachments_with_instance_ch
 
         assert "# Test Page" in result
         assert "**Attachments:**" in result
-        assert "timeout 30s" in result
+        assert "image attachment not auto-expanded" in result
 
         mock_channel.get_instance_client.assert_called_once_with(
             url="https://right.example/wiki/spaces/SPACE/pages/123456/Page-Title",
             strict=True,
         )
-        mock_download.assert_called_once()
-        call_kwargs = mock_download.call_args.kwargs
-        assert call_kwargs["auth_header"] == instance_channel._auth_header
-        assert call_kwargs["url"].startswith("https://right.example/wiki/")
+        mock_download.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -88,7 +85,8 @@ async def test_confluence_get_page_does_not_emit_raw_base64_for_image_attachment
         assert "**Attachments:**" in result
         assert "image.png" in result
         assert "VERY_LONG_BLOB" not in result
-        assert "no text could be extracted" in result
+        assert "image attachment not auto-expanded" in result
+        mock_download.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Prevent Confluence page reads from automatically downloading/OCR-ing/embedding image attachments which can dramatically inflate LLM context and leak large base64 blobs. 
- Implement a narrow, Confluence-only policy so images are stable metadata-only entries while preserving existing flows for non-image attachments.

### Description
- Modified `src/confluence/__init__.py` to add two helpers: `_infer_attachment_media_type(att, filename)` which infers MIME type from `metadata`, `extensions`, or filename suffix, and `_is_image_attachment(att, filename)` which returns true when the inferred media type starts with `image/`.
- Rewrote `_process_confluence_attachments(page_id, channel=None)` in `src/confluence/__init__.py` to: show only the first 5 attachments with header `**Attachments:** (showing first N of total)`, treat image attachments as metadata-only lines (e.g. `- **step-01.png** (image, 187622 bytes) [image attachment not auto-expanded]`) and absolutely do not call `download_and_process_attachment` for images, and keep the existing download/preview flow for non-image attachments while replacing any `base64` results with a safe placeholder (`[binary attachment omitted]`).
- Did not change `src/utils/attachment.py`, any `src/jira/...` code, nor legacy wrappers in `src/confluence/api.py`, nor portal/agent/webchat code; only the Confluence user-entrypoint `src/confluence/__init__.py` and tests were modified.
- Tests: added `tests/test_confluence_attachment_policy.py` with four focused tests covering image metadata-only behavior, text-attachment preview, bounded output with omitted count, and a base64 non-inline guard; also updated `tests/test_confluence_image_handling.py` expectations to match the metadata-only behavior.

### Testing
- Ran `pytest -q tests/test_confluence_attachment_policy.py tests/test_confluence_image_handling.py` and all tests passed (8 passed).
- Verified the key invariants by tests: image attachments do not trigger `download_and_process_attachment`, image OCR/text is not included, raw base64 is not inlined, non-image text attachments still produce previews, and header reports `showing first N of total` with omitted count when applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df076882fc832aac9dfbe27628f981)