### PR TITLE
Remove runtime max_prompt_images truncation for attached images

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -38,10 +38,6 @@ llm:
   # model: "claude-sonnet-4-20250514"  # or claude-haiku-4-20250514, claude-opus-4-20250514
   
   max_tokens: 1000
-  # Local EFP cap for how many image blocks can be sent in one prompt.
-  # Keep this <= the actual capability of your upstream model/runtime.
-  # Default behavior is 1 for backward compatibility.
-  max_prompt_images: 1
   temperature: 0.7
   max_retries: 3
   retry_delay: 1

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -151,7 +151,6 @@ def _format_content(content: str, prefix: str = "", max_length: int = 500) -> st
 def _inject_attached_images_into_last_user_message(
     messages: List[Dict[str, Any]],
     attached_images: Optional[List[str]],
-    max_prompt_images: int,
 ) -> int:
     if not attached_images or not messages:
         return 0
@@ -176,16 +175,18 @@ def _inject_attached_images_into_last_user_message(
         else:
             msg_content = [{"type": "input_text", "text": str(user_content)}]
 
-        existing_images = sum(
-            1 for block in msg_content
-            if isinstance(block, dict) and block.get("type") == "input_image"
-        )
-        remaining_slots = max_prompt_images - existing_images
+        existing_image_urls = {
+            block.get("image_url")
+            for block in msg_content
+            if isinstance(block, dict) and block.get("type") == "input_image" and block.get("image_url")
+        }
         added_count = 0
-        if remaining_slots > 0:
-            for img in attached_images[:remaining_slots]:
-                msg_content.append({"type": "input_image", "image_url": img})
-                added_count += 1
+        for img in attached_images:
+            if img in existing_image_urls:
+                continue
+            msg_content.append({"type": "input_image", "image_url": img})
+            existing_image_urls.add(img)
+            added_count += 1
 
         messages[i] = {"role": "user", "content": msg_content}
         return added_count
@@ -1023,17 +1024,14 @@ You have access to the following tools. When a user asks you to do something tha
                 ),
             )
         
-        max_prompt_images = config.get_max_prompt_images()
         added_images = _inject_attached_images_into_last_user_message(
             messages,
             attached_images,
-            max_prompt_images,
         )
         if added_images:
             logger.info(
-                "[Agent] Attached %s image(s) to user message (Responses format, max_prompt_images=%s)",
+                "[Agent] Attached %s image(s) to user message (Responses format)",
                 added_images,
-                max_prompt_images,
             )
 
         # Convert messages to input_items for Responses API

--- a/src/config.py
+++ b/src/config.py
@@ -414,19 +414,6 @@ class Config:
         """Get LLM configuration."""
         return self._config.get("llm", {})
 
-    def get_max_prompt_images(self) -> int:
-        """Return the local EFP cap for image blocks per prompt.
-
-        This is NOT automatic provider capability discovery.
-        It is an operator-configured transport cap. Default: 1.
-        """
-        raw = self.llm.get("max_prompt_images", 1)
-        try:
-            value = int(raw)
-        except (TypeError, ValueError):
-            return 1
-        return value if value > 0 else 1
-
     @property
     def session(self) -> Dict[str, Any]:
         """Get session configuration."""

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -233,13 +233,10 @@ async def _collect_attached_images(
     message: str,
     attachments: Optional[List[str]],
 ) -> List[str]:
-    max_prompt_images = global_config.get_max_prompt_images()
     attached_images: List[str] = []
     processed_file_ids: Set[str] = set()
 
     async def process_file(file_id: str) -> bool:
-        if len(attached_images) >= max_prompt_images:
-            return False
         if not isinstance(file_id, str) or not file_id:
             return False
         if file_id in processed_file_ids:
@@ -281,16 +278,12 @@ async def _collect_attached_images(
                         await process_file(fid)
                 except ValueError as ve:
                     logger.warning(f"[api_chat] Prefix lookup failed: {sanitize_exception_message(ve)}")
-            if len(attached_images) >= max_prompt_images:
-                break
     except Exception as e:
         logger.warning(f"[api_chat] @file_ parse error: {sanitize_exception_message(e)}")
 
     if attachments and isinstance(attachments, list):
         for file_id in attachments:
             await process_file(file_id)
-            if len(attached_images) >= max_prompt_images:
-                break
 
     return attached_images
 

--- a/tests/test_agent_multiple_images.py
+++ b/tests/test_agent_multiple_images.py
@@ -8,7 +8,6 @@ def test_inject_attached_images_into_last_user_message_adds_two_images():
     added_count = _inject_attached_images_into_last_user_message(
         messages=messages,
         attached_images=attached_images,
-        max_prompt_images=2,
     )
 
     assert added_count == 2
@@ -23,7 +22,7 @@ def test_inject_attached_images_into_last_user_message_adds_two_images():
     assert image_blocks[1]["image_url"] == "data:image/png;base64,BBB"
 
 
-def test_inject_attached_images_respects_existing_image_blocks_and_remaining_capacity():
+def test_inject_attached_images_skips_duplicate_existing_image_url():
     messages = [{
         "role": "user",
         "content": [
@@ -31,15 +30,15 @@ def test_inject_attached_images_respects_existing_image_blocks_and_remaining_cap
             {"type": "input_image", "image_url": "data:image/png;base64,EXISTING"},
         ],
     }]
-    attached_images = ["data:image/png;base64,AAA", "data:image/png;base64,BBB"]
+    attached_images = ["data:image/png;base64,EXISTING", "data:image/png;base64,AAA"]
 
     added_count = _inject_attached_images_into_last_user_message(
         messages=messages,
         attached_images=attached_images,
-        max_prompt_images=2,
     )
 
     assert added_count == 1
     image_blocks = [b for b in messages[0]["content"] if isinstance(b, dict) and b.get("type") == "input_image"]
     assert len(image_blocks) == 2
+    assert image_blocks[0]["image_url"] == "data:image/png;base64,EXISTING"
     assert image_blocks[1]["image_url"] == "data:image/png;base64,AAA"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,43 +10,6 @@ import pytest
 from src.config import Config
 
 
-def test_get_max_prompt_images_defaults_to_one(tmp_path):
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text(
-        "llm:\n"
-        "  api_key: test\n"
-        "  model: gpt-5-mini\n"
-    )
-    config = Config(str(config_path))
-
-    assert config.get_max_prompt_images() == 1
-
-
-def test_get_max_prompt_images_parses_and_clamps_values(tmp_path):
-    config_path = tmp_path / "config.yaml"
-
-    config_path.write_text(
-        "llm:\n"
-        "  max_prompt_images: \"2\"\n"
-    )
-    config = Config(str(config_path))
-    assert config.get_max_prompt_images() == 2
-
-    config_path.write_text(
-        "llm:\n"
-        "  max_prompt_images: 0\n"
-    )
-    config.load()
-    assert config.get_max_prompt_images() == 1
-
-    config_path.write_text(
-        "llm:\n"
-        "  max_prompt_images: abc\n"
-    )
-    config.load()
-    assert config.get_max_prompt_images() == 1
-
-
 class TestConfigBasic:
     """Basic configuration tests."""
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -678,113 +678,7 @@ async def test_api_chat_stream_uses_trusted_portal_agent_name_for_agent_identity
 
 
 @pytest.mark.asyncio
-async def test_api_chat_forwards_two_attached_images_when_max_prompt_images_is_two(monkeypatch, tmp_path):
-    from src.gateway import webchat
-    from src.utils.file_parser import storage
-
-    captured = {}
-    one = tmp_path / "one.png"
-    two = tmp_path / "two.png"
-    one.write_bytes(b"one")
-    two.write_bytes(b"two")
-
-    class _Meta:
-        def __init__(self, file_id: str, session_id: str):
-            self.file_id = file_id
-            self.session_id = session_id
-            self.content_type = "image/png"
-
-    metadata_map = {"f1": _Meta("f1", "s1"), "f2": _Meta("f2", "s1")}
-    file_map = {"f1": one, "f2": two}
-
-    async def _fake_run_chat_via_execution_bus(**kwargs):
-        captured.update(kwargs)
-        return {"response": "ok", "usage": {}}
-
-    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
-    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
-    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai", "max_prompt_images": 2}}, raising=False)
-    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
-    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
-    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
-    monkeypatch.setattr(webchat, "get_metadata", lambda file_id: metadata_map[file_id])
-    monkeypatch.setattr(storage, "get_file_path", lambda file_id: file_map[file_id])
-
-    class _Request:
-        app = {}
-        headers = {}
-
-        async def json(self):
-            return {"message": "compare", "session_id": "s1", "attachments": ["f1", "f2"]}
-
-    response = await webchat.api_chat(_Request())
-    assert response.status == 200
-    assert len(captured["attached_images"]) == 2
-    assert captured["attached_images"][0].startswith("data:image/png;base64,")
-    assert captured["attached_images"][1].startswith("data:image/png;base64,")
-    assert captured["attached_images"][0].endswith("b25l")
-    assert captured["attached_images"][1].endswith("dHdv")
-
-
-@pytest.mark.asyncio
-async def test_api_chat_stream_forwards_two_attached_images_when_max_prompt_images_is_two(monkeypatch, tmp_path):
-    from src.gateway import webchat
-    from src.utils.file_parser import storage
-
-    captured = {}
-    one = tmp_path / "one.png"
-    two = tmp_path / "two.png"
-    one.write_bytes(b"one")
-    two.write_bytes(b"two")
-
-    class _Meta:
-        def __init__(self, file_id: str, session_id: str):
-            self.file_id = file_id
-            self.session_id = session_id
-            self.content_type = "image/png"
-
-    metadata_map = {"f1": _Meta("f1", "s2"), "f2": _Meta("f2", "s2")}
-    file_map = {"f1": one, "f2": two}
-
-    async def _fake_run_chat_via_execution_bus(**kwargs):
-        captured.update(kwargs)
-        return {"response": "ok", "usage": {}}
-
-    class _FakeStreamResponse:
-        def __init__(self, status=200, headers=None):
-            self.status = status
-            self.headers = headers or {}
-            self.writes = []
-
-        async def prepare(self, request):
-            return self
-
-        async def write(self, data):
-            self.writes.append(data)
-
-    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
-    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai", "max_prompt_images": 2}}, raising=False)
-    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
-    monkeypatch.setattr(webchat, "get_metadata", lambda file_id: metadata_map[file_id])
-    monkeypatch.setattr(storage, "get_file_path", lambda file_id: file_map[file_id])
-
-    class _Request:
-        app = {}
-        headers = {}
-
-        async def json(self):
-            return {"message": "compare", "session_id": "s2", "attachments": ["f1", "f2"]}
-
-    response = await webchat.api_chat_stream(_Request())
-    assert response.status == 200
-    assert len(captured["attached_images"]) == 2
-    assert captured["attached_images"][0].endswith("b25l")
-    assert captured["attached_images"][1].endswith("dHdv")
-    assert captured["attachments"] == ["f1", "f2"]
-
-
-@pytest.mark.asyncio
-async def test_api_chat_defaults_to_one_image_when_max_prompt_images_is_unset(monkeypatch, tmp_path):
+async def test_api_chat_forwards_all_attached_images(monkeypatch, tmp_path):
     from src.gateway import webchat
     from src.utils.file_parser import storage
 
@@ -825,7 +719,113 @@ async def test_api_chat_defaults_to_one_image_when_max_prompt_images_is_unset(mo
 
     response = await webchat.api_chat(_Request())
     assert response.status == 200
-    assert len(captured["attached_images"]) == 1
+    assert len(captured["attached_images"]) == 2
+    assert captured["attached_images"][0].startswith("data:image/png;base64,")
+    assert captured["attached_images"][1].startswith("data:image/png;base64,")
+    assert captured["attached_images"][0].endswith("b25l")
+    assert captured["attached_images"][1].endswith("dHdv")
+
+
+@pytest.mark.asyncio
+async def test_api_chat_stream_forwards_all_attached_images(monkeypatch, tmp_path):
+    from src.gateway import webchat
+    from src.utils.file_parser import storage
+
+    captured = {}
+    one = tmp_path / "one.png"
+    two = tmp_path / "two.png"
+    one.write_bytes(b"one")
+    two.write_bytes(b"two")
+
+    class _Meta:
+        def __init__(self, file_id: str, session_id: str):
+            self.file_id = file_id
+            self.session_id = session_id
+            self.content_type = "image/png"
+
+    metadata_map = {"f1": _Meta("f1", "s2"), "f2": _Meta("f2", "s2")}
+    file_map = {"f1": one, "f2": two}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data)
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+    monkeypatch.setattr(webchat, "get_metadata", lambda file_id: metadata_map[file_id])
+    monkeypatch.setattr(storage, "get_file_path", lambda file_id: file_map[file_id])
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "compare", "session_id": "s2", "attachments": ["f1", "f2"]}
+
+    response = await webchat.api_chat_stream(_Request())
+    assert response.status == 200
+    assert len(captured["attached_images"]) == 2
+    assert captured["attached_images"][0].endswith("b25l")
+    assert captured["attached_images"][1].endswith("dHdv")
+    assert captured["attachments"] == ["f1", "f2"]
+
+
+@pytest.mark.asyncio
+async def test_api_chat_forwards_all_attached_images_without_local_cap_config(monkeypatch, tmp_path):
+    from src.gateway import webchat
+    from src.utils.file_parser import storage
+
+    captured = {}
+    one = tmp_path / "one.png"
+    two = tmp_path / "two.png"
+    one.write_bytes(b"one")
+    two.write_bytes(b"two")
+
+    class _Meta:
+        def __init__(self, file_id: str, session_id: str):
+            self.file_id = file_id
+            self.session_id = session_id
+            self.content_type = "image/png"
+
+    metadata_map = {"f1": _Meta("f1", "s1"), "f2": _Meta("f2", "s1")}
+    file_map = {"f1": one, "f2": two}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+    monkeypatch.setattr(webchat, "get_metadata", lambda file_id: metadata_map[file_id])
+    monkeypatch.setattr(storage, "get_file_path", lambda file_id: file_map[file_id])
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "compare", "session_id": "s1", "attachments": ["f1", "f2"]}
+
+    response = await webchat.api_chat(_Request())
+    assert response.status == 200
+    assert len(captured["attached_images"]) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Remove EFP runtime's local per-prompt image cap so all valid images received from the front-end are forwarded to the LLM without EFP-side truncation. 
- The cap existed in two places and caused attachments to be clipped twice; the goal is a minimal, targeted fix that preserves safety checks (session, content type, file dedupe) and does not add any replacement config.

### Description
- Deleted the `Config.get_max_prompt_images()` method and removed `llm.max_prompt_images` from `config.yaml.example` so the runtime no longer exposes a local prompt-image cap.
- Updated `src/gateway/webchat.py::_collect_attached_images()` to stop reading any local cap and to collect all valid session images while keeping `file_id` dedupe, `metadata.session_id` check, `content_type.startswith("image/")` check, and non-fatal error handling when files are missing or unreadable.
- Updated `src/agents/core.py::_inject_attached_images_into_last_user_message()` to drop the `max_prompt_images` parameter and remaining-slot logic, preserve content normalization (`text` -> `input_text`, `image_url` -> `input_image`), append all attached images, and dedupe by `image_url` to avoid duplicate injection into the last user message.
- Removed the `config.get_max_prompt_images()` call and changed the callsite/log message to only report the actual number of images attached (no mention of any local cap).
- Updated tests to reflect the new semantics: removed the two config tests for `get_max_prompt_images`, adjusted webchat tests to assert that all valid attached images are forwarded for both `/api/chat` and `/api/chat/stream`, and updated agent image tests to remove the cap argument and validate duplicate-image skipping.
- Files changed: `src/config.py`, `config.yaml.example`, `src/gateway/webchat.py`, `src/agents/core.py`, `tests/test_config.py`, `tests/test_webchat.py`, `tests/test_agent_multiple_images.py`.

### Testing
- Ran targeted webchat tests with `pytest -q tests/test_webchat.py -k 'forwards_all_attached_images'` and they passed. 
- Ran agent image tests with `pytest -q tests/test_agent_multiple_images.py` and they passed. 
- Ran config tests excluding an unrelated accessor test with `pytest -q tests/test_config.py -k 'not property_accessors'` and they passed. 
- Ran the combined command `pytest -q tests/test_config.py tests/test_webchat.py tests/test_agent_multiple_images.py`; the majority of tests passed but 4 unrelated existing failures surfaced in the full run: `TestConfigEdgeCases::test_config_property_accessors` and three WebChat JS renderer assertions, which are pre-existing and outside the scope of this change. 
- Confirmed `rg -n "max_prompt_images" .` returns no matches (no residual references).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5872f758832a833307dc3076c7af)