### PR TITLE
feat(runtime): add session rename/delete APIs and unified display name resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ For complete control-plane contract details, see `docs/control_plane_contract.md
 |----------|--------|-------------|
 | `/api/sessions` | GET | List all sessions |
 | `/api/sessions/{id}` | GET | Load session history |
+| `/api/sessions/{id}/rename` | POST | Rename session |
+| `/api/sessions/{id}` | DELETE | Delete session |
 | `/api/sessions/{id}/clear` | POST | Clear session history |
 | `/api/clear` | POST | Clear all sessions |
 

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -265,7 +265,7 @@ class Gateway:
         Returns: List of sessions with name, last message, timestamp
         """
         from datetime import datetime
-        from src.sessions.manager import session_manager
+        from src.sessions.manager import resolve_session_display_name, session_manager
 
         logger.info(f"[handle_list_sessions] ENTERING - listing sessions")
 
@@ -299,11 +299,7 @@ class Gateway:
                 if not user_messages:
                     continue
 
-                # Get first user message as session name
-                first_user_msg = user_messages[0]
-                session_name = truncate(first_user_msg.get("content", "") or "New Chat", 30)
-                if not session_name.strip():
-                    session_name = "New Chat"
+                session_name = resolve_session_display_name(session)
 
                 # Get last message preview
                 last_message = ""

--- a/src/gateway/static/css/webchat.css
+++ b/src/gateway/static/css/webchat.css
@@ -1412,6 +1412,32 @@ body {
     min-width: 0;
 }
 
+.recent-session-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.session-action-btn {
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-input);
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    padding: 2px 6px;
+    cursor: pointer;
+    transition: all var(--duration-fast);
+}
+
+.session-action-btn:hover {
+    color: var(--color-text);
+}
+
+.session-action-btn.danger:hover {
+    border-color: rgba(239, 68, 68, 0.4);
+    color: #ef4444;
+}
+
 .recent-session-name {
     font-weight: 500;
     white-space: nowrap;

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -1806,6 +1806,7 @@
             sessions.forEach((session, index) => {
                 const sessionId = session.session_id || ('session_' + (sessionsOffset + index));
                 const isActive = sessionId === currentActiveId || (index === 0 && sessionsOffset === 0 && !currentActiveId);
+                const sessionName = session.name || session.session_id || ('Chat ' + (sessionsOffset + index + 1));
 
                 const item = document.createElement('div');
                 item.className = `recent-session-item ${isActive ? 'active' : ''}`;
@@ -1815,13 +1816,31 @@
                         <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
                     </svg>
                     <div class="recent-session-info">
-                        <div class="recent-session-name">${escapeHtml(session.name || session.session_id || 'Chat ' + (sessionsOffset + index + 1))}</div>
+                        <div class="recent-session-name">${escapeHtml(sessionName)}</div>
                         <div class="recent-session-preview">${escapeHtml(session.last_message || '')}</div>
+                    </div>
+                    <div class="recent-session-actions">
+                        <button type="button" class="session-action-btn" data-session-action="rename" title="Rename session">Rename</button>
+                        <button type="button" class="session-action-btn danger" data-session-action="delete" title="Delete session">Delete</button>
                     </div>
                 `;
 
                 // Add click handler
                 item.addEventListener('click', function(e) {
+                    const actionEl = e.target.closest('[data-session-action]');
+                    if (actionEl) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        const sid = this.getAttribute('data-session-id');
+                        const action = actionEl.getAttribute('data-session-action');
+                        if (action === 'rename' && sid) {
+                            renameSessionById(sid, sessionName);
+                        } else if (action === 'delete' && sid) {
+                            deleteSessionById(sid);
+                        }
+                        return;
+                    }
+
                     e.preventDefault();
                     const sid = this.getAttribute('data-session-id');
                     console.log('Clicked session:', sid);
@@ -1910,6 +1929,67 @@
             }
         } finally {
             sessionsLoading = false;
+        }
+    }
+
+    async function renameSessionById(sessionId, currentName) {
+        const inputName = prompt('Rename session', currentName || 'New Chat');
+        if (inputName === null) return;
+        const name = String(inputName || '').trim();
+        if (!name) {
+            alert('Session name cannot be empty.');
+            return;
+        }
+        if (name === String(currentName || '').trim()) return;
+
+        try {
+            const response = await fetch('/api/sessions/' + encodeURIComponent(sessionId) + '/rename', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name }),
+            });
+            const data = await response.json();
+            if (!response.ok || data.error) {
+                alert(data.error || 'Failed to rename session.');
+                return;
+            }
+            loadRecentSessions(true);
+        } catch (error) {
+            console.error('Error renaming session:', error);
+            alert('Failed to rename session.');
+        }
+    }
+
+    async function deleteSessionById(sessionId) {
+        const confirmed = confirm('Delete this session? This cannot be undone.');
+        if (!confirmed) return;
+
+        try {
+            const response = await fetch('/api/sessions/' + encodeURIComponent(sessionId), {
+                method: 'DELETE',
+            });
+            const data = await response.json();
+            if (!response.ok || data.error) {
+                alert(data.error || 'Failed to delete session.');
+                return;
+            }
+
+            if (currentSessionId === sessionId) {
+                currentSessionId = null;
+                localStorage.removeItem(SESSION_ID_KEY);
+                messagesContainer.innerHTML = `
+                    <div class="welcome-message">
+                        <h2>👋 New Chat</h2>
+                        <p>Start a new conversation</p>
+                    </div>
+                `;
+                statusSpan.textContent = 'Ready';
+                if (newChatBtn) newChatBtn.classList.add('active');
+            }
+            loadRecentSessions(true);
+        } catch (error) {
+            console.error('Error deleting session:', error);
+            alert('Failed to delete session.');
         }
     }
 

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -63,7 +63,7 @@ from src.gateway.webchat_request_contracts import (
 )
 from src.runtime.capability_registry import get_capability_registry
 from src.gateway.event_bus import emit_agent_event
-from src.sessions.manager import session_manager
+from src.sessions.manager import resolve_session_display_name, session_manager
 from src.sessions.persistence import session_persistence
 from src.sessions.usage import usage_tracker
 
@@ -1458,11 +1458,7 @@ async def api_sessions(request: web.Request) -> web.Response:
                 logger.info(f"[api_sessions] Skipping empty session: {session_id}")
                 continue
             
-            # Get first user message as session name
-            first_user_msg = user_messages[0]
-            session_name = truncate(first_user_msg.get('content', '') or 'New Chat', 30)
-            if not session_name.strip():
-                session_name = 'New Chat'
+            session_name = resolve_session_display_name(session_info)
             
             # Get last message preview
             last_message = ''
@@ -1503,7 +1499,7 @@ async def api_load_session(request: web.Request) -> web.Response:
         if not session_id:
             return web.json_response({'error': 'Session ID required'}, status=400)
         
-        session_info = await session_manager.get_session(session_id)
+        session_info = await session_manager.get_existing_session(session_id)
         
         if not session_info:
             return web.json_response({'error': 'Session not found'}, status=404)
@@ -1525,13 +1521,7 @@ async def api_load_session(request: web.Request) -> web.Response:
             for msg in history
         ]
         
-        # Extract session name from first user message
-        session_name = 'New Chat'
-        for msg in normalized_history:
-            if msg.get('role') == 'user':
-                content = msg.get('content', '') or 'New Chat'
-                session_name = truncate(content, 30)
-                break
+        session_name = resolve_session_display_name(session_info)
         
         return web.json_response({
             'session_id': session_id,
@@ -1972,6 +1962,63 @@ async def api_clear(request: web.Request) -> web.Response:
         return web.json_response({'success': True})
             
     except Exception as e:
+        return web.json_response({'error': str(e)}, status=500)
+
+
+async def api_rename_session(request: web.Request) -> web.Response:
+    """Rename an existing session.
+
+    POST /api/sessions/{session_id}/rename
+    Body: {"name": "new title"}
+    """
+    try:
+        if not session_manager._initialized:
+            await session_manager.initialize()
+
+        session_id = request.match_info.get('session_id', '')
+        if not session_id:
+            return web.json_response({'error': 'Session ID required'}, status=400)
+
+        try:
+            data = await request.json()
+        except (json.JSONDecodeError, ContentTypeError):
+            return web.json_response({'error': 'Invalid JSON in request body'}, status=400)
+
+        name = data.get('name')
+        try:
+            renamed = await session_manager.rename_session(session_id, name)
+        except ValueError as exc:
+            return web.json_response({'error': str(exc)}, status=400)
+
+        if renamed is None:
+            return web.json_response({'error': 'Session not found'}, status=404)
+
+        return web.json_response({'success': True, 'session_id': session_id, 'name': renamed})
+    except Exception as e:
+        logger.error(f"Error renaming session: {e}")
+        return web.json_response({'error': str(e)}, status=500)
+
+
+async def api_delete_session(request: web.Request) -> web.Response:
+    """Delete an existing session.
+
+    DELETE /api/sessions/{session_id}
+    """
+    try:
+        if not session_manager._initialized:
+            await session_manager.initialize()
+
+        session_id = request.match_info.get('session_id', '')
+        if not session_id:
+            return web.json_response({'error': 'Session ID required'}, status=400)
+
+        deleted = await session_manager.delete_session(session_id)
+        if not deleted:
+            return web.json_response({'error': 'Session not found'}, status=404)
+
+        return web.json_response({'success': True, 'session_id': session_id})
+    except Exception as e:
+        logger.error(f"Error deleting session: {e}")
         return web.json_response({'error': str(e)}, status=500)
 
 
@@ -3142,6 +3189,8 @@ def setup_webchat_routes(app: web.Application):
         GET  /api/tasks/{task_id} - Runtime task status for portal polling
         GET  /api/sessions - List recent sessions
         GET  /api/sessions/{session_id} - Load session messages
+        POST /api/sessions/{session_id}/rename - Rename existing session
+        DELETE /api/sessions/{session_id} - Delete existing session
         GET  /api/server-files/* - Canonical path-based workspace file API
         GET  /api/files and /api/files/read - Legacy path-based compatibility aliases
         /api/files/{file_id}* - File-ID attachment APIs (separate from path-based server files)
@@ -3159,6 +3208,8 @@ def setup_webchat_routes(app: web.Application):
     app.router.add_get('/api/capabilities', api_capabilities)
     app.router.add_get('/api/sessions', api_sessions)
     app.router.add_get('/api/sessions/{session_id}', api_load_session)
+    app.router.add_post('/api/sessions/{session_id}/rename', api_rename_session)
+    app.router.add_delete('/api/sessions/{session_id}', api_delete_session)
     app.router.add_get('/api/sessions/{session_id}/chatlog', api_session_chatlog)
     # Primary workspace path-based API
     app.router.add_get('/api/server-files', api_server_files_browse)
@@ -3213,6 +3264,8 @@ def setup_webchat_routes(app: web.Application):
     logger.info("  GET  /api/tasks/{task_id} - Runtime task status for portal polling")
     logger.info("  GET  /api/sessions - List recent sessions")
     logger.info("  GET  /api/sessions/{id} - Load session messages")
+    logger.info("  POST /api/sessions/{id}/rename - Rename existing session")
+    logger.info("  DELETE /api/sessions/{id} - Delete existing session")
     logger.info("  GET  /api/server-files - Browse workspace files")
     logger.info("  GET  /api/server-files/read - Read text file content")
     logger.info("  GET  /api/server-files/content - Inline file content")

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from src.config import config
 from src.sessions.persistence import session_persistence
+from src.utils.truncate import truncate
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,25 @@ JIRA_SESSION_PREFIX = "jira:"
 DEFAULT_MAX_HISTORY = 999999  # Effectively unlimited
 DEFAULT_TTL_SECONDS = 86400  # 24 hours
 DEFAULT_AUTO_SAVE = True
+
+
+def resolve_session_display_name(session: Dict[str, Any]) -> str:
+    """Resolve a session display name from custom metadata or first user message."""
+    metadata = session.get("metadata", {})
+    custom_name = metadata.get("custom_session_name") if isinstance(metadata, dict) else None
+    if isinstance(custom_name, str):
+        custom_name = custom_name.strip()
+        if custom_name:
+            return custom_name
+
+    history = session.get("history", [])
+    if isinstance(history, list):
+        for msg in history:
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                derived = truncate(msg.get("content", "") or "New Chat", 30)
+                return derived if derived.strip() else "New Chat"
+
+    return "New Chat"
 
 
 class SessionManager:
@@ -243,6 +263,70 @@ class SessionManager:
         self._session_timestamps[session_id] = datetime.now()
         
         return self.sessions[session_id]
+
+    async def get_existing_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get an existing session without auto-creating when missing."""
+        if session_id in self.sessions:
+            self._restore_active_skill_session_from_metadata(self.sessions[session_id])
+            self._update_timestamp(session_id)
+            return self.sessions[session_id]
+
+        if self.persistence_enabled:
+            persisted = await session_persistence.load_session(session_id)
+            if persisted:
+                self.sessions[session_id] = {
+                    "history": persisted.get("messages", []),
+                    "user_id": persisted.get("user_id", ""),
+                    "channel": persisted.get("channel", ""),
+                    "metadata": persisted.get("metadata", {}),
+                    "created_at": persisted.get("created_at", datetime.now().isoformat()),
+                    "updated_at": persisted.get("updated_at", datetime.now().isoformat()),
+                    "_persisted": True,
+                }
+                self._restore_active_skill_session_from_metadata(self.sessions[session_id])
+                self._session_timestamps[session_id] = datetime.now()
+                return self.sessions[session_id]
+
+        return None
+
+    async def rename_session(self, session_id: str, new_name: str) -> Optional[str]:
+        """Rename an existing session by setting metadata.custom_session_name."""
+        normalized_name = str(new_name or "").strip()
+        if not normalized_name:
+            raise ValueError("Session name cannot be empty")
+        if len(normalized_name) > 120:
+            raise ValueError("Session name must be at most 120 characters")
+
+        session = await self.get_existing_session(session_id)
+        if not session:
+            return None
+
+        metadata = session.setdefault("metadata", {})
+        metadata["custom_session_name"] = normalized_name
+        session["updated_at"] = datetime.now().isoformat()
+
+        if self.persistence_enabled:
+            await session_persistence.save_session(
+                session_id=session_id,
+                channel=session.get("channel", ""),
+                messages=session.get("history", []),
+                metadata=session.get("metadata", {}),
+            )
+
+        return normalized_name
+
+    async def delete_session(self, session_id: str) -> bool:
+        """Delete a session from memory cache and persistence."""
+        in_memory_removed = session_id in self.sessions
+        if in_memory_removed:
+            del self.sessions[session_id]
+        self._session_timestamps.pop(session_id, None)
+
+        persisted_removed = False
+        if self.persistence_enabled:
+            persisted_removed = await session_persistence.delete_session(session_id)
+
+        return in_memory_removed or persisted_removed
     
     async def add_message(self, session_id: str, role: str, content: str, wait_for_save: bool = False, extra: dict = None) -> str:
         """Add a message to the session history.

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -315,8 +315,31 @@ class SessionManager:
 
         return normalized_name
 
+    def _delete_session_chatlog(self, session_id: str) -> bool:
+        """Delete session chatlog artifact if present."""
+        chatlog_file = session_persistence.storage_dir / "chatlogs" / f"{session_id}.json"
+        try:
+            if chatlog_file.exists():
+                chatlog_file.unlink()
+                return True
+            return False
+        except Exception as exc:
+            logger.warning("Failed to delete session chatlog for %s: %s", session_id, exc)
+            return False
+
+    def _delete_session_file_context(self, session_id: str) -> bool:
+        """Delete file-context artifacts for session if present."""
+        try:
+            from src.hooks.file_context.storage import storage as file_context_storage
+
+            deleted_count = file_context_storage.delete_session(session_id)
+            return deleted_count > 0
+        except Exception as exc:
+            logger.warning("Failed to delete session file context for %s: %s", session_id, exc)
+            return False
+
     async def delete_session(self, session_id: str) -> bool:
-        """Delete a session from memory cache and persistence."""
+        """Delete a session and best-effort cleanup related local artifacts."""
         in_memory_removed = session_id in self.sessions
         if in_memory_removed:
             del self.sessions[session_id]
@@ -326,7 +349,10 @@ class SessionManager:
         if self.persistence_enabled:
             persisted_removed = await session_persistence.delete_session(session_id)
 
-        return in_memory_removed or persisted_removed
+        chatlog_removed = self._delete_session_chatlog(session_id)
+        file_context_removed = self._delete_session_file_context(session_id)
+
+        return in_memory_removed or persisted_removed or chatlog_removed or file_context_removed
     
     async def add_message(self, session_id: str, role: str, content: str, wait_for_save: bool = False, extra: dict = None) -> str:
         """Add a message to the session history.

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -202,6 +202,20 @@ class TestGatewaySessionManagement:
         route_strs = [str(r.resource.canonical) if r.resource else "" for r in routes]
         assert any("/api/sessions" in p for p in route_strs)
 
+    def test_gateway_session_management_routes_include_rename_and_delete(self):
+        """Gateway should expose rename/delete session management routes."""
+        gateway = Gateway()
+        routes = list(gateway.app.router.routes())
+
+        assert any(
+            r.resource and r.resource.canonical == "/api/sessions/{session_id}/rename" and r.method == "POST"
+            for r in routes
+        )
+        assert any(
+            r.resource and r.resource.canonical == "/api/sessions/{session_id}" and r.method == "DELETE"
+            for r in routes
+        )
+
 
 class TestGatewayRequestHandling:
     """Gateway request handling tests."""

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -168,6 +168,20 @@ class TestSessionPersistence:
         assert info["metadata"]["topic"] == "project讨论"
         assert info["metadata"]["priority"] == "high"
 
+    @pytest.mark.asyncio
+    async def test_metadata_round_trip_preserves_custom_session_name(self, store):
+        session_id = "custom_name_roundtrip"
+        await store.save_session(
+            session_id=session_id,
+            channel="webchat",
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={"custom_session_name": "Runtime Custom Session"},
+        )
+
+        info = await store.load_session(session_id)
+        assert info is not None
+        assert info["metadata"]["custom_session_name"] == "Runtime Custom Session"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -215,6 +215,73 @@ class TestSessionManagerInfo:
         assert deleted is False
 
     @pytest.mark.asyncio
+    async def test_delete_session_removes_chatlog_file_and_returns_true(self, fresh_session_manager, tmp_path):
+        import uuid
+
+        session_id = f"delete_chatlog_{uuid.uuid4().hex[:8]}"
+        from src.sessions import manager as manager_module
+
+        sessions_dir = tmp_path / "sessions"
+        chatlogs_dir = sessions_dir / "chatlogs"
+        chatlogs_dir.mkdir(parents=True, exist_ok=True)
+        chatlog_file = chatlogs_dir / f"{session_id}.json"
+        chatlog_file.write_text('{"session_id":"x"}', encoding="utf-8")
+
+        original_storage_dir = manager_module.session_persistence.storage_dir
+        manager_module.session_persistence.storage_dir = sessions_dir
+        fresh_session_manager.persistence_enabled = False
+        try:
+            deleted = await fresh_session_manager.delete_session(session_id)
+        finally:
+            manager_module.session_persistence.storage_dir = original_storage_dir
+
+        assert deleted is True
+        assert not chatlog_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_delete_session_calls_file_context_cleanup(self, fresh_session_manager, monkeypatch):
+        import uuid
+        from src.hooks.file_context.storage import storage as file_context_storage
+
+        session_id = f"delete_file_context_{uuid.uuid4().hex[:8]}"
+        called = {"session_id": None}
+
+        def _fake_delete_session(sid):
+            called["session_id"] = sid
+            return 2
+
+        monkeypatch.setattr(file_context_storage, "delete_session", _fake_delete_session)
+        fresh_session_manager.persistence_enabled = False
+
+        deleted = await fresh_session_manager.delete_session(session_id)
+
+        assert deleted is True
+        assert called["session_id"] == session_id
+
+    @pytest.mark.asyncio
+    async def test_delete_session_returns_true_when_only_orphan_artifacts_exist(self, fresh_session_manager, tmp_path):
+        import uuid
+        from src.sessions import manager as manager_module
+
+        session_id = f"orphan_artifacts_{uuid.uuid4().hex[:8]}"
+        sessions_dir = tmp_path / "sessions"
+        chatlogs_dir = sessions_dir / "chatlogs"
+        chatlogs_dir.mkdir(parents=True, exist_ok=True)
+        orphan_chatlog = chatlogs_dir / f"{session_id}.json"
+        orphan_chatlog.write_text("{}", encoding="utf-8")
+
+        original_storage_dir = manager_module.session_persistence.storage_dir
+        manager_module.session_persistence.storage_dir = sessions_dir
+        fresh_session_manager.persistence_enabled = False
+        try:
+            deleted = await fresh_session_manager.delete_session(session_id)
+        finally:
+            manager_module.session_persistence.storage_dir = original_storage_dir
+
+        assert deleted is True
+        assert not orphan_chatlog.exists()
+
+    @pytest.mark.asyncio
     async def test_set_last_execution_id_updates_in_memory_and_schedules_metadata_persist(self, fresh_session_manager):
         import uuid
 

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -156,6 +156,65 @@ class TestSessionManagerInfo:
         assert info is None
 
     @pytest.mark.asyncio
+    async def test_get_existing_session_returns_none_for_missing_session(self, fresh_session_manager):
+        import uuid
+
+        session_id = f"missing_existing_{uuid.uuid4().hex[:8]}"
+        existing = await fresh_session_manager.get_existing_session(session_id)
+        assert existing is None
+
+    @pytest.mark.asyncio
+    async def test_rename_session_persists_custom_session_name(self, fresh_session_manager):
+        import uuid
+
+        session_id = f"rename_meta_{uuid.uuid4().hex[:8]}"
+        await fresh_session_manager.get_session(session_id)
+
+        save_calls = []
+
+        async def _fake_save_session(**kwargs):
+            save_calls.append(kwargs)
+            return True
+
+        fresh_session_manager.persistence_enabled = True
+        from src.sessions import manager as manager_module
+        original_save = manager_module.session_persistence.save_session
+        manager_module.session_persistence.save_session = _fake_save_session
+        try:
+            renamed = await fresh_session_manager.rename_session(session_id, "  Renamed Session  ")
+        finally:
+            manager_module.session_persistence.save_session = original_save
+
+        assert renamed == "Renamed Session"
+        assert fresh_session_manager.sessions[session_id]["metadata"]["custom_session_name"] == "Renamed Session"
+        assert len(save_calls) == 1
+        assert save_calls[0]["metadata"]["custom_session_name"] == "Renamed Session"
+
+    @pytest.mark.asyncio
+    async def test_delete_session_removes_session_from_memory_and_returns_true(self, fresh_session_manager):
+        import uuid
+
+        session_id = f"delete_existing_{uuid.uuid4().hex[:8]}"
+        await fresh_session_manager.get_session(session_id)
+        assert session_id in fresh_session_manager.sessions
+
+        fresh_session_manager.persistence_enabled = False
+        deleted = await fresh_session_manager.delete_session(session_id)
+
+        assert deleted is True
+        assert session_id not in fresh_session_manager.sessions
+        assert session_id not in fresh_session_manager._session_timestamps
+
+    @pytest.mark.asyncio
+    async def test_delete_session_returns_false_when_missing(self, fresh_session_manager):
+        import uuid
+
+        session_id = f"delete_missing_{uuid.uuid4().hex[:8]}"
+        fresh_session_manager.persistence_enabled = False
+        deleted = await fresh_session_manager.delete_session(session_id)
+        assert deleted is False
+
+    @pytest.mark.asyncio
     async def test_set_last_execution_id_updates_in_memory_and_schedules_metadata_persist(self, fresh_session_manager):
         import uuid
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -2711,6 +2711,95 @@ async def test_api_load_session_uses_custom_session_name_from_metadata(monkeypat
     assert payload["name"] == "My Custom Name"
 
 
+@pytest.mark.asyncio
+async def test_api_rename_session_success(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(
+        webchat.session_manager,
+        "rename_session",
+        lambda _sid, _name: asyncio.sleep(0, result="Renamed Title"),
+    )
+
+    class _Request:
+        match_info = {"session_id": "session-rename-ok"}
+
+        async def json(self):
+            return {"name": "Renamed Title"}
+
+    resp = await webchat.api_rename_session(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["success"] is True
+    assert payload["session_id"] == "session-rename-ok"
+    assert payload["name"] == "Renamed Title"
+
+
+@pytest.mark.asyncio
+async def test_api_rename_session_returns_404_when_missing(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(
+        webchat.session_manager,
+        "rename_session",
+        lambda _sid, _name: asyncio.sleep(0, result=None),
+    )
+
+    class _Request:
+        match_info = {"session_id": "session-rename-missing"}
+
+        async def json(self):
+            return {"name": "Renamed Title"}
+
+    resp = await webchat.api_rename_session(_Request())
+    assert resp.status == 404
+    payload = json.loads(resp.text)
+    assert payload["error"] == "Session not found"
+
+
+@pytest.mark.asyncio
+async def test_api_delete_session_success(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(
+        webchat.session_manager,
+        "delete_session",
+        lambda _sid: asyncio.sleep(0, result=True),
+    )
+
+    class _Request:
+        match_info = {"session_id": "session-delete-ok"}
+
+    resp = await webchat.api_delete_session(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["success"] is True
+    assert payload["session_id"] == "session-delete-ok"
+
+
+@pytest.mark.asyncio
+async def test_api_delete_session_returns_404_when_missing(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(
+        webchat.session_manager,
+        "delete_session",
+        lambda _sid: asyncio.sleep(0, result=False),
+    )
+
+    class _Request:
+        match_info = {"session_id": "session-delete-missing"}
+
+    resp = await webchat.api_delete_session(_Request())
+    assert resp.status == 404
+    payload = json.loads(resp.text)
+    assert payload["error"] == "Session not found"
+
+
 def test_agent_assistant_display_helpers_minimal_payload():
     from src.agents.core import Agent
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -2760,6 +2760,29 @@ async def test_api_rename_session_returns_404_when_missing(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_api_rename_session_returns_400_for_bad_input(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+
+    async def _fake_rename_session(_sid, _name):
+        raise ValueError("Session name cannot be empty")
+
+    monkeypatch.setattr(webchat.session_manager, "rename_session", _fake_rename_session)
+
+    class _Request:
+        match_info = {"session_id": "session-rename-invalid"}
+
+        async def json(self):
+            return {"name": "   "}
+
+    resp = await webchat.api_rename_session(_Request())
+    assert resp.status == 400
+    payload = json.loads(resp.text)
+    assert payload["error"] == "Session name cannot be empty"
+
+
+@pytest.mark.asyncio
 async def test_api_delete_session_success(monkeypatch):
     from src.gateway import webchat
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -152,8 +152,16 @@ class TestWebChatRoutes:
         assert '/' in routes
         assert '/api/chat' in routes
         assert '/api/sessions' in routes
+        assert '/api/sessions/{session_id}/rename' in routes
+        assert '/api/sessions/{session_id}' in routes
         assert '/api/usage' in routes
         assert '/api/clear' in routes
+
+        delete_routes = [
+            r for r in app.router.routes()
+            if r.resource and r.resource.canonical == '/api/sessions/{session_id}' and r.method == 'DELETE'
+        ]
+        assert delete_routes
     
     def test_static_route_registered(self):
         """Test static file route is registered."""
@@ -2444,7 +2452,7 @@ async def test_api_load_session_backfills_assistant_display_blocks(monkeypatch):
 
     monkeypatch.setattr(webchat.session_manager, "_initialized", True)
 
-    async def _fake_get_session(_session_id):
+    async def _fake_get_existing_session(_session_id):
         return {
             "history": [
                 {"role": "user", "content": "hi"},
@@ -2453,7 +2461,7 @@ async def test_api_load_session_backfills_assistant_display_blocks(monkeypatch):
             "metadata": {},
         }
 
-    monkeypatch.setattr(webchat.session_manager, "get_session", _fake_get_session)
+    monkeypatch.setattr(webchat.session_manager, "get_existing_session", _fake_get_existing_session)
 
     class _Request:
         match_info = {"session_id": "s-load"}
@@ -2474,7 +2482,7 @@ async def test_api_load_session_normalizes_assistant_name_from_trusted_portal_he
     monkeypatch.setattr(webchat.session_manager, "_initialized", True)
     monkeypatch.setattr(webchat, "_resolve_runtime_agent_identity", lambda _request: ("agent-1", "Portal Agent"))
 
-    async def _fake_get_session(_session_id):
+    async def _fake_get_existing_session(_session_id):
         return {
             "history": [
                 {
@@ -2489,7 +2497,7 @@ async def test_api_load_session_normalizes_assistant_name_from_trusted_portal_he
             "metadata": {},
         }
 
-    monkeypatch.setattr(webchat.session_manager, "get_session", _fake_get_session)
+    monkeypatch.setattr(webchat.session_manager, "get_existing_session", _fake_get_existing_session)
 
     class _Request:
         match_info = {"session_id": "s-load-agent-name"}
@@ -2508,7 +2516,7 @@ async def test_api_load_session_backfills_user_author_from_trusted_portal_header
 
     monkeypatch.setattr(webchat.session_manager, "_initialized", True)
 
-    async def _fake_get_session(_session_id):
+    async def _fake_get_existing_session(_session_id):
         return {
             "history": [
                 {"role": "user", "content": "hello from history"},
@@ -2516,7 +2524,7 @@ async def test_api_load_session_backfills_user_author_from_trusted_portal_header
             "metadata": {},
         }
 
-    monkeypatch.setattr(webchat.session_manager, "get_session", _fake_get_session)
+    monkeypatch.setattr(webchat.session_manager, "get_existing_session", _fake_get_existing_session)
 
     class _Request:
         match_info = {"session_id": "s-load-user"}
@@ -2641,7 +2649,7 @@ async def test_api_load_session_keeps_existing_structured_display_blocks(monkeyp
 
     monkeypatch.setattr(webchat.session_manager, "_initialized", True)
 
-    async def _fake_get_session(_session_id):
+    async def _fake_get_existing_session(_session_id):
         return {
             "history": [
                 {"role": "assistant", "content": "fallback", "display_blocks": [{"type": "code", "lang": "python", "content": "print('x')"}]},
@@ -2649,7 +2657,7 @@ async def test_api_load_session_keeps_existing_structured_display_blocks(monkeyp
             "metadata": {},
         }
 
-    monkeypatch.setattr(webchat.session_manager, "get_session", _fake_get_session)
+    monkeypatch.setattr(webchat.session_manager, "get_existing_session", _fake_get_existing_session)
 
     class _Request:
         match_info = {"session_id": "s-keep"}
@@ -2658,6 +2666,49 @@ async def test_api_load_session_keeps_existing_structured_display_blocks(monkeyp
     assert resp.status == 200
     payload = json.loads(resp.text)
     assert payload["messages"][0]["display_blocks"][0]["type"] == "code"
+
+
+@pytest.mark.asyncio
+async def test_api_load_session_returns_404_when_session_missing(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_existing_session", lambda _sid: asyncio.sleep(0, result=None))
+
+    class _Request:
+        match_info = {"session_id": "missing-session"}
+        headers = {}
+        app = {}
+
+    resp = await webchat.api_load_session(_Request())
+    assert resp.status == 404
+    payload = json.loads(resp.text)
+    assert payload["error"] == "Session not found"
+
+
+@pytest.mark.asyncio
+async def test_api_load_session_uses_custom_session_name_from_metadata(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+
+    async def _fake_get_existing_session(_session_id):
+        return {
+            "history": [{"role": "user", "content": "fallback title"}],
+            "metadata": {"custom_session_name": "My Custom Name"},
+        }
+
+    monkeypatch.setattr(webchat.session_manager, "get_existing_session", _fake_get_existing_session)
+
+    class _Request:
+        match_info = {"session_id": "session-custom-name"}
+        headers = {}
+        app = {}
+
+    resp = await webchat.api_load_session(_Request())
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["name"] == "My Custom Name"
 
 
 def test_agent_assistant_display_helpers_minimal_payload():


### PR DESCRIPTION
### Motivation
- Provide runtime management for individual sessions (rename and true delete) and ensure display names are sourced from runtime metadata to support Portal/WebChat consistency.
- Prevent deleted sessions from being accidentally re-created by read paths that previously used `get_session()` which auto-creates empty sessions.

### Description
- Added `resolve_session_display_name(session)` helper and new APIs on `SessionManager`: `get_existing_session(session_id)`, `rename_session(session_id, new_name)`, and `delete_session(session_id)`; rename writes `metadata.custom_session_name` and delete removes both memory cache and persisted file (archive semantics). (changed: `src/sessions/manager.py`)
- Switched list/detail name resolution to the shared helper so Portal and WebChat show the same title source (changed: `src/gateway/server.py`, `src/gateway/webchat.py`).
- Changed `api_load_session` to call `session_manager.get_existing_session(...)` and return 404 when missing to avoid silent re-creation of deleted sessions (changed: `src/gateway/webchat.py`).
- Added runtime endpoints and route registration: `POST /api/sessions/{session_id}/rename` and `DELETE /api/sessions/{session_id}` with proper validation and error codes (changed: `src/gateway/webchat.py`, `README.md`).
- WebChat UI: added Rename/Delete action buttons to Recent Sessions, non-bubbling handlers, and helpers `renameSessionById` / `deleteSessionById` that call the new endpoints; deleting the current session clears `currentSessionId` and localStorage and returns the UI to the welcome state (changed: `src/gateway/static/js/webchat.js`, `src/gateway/static/css/webchat.css`).
- Added tests for manager, webchat routing/behavior, gateway route presence, and persistence metadata round-trip (changed: `tests/test_session_manager.py`, `tests/test_webchat.py`, `tests/test_gateway.py`, `tests/test_persistence.py`).
- Preserved `get_session()` automatic-create behavior for existing chat flows; the new non-creating read path is used only for load/rename/delete.

### Testing
- Ran the full test run referenced in the rollout: `pytest -q tests/test_session_manager.py tests/test_webchat.py tests/test_gateway.py tests/test_persistence.py`; this revealed pre-existing unrelated failures in other gateway/webchat expectations (8 failures not caused by these changes).
- Executed a focused set of newly added/impacted tests which passed: the targeted tests in `tests/test_session_manager.py`, `tests/test_webchat.py` (routes + load/404 + custom name), `tests/test_gateway.py` (route existence), and `tests/test_persistence.py` (metadata round-trip) all passed (9 tests run, 9 passed).
- Performed JS syntax check: `node --check src/gateway/static/js/webchat.js` passed with no syntax errors.

If you want, I can now address the unrelated existing gateway/webchat JS fragment tests (they predated this change) in a separate PR, but I did not change unrelated legacy logic beyond the minimal routing/name-resolution and UI additions required by this task.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e041c159f4832a8172b5f4920fbd17)