### PR TITLE
Support trusted request-scoped `model_override` for webchat and fix compaction model usage

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -817,7 +817,7 @@ You have access to the following tools. When a user asks you to do something tha
         )
         
         # Get context window for the model (not max_tokens which is for responses)
-        model = config.llm.get("model", "gpt-5-mini")
+        model = self.model or config.llm.get("model", "gpt-5-mini")
         context_window = resolve_context_window_tokens(model)
         
         # Use 80% of context window as the limit for prompt history
@@ -855,9 +855,8 @@ You have access to the following tools. When a user asks you to do something tha
             )
             
             # Get context window for the model
-            context_window = resolve_context_window_tokens(
-                config.llm.get("model", "gpt-5-mini")
-            )
+            model = self.model or config.llm.get("model", "gpt-5-mini")
+            context_window = resolve_context_window_tokens(model)
             
             # Compact messages
             compacted_messages, compaction_stats = await compact_messages(

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -166,6 +166,16 @@ def _extract_trusted_client_request_id(request: web.Request, data: Dict[str, Any
     return extract_trusted_client_request_id(_is_trusted_portal_request(request), data)
 
 
+def _extract_trusted_model_override(request: web.Request, data: Dict[str, Any]) -> Optional[str]:
+    if not _is_trusted_portal_request(request):
+        return None
+    value = data.get("model_override")
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
 def _require_non_empty_string(data: Dict[str, Any], key: str) -> str:
     value = data.get(key)
     if not isinstance(value, str) or not value.strip():
@@ -678,8 +688,9 @@ async def api_chat(request: web.Request) -> web.Response:
         # Tools are registered via src/__init__.py and available to LLM via tool_calls
         # This is the Claude Code style - no separate skill matching/execution needed
         
-        # Get model from config
-        model = global_config.llm.get('model', 'gpt-5-mini')
+        # Get request-scoped model (trusted portal override only)
+        model_override = _extract_trusted_model_override(request, data)
+        model = model_override or global_config.llm.get('model', 'gpt-5-mini')
         
         # Run agent (history is managed internally by session_manager)
         runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
@@ -758,10 +769,13 @@ async def api_chat(request: web.Request) -> web.Response:
         # Record usage if available
         if usage:
             provider = global_config.llm.get('provider', 'openai')
-            model = global_config.llm.get('model', 'gpt-5-mini')
+            actual_model = (
+                ((response_data.get("_llm_debug") or {}).get("request") or {}).get("model")
+                or model
+            )
             usage_tracker.record_usage(
                 provider=provider,
-                model=model,
+                model=actual_model,
                 input_tokens=usage.get("prompt_tokens", 0),
                 output_tokens=usage.get("completion_tokens", 0),
                 session_id=session_id,
@@ -900,8 +914,9 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
 
         event_queue = asyncio.Queue()
 
-        # Get model from config
-        model = global_config.llm.get('model', 'gpt-5-mini')
+        # Get request-scoped model (trusted portal override only)
+        model_override = _extract_trusted_model_override(request, data)
+        model = model_override or global_config.llm.get('model', 'gpt-5-mini')
 
         # Run agent and stream response
         runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
@@ -975,10 +990,13 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         # Record usage
         if usage:
             provider = global_config.llm.get('provider', 'openai')
-            model = global_config.llm.get('model', 'gpt-5-mini')
+            actual_model = (
+                ((result.get("_llm_debug") or {}).get("request") or {}).get("model")
+                or model
+            )
             usage_tracker.record_usage(
                 provider=provider,
-                model=model,
+                model=actual_model,
                 input_tokens=usage.get("prompt_tokens", 0),
                 output_tokens=usage.get("completion_tokens", 0),
                 session_id=session_id,

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -66,3 +66,11 @@ def test_attach_governance_hint_preserves_tool_result_fields():
     assert returned.content == "body"
     assert returned.error == "err"
     assert core._read_governance_hint(returned).get("tool_result_passthrough_recommended") is True
+
+
+def test_agent_process_source_prefers_self_model_in_multiple_paths():
+    from src.agents import core
+
+    source = inspect.getsource(core.Agent.process)
+    expected = 'self.model or config.llm.get("model", "gpt-5-mini")'
+    assert source.count(expected) >= 2

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -259,6 +259,20 @@ def test_is_trusted_portal_request_depends_only_on_portal_source_marker():
     assert untrusted is False
 
 
+def test_extract_trusted_model_override_accepts_trimmed_value_for_trusted_request():
+    from src.gateway import webchat
+
+    request = _HeaderOnlyRequest({"X-Portal-Author-Source": "portal"})
+    assert webchat._extract_trusted_model_override(request, {"model_override": "  gpt-5  "}) == "gpt-5"
+
+
+def test_extract_trusted_model_override_ignores_untrusted_request():
+    from src.gateway import webchat
+
+    request = _HeaderOnlyRequest({})
+    assert webchat._extract_trusted_model_override(request, {"model_override": "gpt-5"}) is None
+
+
 @pytest.mark.asyncio
 async def test_chat_execution_bus_adapter_non_stream(monkeypatch):
     from src.gateway import webchat
@@ -683,6 +697,249 @@ async def test_api_chat_stream_uses_trusted_portal_agent_name_for_agent_identity
     response = await webchat.api_chat_stream(_Request())
     assert response.status == 200
     assert captured["agent"].agent_name == "Portal Agent"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_uses_trusted_model_override_when_present(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    class _FakeAgentCore:
+        def __init__(self, model, session_id, agent_id, agent_name):
+            captured["model"] = model
+            self.model = model
+            self.agent_id = agent_id
+            self.agent_name = agent_name
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {"response": "ok", "usage": {}}
+
+    monkeypatch.setattr(webchat, "AgentCore", _FakeAgentCore)
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "default-model", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-model-1", "model_override": "gpt-5-override"}
+
+    response = await webchat.api_chat(_Request())
+    assert response.status == 200
+    assert captured["model"] == "gpt-5-override"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_ignores_model_override_for_untrusted_request(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    class _FakeAgentCore:
+        def __init__(self, model, session_id, agent_id, agent_name):
+            captured["model"] = model
+            self.model = model
+            self.agent_id = agent_id
+            self.agent_name = agent_name
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {"response": "ok", "usage": {}}
+
+    monkeypatch.setattr(webchat, "AgentCore", _FakeAgentCore)
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "default-model", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-model-2", "model_override": "gpt-5-override"}
+
+    response = await webchat.api_chat(_Request())
+    assert response.status == 200
+    assert captured["model"] == "default-model"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_stream_uses_trusted_model_override_when_present(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    class _FakeAgentCore:
+        def __init__(self, model, session_id, agent_id, agent_name):
+            captured["model"] = model
+            self.model = model
+            self.agent_id = agent_id
+            self.agent_name = agent_name
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {"response": "ok", "usage": {}}
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data)
+
+    monkeypatch.setattr(webchat, "AgentCore", _FakeAgentCore)
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "default-model", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-model-stream-1", "model_override": "gpt-5-override"}
+
+    response = await webchat.api_chat_stream(_Request())
+    assert response.status == 200
+    assert captured["model"] == "gpt-5-override"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_stream_ignores_model_override_for_untrusted_request(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    class _FakeAgentCore:
+        def __init__(self, model, session_id, agent_id, agent_name):
+            captured["model"] = model
+            self.model = model
+            self.agent_id = agent_id
+            self.agent_name = agent_name
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {"response": "ok", "usage": {}}
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data)
+
+    monkeypatch.setattr(webchat, "AgentCore", _FakeAgentCore)
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "default-model", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-model-stream-2", "model_override": "gpt-5-override"}
+
+    response = await webchat.api_chat_stream(_Request())
+    assert response.status == 200
+    assert captured["model"] == "default-model"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_usage_tracker_records_actual_override_model(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {
+            "response": "ok",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 6},
+            "_llm_debug": {"request": {"model": "gpt-5-actual"}},
+        }
+
+    def _fake_record_usage(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat.usage_tracker, "record_usage", _fake_record_usage)
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "default-model", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-usage-1", "model_override": "gpt-5-override"}
+
+    response = await webchat.api_chat(_Request())
+    assert response.status == 200
+    assert captured["model"] == "gpt-5-actual"
+
+
+@pytest.mark.asyncio
+async def test_api_chat_stream_usage_tracker_records_actual_override_model(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        return {
+            "response": "ok",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 6},
+            "_llm_debug": {"request": {"model": "gpt-5-actual"}},
+        }
+
+    def _fake_record_usage(**kwargs):
+        captured.update(kwargs)
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data)
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat.usage_tracker, "record_usage", _fake_record_usage)
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "default-model", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-usage-2", "model_override": "gpt-5-override"}
+
+    response = await webchat.api_chat_stream(_Request())
+    assert response.status == 200
+    assert captured["model"] == "gpt-5-actual"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Allow Portal to provide a per-request `model_override` that only affects the current chat/stream request while preserving existing runtime/profile/global config boundaries.
- Ensure compaction uses the actual model for this request so context-window calculations match the LLM used. 
- Make usage tracking record the actual model used for billing/telemetry instead of always logging the global default.

### Description
- Added a helper `def _extract_trusted_model_override(request, data) -> Optional[str]` in `src/gateway/webchat.py` that returns a trimmed string only when `_is_trusted_portal_request(request)` is true and `model_override` is a non-empty string. 
- Updated `api_chat()` and `api_chat_stream()` in `src/gateway/webchat.py` to call `_extract_trusted_model_override(request, data)` and pass `model = model_override or global_config.llm.get('model', ...)` to `AgentCore(...)`, ensuring the override is request-scoped and not persisted or written to global config. 
- Adjusted usage recording in both chat paths to compute `actual_model` from `_llm_debug.request.model` falling back to the request `model`, and pass `actual_model` to `usage_tracker.record_usage(...)` so recorded model matches what was used. 
- Fixed compaction model bug in `src/agents/core.py` by changing both ordinary-message compaction sites to use `model = self.model or config.llm.get('model', ...)` and then call `resolve_context_window_tokens(model)`, ensuring compaction honors a request-scoped `self.model`. 
- Added tests in `tests/test_webchat.py` covering trusted/untrusted `_extract_trusted_model_override`, `api_chat`/`api_chat_stream` override acceptance/ignoring, and usage-tracker recording of the actual model; and added a small source-regression test in `tests/test_core_runtime_boundary.py` to ensure `self.model` precedence appears in multiple `Agent.process` paths.

### Testing
- Ran `pytest tests/test_webchat.py -q`; the new model/usage tests passed but three pre-existing JavaScript-renderer assertions in that suite failed (unrelated to the Python runtime/model changes). 
- Ran `pytest tests/test_core_runtime_boundary.py -q` and it passed (regression test confirming `self.model` precedence). 
- Ran `pytest tests/test_webchat_runtime_profile.py -q` and it passed. 
- Ran `pytest tests/test_compaction.py -q`; five tests around `resolve_context_window_tokens` failed (these reflect repository expectations for context-window values and are unrelated to the request-scoped override logic).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b054ab2c832aa7cbdf97a59b15fe)