### PR TITLE
feat(runtime): make llm.tools globally configurable with hard guard

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -815,7 +815,10 @@ You have access to the following tools. When a user asks you to do something tha
             if best_skill.path:
                 logger.info(f"[Skill] Workdir: {best_skill.path}")
 
-            active_skill_runtime = skill_registry.get_skill_runtime_config(best_skill)
+            active_skill_runtime = skill_registry.get_skill_runtime_config(
+                best_skill,
+                globally_allowed_tool_names=getattr(self, "allowed_tool_names", set()),
+            )
             # Log matched skill
             tracer.log_tool_call(
                 tool_name="skill_matched",
@@ -1289,13 +1292,8 @@ You have access to the following tools. When a user asks you to do something tha
             
             # Only pass model if explicitly set
             loop_tools = self.tools
-            if active_skill_runtime and active_skill_runtime.allowed_tools:
-                allowed = active_skill_runtime.allowed_tools_set
-                loop_tools = [
-                    tool_schema
-                    for tool_schema in self.tools
-                    if tool_schema.get("function", {}).get("name") in allowed
-                ]
+            if active_skill_runtime and active_skill_runtime.tool_policy_declared:
+                loop_tools = intersect_tool_schemas_by_names(self.tools, active_skill_runtime.allowed_tools_set)
 
             llm_kwargs = dict(
                 input_items=input_items,
@@ -1595,7 +1593,7 @@ You have access to the following tools. When a user asks you to do something tha
                 })
 
                 # Runtime skill policy enforcement (hard guard, not prompt-only)
-                if active_skill_runtime and active_skill_runtime.allowed_tools:
+                if active_skill_runtime and active_skill_runtime.tool_policy_declared:
                     if tool_name not in active_skill_runtime.allowed_tools_set:
                         deny_result = build_skill_tool_denied_result(active_skill_runtime, tool_name)
                         logger.warning(
@@ -1987,7 +1985,13 @@ You have access to the following tools. When a user asks you to do something tha
         skill_session = SkillSession.from_dict(skill_state)
         skill = skill or skill_registry.get_skill(skill_session.skill_name)
         try:
-            skill_runtime_config = skill_registry.get_skill_runtime_config(skill) if skill else None
+            skill_runtime_config = (
+                skill_registry.get_skill_runtime_config(
+                    skill,
+                    globally_allowed_tool_names=getattr(self, "allowed_tool_names", set()),
+                )
+                if skill else None
+            )
         except Exception:
             logger.debug(
                 "[SkillMode] Failed to resolve runtime config for skill %s; continuing without runtime config",

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -55,6 +55,11 @@ from src.agents.skill_runtime import (
 from src.skills.runtime import SkillRuntimeConfig
 from src.runtime.chat_orchestration_adapter import execute_tool_or_task_orchestration
 from src.runtime.display_blocks import normalize_display_blocks
+from src.runtime.tool_filtering import (
+    extract_tool_name,
+    filter_tool_schemas_for_llm,
+    intersect_tool_schemas_by_names,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -489,19 +494,34 @@ class Agent:
         
         # Build Engineering Flow Platform-style system prompt
         # NOTE: get_tools_schema() already includes INTEGRATION_TOOLS (JIRA + Confluence + GitHub tools)
-        base_tools = get_tools_schemas()
-        self.tools = base_tools  # Already contains all tools from TOOLS + INTEGRATION_TOOLS
-        
-        # Debug logging for tools initialization
-        logger.debug(f"Tools initialized: count={len(self.tools)}, "
-                    f"names={[t['function']['name'] for t in self.tools]}, "
-                    f"think_level={self.think_level.value}")
-        
+        full_tool_catalog = get_tools_schemas()
+        llm_tool_filter_result = filter_tool_schemas_for_llm(full_tool_catalog, config.llm or {})
+        self.tools = llm_tool_filter_result.filtered_schemas
+        self.allowed_tool_names = set(llm_tool_filter_result.allowed_tool_names)
+
+        logger.info(
+            "[Tool Policy] Initialized llm.tools filter: full_count=%s filtered_count=%s mode=%s configured=%s unmatched_patterns=%s",
+            len(full_tool_catalog),
+            len(self.tools),
+            llm_tool_filter_result.mode,
+            llm_tool_filter_result.configured,
+            llm_tool_filter_result.unmatched_patterns,
+        )
+        logger.debug(
+            "Tools initialized: count=%s names=%s think_level=%s",
+            len(self.tools),
+            [extract_tool_name(t) for t in self.tools if extract_tool_name(t)],
+            self.think_level.value,
+        )
+
         # Human-readable tool list
-        tools_list = "\n".join([
-            f"- **{t['function']['name']}**: {t['function'].get('description', '')}"
-            for t in self.tools
-        ])
+        if self.tools:
+            tools_list = "\n".join([
+                f"- **{(extract_tool_name(t) or 'unknown_tool')}**: {t.get('function', {}).get('description') or t.get('description', '')}"
+                for t in self.tools
+            ])
+        else:
+            tools_list = "No runtime tools are enabled for this agent by llm.tools policy."
         
         # Load memory files for system prompt
         # For main session (includes memory), include MEMORY.md
@@ -2094,20 +2114,39 @@ You have access to the following tools. When a user asks you to do something tha
             logger.debug(f"[SkillMode] system_prompt length={len(system_prompt)}")
             logger.debug(f"[SkillMode] input_items count={len(input_items)}")
             
-            # Get tools - use skill's tools if available, otherwise fall back to all tools
+            # Get tools - always from globally filtered tools surface, then intersect with skill tools if present
             skill_tool_names = getattr(skill, 'tools', []) or []
+            globally_allowed_tool_names = getattr(self, "allowed_tool_names", None)
+            if not globally_allowed_tool_names:
+                globally_allowed_tool_names = {
+                    name
+                    for name in (extract_tool_name(schema) for schema in (self.tools or []))
+                    if name
+                }
             
-            # If skill defines tool names (List[str]), convert to schemas
-            # If skill defines tool schemas (List[Dict]), use directly
+            # If skill defines tool names (List[str]), intersect from globally filtered tools only.
+            # If skill defines tool schemas (List[Dict]), intersect with globally allowed names.
             if skill_tool_names and isinstance(skill_tool_names[0], str):
-                # Convert tool names to schemas
-                all_tool_schemas = get_tools_schemas()
-                available_tools = [t for t in all_tool_schemas if t.get("function", {}).get("name") in skill_tool_names]
-                logger.debug(f"[SkillMode] Converted {len(skill_tool_names)} tool names to {len(available_tools)} tool schemas")
+                available_tools = intersect_tool_schemas_by_names(self.tools, skill_tool_names)
+                logger.debug(
+                    "[SkillMode] Intersected skill tool names with llm.tools policy: requested=%s available=%s",
+                    len(skill_tool_names),
+                    len(available_tools),
+                )
             elif not skill_tool_names and self.tools:
                 available_tools = self.tools
+                logger.debug("[SkillMode] No skill-specific tools; using globally filtered tools")
             else:
-                available_tools = skill_tool_names if skill_tool_names and isinstance(skill_tool_names[0], dict) else []
+                skill_tool_schemas = skill_tool_names if skill_tool_names and isinstance(skill_tool_names[0], dict) else []
+                available_tools = [
+                    schema for schema in skill_tool_schemas
+                    if (extract_tool_name(schema) or "") in globally_allowed_tool_names
+                ]
+                logger.debug(
+                    "[SkillMode] Intersected skill tool schemas with llm.tools policy: declared=%s available=%s",
+                    len(skill_tool_schemas),
+                    len(available_tools),
+                )
             
             logger.debug(f"[SkillMode] available_tools count={len(available_tools)}")
             if available_tools and isinstance(available_tools[0], dict):

--- a/src/agents/executor.py
+++ b/src/agents/executor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from src.config import config
+from src.runtime.tool_filtering import is_tool_name_enabled_for_llm
 
 logger = logging.getLogger(__name__)
 
@@ -387,4 +388,8 @@ def get_tools_schemas() -> List[Dict]:
 
 async def execute_tool_by_name(name: str, **kwargs) -> ToolResult:
     """Execute a tool by name."""
+    if not is_tool_name_enabled_for_llm(name, config.llm or {}):
+        message = f"Tool '{name}' is disabled by llm.tools policy."
+        logger.warning("[Tool Policy] Denied tool execution: tool=%s reason=llm.tools_policy", name)
+        return ToolResult(success=False, content=message, error=message)
     return await execute_tool(name, **kwargs)

--- a/src/runtime/tool_filtering.py
+++ b/src/runtime/tool_filtering.py
@@ -1,0 +1,182 @@
+"""Helpers for global llm.tools filtering semantics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+
+
+@dataclass(frozen=True)
+class LlmToolsSpec:
+    configured: bool
+    mode: str  # all | none | patterns
+    patterns: List[str]
+    raw_value: Any = None
+
+
+@dataclass(frozen=True)
+class FilteredToolSchemasResult:
+    filtered_schemas: List[Dict[str, Any]]
+    allowed_tool_names: List[str]
+    matched_tool_names: List[str]
+    unmatched_patterns: List[str]
+    configured: bool
+    mode: str
+    patterns: List[str]
+
+
+def extract_tool_name(tool_schema: Dict[str, Any]) -> Optional[str]:
+    """Extract tool name from an OpenAI function-style or flat schema."""
+    if not isinstance(tool_schema, dict):
+        return None
+    function_obj = tool_schema.get("function")
+    if isinstance(function_obj, dict):
+        function_name = function_obj.get("name")
+        if isinstance(function_name, str) and function_name.strip():
+            return function_name.strip()
+    tool_name = tool_schema.get("name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        return tool_name.strip()
+    return None
+
+
+def _dedupe_preserve_order(values: Sequence[str]) -> List[str]:
+    seen: Set[str] = set()
+    deduped: List[str] = []
+    for value in values:
+        key = value.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(value)
+    return deduped
+
+
+def normalize_llm_tools_spec(llm_config: Dict[str, Any]) -> LlmToolsSpec:
+    """Normalize llm.tools configuration while preserving missing vs explicit-empty."""
+    if not isinstance(llm_config, dict):
+        return LlmToolsSpec(configured=False, mode="all", patterns=[], raw_value=None)
+
+    if "tools" not in llm_config:
+        return LlmToolsSpec(configured=False, mode="all", patterns=[], raw_value=None)
+
+    raw_value = llm_config.get("tools")
+
+    if raw_value is None:
+        return LlmToolsSpec(configured=True, mode="none", patterns=[], raw_value=raw_value)
+
+    if isinstance(raw_value, str):
+        value = raw_value.strip()
+        if not value:
+            return LlmToolsSpec(configured=True, mode="none", patterns=[], raw_value=raw_value)
+        if value == "*":
+            return LlmToolsSpec(configured=True, mode="all", patterns=[], raw_value=raw_value)
+        return LlmToolsSpec(configured=True, mode="patterns", patterns=[value], raw_value=raw_value)
+
+    if isinstance(raw_value, list):
+        normalized: List[str] = []
+        for idx, item in enumerate(raw_value):
+            if not isinstance(item, str):
+                raise ValueError(f"llm.tools[{idx}] must be a string, got {type(item).__name__}")
+            item_text = item.strip()
+            if item_text:
+                normalized.append(item_text)
+
+        normalized = _dedupe_preserve_order(normalized)
+
+        if any(item == "*" for item in normalized):
+            return LlmToolsSpec(configured=True, mode="all", patterns=[], raw_value=raw_value)
+        if not normalized:
+            return LlmToolsSpec(configured=True, mode="none", patterns=[], raw_value=raw_value)
+        return LlmToolsSpec(configured=True, mode="patterns", patterns=normalized, raw_value=raw_value)
+
+    raise ValueError(f"llm.tools must be a string, list, or null, got {type(raw_value).__name__}")
+
+
+def filter_tool_schemas_for_llm(
+    tool_schemas: List[Dict[str, Any]],
+    llm_config: Dict[str, Any],
+) -> FilteredToolSchemasResult:
+    """Filter tool schemas by llm.tools policy without mutating schemas."""
+    spec = normalize_llm_tools_spec(llm_config)
+
+    if spec.mode == "all":
+        names = [name for name in (extract_tool_name(schema) for schema in tool_schemas) if name]
+        return FilteredToolSchemasResult(
+            filtered_schemas=list(tool_schemas),
+            allowed_tool_names=names,
+            matched_tool_names=names,
+            unmatched_patterns=[],
+            configured=spec.configured,
+            mode=spec.mode,
+            patterns=list(spec.patterns),
+        )
+
+    if spec.mode == "none":
+        return FilteredToolSchemasResult(
+            filtered_schemas=[],
+            allowed_tool_names=[],
+            matched_tool_names=[],
+            unmatched_patterns=[],
+            configured=spec.configured,
+            mode=spec.mode,
+            patterns=list(spec.patterns),
+        )
+
+    matched_schemas: List[Dict[str, Any]] = []
+    matched_names: List[str] = []
+    matched_patterns: Set[str] = set()
+    patterns_lower = [(pattern, pattern.lower()) for pattern in spec.patterns]
+
+    for schema in tool_schemas:
+        name = extract_tool_name(schema)
+        if not name:
+            continue
+        name_lower = name.lower()
+        schema_matches = False
+        for pattern, pattern_lower in patterns_lower:
+            if fnmatchcase(name_lower, pattern_lower):
+                schema_matches = True
+                matched_patterns.add(pattern.lower())
+        if schema_matches:
+            matched_schemas.append(schema)
+            matched_names.append(name)
+
+    unmatched_patterns = [pattern for pattern in spec.patterns if pattern.lower() not in matched_patterns]
+
+    return FilteredToolSchemasResult(
+        filtered_schemas=matched_schemas,
+        allowed_tool_names=matched_names,
+        matched_tool_names=matched_names,
+        unmatched_patterns=unmatched_patterns,
+        configured=spec.configured,
+        mode=spec.mode,
+        patterns=list(spec.patterns),
+    )
+
+
+def is_tool_name_enabled_for_llm(tool_name: str, llm_config: Dict[str, Any]) -> bool:
+    """Return whether tool_name is enabled by llm.tools policy."""
+    if not isinstance(tool_name, str) or not tool_name.strip():
+        return False
+    spec = normalize_llm_tools_spec(llm_config)
+    if spec.mode == "all":
+        return True
+    if spec.mode == "none":
+        return False
+    lowered_name = tool_name.strip().lower()
+    return any(fnmatchcase(lowered_name, pattern.lower()) for pattern in spec.patterns)
+
+
+def intersect_tool_schemas_by_names(
+    tool_schemas: List[Dict[str, Any]],
+    allowed_names: Iterable[str],
+) -> List[Dict[str, Any]]:
+    """Intersect tool schemas by exact tool name match."""
+    allowed_name_set = {str(name) for name in allowed_names if isinstance(name, str) and name}
+    return [
+        tool_schema
+        for tool_schema in tool_schemas
+        if (extract_tool_name(tool_schema) or "") in allowed_name_set
+    ]

--- a/src/skills/registry.py
+++ b/src/skills/registry.py
@@ -360,10 +360,10 @@ class SkillRegistry:
             part for part in [blocks.system_rules, blocks.developer_instructions, blocks.references_summary] if part
         )
 
-    def get_skill_runtime_config(self, skill: Skill):
+    def get_skill_runtime_config(self, skill: Skill, globally_allowed_tool_names=None):
         from src.skills.runtime import build_skill_runtime_config
 
-        return build_skill_runtime_config(skill)
+        return build_skill_runtime_config(skill, globally_allowed_tool_names=globally_allowed_tool_names)
 
     def get_reference_file_list(self, skill: Skill) -> List[str]:
         from src.skills.runtime import summarize_skill_references

--- a/src/skills/runtime.py
+++ b/src/skills/runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Iterable, List, Optional, Set
 
 from src.skills.registry import Skill
 
@@ -48,6 +48,7 @@ class SkillRuntimeConfig:
     skill_name: str
     allowed_tools: List[str] = field(default_factory=list)
     allowed_tools_set: Set[str] = field(default_factory=set)
+    tool_policy_declared: bool = False
     task_tools: List[str] = field(default_factory=list)
     model_override: Optional[str] = None
     hooks: List[str] = field(default_factory=list)
@@ -108,12 +109,24 @@ def build_reference_context(reference_paths: List[str], max_items: int = 8) -> s
     return f"Available references: {', '.join(names)}{suffix}"
 
 
-def build_skill_prompt_blocks(skill: Skill, references: Optional[List[str]] = None) -> SkillPromptBlocks:
-    allowed_tools = ", ".join(skill.tools) if skill.tools else "all tools"
-    task_tools = ", ".join(skill.task_tools) if skill.task_tools else "none"
+def build_skill_prompt_blocks(
+    skill: Skill,
+    references: Optional[List[str]] = None,
+    allowed_tools: Optional[List[str]] = None,
+    task_tools: Optional[List[str]] = None,
+    tool_policy_declared: Optional[bool] = None,
+) -> SkillPromptBlocks:
+    declared_policy = bool(skill.tools) if tool_policy_declared is None else bool(tool_policy_declared)
+    effective_allowed_tools = list(skill.tools or []) if allowed_tools is None else list(allowed_tools or [])
+    effective_task_tools = list(skill.task_tools or []) if task_tools is None else list(task_tools or [])
+    if declared_policy:
+        allowed_tools_text = ", ".join(effective_allowed_tools) if effective_allowed_tools else "none"
+    else:
+        allowed_tools_text = "all currently available tools"
+    task_tools_text = ", ".join(effective_task_tools) if effective_task_tools else "none"
     system_rules = (
-        f"Active skill: {skill.name}. Runtime policy: only use allowed tools ({allowed_tools}). "
-        f"Task-capable tools: {task_tools}."
+        f"Active skill: {skill.name}. Runtime policy: only use allowed tools ({allowed_tools_text}). "
+        f"Task-capable tools: {task_tools_text}."
     )
 
     strategy = "\n".join(f"- {item}" for item in (skill.strategy or []))
@@ -181,15 +194,46 @@ def attach_skill_references(runtime_config: Optional[SkillRuntimeConfig]) -> Ref
     return ReferenceAttachment(references=refs, context_text=build_reference_context(refs), attachment_mode="compact")
 
 
-def build_skill_runtime_config(skill: Skill) -> SkillRuntimeConfig:
+def build_skill_runtime_config(
+    skill: Skill,
+    globally_allowed_tool_names: Optional[Iterable[str]] = None,
+) -> SkillRuntimeConfig:
     references = summarize_skill_references(skill)
-    allowed_tools = list(skill.tools or [])
-    prompt_blocks = build_skill_prompt_blocks(skill, references=references)
+    raw_skill_tools = list(skill.tools or [])
+    raw_task_tools = list(skill.task_tools or [])
+    tool_policy_declared = bool(raw_skill_tools)
+
+    if globally_allowed_tool_names is None:
+        effective_allowed_tools = list(raw_skill_tools)
+        if raw_skill_tools:
+            raw_skill_tool_set = set(raw_skill_tools)
+            effective_task_tools = [tool_name for tool_name in raw_task_tools if tool_name in raw_skill_tool_set]
+        else:
+            effective_task_tools = list(raw_task_tools)
+    else:
+        allowset = {str(tool_name) for tool_name in globally_allowed_tool_names}
+        if tool_policy_declared:
+            effective_allowed_tools = [tool_name for tool_name in raw_skill_tools if tool_name in allowset]
+        else:
+            effective_allowed_tools = []
+        effective_task_tools = [tool_name for tool_name in raw_task_tools if tool_name in allowset]
+        if tool_policy_declared:
+            effective_allowed_tool_set = set(effective_allowed_tools)
+            effective_task_tools = [tool_name for tool_name in effective_task_tools if tool_name in effective_allowed_tool_set]
+
+    prompt_blocks = build_skill_prompt_blocks(
+        skill,
+        references=references,
+        allowed_tools=effective_allowed_tools,
+        task_tools=effective_task_tools,
+        tool_policy_declared=tool_policy_declared,
+    )
     return SkillRuntimeConfig(
         skill_name=skill.name,
-        allowed_tools=allowed_tools,
-        allowed_tools_set=set(allowed_tools),
-        task_tools=list(skill.task_tools or []),
+        allowed_tools=effective_allowed_tools,
+        allowed_tools_set=set(effective_allowed_tools),
+        tool_policy_declared=tool_policy_declared,
+        task_tools=effective_task_tools,
         model_override=skill.model or None,
         hooks=list(skill.hooks or []),
         workdir=skill.path or "",

--- a/tests/test_agent_llm_tools_surface.py
+++ b/tests/test_agent_llm_tools_surface.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.agents.core import Agent
+
+
+class _FakeTracer:
+    def log_tool_call(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_action(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_step(self, *args, **kwargs):
+        return None
+
+    def log_skill_mode_complete(self, *args, **kwargs):
+        return None
+
+    def get_events_for_ui(self, **kwargs):
+        return []
+
+
+def test_agent_init_filters_global_tool_surface(monkeypatch):
+    from src.agents import core as core_mod
+
+    tool_catalog = [
+        {"type": "function", "function": {"name": "git_clone", "description": "clone"}},
+        {"type": "function", "function": {"name": "jira_get_issue", "description": "jira"}},
+        {"type": "function", "function": {"name": "read", "description": "read"}},
+    ]
+
+    monkeypatch.setattr(core_mod, "get_tools_schemas", lambda: tool_catalog)
+    monkeypatch.setitem(core_mod.config._config, "llm", {"tools": ["jira_*", "git_clone"]})
+    monkeypatch.setattr(
+        core_mod,
+        "memory_system",
+        SimpleNamespace(workspace="/tmp", build_system_prompt=lambda include_memory: ""),
+    )
+
+    agent = Agent(session_id="surface-test")
+
+    assert [t["function"]["name"] for t in agent.tools] == ["git_clone", "jira_get_issue"]
+    assert agent.allowed_tool_names == {"git_clone", "jira_get_issue"}
+
+
+@pytest.mark.asyncio
+async def test_skill_mode_tool_names_intersect_with_global_surface(monkeypatch):
+    from src.agents import core as core_mod
+
+    monkeypatch.setattr(core_mod, "get_tools_schemas", lambda: (_ for _ in ()).throw(AssertionError("must not fetch full catalog")))
+    monkeypatch.setattr("src.skills.get_tracer", lambda: _FakeTracer())
+
+    async def _fake_add_message(*args, **kwargs):
+        return "m1"
+
+    async def _fake_set_active(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(core_mod, "session_manager", SimpleNamespace(add_message=_fake_add_message, set_active_skill_session=_fake_set_active))
+
+    captured = []
+
+    async def _fake_responses(**kwargs):
+        captured.append(kwargs.get("tools") or [])
+        return {"content": "", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr(core_mod, "llm_client", SimpleNamespace(responses=_fake_responses))
+
+    agent = Agent.__new__(Agent)
+    agent.model = None
+    agent.agent_id = None
+    agent.agent_name = None
+    agent.tools = [
+        {"type": "function", "function": {"name": "git_clone", "description": "clone"}},
+        {"type": "function", "function": {"name": "jira_get_issue", "description": "jira"}},
+    ]
+    agent.allowed_tool_names = {"git_clone", "jira_get_issue"}
+
+    skill = SimpleNamespace(name="demo", description="demo", path="", tools=["git_clone", "read"], strategy=[])
+    skill_state = {"skill_name": "demo", "original_user_request": "run", "completed_steps": [], "artifacts": {}}
+
+    await agent._continue_skill_mode(
+        message="run",
+        session_id="s1",
+        user_message_id="u1",
+        skill_state=skill_state,
+        skill=skill,
+    )
+
+    assert any([item["function"]["name"] for item in tools] == ["git_clone"] for tools in captured)

--- a/tests/test_agent_llm_tools_surface.py
+++ b/tests/test_agent_llm_tools_surface.py
@@ -90,3 +90,59 @@ async def test_skill_mode_tool_names_intersect_with_global_surface(monkeypatch):
     )
 
     assert any([item["function"]["name"] for item in tools] == ["git_clone"] for tools in captured)
+
+
+@pytest.mark.asyncio
+async def test_skill_mode_tool_schema_list_intersect_with_global_surface(monkeypatch):
+    from src.agents import core as core_mod
+
+    monkeypatch.setattr(core_mod, "get_tools_schemas", lambda: (_ for _ in ()).throw(AssertionError("must not fetch full catalog")))
+    monkeypatch.setattr("src.skills.get_tracer", lambda: _FakeTracer())
+
+    async def _fake_add_message(*args, **kwargs):
+        return "m1"
+
+    async def _fake_set_active(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(core_mod, "session_manager", SimpleNamespace(add_message=_fake_add_message, set_active_skill_session=_fake_set_active))
+
+    captured = []
+
+    async def _fake_responses(**kwargs):
+        captured.append(kwargs.get("tools") or [])
+        return {"content": "", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr(core_mod, "llm_client", SimpleNamespace(responses=_fake_responses))
+
+    agent = Agent.__new__(Agent)
+    agent.model = None
+    agent.agent_id = None
+    agent.agent_name = None
+    agent.tools = [
+        {"type": "function", "function": {"name": "git_clone", "description": "clone"}},
+        {"type": "function", "function": {"name": "jira_get_issue", "description": "jira"}},
+    ]
+    agent.allowed_tool_names = {"git_clone"}
+
+    skill = SimpleNamespace(
+        name="demo",
+        description="demo",
+        path="",
+        tools=[
+            {"type": "function", "function": {"name": "git_clone", "description": "clone"}},
+            {"type": "function", "function": {"name": "jira_get_issue", "description": "jira"}},
+        ],
+        strategy=[],
+    )
+    skill_state = {"skill_name": "demo", "original_user_request": "run", "completed_steps": [], "artifacts": {}}
+
+    await agent._continue_skill_mode(
+        message="run",
+        session_id="s1",
+        user_message_id="u1",
+        skill_state=skill_state,
+        skill=skill,
+    )
+
+    assert any([item["function"]["name"] for item in tools] == ["git_clone"] for tools in captured)

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -3,6 +3,7 @@ from src.runtime.capability_registry import (
     DefaultCapabilityRegistry,
     build_default_capability_registry,
 )
+from src.config import config
 
 
 def test_registry_register_and_get_descriptor():
@@ -142,3 +143,19 @@ def test_registry_adapter_action_entries_include_alias_and_system():
     adapter_entry = next(item for item in registry.export_catalog() if item["type"] == "adapter_action")
     assert adapter_entry["action_alias"]
     assert adapter_entry["adapter_system"] in {"github", "jira", "portal"}
+
+
+def test_capability_registry_uses_full_tool_catalog_even_when_llm_tools_restricted(monkeypatch):
+    monkeypatch.setitem(config._config, "llm", {"tools": ["git_clone"]})
+    from src import get_tools_schema
+
+    all_tool_names = {
+        (item.get("function", {}) or {}).get("name") or item.get("name")
+        for item in get_tools_schema()
+        if isinstance(item, dict)
+    }
+    all_tool_names.discard(None)
+
+    registry = build_default_capability_registry()
+    registry_tool_names = {item.name for item in registry.list_by_type("tool")}
+    assert all_tool_names.issubset(registry_tool_names)

--- a/tests/test_llm_tools_executor_guard.py
+++ b/tests/test_llm_tools_executor_guard.py
@@ -1,0 +1,42 @@
+import pytest
+
+from src import ToolResult
+from src.agents import executor as executor_module
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_by_name_denied_by_llm_tools_policy(monkeypatch):
+    original_llm = dict(executor_module.config.llm or {})
+    monkeypatch.setitem(executor_module.config._config, "llm", {"tools": ["git_clone"]})
+
+    called = {"value": False}
+
+    async def _fake_execute_tool(name, **kwargs):
+        called["value"] = True
+        return ToolResult(success=True, content="should not run")
+
+    monkeypatch.setattr(executor_module, "execute_tool", _fake_execute_tool)
+
+    result = await executor_module.execute_tool_by_name("jira_get_issue", issue_key="EFP-1")
+
+    assert result.success is False
+    assert "disabled by llm.tools policy" in (result.error or "")
+    assert called["value"] is False
+    monkeypatch.setitem(executor_module.config._config, "llm", original_llm)
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_by_name_allowed_keeps_existing_behavior(monkeypatch):
+    original_llm = dict(executor_module.config.llm or {})
+    monkeypatch.setitem(executor_module.config._config, "llm", {"tools": ["git_clone"]})
+
+    async def _fake_execute_tool(name, **kwargs):
+        return ToolResult(success=True, content=f"ok:{name}:{kwargs.get('repo')}")
+
+    monkeypatch.setattr(executor_module, "execute_tool", _fake_execute_tool)
+
+    result = await executor_module.execute_tool_by_name("git_clone", repo="org/repo")
+
+    assert result.success is True
+    assert result.content == "ok:git_clone:org/repo"
+    monkeypatch.setitem(executor_module.config._config, "llm", original_llm)

--- a/tests/test_llm_tools_filtering.py
+++ b/tests/test_llm_tools_filtering.py
@@ -1,0 +1,73 @@
+import pytest
+
+from src.runtime.tool_filtering import (
+    filter_tool_schemas_for_llm,
+    is_tool_name_enabled_for_llm,
+    normalize_llm_tools_spec,
+)
+
+
+TOOL_SCHEMAS = [
+    {"type": "function", "function": {"name": "git_clone", "description": "clone"}},
+    {"type": "function", "function": {"name": "jira_get_issue", "description": "jira"}},
+    {"type": "function", "function": {"name": "jira_search", "description": "jira"}},
+    {"type": "function", "function": {"name": "read", "description": "read"}},
+]
+
+
+def _names(result):
+    return [item["function"]["name"] for item in result.filtered_schemas]
+
+
+def test_normalize_missing_tools_is_all():
+    spec = normalize_llm_tools_spec({"model": "x"})
+    assert spec.configured is False
+    assert spec.mode == "all"
+
+
+@pytest.mark.parametrize(
+    "tools_value",
+    [[], None, "", "   "],
+)
+def test_normalize_explicit_empty_is_none(tools_value):
+    spec = normalize_llm_tools_spec({"tools": tools_value})
+    assert spec.configured is True
+    assert spec.mode == "none"
+
+
+@pytest.mark.parametrize("tools_value", ["*", ["*"]])
+def test_normalize_wildcard_all(tools_value):
+    spec = normalize_llm_tools_spec({"tools": tools_value})
+    assert spec.mode == "all"
+
+
+def test_filter_single_pattern_jira_prefix():
+    result = filter_tool_schemas_for_llm(TOOL_SCHEMAS, {"tools": "jira_*"})
+    assert _names(result) == ["jira_get_issue", "jira_search"]
+
+
+def test_filter_union_exact_and_wildcard():
+    result = filter_tool_schemas_for_llm(TOOL_SCHEMAS, {"tools": ["git_clone", "jira_*"]})
+    assert _names(result) == ["git_clone", "jira_get_issue", "jira_search"]
+
+
+def test_filter_case_insensitive_pattern():
+    result = filter_tool_schemas_for_llm(TOOL_SCHEMAS, {"tools": ["JIRA_*", "Git_Clone"]})
+    assert _names(result) == ["git_clone", "jira_get_issue", "jira_search"]
+
+
+def test_filter_unmatched_patterns_reported():
+    result = filter_tool_schemas_for_llm(TOOL_SCHEMAS, {"tools": ["jira_*", "unknown_*"]})
+    assert result.unmatched_patterns == ["unknown_*"]
+
+
+def test_normalize_list_non_string_raises():
+    with pytest.raises(ValueError):
+        normalize_llm_tools_spec({"tools": ["jira_*", 1]})
+
+
+def test_is_tool_name_enabled_matches_filtering_rules():
+    llm_config = {"tools": ["git_clone", "jira_*"]}
+    assert is_tool_name_enabled_for_llm("git_clone", llm_config) is True
+    assert is_tool_name_enabled_for_llm("JIRA_SEARCH", llm_config) is True
+    assert is_tool_name_enabled_for_llm("read", llm_config) is False

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -128,3 +128,20 @@ def test_runtime_profile_overlay_section_removal_includes_proxy_change_and_rolls
     assert apply_calls["count"] >= 2
     assert cfg.proxy.get("enabled") is False
     assert cfg.proxy.get("url") is None
+
+
+def test_runtime_profile_overlay_preserves_llm_tools_configuration(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    runtime_profile_path = tmp_path / "runtime_profile.yaml"
+    _write_base_config(config_path)
+
+    cfg = Config(str(config_path))
+    cfg.runtime_profile_path = runtime_profile_path
+    cfg.set_managed_overlay(
+        "rp_tools",
+        1,
+        {"llm": {"tools": ["git_clone", "jira_*"]}},
+    )
+
+    effective = cfg.get_effective_config()
+    assert effective["llm"]["tools"] == ["git_clone", "jira_*"]

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -63,9 +63,12 @@ def base_agent(monkeypatch):
         {"function": {"name": "allowed_tool", "description": "ok"}},
         {"function": {"name": "blocked_tool", "description": "no"}},
     ]
+    agent.allowed_tool_names = {"allowed_tool", "blocked_tool"}
     agent.include_memory = False
     agent.think_level = SimpleNamespace(value="off")
     agent.model = None
+    agent.agent_id = None
+    agent.agent_name = None
     agent.memory_update_manager = None
 
     sess = _SessionManager()
@@ -339,6 +342,89 @@ def test_build_skill_runtime_config_scans_references_once(monkeypatch):
     assert "ref-a.md" in runtime_config.prompt_blocks.references_summary
 
 
+def test_build_skill_runtime_config_intersects_declared_tools_with_global_allowlist():
+    skill = SimpleNamespace(
+        name="demo",
+        description="demo",
+        tools=["git_clone", "jira_get_issue"],
+        task_tools=["git_clone", "jira_get_issue"],
+        strategy=[],
+        body="",
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+    )
+    runtime_config = build_skill_runtime_config(skill, globally_allowed_tool_names={"git_clone"})
+
+    assert runtime_config.tool_policy_declared is True
+    assert runtime_config.allowed_tools == ["git_clone"]
+    assert runtime_config.allowed_tools_set == {"git_clone"}
+    assert runtime_config.task_tools == ["git_clone"]
+    assert "git_clone" in runtime_config.prompt_blocks.system_rules
+    assert "jira_get_issue" not in runtime_config.prompt_blocks.system_rules
+
+
+def test_build_skill_runtime_config_declared_tools_empty_after_intersection():
+    skill = SimpleNamespace(
+        name="demo",
+        description="demo",
+        tools=["jira_get_issue"],
+        task_tools=[],
+        strategy=[],
+        body="",
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+    )
+    runtime_config = build_skill_runtime_config(skill, globally_allowed_tool_names={"git_clone"})
+
+    assert runtime_config.tool_policy_declared is True
+    assert runtime_config.allowed_tools == []
+    assert runtime_config.allowed_tools_set == set()
+    assert "allowed tools (none)" in runtime_config.prompt_blocks.system_rules
+    assert "all currently available tools" not in runtime_config.prompt_blocks.system_rules
+
+
+def test_build_skill_runtime_config_without_declared_tools_keeps_policy_open():
+    skill = SimpleNamespace(
+        name="demo",
+        description="demo",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body="",
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+    )
+    runtime_config = build_skill_runtime_config(skill, globally_allowed_tool_names={"git_clone"})
+
+    assert runtime_config.tool_policy_declared is False
+    assert runtime_config.allowed_tools == []
+    assert "all currently available tools" in runtime_config.prompt_blocks.system_rules
+
+
+def test_build_skill_runtime_config_task_tools_trimmed_by_global_allowlist():
+    skill = SimpleNamespace(
+        name="demo",
+        description="demo",
+        tools=["git_clone", "jira_get_issue"],
+        task_tools=["jira_get_issue"],
+        strategy=[],
+        body="",
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+    )
+    runtime_config = build_skill_runtime_config(skill, globally_allowed_tool_names={"git_clone"})
+
+    assert runtime_config.task_tools == []
+
+
 def test_build_skill_tool_denied_result_contains_policy():
     runtime_config = build_skill_runtime_config(
         SimpleNamespace(
@@ -377,7 +463,7 @@ async def test_matched_skill_does_not_route_to_legacy_skill_mode(monkeypatch, ba
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s: build_skill_runtime_config(s)),
+        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
     )
 
     async def fake_responses(**kwargs):
@@ -436,7 +522,7 @@ async def test_matched_skill_workdir_updates_and_clears_when_path_falsy(monkeypa
         SimpleNamespace(
             _initialized=True,
             match_skill=_match_skill,
-            get_skill_runtime_config=lambda s: build_skill_runtime_config(s),
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names),
         ),
     )
 
@@ -477,7 +563,7 @@ async def test_disallowed_tool_is_denied_and_allowed_tool_executes(monkeypatch, 
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s: build_skill_runtime_config(s)),
+        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
     )
 
     calls = {"execute": 0, "names": []}
@@ -529,7 +615,7 @@ async def test_hooks_and_task_path_emit_events(monkeypatch, base_agent):
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s: build_skill_runtime_config(s)),
+        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
     )
 
     async def _exec(*args, **kwargs):
@@ -572,7 +658,7 @@ async def test_hook_failure_does_not_break_request(monkeypatch, base_agent):
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s: build_skill_runtime_config(s)),
+        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
     )
 
     async def _exec(*args, **kwargs):
@@ -611,7 +697,7 @@ async def test_pre_hook_can_modify_args(monkeypatch, base_agent):
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s: build_skill_runtime_config(s)),
+        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
     )
     captured = {}
 
@@ -656,7 +742,7 @@ async def test_pre_hook_can_short_circuit(monkeypatch, base_agent):
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s: build_skill_runtime_config(s)),
+        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
     )
     called = {"tool": 0}
 
@@ -702,7 +788,7 @@ async def test_pre_hook_short_circuit_failure_emits_failed_tool_result(monkeypat
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s: build_skill_runtime_config(s)),
+        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
     )
     called = {"tool": 0}
 
@@ -744,7 +830,7 @@ async def test_post_hook_can_override_result(monkeypatch, base_agent):
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s: build_skill_runtime_config(s)),
+        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
     )
 
     async def _exec(*args, **kwargs):
@@ -768,7 +854,7 @@ async def test_non_skill_request_unaffected(monkeypatch, base_agent):
     agent, _ = base_agent
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [], get_skill_runtime_config=lambda s: None),
+        SimpleNamespace(_initialized=True, match_skill=lambda *_: [], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: None),
     )
 
     async def fake_responses(**kwargs):

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -594,6 +594,63 @@ async def test_disallowed_tool_is_denied_and_allowed_tool_executes(monkeypatch, 
 
 
 @pytest.mark.asyncio
+async def test_skill_declared_tools_empty_intersection_sends_empty_llm_tool_surface(monkeypatch, base_agent):
+    agent, _ = base_agent
+    agent.tools = [{"function": {"name": "allowed_tool", "description": "ok"}}]
+    agent.allowed_tool_names = {"allowed_tool"}
+
+    matched_skill = SimpleNamespace(
+        name="runtime-skill",
+        description="d",
+        path="",
+        tools=["blocked_tool"],
+        task_tools=[],
+        strategy=[],
+        body="instructions",
+        references=[],
+        model="",
+        hooks=[],
+    )
+    monkeypatch.setattr(
+        "src.skills.skill_registry",
+        SimpleNamespace(
+            _initialized=True,
+            match_skill=lambda *_: [matched_skill],
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(
+                s,
+                globally_allowed_tool_names=globally_allowed_tool_names,
+            ),
+        ),
+    )
+
+    seen_llm_tools = []
+    tool_exec_calls = {"count": 0}
+
+    async def _fake_execute_tool(*args, **kwargs):
+        tool_exec_calls["count"] += 1
+        return ToolResult(True, "unexpected")
+
+    monkeypatch.setattr("src.agents.core.execute_tool_by_name", _fake_execute_tool)
+
+    responses = [
+        {"content": "", "function_calls": [{"call_id": "1", "name": "blocked_tool", "arguments": "{}"}], "usage": {}},
+        {"content": "done", "function_calls": [], "usage": {}},
+    ]
+
+    async def _fake_responses(**kwargs):
+        seen_llm_tools.append(kwargs.get("tools"))
+        return responses.pop(0)
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=_fake_responses, default_provider="openai"))
+
+    result = await agent.process("runtime test", session_id="s-empty-intersection")
+    assert result["response"] == "done"
+    assert seen_llm_tools
+    assert seen_llm_tools[0] == []
+    assert tool_exec_calls["count"] == 0
+
+
+@pytest.mark.asyncio
 async def test_hooks_and_task_path_emit_events(monkeypatch, base_agent):
     agent, _ = base_agent
     events = []


### PR DESCRIPTION
### Motivation
- Provide a global, configurable LLm tool surface controlled by `llm.tools` in `config.yaml` while preserving existing semantics when the key is missing.
- Ensure this policy applies both to the tools advertised to the LLM and to actual execution (hard guard), and prevent skill-mode paths from bypassing the global filter.
- Keep capability registry behavior unchanged and avoid adding new APIs or changing portal/DB/capability profile flows.

### Description
- Add a pure helper module `src/runtime/tool_filtering.py` implementing `extract_tool_name`, `normalize_llm_tools_spec`, `filter_tool_schemas_for_llm`, `is_tool_name_enabled_for_llm`, and `intersect_tool_schemas_by_names` to encapsulate all matching/normalization logic and preserve missing vs explicit-empty semantics.
- Update `Agent` initialization in `src/agents/core.py` to load the full catalog via `get_tools_schemas()`, apply `filter_tool_schemas_for_llm(full_catalog, config.llm or {})`, set `self.tools` to the filtered schemas, cache `self.allowed_tool_names`, and log `full_count/filtered_count/mode/configured/unmatched_patterns`; build `tools_list` from `self.tools` and show a clear message when empty.
- Fix skill-mode continue path in `src/agents/core.py` so `skill.tools` never re-fetches the full catalog: if `skill.tools` is `List[str]` intersect against `self.tools`; if `List[dict]` intersect by extracted names against `self.allowed_tool_names`; if not declared, inherit `self.tools` — ensuring skill tools are always a subset of the global policy.
- Add an execution-level hard guard in `src/agents/executor.py::execute_tool_by_name()` calling `is_tool_name_enabled_for_llm(name, config.llm or {})` and returning a denied `ToolResult` (with stable readable message and warning log) when the tool is disabled, preventing any bypass of the global policy.
- Explicitly did not change `src/__init__.py::get_tools_schema()` or `src/runtime/capability_registry.py` semantics so `/api/capabilities` and capability registry still use the full catalog.
- Tests added/updated: `tests/test_llm_tools_filtering.py`, `tests/test_llm_tools_executor_guard.py`, `tests/test_agent_llm_tools_surface.py`, `tests/test_capability_registry.py` (extended), and `tests/test_runtime_profile_overlay.py` (small overlay preservation case).

### Testing
- Ran targeted pytest: `pytest -q tests/test_llm_tools_filtering.py tests/test_llm_tools_executor_guard.py tests/test_agent_llm_tools_surface.py tests/test_runtime_profile_overlay.py tests/test_capability_registry.py` and all tests passed (`33 passed, 1 warning`).
- `tests/test_llm_tools_filtering.py` verifies missing/all/none/patterns semantics, case-insensitivity, unmatched patterns reporting and non-string list item error behavior.
- `tests/test_llm_tools_executor_guard.py` verifies that a disabled tool is denied at `execute_tool_by_name()` (underlying `execute_tool` is not called) and that allowed tools keep original behavior.
- `tests/test_agent_llm_tools_surface.py` verifies `Agent` initialization filters the LLM-visible tool surface and that skill-mode tool selection intersects with the global surface (no re-fetch of full catalog).
- `tests/test_capability_registry.py` added a test demonstrating the capability registry still registers the full tool catalog even when `llm.tools` is restricted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e101b85ab8832abb0a3ef667d48bc2)