### PR TITLE
Persist Portal-managed runtime profile fields into config.yaml (remove runtime_profile overlay)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
 
 
 logger = logging.getLogger(__name__)
@@ -101,6 +102,72 @@ class Config:
         "git",
         "debug",
     }
+    PORTAL_MANAGED_FIELD_TREE = {
+        "llm": {
+            "provider": True,
+            "model": True,
+            "api_key": True,
+            "temperature": True,
+            "max_tokens": True,
+            "tools": True,
+        },
+        "proxy": {
+            "enabled": True,
+            "url": True,
+            "username": True,
+            "password": True,
+        },
+        "jira": {
+            "enabled": True,
+            "instances": True,
+            "automation": {
+                "assignments": {
+                    "enabled": True,
+                    "projects": True,
+                },
+                "mentions": {
+                    "enabled": True,
+                    "projects": True,
+                },
+            },
+        },
+        "confluence": {
+            "enabled": True,
+            "instances": True,
+            "automation": {
+                "mentions": {
+                    "enabled": True,
+                    "spaces": True,
+                },
+            },
+        },
+        "github": {
+            "enabled": True,
+            "api_token": True,
+            "base_url": True,
+            "automation": {
+                "review_requests": {
+                    "enabled": True,
+                    "repos": True,
+                },
+                "mentions": {
+                    "enabled": True,
+                    "repos": True,
+                    "include_review_comments": True,
+                },
+            },
+        },
+        "git": {
+            "user": {
+                "name": True,
+                "email": True,
+            },
+        },
+        "debug": {
+            "enabled": True,
+            "log_level": True,
+        },
+    }
 
     def __init__(self, config_path: Optional[str] = None):
         if config_path is None:
@@ -111,13 +178,12 @@ class Config:
         self.runtime_profile_path = Path.home() / ".efp" / "runtime_profile.yaml"
         self._config: Dict[str, Any] = {}
         self._base_config: Dict[str, Any] = {}
-        self._managed_overlay: Dict[str, Any] = {}
         self._managed_overlay_meta: Dict[str, Any] = {
             "runtime_profile_id": None,
             "revision": None,
         }
+        self._managed_sections: List[str] = []
         self._last_modified: float = 0
-        self._managed_overlay_last_modified: float = 0
         self._yaml = _yaml  # Use module-level instance
         self.load()
 
@@ -135,27 +201,71 @@ class Config:
 
     def load(self) -> None:
         """Load configuration from YAML file."""
-        if self.config_path.exists():
-            with open(self.config_path, "r", encoding="utf-8") as f:
-                self._base_config = self._yaml.load(f) or {}
-            self._last_modified = self.config_path.stat().st_mtime
-        else:
-            self._base_config = {}
-            self._last_modified = 0
+        self._base_config = self._load_yaml_document(self.config_path)
+        self._last_modified = self.config_path.stat().st_mtime if self.config_path.exists() else 0
         
         # Decrypt sensitive fields
         self._decrypt_sensitive_fields(self._base_config)
-        self.load_managed_overlay()
         self._rebuild_effective_config()
+
+    def _load_yaml_document(self, path: Path) -> Dict[str, Any]:
+        if not path.exists():
+            return CommentedMap()
+        with open(path, "r", encoding="utf-8") as f:
+            document = self._yaml.load(f) or CommentedMap()
+        return document if isinstance(document, dict) else CommentedMap()
+
+    def _write_yaml_document(self, path: Path, document: Dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            self._yaml.dump(document, f)
 
     def _deep_merge(self, base: Dict[str, Any], overlay: Dict[str, Any]) -> Dict[str, Any]:
         result = copy.deepcopy(base)
-        for key, value in (overlay or {}).items():
-            if isinstance(result.get(key), dict) and isinstance(value, dict):
-                result[key] = self._deep_merge(result[key], value)
-            else:
-                result[key] = copy.deepcopy(value)
+        self._deep_merge_into(result, overlay)
         return result
+
+    def _deep_merge_into(self, base: Dict[str, Any], overlay: Dict[str, Any]) -> Dict[str, Any]:
+        for key, value in (overlay or {}).items():
+            if self._is_mapping(base.get(key)) and self._is_mapping(value):
+                self._deep_merge_into(base[key], value)
+            else:
+                base[key] = copy.deepcopy(value)
+        return base
+
+    def _prune_by_field_tree(self, target: Dict[str, Any], field_tree: Dict[str, Any]) -> None:
+        if not self._is_mapping(target) or not self._is_mapping(field_tree):
+            return
+        for key, subtree in field_tree.items():
+            if key not in target:
+                continue
+            if subtree is True:
+                del target[key]
+                continue
+            current_value = target.get(key)
+            if self._is_mapping(current_value):
+                self._prune_by_field_tree(current_value, subtree)
+                if not current_value:
+                    del target[key]
+            else:
+                del target[key]
+
+    def _filter_by_field_tree(self, source: Dict[str, Any], field_tree: Dict[str, Any]) -> Dict[str, Any]:
+        filtered: Dict[str, Any] = {}
+        if not self._is_mapping(source) or not self._is_mapping(field_tree):
+            return filtered
+        for key, subtree in field_tree.items():
+            if key not in source:
+                continue
+            value = source.get(key)
+            if subtree is True:
+                filtered[key] = copy.deepcopy(value)
+                continue
+            if self._is_mapping(value):
+                nested = self._filter_by_field_tree(value, subtree)
+                if nested:
+                    filtered[key] = nested
+        return filtered
 
     def _filter_managed_overlay_sections(self, overlay_config: Dict[str, Any]) -> Dict[str, Any]:
         if not isinstance(overlay_config, dict):
@@ -164,36 +274,21 @@ class Config:
         for section, value in overlay_config.items():
             if section in self.MANAGED_OVERLAY_SECTIONS:
                 filtered[section] = copy.deepcopy(value)
-        return filtered
+        return self._filter_by_field_tree(filtered, self.PORTAL_MANAGED_FIELD_TREE)
 
     def _rebuild_effective_config(self) -> None:
-        self._config = self._deep_merge(self._base_config, self._managed_overlay)
+        self._config = copy.deepcopy(self._base_config)
 
     def load_managed_overlay(self) -> Dict[str, Any]:
-        """Load runtime managed overlay from runtime_profile.yaml."""
-        self._managed_overlay = {}
+        """Legacy compatibility no-op (overlay file model removed)."""
         self._managed_overlay_meta = {"runtime_profile_id": None, "revision": None}
+        self._managed_sections = []
+        return {}
 
-        if not self.runtime_profile_path.exists():
-            self._managed_overlay_last_modified = 0
-            return {}
-
-        with open(self.runtime_profile_path, "r", encoding="utf-8") as f:
-            payload = self._yaml.load(f) or {}
-        if not isinstance(payload, dict):
-            payload = {}
-
-        overlay_config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
-        overlay_config = self._filter_managed_overlay_sections(overlay_config)
-        self._decrypt_sensitive_fields(overlay_config)
-
-        self._managed_overlay = overlay_config
-        self._managed_overlay_meta = {
-            "runtime_profile_id": payload.get("runtime_profile_id"),
-            "revision": payload.get("revision"),
-        }
-        self._managed_overlay_last_modified = self.runtime_profile_path.stat().st_mtime
-        return copy.deepcopy(self._managed_overlay)
+    def _persist_runtime_config(self, config_document: Dict[str, Any]) -> None:
+        encrypted = copy.deepcopy(config_document)
+        self._encrypt_sensitive_fields(encrypted)
+        self._write_yaml_document(self.config_path, encrypted)
 
     def set_managed_overlay(
         self,
@@ -201,21 +296,24 @@ class Config:
         revision: Optional[int],
         overlay_config: Dict[str, Any],
     ) -> List[str]:
-        """Set and persist managed overlay config, then reload effective config."""
-        previous_sections = set(self._managed_overlay.keys())
+        """Apply Portal-managed snapshot into config.yaml and reload."""
+        previous_sections = set(self._managed_sections)
         filtered_overlay = self._filter_managed_overlay_sections(overlay_config or {})
         new_sections = set(filtered_overlay.keys())
-        payload = {
+
+        config_document = self._load_yaml_document(self.config_path)
+        self._decrypt_sensitive_fields(config_document)
+        self._prune_by_field_tree(config_document, self.PORTAL_MANAGED_FIELD_TREE)
+        self._deep_merge_into(config_document, filtered_overlay)
+        self._persist_runtime_config(config_document)
+
+        self._managed_overlay_meta = {
             "runtime_profile_id": runtime_profile_id,
             "revision": revision,
-            "config": copy.deepcopy(filtered_overlay),
         }
-        encrypted_payload = copy.deepcopy(payload)
-        self._encrypt_sensitive_fields(encrypted_payload)
-
-        self.runtime_profile_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.runtime_profile_path, "w", encoding="utf-8") as f:
-            self._yaml.dump(encrypted_payload, f)
+        self._managed_sections = sorted(new_sections)
+        if self.runtime_profile_path.exists():
+            self.runtime_profile_path.unlink()
 
         # Use union so section removals (e.g. proxy removed from overlay) still
         # trigger reload/apply side effects for the removed section.
@@ -226,8 +324,15 @@ class Config:
         return changed_sections
 
     def clear_managed_overlay(self) -> None:
-        """Clear managed runtime overlay and reload effective config."""
-        previous_sections = sorted(self._managed_overlay.keys())
+        """Remove all Portal-managed fields from config.yaml and reload."""
+        previous_sections = sorted(self._managed_sections)
+        config_document = self._load_yaml_document(self.config_path)
+        self._decrypt_sensitive_fields(config_document)
+        self._prune_by_field_tree(config_document, self.PORTAL_MANAGED_FIELD_TREE)
+        self._persist_runtime_config(config_document)
+
+        self._managed_overlay_meta = {"runtime_profile_id": None, "revision": None}
+        self._managed_sections = []
         if self.runtime_profile_path.exists():
             self.runtime_profile_path.unlink()
         self.reload(changed_sections=previous_sections)
@@ -241,8 +346,31 @@ class Config:
         return {
             "runtime_profile_id": self._managed_overlay_meta.get("runtime_profile_id"),
             "revision": self._managed_overlay_meta.get("revision"),
-            "managed_sections": sorted(self._managed_overlay.keys()),
+            "managed_sections": sorted(self._managed_sections),
         }
+
+    def save_partial_sections(self, updates: Dict[str, Any], sections: List[str]) -> List[str]:
+        """Persist partial section updates into config.yaml preserving YAML structure."""
+        config_document = self._load_yaml_document(self.config_path)
+        self._decrypt_sensitive_fields(config_document)
+        updated_sections: List[str] = []
+
+        for section in sections:
+            if section not in updates:
+                continue
+            if (
+                section in config_document
+                and self._is_mapping(config_document.get(section))
+                and self._is_mapping(updates[section])
+            ):
+                self._deep_merge_into(config_document[section], updates[section])
+            else:
+                config_document[section] = copy.deepcopy(updates[section])
+            updated_sections.append(section)
+
+        self._persist_runtime_config(config_document)
+        self.reload(changed_sections=updated_sections)
+        return updated_sections
     
     def _is_mapping(self, obj: Any) -> bool:
         """Check if obj is a mapping (dict or CommentedMap)."""
@@ -358,21 +486,16 @@ class Config:
         Returns:
             True if config was reloaded, False otherwise.
         """
-        base_exists = self.config_path.exists()
-        overlay_exists = self.runtime_profile_path.exists()
-        if not base_exists and not overlay_exists:
+        if not self.config_path.exists():
             return False
         
         try:
-            current_mtime = self.config_path.stat().st_mtime if base_exists else 0
-            overlay_mtime = self.runtime_profile_path.stat().st_mtime if overlay_exists else 0
+            current_mtime = self.config_path.stat().st_mtime
             # Force reload if changed_sections is provided (user explicitly saved config)
             # Otherwise only reload if file was modified
             if (
                 changed_sections
                 or current_mtime > self._last_modified
-                or overlay_mtime > self._managed_overlay_last_modified
-                or (not overlay_exists and self._managed_overlay_last_modified > 0)
             ):
                 self.load()
                 # Notify registered services if sections are specified

--- a/src/config.py
+++ b/src/config.py
@@ -200,13 +200,32 @@ class Config:
         return target
 
     def load(self) -> None:
-        """Load configuration from YAML file."""
+        """Load configuration from config.yaml and clean up legacy sidecar state."""
         self._base_config = self._load_yaml_document(self.config_path)
         self._last_modified = self.config_path.stat().st_mtime if self.config_path.exists() else 0
         
         # Decrypt sensitive fields
         self._decrypt_sensitive_fields(self._base_config)
+        self._cleanup_legacy_runtime_profile_file()
         self._rebuild_effective_config()
+
+    def _cleanup_legacy_runtime_profile_file(self) -> None:
+        """Delete legacy runtime_profile.yaml sidecar if it exists.
+
+        NOTE: runtime_profile.yaml is no longer an active runtime configuration
+        input. Portal bootstrap remains the source of truth for managed fields.
+        """
+        if not self.runtime_profile_path.exists():
+            return
+        try:
+            self.runtime_profile_path.unlink()
+            logger.info("Removed legacy runtime profile sidecar: %s", self.runtime_profile_path)
+        except Exception as exc:
+            logger.warning(
+                "Failed to remove legacy runtime profile sidecar %s: %s",
+                self.runtime_profile_path,
+                exc,
+            )
 
     def _load_yaml_document(self, path: Path) -> Dict[str, Any]:
         if not path.exists():
@@ -280,7 +299,11 @@ class Config:
         self._config = copy.deepcopy(self._base_config)
 
     def load_managed_overlay(self) -> Dict[str, Any]:
-        """Legacy compatibility no-op (overlay file model removed)."""
+        """Legacy compatibility no-op.
+
+        Runtime no longer loads any overlay sidecar file. Managed runtime-profile
+        fields are applied directly into config.yaml via set_managed_overlay().
+        """
         self._managed_overlay_meta = {"runtime_profile_id": None, "revision": None}
         self._managed_sections = []
         return {}
@@ -312,8 +335,7 @@ class Config:
             "revision": revision,
         }
         self._managed_sections = sorted(new_sections)
-        if self.runtime_profile_path.exists():
-            self.runtime_profile_path.unlink()
+        self._cleanup_legacy_runtime_profile_file()
 
         # Use union so section removals (e.g. proxy removed from overlay) still
         # trigger reload/apply side effects for the removed section.
@@ -333,8 +355,7 @@ class Config:
 
         self._managed_overlay_meta = {"runtime_profile_id": None, "revision": None}
         self._managed_sections = []
-        if self.runtime_profile_path.exists():
-            self.runtime_profile_path.unlink()
+        self._cleanup_legacy_runtime_profile_file()
         self.reload(changed_sections=previous_sections)
         if "proxy" in previous_sections:
             self.apply_proxy()

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -31,15 +31,6 @@ from src.utils.redaction import safe_preview, safe_log_field, sanitize_exception
 from src.utils.logger import clear_log_context, set_log_context
 
 
-from ruamel.yaml import YAML
-from ruamel.yaml.comments import CommentedMap
-
-# Module-level YAML instance for reuse
-_yaml = YAML()
-_yaml.preserve_quotes = True
-_yaml.indent(mapping=2, sequence=4, offset=2)
-_yaml.width = 4096
-
 from src.agents.core import Agent as AgentCore
 from src.agents.core import run_chat_execution
 from src.hooks.session_memory import save_session_summary
@@ -2160,83 +2151,10 @@ async def api_save_config(request: web.Request) -> web.Response:
     """
     try:
         data = await request.json()
-        
-        # Try project config first, then fallback to ~/.efp/
-        project_config = Path(__file__).parent.parent.parent / 'config.yaml'
-        project_example = Path(__file__).parent.parent.parent / 'config.yaml.example'
-        efp_config = Path.home() / '.efp' / 'config.yaml'
-        
-        # Determine config path
-        if project_config.exists():
-            config_path = project_config
-        elif efp_config.exists():
-            config_path = efp_config
-        else:
-            # Create new config from example
-            efp_config.parent.mkdir(parents=True, exist_ok=True)
-            if project_example.exists():
-                import shutil
-                shutil.copy(project_example, efp_config)
-                config_path = efp_config
-            else:
-                config_path = efp_config
-            config = {}
-        
-        # Use module-level YAML instance (reused for performance)
-        yaml = _yaml
-        
-        # Read existing config with ruamel.yaml (preserves comments)
-        existing_config = CommentedMap()
-        try:
-            if config_path.exists():
-                with open(config_path, 'r', encoding='utf-8') as f:
-                    existing_config = yaml.load(f) or CommentedMap()
-        except Exception as e:
-            logger.warning(f"Could not parse existing config, starting fresh: {e}")
-            existing_config = CommentedMap()
-        
-        # Deep merge function - only updates provided fields, preserves others
-        def deep_merge(base: Dict, update: Dict) -> Dict:
-            """Deep merge update into base, preserving unchanged fields."""
-            result = base.copy()
-            for key, value in update.items():
-                if key in result and isinstance(result.get(key), (dict, CommentedMap)) and isinstance(value, dict):
-                    result[key] = deep_merge(result[key], value)
-                else:
-                    result[key] = value
-            return result
-        
-        # Perform partial update - only merge provided sections
-        config = existing_config.copy()
         sections = ['llm', 'jira', 'confluence', 'github', 'git', 'debug', 'proxy']
-        
-        for section in sections:
-            if section in data:
-                # Deep merge to preserve other fields in this section
-                if section in config and isinstance(global_config.get(section), (dict, CommentedMap)):
-                    config[section] = deep_merge(config[section], data[section])
-                else:
-                    config[section] = data[section]
-        
-        # Remove deprecated SSH configuration from persisted config
-        _remove_legacy_ssh_config(config)
-
-        # Encrypt sensitive fields before saving
-        global_config._encrypt_sensitive_fields(config)
-        
-        # Write back with preserved formatting and comments
-        with open(config_path, 'w', encoding='utf-8') as f:
-            yaml.dump(config, f)
-        
-        # Determine which sections changed and reload services
-        updated_sections = [s for s in sections if s in data]
-        if not global_config.config_path.exists():
-            global_config.config_path = config_path
-        global_config.reload(changed_sections=updated_sections)
-        
-        # Apply proxy settings if proxy section was updated
-        if 'proxy' in updated_sections:
-            global_config.apply_proxy()
+        payload = dict(data) if isinstance(data, dict) else {}
+        _remove_legacy_ssh_config(payload)
+        updated_sections = global_config.save_partial_sections(payload, sections)
         
         return web.json_response({
             'success': True, 
@@ -2268,7 +2186,7 @@ async def api_get_config(request: web.Request) -> web.Response:
 
 
 async def api_apply_runtime_profile(request: web.Request) -> web.Response:
-    """Apply runtime managed profile overlay from trusted Portal control-plane request."""
+    """Apply managed runtime-profile snapshot from trusted Portal control-plane request."""
     if not _is_trusted_portal_request(request):
         return web.json_response({"error": "Forbidden"}, status=403)
 
@@ -2301,7 +2219,7 @@ async def api_apply_runtime_profile(request: web.Request) -> web.Response:
             }
         )
     except Exception as e:
-        logger.error("Error applying runtime profile overlay: %s", e, exc_info=True)
+        logger.error("Error applying runtime profile config: %s", e, exc_info=True)
         return web.json_response({"success": False, "error": str(e)}, status=500)
 
 

--- a/src/runtime/runtime_profile_client.py
+++ b/src/runtime/runtime_profile_client.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 def _extract_runtime_profile_overlay(
     payload: Dict[str, Any],
 ) -> Tuple[Optional[str], Optional[int], Optional[Dict[str, Any]], bool]:
-    """Extract overlay fields from portal response.
+    """Extract managed runtime-profile snapshot fields from portal response.
 
     Expected structured Portal payload:
     {
@@ -33,12 +33,12 @@ def _extract_runtime_profile_overlay(
       }
     }
 
-    Runtime only consumes ``runtime_profile_context.config`` (overlay body)
+    Runtime only consumes ``runtime_profile_context.config`` (managed config body)
     and ``runtime_profile_context.revision``. Extra Portal-side ownership /
     default metadata (for example ``owner_user_id`` or ``is_default``)
     remains control-plane-only and is ignored here.
 
-    Returns: (runtime_profile_id, revision, overlay_config, clear_flag)
+    Returns: (runtime_profile_id, revision, managed_config, clear_flag)
     """
     runtime_profile_id = payload.get("runtime_profile_id")
     runtime_profile_context = payload.get("runtime_profile_context")
@@ -73,7 +73,7 @@ def _extract_runtime_profile_overlay(
 
 
 async def bootstrap_runtime_profile_from_portal() -> bool:
-    """Best-effort bootstrap for runtime profile overlay from Portal internal API."""
+    """Best-effort bootstrap for managed runtime-profile apply from Portal internal API."""
     base_url = get_portal_internal_base_url()
     agent_id = get_portal_agent_id()
     if not base_url or not agent_id:
@@ -111,7 +111,7 @@ async def bootstrap_runtime_profile_from_portal() -> bool:
     if clear_flag:
         config.clear_managed_overlay()
         logger.info(
-            "Runtime profile overlay cleared from portal bootstrap: agent_id=%s profile_id=%s",
+            "Runtime profile config cleared from portal bootstrap: agent_id=%s profile_id=%s",
             agent_id,
             runtime_profile_id,
         )
@@ -120,7 +120,7 @@ async def bootstrap_runtime_profile_from_portal() -> bool:
     if isinstance(overlay_config, dict):
         updated_sections = config.set_managed_overlay(runtime_profile_id, revision, overlay_config)
         logger.info(
-            "Runtime profile overlay applied from portal bootstrap: agent_id=%s profile_id=%s revision=%s sections=%s",
+            "Runtime profile config applied from portal bootstrap: agent_id=%s profile_id=%s revision=%s sections=%s",
             agent_id,
             runtime_profile_id,
             revision,

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -8,6 +8,11 @@ def _write_base_config(path):
         "llm:\n"
         "  provider: openai\n"
         "  model: gpt-4o\n"
+        "  api_base: https://api.local\n"
+        "  max_retries: 3\n"
+        "  system-prompt:\n"
+        "    tools:\n"
+        "      enabled: true\n"
         "jira:\n"
         "  enabled: false\n"
         "proxy:\n"
@@ -16,14 +21,13 @@ def _write_base_config(path):
     )
 
 
-def test_runtime_profile_overlay_deep_merge_and_managed_sections(tmp_path):
+def test_runtime_profile_apply_writes_config_yaml_without_sidecar(tmp_path):
     config_path = tmp_path / "config.yaml"
     runtime_profile_path = tmp_path / "runtime_profile.yaml"
     _write_base_config(config_path)
 
     cfg = Config(str(config_path))
     cfg.runtime_profile_path = runtime_profile_path
-
     updated = cfg.set_managed_overlay(
         "rp_1",
         3,
@@ -34,10 +38,12 @@ def test_runtime_profile_overlay_deep_merge_and_managed_sections(tmp_path):
         },
     )
     assert updated == ["jira", "llm"]
+    assert not runtime_profile_path.exists()
 
+    cfg.load()
     effective = cfg.get_effective_config()
     assert effective["llm"]["provider"] == "anthropic"
-    assert effective["llm"]["model"] == "gpt-4o"
+    assert effective["llm"].get("model") is None
     assert effective["jira"]["enabled"] is True
     assert "unknown" not in effective
 
@@ -47,32 +53,61 @@ def test_runtime_profile_overlay_deep_merge_and_managed_sections(tmp_path):
     assert meta["managed_sections"] == ["jira", "llm"]
 
 
-def test_runtime_profile_overlay_clear_restores_base(tmp_path):
+def test_runtime_profile_apply_preserves_unmanaged_llm_subtree(tmp_path):
     config_path = tmp_path / "config.yaml"
-    runtime_profile_path = tmp_path / "runtime_profile.yaml"
     _write_base_config(config_path)
 
     cfg = Config(str(config_path))
-    cfg.runtime_profile_path = runtime_profile_path
-    cfg.set_managed_overlay("rp_2", 1, {"jira": {"enabled": True}})
-    assert cfg.jira.get("enabled") is True
+    cfg.set_managed_overlay(
+        "rp_tools",
+        1,
+        {"llm": {"provider": "openai", "model": "gpt-4.1", "tools": ["git_clone", "jira_*"]}},
+    )
 
-    cfg.clear_managed_overlay()
-    assert cfg.jira.get("enabled") is False
-    assert not runtime_profile_path.exists()
+    cfg.load()
+    effective = cfg.get_effective_config()
+    assert effective["llm"]["provider"] == "openai"
+    assert effective["llm"]["model"] == "gpt-4.1"
+    assert effective["llm"]["tools"] == ["git_clone", "jira_*"]
+    assert effective["llm"]["api_base"] == "https://api.local"
+    assert effective["llm"]["max_retries"] == 3
+    assert effective["llm"]["system-prompt"]["tools"]["enabled"] is True
 
 
-def test_runtime_profile_overlay_encrypt_decrypt_sensitive_fields(tmp_path, monkeypatch):
+def test_runtime_profile_apply_prunes_stale_managed_proxy_fields(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
-    runtime_profile_path = tmp_path / "runtime_profile.yaml"
+    _write_base_config(config_path)
+    for key in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
+        monkeypatch.delenv(key, raising=False)
+
+    cfg = Config(str(config_path))
+    cfg.set_managed_overlay(
+        "rp_proxy",
+        1,
+        {"proxy": {"enabled": True, "url": "http://overlay.proxy.local:8080", "password": "secret"}},
+    )
+    assert os.environ["http_proxy"] == "http://overlay.proxy.local:8080"
+
+    cfg.set_managed_overlay("rp_proxy", 2, {"llm": {"provider": "openai"}})
+    cfg.load()
+    assert cfg.proxy.get("enabled") is None
+    assert cfg.proxy.get("url") is None
+    assert cfg.proxy.get("password") is None
+
+
+def test_runtime_profile_apply_encrypts_sensitive_fields_in_config_yaml(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
     _write_base_config(config_path)
     monkeypatch.setenv("EFP_CONFIG_KEY", "test-key")
 
     cfg = Config(str(config_path))
-    cfg.runtime_profile_path = runtime_profile_path
-    cfg.set_managed_overlay("rp_3", 7, {"proxy": {"enabled": True, "url": "http://proxy:8080", "password": "secret"}})
+    cfg.set_managed_overlay(
+        "rp_3",
+        7,
+        {"proxy": {"enabled": True, "url": "http://proxy:8080", "password": "secret"}},
+    )
 
-    raw_content = runtime_profile_path.read_text(encoding="utf-8")
+    raw_content = config_path.read_text(encoding="utf-8")
     assert "ENC:" in raw_content
     assert "secret" not in raw_content
 
@@ -80,68 +115,20 @@ def test_runtime_profile_overlay_encrypt_decrypt_sensitive_fields(tmp_path, monk
     assert cfg.proxy.get("password") == "secret"
 
 
-def test_runtime_profile_overlay_proxy_applies_env(tmp_path, monkeypatch):
+def test_runtime_profile_clear_removes_managed_subtree_and_metadata(tmp_path):
     config_path = tmp_path / "config.yaml"
     runtime_profile_path = tmp_path / "runtime_profile.yaml"
     _write_base_config(config_path)
-    for key in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
-        monkeypatch.delenv(key, raising=False)
+    runtime_profile_path.write_text("legacy: true\n", encoding="utf-8")
 
     cfg = Config(str(config_path))
     cfg.runtime_profile_path = runtime_profile_path
-    cfg.set_managed_overlay("rp_4", 1, {"proxy": {"enabled": True, "url": "http://proxy.example.com:8080"}})
+    cfg.set_managed_overlay("rp_2", 1, {"jira": {"enabled": True}, "proxy": {"enabled": True, "url": "http://x"}})
+    cfg.clear_managed_overlay()
 
-    assert os.environ["http_proxy"] == "http://proxy.example.com:8080"
-    assert os.environ["HTTPS_PROXY"] == "http://proxy.example.com:8080"
-
-
-def test_runtime_profile_overlay_section_removal_includes_proxy_change_and_rolls_back_to_base(tmp_path, monkeypatch):
-    config_path = tmp_path / "config.yaml"
-    runtime_profile_path = tmp_path / "runtime_profile.yaml"
-    _write_base_config(config_path)
-
-    cfg = Config(str(config_path))
-    cfg.runtime_profile_path = runtime_profile_path
-
-    apply_calls = {"count": 0}
-    original_apply_proxy = cfg.apply_proxy
-
-    def _count_apply_proxy():
-        apply_calls["count"] += 1
-        original_apply_proxy()
-
-    monkeypatch.setattr(cfg, "apply_proxy", _count_apply_proxy)
-
-    first_changed = cfg.set_managed_overlay(
-        "rp_5",
-        1,
-        {
-            "proxy": {"enabled": True, "url": "http://overlay.proxy.local:8080"},
-            "llm": {"provider": "anthropic"},
-        },
-    )
-    assert "proxy" in first_changed
-    assert cfg.proxy.get("url") == "http://overlay.proxy.local:8080"
-
-    second_changed = cfg.set_managed_overlay("rp_5", 2, {"llm": {"provider": "openai"}})
-    assert "proxy" in second_changed
-    assert apply_calls["count"] >= 2
-    assert cfg.proxy.get("enabled") is False
-    assert cfg.proxy.get("url") is None
-
-
-def test_runtime_profile_overlay_preserves_llm_tools_configuration(tmp_path):
-    config_path = tmp_path / "config.yaml"
-    runtime_profile_path = tmp_path / "runtime_profile.yaml"
-    _write_base_config(config_path)
-
-    cfg = Config(str(config_path))
-    cfg.runtime_profile_path = runtime_profile_path
-    cfg.set_managed_overlay(
-        "rp_tools",
-        1,
-        {"llm": {"tools": ["git_clone", "jira_*"]}},
-    )
-
-    effective = cfg.get_effective_config()
-    assert effective["llm"]["tools"] == ["git_clone", "jira_*"]
+    cfg.load()
+    meta = cfg.get_managed_overlay_meta()
+    assert meta == {"runtime_profile_id": None, "revision": None, "managed_sections": []}
+    assert cfg.jira.get("enabled") is None
+    assert "proxy" not in cfg.get_effective_config()
+    assert not runtime_profile_path.exists()

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -74,6 +74,40 @@ def test_runtime_profile_apply_preserves_unmanaged_llm_subtree(tmp_path):
     assert effective["llm"]["system-prompt"]["tools"]["enabled"] is True
 
 
+def test_runtime_profile_apply_filters_unmanaged_nested_fields_from_snapshot(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    _write_base_config(config_path)
+
+    cfg = Config(str(config_path))
+    cfg.set_managed_overlay(
+        "rp_filter",
+        9,
+        {
+            "llm": {
+                "provider": "openai",
+                "model": "gpt-5",
+                "api_base": "https://should-not-be-written",
+                "system-prompt": {"tools": {"enabled": False}},
+            },
+            "github": {
+                "enabled": True,
+                "base_url": "https://github.example/api",
+                "unexpected_nested": {"x": 1},
+            },
+        },
+    )
+
+    cfg.load()
+    effective = cfg.get_effective_config()
+    assert effective["llm"]["provider"] == "openai"
+    assert effective["llm"]["model"] == "gpt-5"
+    assert effective["llm"]["api_base"] == "https://api.local"
+    assert effective["llm"]["system-prompt"]["tools"]["enabled"] is True
+    assert effective["github"]["enabled"] is True
+    assert effective["github"]["base_url"] == "https://github.example/api"
+    assert "unexpected_nested" not in effective["github"]
+
+
 def test_runtime_profile_apply_prunes_stale_managed_proxy_fields(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
     _write_base_config(config_path)
@@ -132,3 +166,19 @@ def test_runtime_profile_clear_removes_managed_subtree_and_metadata(tmp_path):
     assert cfg.jira.get("enabled") is None
     assert "proxy" not in cfg.get_effective_config()
     assert not runtime_profile_path.exists()
+
+
+def test_runtime_profile_load_removes_legacy_sidecar_on_startup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    home_efp_dir = tmp_path / ".efp"
+    home_efp_dir.mkdir(parents=True, exist_ok=True)
+
+    config_path = home_efp_dir / "config.yaml"
+    runtime_profile_path = home_efp_dir / "runtime_profile.yaml"
+    _write_base_config(config_path)
+    runtime_profile_path.write_text("llm:\n  provider: old\n", encoding="utf-8")
+
+    cfg = Config(str(config_path))
+
+    assert not runtime_profile_path.exists()
+    assert cfg.get_effective_config()["llm"]["provider"] == "openai"


### PR DESCRIPTION
### Motivation

- Remove the runtime-side overlay file model (`~/.efp/runtime_profile.yaml`) and treat `config.yaml` as the single persisted runtime config while keeping Portal as the source of truth for managed runtime profiles.
- Ensure Portal can only manage a defined subtree of fields and that unmanaged/local config keys are preserved.
- Prevent stale managed keys from persisting by pruning the managed subtree before applying a new snapshot. 

### Description

- Introduced `PORTAL_MANAGED_FIELD_TREE` and helpers in `Config` for loading/writing YAML documents, recursive deep-merge, filtering by allowed field-tree, and pruning managed subtrees so Portal apply only touches allowed fields. (see `_load_yaml_document`, `_write_yaml_document`, `_deep_merge_into`, `_prune_by_field_tree`, `_filter_by_field_tree`).
- Reworked `set_managed_overlay` to: filter the incoming snapshot, load and decrypt the existing `config.yaml`, prune the Portal-managed subtree, merge the filtered snapshot into the document, encrypt and persist back to `config.yaml`, update in-memory runtime-profile metadata, delete any legacy `runtime_profile.yaml`, and trigger reloads/`apply_proxy` as needed.
- Reworked `clear_managed_overlay` to prune all Portal-managed fields from `config.yaml`, clear in-memory profile metadata, remove legacy sidecar if present, persist and reload affected sections.
- Extracted YAML persistence/partial-save logic into `Config.save_partial_sections` and updated `/api/config/save` in `src/gateway/webchat.py` to reuse the same helpers instead of duplicating ruamel YAML write logic.
- Kept Portal-facing apply contract and method names (`/api/internal/runtime-profile/apply`, `set_managed_overlay`, `clear_managed_overlay`) unchanged while updating wording/comments in `src/runtime/runtime_profile_client.py` and `src/gateway/webchat.py` to reflect the new managed-snapshot semantics.
- Tests: replaced and updated runtime-profile overlay tests to assert new semantics (write into `config.yaml`, do not create sidecar, preserve unmanaged keys, prune stale managed keys, encryption behavior) and kept client/webchat tests compatible.

Files changed: `src/config.py`, `src/gateway/webchat.py`, `src/runtime/runtime_profile_client.py`, `tests/test_runtime_profile_overlay.py`.

### Testing

- Ran `pytest tests/test_runtime_profile_overlay.py -q` and the updated overlay tests passed. 
- Ran `pytest tests/test_runtime_profile_client.py -q` and `pytest tests/test_webchat_runtime_profile.py -q` and both test suites passed. 
- Ran nearby `tests/test_config.py -q` to validate refactor and it passed.

All automated tests mentioned above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1e24b02e0832a8f60329fa347da72)