### PR TITLE
Fix Responses max_output_tokens misclassification and propagate structured webchat errors

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -132,6 +132,11 @@ _DEBUG_ENABLED = None  # Lazy initialization
 _TOOL_RESULT_GOVERNANCE_ATTR = "_governance"
 
 
+def _tool_feedback_text(value: Any, max_length: int = 4000) -> str:
+    """Build bounded tool feedback text for next-round LLM input only."""
+    return truncate_with_count(str(value), max_length)
+
+
 def _is_debug_enabled() -> bool:
     """Check if debug mode is enabled (logger is DEBUG level)."""
     global _DEBUG_ENABLED
@@ -1635,7 +1640,7 @@ You have access to the following tools. When a user asks you to do something tha
                         loop_messages.append(
                             {
                                 "role": "tool",
-                                "content": str(deny_result),
+                                "content": _tool_feedback_text(deny_result),
                                 "tool_call_id": call_id,
                             }
                         )
@@ -1670,7 +1675,7 @@ You have access to the following tools. When a user asks you to do something tha
                     loop_messages.append(
                         {
                             "role": "tool",
-                            "content": str(short_result),
+                            "content": _tool_feedback_text(short_result),
                             "tool_call_id": call_id,
                         }
                     )
@@ -1753,7 +1758,7 @@ You have access to the following tools. When a user asks you to do something tha
                 # The tool result naturally comes after the assistant message in the iteration order.
                 tool_result_msg = {
                     "role": "tool",
-                    "content": truncate(str(tool_result), 4000),
+                    "content": _tool_feedback_text(tool_result),
                     "tool_call_id": call_id,
                 }
                 
@@ -2271,7 +2276,7 @@ You have access to the following tools. When a user asks you to do something tha
                         args=normalized_args,
                         source_ref="agents.core.skill_mode_loop",
                     )
-                    output_text = str(tool_result)
+                    output_text = _tool_feedback_text(tool_result)
                     logger.debug(f"[SkillMode] [TOOL_RESULT] tool={tool_name}, result length={len(output_text)}, preview={safe_preview(output_text, 200)}")
                 except Exception as tool_exc:
                     output_text = f"Error: Tool '{tool_name}' failed with {tool_exc}"

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -1314,11 +1314,18 @@ You have access to the following tools. When a user asks you to do something tha
                 error_info = llm_result["error"]
                 error_msg = error_info.get("message", "Unknown LLM error")
                 logger.error(f"LLM error: {error_msg}")
-                return {
+                error_response = {
                     "error": error_msg,
                     "error_type": error_info.get("type", "llm_error"),
                     "code": error_info.get("code", "")
                 }
+                details = error_info.get("details")
+                status_code = error_info.get("status_code")
+                if isinstance(details, dict):
+                    error_response["details"] = details
+                if isinstance(status_code, int):
+                    error_response["status_code"] = status_code
+                return error_response
             
             # Debug logging for LLM response
             if _is_debug_enabled():
@@ -1746,7 +1753,7 @@ You have access to the following tools. When a user asks you to do something tha
                 # The tool result naturally comes after the assistant message in the iteration order.
                 tool_result_msg = {
                     "role": "tool",
-                    "content": str(tool_result),
+                    "content": truncate(str(tool_result), 4000),
                     "tool_call_id": call_id,
                 }
                 
@@ -2178,12 +2185,19 @@ You have access to the following tools. When a user asks you to do something tha
                 error_info = llm_result["error"]
                 error_msg = error_info.get("message", "Unknown LLM error")
                 logger.error(f"[SkillMode] LLM error: {error_msg}")
-                return {
+                error_response = {
                     "error": error_msg,
                     "error_type": error_info.get("type", "llm_error"),
                     "code": error_info.get("code", ""),
                     "user_message_id": user_message_id,
                 }
+                details = error_info.get("details")
+                status_code = error_info.get("status_code")
+                if isinstance(details, dict):
+                    error_response["details"] = details
+                if isinstance(status_code, int):
+                    error_response["status_code"] = status_code
+                return error_response
 
             if track_usage:
                 iter_usage = llm_result.get("usage", {}) or {}

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -1074,7 +1074,7 @@ You have access to the following tools. When a user asks you to do something tha
                     items.append({
                         "type": "function_call_output",
                         "call_id": tool_call_id,
-                        "output": str(content) if content else "",
+                        "output": _tool_feedback_text(content) if content else "",
                     })
                     continue
                 
@@ -1112,7 +1112,7 @@ You have access to the following tools. When a user asks you to do something tha
                     items.append({
                         "type": "function_call_output",
                         "call_id": tool_call_id,
-                        "output": str(content) if content else "",
+                        "output": _tool_feedback_text(content) if content else "",
                     })
                     continue
                 

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -693,6 +693,24 @@ class OpenAIProvider(BaseProvider):
                         "cost_usd": estimate_cost(model_name, prompt_tokens, completion_tokens)
                     }
                 }
+            incomplete_reason = data.get("incomplete_details", {}).get("reason")
+            if incomplete_reason == "max_output_tokens":
+                logger.error(
+                    "[LLM] Copilot API returned incomplete response because max_output_tokens was reached. payload=%s response=%s",
+                    safe_preview(payload, 600),
+                    safe_preview(data, 600),
+                )
+                return {
+                    "error": {
+                        "message": "Model output was truncated because max_output_tokens was reached. Reduce context or increase the output token limit and retry.",
+                        "type": "truncated_response",
+                        "code": "max_output_tokens_exceeded",
+                        "details": {
+                            "incomplete_reason": "max_output_tokens"
+                        },
+                        "status_code": 500,
+                    }
+                }
             logger.error("[LLM] Copilot API returned empty content. payload=%s response=%s", safe_preview(payload, 600), safe_preview(data, 600))
             return {"error": {"message": "Copilot API returned empty message. Please try rephrasing your prompt or check your input.", "type": "empty_response", "code": "empty_message"}}
 
@@ -1090,6 +1108,24 @@ class GitHubCopilotProvider(BaseProvider):
                         "completion_tokens": completion_tokens,
                         "total_tokens": prompt_tokens + completion_tokens,
                         "cost_usd": estimate_cost(model_name, prompt_tokens, completion_tokens)
+                    }
+                }
+            incomplete_reason = data.get("incomplete_details", {}).get("reason")
+            if incomplete_reason == "max_output_tokens":
+                logger.error(
+                    "[LLM] Copilot API returned incomplete response because max_output_tokens was reached. payload=%s response=%s",
+                    safe_preview(payload, 600),
+                    safe_preview(data, 600),
+                )
+                return {
+                    "error": {
+                        "message": "Model output was truncated because max_output_tokens was reached. Reduce context or increase the output token limit and retry.",
+                        "type": "truncated_response",
+                        "code": "max_output_tokens_exceeded",
+                        "details": {
+                            "incomplete_reason": "max_output_tokens"
+                        },
+                        "status_code": 500,
                     }
                 }
             logger.error("[LLM] Copilot API returned empty content. payload=%s response=%s", safe_preview(payload, 600), safe_preview(data, 600))

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -387,16 +387,47 @@ async def _run_chat_via_execution_bus(
     output_payload["_execution_result"] = execution_result
     if execution_result.status == "error" or output_payload.get("error"):
         error_value = output_payload.get("error", "Execution bus error")
-        if isinstance(error_value, dict):
+        structured_error = error_value if isinstance(error_value, dict) else {}
+        status_code = None
+
+        if structured_error:
             error_message = (
-                error_value.get("message")
-                or error_value.get("error")
-                or json.dumps(error_value, ensure_ascii=False)
+                structured_error.get("message")
+                or structured_error.get("error")
+                or json.dumps(structured_error, ensure_ascii=False)
             )
+            error_type = structured_error.get("type")
+            code = structured_error.get("code")
+            details = structured_error.get("details")
+            status_code = structured_error.get("status_code")
         else:
             error_message = str(error_value)
-        raise web.HTTPInternalServerError(
-            text=json.dumps({"error": error_message}, ensure_ascii=False),
+            error_type = output_payload.get("error_type")
+            code = output_payload.get("code")
+            details = output_payload.get("details")
+            status_code = output_payload.get("status_code")
+
+        response_body = {
+            "error": error_message,
+            "detail": error_message,
+            "error_type": error_type if isinstance(error_type, str) else "",
+            "code": code if isinstance(code, str) else "",
+            "details": details if isinstance(details, dict) else {},
+            "request_id": output_payload.get("request_id"),
+        }
+        resolved_status_code = status_code if isinstance(status_code, int) and 400 <= status_code <= 599 else 500
+
+        if resolved_status_code == 500:
+            raise web.HTTPInternalServerError(
+                text=json.dumps(response_body, ensure_ascii=False),
+                content_type="application/json",
+            )
+
+        class _StructuredHTTPError(web.HTTPException):
+            status_code = resolved_status_code
+
+        raise _StructuredHTTPError(
+            text=json.dumps(response_body, ensure_ascii=False),
             content_type="application/json",
         )
     return output_payload

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -105,3 +105,15 @@ def test_agent_process_source_uses_tool_feedback_text_for_all_tool_feedback_path
     assert process_source.count("_tool_feedback_text(") >= 3
     # Module-level coverage also includes skill mode function_call_output feedback.
     assert module_source.count("_tool_feedback_text(") >= 4
+
+
+def test_to_input_items_source_bounds_historical_function_call_output_content():
+    from src.agents import core
+
+    module_source = inspect.getsource(core)
+    expected = '"output": _tool_feedback_text(content) if content else ""'
+
+    # Historical tool feedback can flow through two branches in _to_input_items:
+    # 1) role == "tool" with tool_call_id
+    # 2) generic fallback with tool_call_id
+    assert module_source.count(expected) >= 2

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -74,3 +74,34 @@ def test_agent_process_source_prefers_self_model_in_multiple_paths():
     source = inspect.getsource(core.Agent.process)
     expected = 'self.model or config.llm.get("model", "gpt-5-mini")'
     assert source.count(expected) >= 2
+
+
+def test_tool_feedback_text_preserves_short_text():
+    from src.agents import core
+
+    value = "short tool output"
+    assert core._tool_feedback_text(value) == value
+    assert "chars hidden" not in core._tool_feedback_text(value)
+
+
+def test_tool_feedback_text_truncates_long_text_with_count():
+    from src.agents import core
+
+    long_value = "A" * 5005
+    output = core._tool_feedback_text(long_value)
+
+    assert output.startswith("A" * 20)
+    assert "chars hidden" in output
+    assert len(output) < len(long_value)
+
+
+def test_agent_process_source_uses_tool_feedback_text_for_all_tool_feedback_paths():
+    from src.agents import core
+
+    process_source = inspect.getsource(core.Agent.process)
+    module_source = inspect.getsource(core)
+
+    # Agent.process should cover deny / short-circuit / normal tool result feedback.
+    assert process_source.count("_tool_feedback_text(") >= 3
+    # Module-level coverage also includes skill mode function_call_output feedback.
+    assert module_source.count("_tool_feedback_text(") >= 4

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -70,6 +70,15 @@ def openai_provider():
     return provider
 
 
+@pytest.fixture
+def github_copilot_provider():
+    """Create a GitHubCopilotProvider with _check_api_key patched."""
+    from src.agents.llm import GitHubCopilotProvider
+    provider = GitHubCopilotProvider()
+    provider._check_api_key = lambda: None
+    return provider
+
+
 class TestLLMClientSuccess:
     """Successful LLM client tests."""
 
@@ -417,6 +426,45 @@ class TestResponsesAPI:
             # Should accumulate both parts
             assert "Part1" in result["content"]
             assert "Part2" in result["content"]
+
+    @pytest.mark.asyncio
+    async def test_openai_responses_empty_output_max_output_tokens_returns_truncated_error(self, openai_provider):
+        mock_response = MockResponse({
+            "output": [],
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "usage": {"input_tokens": 10, "output_tokens": 0},
+        })
+        mock_client = MockHttpClient(mock_response)
+
+        with patch('httpx.AsyncClient', return_value=mock_client):
+            result = await openai_provider.responses(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+
+        assert result["error"]["type"] == "truncated_response"
+        assert result["error"]["code"] == "max_output_tokens_exceeded"
+        assert result["error"]["details"]["incomplete_reason"] == "max_output_tokens"
+
+    @pytest.mark.asyncio
+    async def test_github_copilot_responses_empty_output_max_output_tokens_returns_truncated_error(
+        self,
+        github_copilot_provider,
+    ):
+        mock_response = MockResponse({
+            "output": [],
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "usage": {"input_tokens": 10, "output_tokens": 0},
+        })
+        mock_client = MockHttpClient(mock_response)
+
+        with patch('httpx.AsyncClient', return_value=mock_client):
+            result = await github_copilot_provider.responses(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+
+        assert result["error"]["type"] == "truncated_response"
+        assert result["error"]["code"] == "max_output_tokens_exceeded"
+        assert result["error"]["details"]["incomplete_reason"] == "max_output_tokens"
 
     @pytest.mark.asyncio
     async def test_responses_tool_calls(self, openai_provider):

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -458,11 +458,26 @@ async def test_chat_execution_bus_adapter_persists_last_execution_id(monkeypatch
 
 @pytest.mark.asyncio
 async def test_chat_execution_bus_adapter_raises_on_error_status(monkeypatch):
+    import json
     from aiohttp import web
     from src.gateway import webchat
 
     async def _fake_execute_chat_orchestration(**kwargs):
-            return type("R", (), {"status": "error", "output_payload": {"error": {"message": "boom"}}})()
+        return type(
+            "R",
+            (),
+            {
+                "status": "error",
+                "request_id": "chat-structured-1",
+                "output_payload": {
+                    "error": "Model output was truncated because max_output_tokens was reached.",
+                    "error_type": "truncated_response",
+                    "code": "max_output_tokens_exceeded",
+                    "details": {"incomplete_reason": "max_output_tokens"},
+                    "status_code": 500,
+                },
+            },
+        )()
 
     monkeypatch.setattr(webchat, "execute_chat_orchestration", _fake_execute_chat_orchestration)
 
@@ -471,7 +486,7 @@ async def test_chat_execution_bus_adapter_raises_on_error_status(monkeypatch):
 
     monkeypatch.setattr(webchat, "run_chat_execution", _fake_run_chat_execution)
 
-    with pytest.raises(web.HTTPInternalServerError):
+    with pytest.raises(web.HTTPInternalServerError) as exc_info:
         await webchat._run_chat_via_execution_bus(
             agent=object(),
             session_id="s-chat",
@@ -480,6 +495,52 @@ async def test_chat_execution_bus_adapter_raises_on_error_status(monkeypatch):
             portal_user_id=None,
             portal_user_name=None,
         )
+    body = json.loads(exc_info.value.text)
+    assert body["error"]
+    assert body["detail"] == body["error"]
+    assert body["error_type"] == "truncated_response"
+    assert body["code"] == "max_output_tokens_exceeded"
+    assert body["details"]["incomplete_reason"] == "max_output_tokens"
+    assert body["request_id"] == "chat-structured-1"
+
+
+@pytest.mark.asyncio
+async def test_chat_execution_bus_adapter_raises_on_legacy_string_error(monkeypatch):
+    import json
+    from aiohttp import web
+    from src.gateway import webchat
+
+    async def _fake_execute_chat_orchestration(**kwargs):
+        return type(
+            "R",
+            (),
+            {
+                "status": "error",
+                "request_id": "chat-legacy-1",
+                "output_payload": {"error": "legacy failure"},
+            },
+        )()
+
+    monkeypatch.setattr(webchat, "execute_chat_orchestration", _fake_execute_chat_orchestration)
+    monkeypatch.setattr(webchat, "run_chat_execution", lambda *args, **kwargs: {"response": "ignored"})
+
+    with pytest.raises(web.HTTPInternalServerError) as exc_info:
+        await webchat._run_chat_via_execution_bus(
+            agent=object(),
+            session_id="s-chat",
+            message="hello",
+            user_name="u1",
+            portal_user_id=None,
+            portal_user_name=None,
+        )
+
+    body = json.loads(exc_info.value.text)
+    assert body["error"] == "legacy failure"
+    assert body["detail"] == "legacy failure"
+    assert body["error_type"] == ""
+    assert body["code"] == ""
+    assert body["details"] == {}
+    assert body["request_id"] == "chat-legacy-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Fix a bug where Responses API empty output with `incomplete_details.reason == "max_output_tokens"` was misclassified as an `empty_response` and lost useful diagnostics.
- Ensure structured provider errors (including `details` and `status_code`) are preserved and forwarded through the runtime to Portal so the front-end can show meaningful error information.

### Description
- `src/agents/llm.py`: In both Responses API empty-content branches, check `data.get("incomplete_details", {}).get("reason")` and when it equals `max_output_tokens` return a structured error payload with `type: "truncated_response"`, `code: "max_output_tokens_exceeded"`, `details` and `status_code: 500`, and update logging to indicate truncation rather than "empty content".
- `src/agents/core.py`: When `llm_result.get("error")` is present (main loop and skill mode), preserve and forward `details` (if dict) and `status_code` (if int) in addition to existing `error/error_type/code`; also apply a conservative truncation of `tool_result` content inserted into `loop_messages` using `truncate(..., 4000)` without mutating the original `tool_result` object.
- `src/gateway/webchat.py`: In `_run_chat_via_execution_bus()` convert execution-bus errors into structured HTTP JSON responses (fields: `error`, `detail`, `error_type`, `code`, `details`, `request_id`), prefer structured `output_payload["error"]` when present, and use provider `status_code` (400–599) if valid otherwise default to 500; keep legacy string `error` handling compatible.
- Tests: Added provider fixtures and tests to cover both OpenAI and GitHub Copilot Responses API branches for `max_output_tokens`, and added webchat tests to assert structured and legacy error payloads are returned.

### Testing
- Ran `pytest -q tests/test_llm_client.py -k "max_output_tokens or responses_empty_output"` and observed the selected tests passed (2 passed).
- Ran `pytest -q tests/test_webchat.py -k "raises_on_error_status or legacy_string_error"` and observed the selected tests passed (2 passed).
- The changes are limited to the specified files and the new tests validate both provider branches and webchat error propagation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20e351bf0832a99879769138e58f7)