### PR TITLE
Fix main.py automation watcher rename follow-up

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,10 +27,10 @@ from src.gateway.server import gateway
 from src.sessions.persistence import session_persistence
 from src.sessions.manager import session_manager
 from src.sessions.usage import usage_tracker
-from src.cron.subscription_watchers import (
-    start_subscription_watchers,
-    stop_subscription_watchers,
-    is_enabled as are_subscription_watchers_enabled,
+from src.cron.automation_watchers import (
+    start_automation_watchers,
+    stop_automation_watchers,
+    is_enabled as are_automation_watchers_enabled,
 )
 from src.cron.jira_reconciliation import start_reconciliation, stop_reconciliation, is_enabled as is_jira_reconciliation_enabled
 from src.git.api import setup_git_user
@@ -170,20 +170,20 @@ async def main() -> None:
         logger.warning(f"Failed to setup git user | error={e}", exc_info=True)
 
     # Initialize watcher task before gateway start
-    polling_task = None
+    automation_watchers_task = None
     jira_reconciliation_task = None
     
     try:
         await gateway.start()
         logger.info("Gateway server started")
         
-        # Start subscription watchers if enabled
-        if are_subscription_watchers_enabled():
-            logger.info("Starting subscription watchers...")
-            polling_task = asyncio.create_task(start_subscription_watchers())
-            logger.info("Subscription watchers started")
+        # Start automation watchers if enabled
+        if are_automation_watchers_enabled():
+            logger.info("Starting automation watchers...")
+            automation_watchers_task = asyncio.create_task(start_automation_watchers())
+            logger.info("Automation watchers started")
         else:
-            logger.debug("Subscription watchers are disabled")
+            logger.debug("Automation watchers are disabled")
 
         if is_jira_reconciliation_enabled():
             logger.info("Starting Jira reconciliation...")
@@ -206,12 +206,12 @@ async def main() -> None:
     except Exception as e:
         logger.error(f"Unexpected error in main loop | error={e}", exc_info=True)
     finally:
-        # Stop subscription watchers
-        if polling_task and not polling_task.done():
-            logger.info("Stopping subscription watchers...")
-            await stop_subscription_watchers()
-            await polling_task
-            logger.info("Subscription watchers stopped")
+        # Stop automation watchers
+        if automation_watchers_task and not automation_watchers_task.done():
+            logger.info("Stopping automation watchers...")
+            await stop_automation_watchers()
+            await automation_watchers_task
+            logger.info("Automation watchers stopped")
 
         await _shutdown_jira_reconciliation_task(jira_reconciliation_task, logger)
         

--- a/tests/test_main_startup.py
+++ b/tests/test_main_startup.py
@@ -1,0 +1,9 @@
+import importlib
+
+
+def test_main_imports_with_automation_watchers():
+    main_module = importlib.import_module("main")
+
+    assert hasattr(main_module, "start_automation_watchers")
+    assert hasattr(main_module, "stop_automation_watchers")
+    assert hasattr(main_module, "are_automation_watchers_enabled")


### PR DESCRIPTION
### Motivation
- `main.py` still imported the removed `src.cron.subscription_watchers` and used old names, causing `ModuleNotFoundError` at startup; this change aligns the entrypoint with the existing `src.cron.automation_watchers` module.

### Description
- Replace the `subscription_watchers` import with `from src.cron.automation_watchers import start_automation_watchers, stop_automation_watchers, is_enabled as are_automation_watchers_enabled`.
- Rename the local task variable from `polling_task` to `automation_watchers_task` and update start/stop calls to use `start_automation_watchers`/`stop_automation_watchers`.
- Update all watcher startup/shutdown log messages to use the phrase "automation watchers" and add a minimal regression test `tests/test_main_startup.py` that imports `main` and asserts the watcher symbols exist.

### Testing
- Ran `python -m py_compile main.py` which succeeded with no syntax errors.
- Ran `python main.py --help` and a short startup run, confirming no `ModuleNotFoundError` for `src.cron.subscription_watchers` during startup.
- Ran `pytest -q tests/test_main_startup.py tests/test_jira_reconciliation.py::test_shutdown_jira_reconciliation_task_cancels_and_swallows_cancelled_error` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2448a27ec832aa603d85b0a381c06)