### PR TITLE
Implement progressive context compaction with durable session context state

### DIFF
--- a/src/agents/compaction.py
+++ b/src/agents/compaction.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from src.utils.truncate import truncate
+from src.runtime.context_summary import build_context_state_from_messages, build_structured_summary
 
 logger = logging.getLogger(__name__)
 
@@ -319,7 +320,31 @@ def is_oversized_for_summary(message: AgentMessage, context_window: int) -> bool
     return tokens > context_window * 0.5
 
 
-# Summary generation (placeholder - implement with LLM)
+def _parse_previous_summary(previous_summary: Optional[str]) -> Dict[str, Any]:
+    """Light parser for prior structured summary lines."""
+    if not previous_summary or not isinstance(previous_summary, str):
+        return {}
+
+    parsed: Dict[str, Any] = {}
+    for raw_line in previous_summary.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("- "):
+            continue
+        if line.startswith("- Objective:"):
+            parsed["objective"] = line.split(":", 1)[1].strip()
+        elif line.startswith("- Current state:"):
+            parsed["current_state"] = line.split(":", 1)[1].strip()
+        elif line.startswith("- Constraints:"):
+            parsed["constraints"] = [part.strip() for part in line.split(":", 1)[1].split(";") if part.strip()]
+        elif line.startswith("- Decisions:"):
+            parsed["decisions"] = [part.strip() for part in line.split(":", 1)[1].split(";") if part.strip()]
+        elif line.startswith("- Open loops:"):
+            parsed["open_loops"] = [part.strip() for part in line.split(":", 1)[1].split(";") if part.strip()]
+        elif line.startswith("- Next step:"):
+            parsed["next_step"] = line.split(":", 1)[1].strip()
+    return parsed
+
+
 async def generate_summary(
     messages: List[AgentMessage],
     model: Optional[str] = None,
@@ -344,25 +369,18 @@ async def generate_summary(
     if not messages:
         return DEFAULT_SUMMARY_FALLBACK
     
-    # Placeholder: In real implementation, call LLM API
     logger.info(f"Generating summary for {len(messages)} messages")
-    
-    # Simple placeholder - in real implementation, call LLM
-    summary_parts = []
-    
-    if previous_summary:
-        summary_parts.append(f"Previous: {previous_summary}")
-    
-    # Extract key information from messages
-    user_messages = [m for m in messages if m.role == "user"]
-    if user_messages:
-        summary_parts.append(f"User asked about {len(user_messages)} things")
-    
-    assistant_messages = [m for m in messages if m.role == "assistant"]
-    if assistant_messages:
-        summary_parts.append(f"Assistant responded {len(assistant_messages)} times")
-    
-    return " | ".join(summary_parts) if summary_parts else DEFAULT_SUMMARY_FALLBACK
+
+    prior_context_state = _parse_previous_summary(previous_summary)
+    context_state = build_context_state_from_messages(
+        messages,
+        prior_context_state=prior_context_state,
+        compaction_level="full",
+        source_message_count=len(messages),
+        recent_count=min(5, max(1, len(messages))),
+    )
+    summary = build_structured_summary(context_state)
+    return summary or DEFAULT_SUMMARY_FALLBACK
 
 
 async def summarize_chunks(
@@ -787,15 +805,14 @@ def resolve_context_window_tokens(model: Optional[str] = None) -> int:
         "gpt-4o": 128000,
         "gpt-4o-mini": 128000,
         # GPT-5 series
-        "gpt-5": 264000,
-        "gpt-5-mini": 264000,
-        "gpt-5-pro": 264000,
+        "gpt-5": 200000,
+        "gpt-5-mini": 200000,
+        "gpt-5-pro": 200000,
         # GPT-3.5
         "gpt-3.5-turbo": 16385,
         # Gemini series (64K context)
-        "gemini-2.5": 264000,
-        "minimax/MiniMax-M3": 264000,
-        "minimax": 264000,
+        "gemini-2.5": 200000,
+        "minimax/MiniMax-M3": 200000,
         "gemini-2.0": 32000,
         "gemini-1.5": 32000,
         # Claude series
@@ -823,7 +840,7 @@ def resolve_context_window_tokens(model: Optional[str] = None) -> int:
             if key in model_lower:
                 return context_windows[key]
     
-    return 264000  # Default to 264K for gpt-5-mini and unknown models
+    return 4096  # Conservative default for unknown models
 
 
 def normalize_compaction_threshold(raw_value, default_value=0.8):

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -60,6 +60,10 @@ from src.runtime.tool_filtering import (
     filter_tool_schemas_for_llm,
     intersect_tool_schemas_by_names,
 )
+from src.runtime.progressive_context import (
+    apply_progressive_context_after_turn,
+    prepare_progressive_messages,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -835,88 +839,14 @@ You have access to the following tools. When a user asks you to do something tha
         # ===== END SKILL MATCHING =====
 
         # ===== MESSAGE COMPACTION =====
-        # Check if messages need compaction to fit within token limits
-        from src.agents.compaction import (
-            compact_messages,
-            estimate_messages_tokens,
-            resolve_context_window_tokens,
-            normalize_compaction_threshold,
-            CompactionStats,
-        )
-        
-        # Get context window for the model (not max_tokens which is for responses)
         model = self.model or config.llm.get("model", "gpt-5-mini")
-        context_window = resolve_context_window_tokens(model)
-        
-        # Use 80% of context window as the limit for prompt history
-        # This delays compaction by allowing more history before triggering it
-        max_tokens = int(context_window * 0.8)
-        
-        # Estimate current token count
-        # Convert session messages to AgentMessage format
-        from src.agents.compaction import AgentMessage
-        
-        agent_messages = [
-            AgentMessage(
-                role=msg.get("role", "user"),
-                content=msg.get("content", ""),
-                timestamp=msg.get("timestamp"),
-                tool_calls=msg.get("tool_calls"),
-                tool_use_id=msg.get("tool_call_id"),
-            )
-            for msg in messages
-        ]
-        
-        current_tokens = estimate_messages_tokens(agent_messages)
-        
-        # Log compaction info
-        logger.info(
-            f"[{session_id}] Compaction check: "
-            f"current_tokens={current_tokens}, max_tokens={max_tokens}"
+        messages, _context_state = await prepare_progressive_messages(
+            messages=messages,
+            model=model,
+            session_id=session_id,
+            stage="pre_request",
+            recent_count=5,
         )
-        
-        # Compact messages if over limit
-        compaction_stats: CompactionStats = None
-        if current_tokens > max_tokens:
-            logger.info(
-                f"[{session_id}] Messages exceed token limit, compacting..."
-            )
-            
-            # Get context window for the model
-            model = self.model or config.llm.get("model", "gpt-5-mini")
-            context_window = resolve_context_window_tokens(model)
-            
-            # Compact messages
-            compacted_messages, compaction_stats = await compact_messages(
-                messages=agent_messages,
-                max_tokens=max_tokens,
-                context_window=context_window,
-                recent_count=5,
-            )
-            
-            # Update messages for LLM call
-            # Convert back to dict format for LLM
-            messages = []
-            for msg in compacted_messages:
-                msg_dict = {
-                    "role": msg.role,
-                    "content": msg.content,
-                    "timestamp": msg.timestamp,
-                }
-                # Preserve tool_calls for assistant messages
-                if msg.tool_calls:
-                    msg_dict["tool_calls"] = msg.tool_calls
-                # Preserve tool_call_id for tool messages
-                if msg.tool_use_id:
-                    msg_dict["tool_call_id"] = msg.tool_use_id
-                messages.append(msg_dict)
-            
-            logger.info(
-                f"[{session_id}] Compaction complete: "
-                f"kept_tokens={compaction_stats.kept_tokens}, "
-                f"dropped_messages={compaction_stats.dropped_messages}, "
-                f"summary={truncate(compaction_stats.summary, 100) if compaction_stats.summary else 'N/A'}"
-            )
         # ===== END MESSAGE COMPACTION =====
 
         # Debug logging for message received
@@ -973,11 +903,6 @@ You have access to the following tools. When a user asks you to do something tha
         # Get max iterations from config, default to 30
         max_tool_iterations = config.session.get("max_iterations", 30) if hasattr(config, 'session') else 30
         
-        # Get compaction threshold from config (default 80%)
-        # This determines when to trigger compaction during tool loops
-        # Normalize and validate the threshold value
-        raw_compaction_threshold = config.session.get("compaction_threshold", 0.8) if hasattr(config, 'session') else 0.8
-        compaction_threshold_pct = normalize_compaction_threshold(raw_compaction_threshold)
         iteration = 0
         
         # Helper function to send stream events
@@ -1154,10 +1079,6 @@ You have access to the following tools. When a user asks you to do something tha
         
         input_items = _to_input_items(messages)
         
-        # Token threshold for compaction (configurable, default 80% of context_window)
-        # This is the TRIGGER threshold - compaction runs when token count exceeds this
-        compaction_threshold = int(context_window * compaction_threshold_pct)
-        
         # Keep track of messages for compaction during loop
         # IMPORTANT: Start fresh for each request to avoid carrying over
         # tool_calls and tool_results from previous requests/iterations.
@@ -1168,54 +1089,14 @@ You have access to the following tools. When a user asks you to do something tha
             iteration += 1
             
             # ===== COMPACTION IN LOOP =====
-            # Build AgentMessage list once for token estimation and compaction
-            agent_msgs_for_compact = [
-                AgentMessage(
-                    role=m.get("role", "user"),
-                    content=m.get("content", ""),
-                    timestamp=m.get("timestamp"),
-                    tool_calls=m.get("tool_calls"),
-                    tool_use_id=m.get("tool_call_id"),
-                )
-                for m in loop_messages
-            ]
-            
-            current_tokens = estimate_messages_tokens(agent_msgs_for_compact)
-            
-            if current_tokens > compaction_threshold and iteration > 1:
-                logger.info(
-                    f"[Tool Loop] Iteration {iteration}: Messages ({current_tokens}) exceed "
-                    f"threshold ({compaction_threshold}), compacting..."
-                )
-                
-                compacted_messages, compaction_stats = await compact_messages(
-                    messages=agent_msgs_for_compact,
-                    max_tokens=compaction_threshold,
-                    context_window=context_window,
+            if iteration > 1:
+                loop_messages, _loop_context_state = await prepare_progressive_messages(
+                    messages=loop_messages,
+                    model=self.model or config.llm.get("model", "gpt-5-mini"),
+                    session_id=session_id,
+                    stage="tool_loop",
                     recent_count=5,
                 )
-                
-                # Convert back to dict format
-                loop_messages = []
-                for msg in compacted_messages:
-                    msg_dict = {
-                        "role": msg.role,
-                        "content": msg.content,
-                        "timestamp": msg.timestamp,
-                    }
-                    if msg.tool_calls:
-                        msg_dict["tool_calls"] = msg.tool_calls
-                    if msg.tool_use_id:
-                        msg_dict["tool_call_id"] = msg.tool_use_id
-                    loop_messages.append(msg_dict)
-                
-                logger.info(
-                    f"[Tool Loop] Compaction complete: "
-                    f"kept_tokens={compaction_stats.kept_tokens}, "
-                    f"dropped_messages={compaction_stats.dropped_messages}"
-                )
-            
-            # Keep input_items in sync with loop_messages (possibly compacted)
             input_items = _to_input_items(loop_messages)
             # ===== END COMPACTION IN LOOP =====
             
@@ -2643,7 +2524,14 @@ async def run_chat_execution(
         "portal_user_id": portal_user_id,
         "portal_user_name": portal_user_name,
     }
-    return await agent.process(**process_kwargs)
+    result = await agent.process(**process_kwargs)
+    context_state = await apply_progressive_context_after_turn(
+        session_id=session_id,
+        model=getattr(agent, "model", None),
+    )
+    if isinstance(result, dict):
+        result["context_state"] = context_state
+    return result
 
 
 # Global agent instance

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -840,7 +840,7 @@ You have access to the following tools. When a user asks you to do something tha
 
         # ===== MESSAGE COMPACTION =====
         model = self.model or config.llm.get("model", "gpt-5-mini")
-        messages, _context_state = await prepare_progressive_messages(
+        messages, _ = await prepare_progressive_messages(
             messages=messages,
             model=model,
             session_id=session_id,
@@ -1090,7 +1090,7 @@ You have access to the following tools. When a user asks you to do something tha
             
             # ===== COMPACTION IN LOOP =====
             if iteration > 1:
-                loop_messages, _loop_context_state = await prepare_progressive_messages(
+                loop_messages, _ = await prepare_progressive_messages(
                     messages=loop_messages,
                     model=self.model or config.llm.get("model", "gpt-5-mini"),
                     session_id=session_id,

--- a/src/agents/skill_mode.py
+++ b/src/agents/skill_mode.py
@@ -630,8 +630,9 @@ async def compact_skill_session_async(skill_session: SkillSession, budget_tokens
         # Use existing compaction module
         compacted_messages, stats = await compact_messages(
             messages=steps_as_messages,
-            budget_tokens=budget_tokens,
+            max_tokens=budget_tokens,
             context_window=context_window,
+            recent_count=3,
         )
         
         if stats and stats.dropped_messages > 0:

--- a/src/agents/subagent.py
+++ b/src/agents/subagent.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from src.utils.truncate import truncate
+from src.agents.core import run_chat_execution
 
 # Import Agent lazily to avoid circular imports
 _subagent_sessions: Dict[str, Dict[str, Any]] = {}
@@ -69,9 +70,12 @@ class SubAgent:
             logger.info(f"Sub-agent {self.session_key} started - think_level={self.thinking}, model={self.model}")
             logger.debug(f"Task: {truncate(self.task, 200)}")
             
-            result = await self.agent.process(
+            result = await run_chat_execution(
+                agent=self.agent,
                 message=self.task,
                 session_id=self.session_key,
+                user_name=self.session_key,
+                track_usage=False,
             )
             
             self.result = result.get("response", "")

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -17,7 +17,7 @@ import re
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.utils.truncate import truncate
-from src.agents.core import agent
+from src.agents.core import agent, run_chat_execution
 from src.channels.jira import jira_channel
 from src.config import config
 from src.cron.automation_watchers import start_automation_watchers, stop_automation_watchers
@@ -66,7 +66,8 @@ async def handle_jira_message(
             return ""
 
         # Normal conversation
-        result = await agent.process(
+        result = await run_chat_execution(
+            agent=agent,
             message=message,
             session_id=session_id,
             user_name=user_name,
@@ -671,7 +672,8 @@ class Gateway:
                 return web.json_response({"status": "error", "message": "message required"}, status=400)
 
             # Process message through agent
-            result = await agent.process(
+            result = await run_chat_execution(
+                agent=agent,
                 message=message,
                 session_id=session_id,
                 user_name="http-tester",

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -44,6 +44,7 @@ from src.runtime.portal_session_metadata_client import (
     extract_session_metadata_publish_fields,
     publish_session_metadata,
 )
+from src.runtime.progressive_context import build_portal_context_preview
 from src.gateway.chat_payloads import (
     build_webchat_response_payload,
     normalize_assistant_history_message,
@@ -116,6 +117,21 @@ def _extract_trusted_portal_agent_name(request: web.Request) -> Optional[str]:
     headers = getattr(request, "headers", {}) or {}
     agent_name = _sanitize_portal_identity_value(headers.get("X-Portal-Agent-Name"))
     return agent_name or None
+
+
+async def _enrich_publish_metadata_with_context_preview(
+    metadata: Optional[Dict[str, Any]],
+    *,
+    session_id: Optional[str],
+) -> Dict[str, Any]:
+    merged = dict(metadata or {})
+    if not session_id:
+        return merged
+    context_state = await session_manager.get_context_state(session_id)
+    preview = build_portal_context_preview(context_state)
+    if preview:
+        merged.update(preview)
+    return merged
 
 
 def _is_trusted_portal_request(request: web.Request) -> bool:
@@ -753,9 +769,13 @@ async def api_chat(request: web.Request) -> web.Response:
         )
         execution_result = result.get("_execution_result")
         if runtime_agent_id and execution_result is not None:
+            publish_metadata = await _enrich_publish_metadata_with_context_preview(
+                execution_metadata,
+                session_id=session_id,
+            )
             publish_fields = extract_session_metadata_publish_fields(
                 execution_result,
-                metadata=execution_metadata,
+                metadata=publish_metadata,
                 default_event_type="chat.completed",
                 default_state="success",
             )
@@ -992,9 +1012,13 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         result = await run_task
         execution_result = result.get("_execution_result")
         if runtime_agent_id and execution_result is not None:
+            publish_metadata = await _enrich_publish_metadata_with_context_preview(
+                execution_metadata,
+                session_id=session_id,
+            )
             publish_fields = extract_session_metadata_publish_fields(
                 execution_result,
-                metadata=execution_metadata,
+                metadata=publish_metadata,
                 default_event_type="chat.completed",
                 default_state="success",
             )
@@ -1286,9 +1310,13 @@ async def _run_task_execution_in_background(
             metadata=metadata,
         )
         if runtime_agent_id and session_id:
+            publish_metadata = await _enrich_publish_metadata_with_context_preview(
+                metadata,
+                session_id=session_id,
+            )
             publish_fields = extract_session_metadata_publish_fields(
                 execution_result,
-                metadata=metadata,
+                metadata=publish_metadata,
                 default_event_type="task.completed" if execution_result.status == "success" else "task.failed",
                 default_state="success" if execution_result.status == "success" else "error",
             )

--- a/src/hooks/session_memory.py
+++ b/src/hooks/session_memory.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Optional, List, Dict, Any
 
 from src.sessions.manager import session_manager
+from src.runtime.context_summary import build_structured_summary
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +96,14 @@ async def summarize_session(
     return "\n".join(summary_parts) if summary_parts else "Session completed."
 
 
+def build_session_memory_summary_from_context_state(context_state: dict) -> str:
+    """Build memory-friendly summary from durable progressive context state."""
+    if not isinstance(context_state, dict) or not context_state:
+        return ""
+    summary = build_structured_summary(context_state)
+    return summary or ""
+
+
 async def save_session_summary(
     session_id: str,
     workspace_dir: Optional[Path] = None,
@@ -138,8 +147,13 @@ async def save_session_summary(
             logger.debug(f"Session {session_id} too short to summarize ({len(user_messages)} user messages)")
             return None
         
-        # Generate summary (heuristic-based, TODO: use LLM)
-        summary = await summarize_session(session_id, history)
+        metadata = session.get("metadata", {}) if isinstance(session.get("metadata"), dict) else {}
+        context_state = metadata.get("context_state")
+
+        summary = build_session_memory_summary_from_context_state(context_state)
+        if not summary:
+            # Generate summary (heuristic fallback)
+            summary = await summarize_session(session_id, history)
         
         if not summary:
             summary = "Session completed."

--- a/src/runtime/chat_orchestration_adapter.py
+++ b/src/runtime/chat_orchestration_adapter.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Dict, Optional
 
 from src.runtime import build_default_execution_bus, make_execution_request
 from src.runtime.contracts import ExecutionResult
+
+logger = logging.getLogger(__name__)
 
 
 async def _execute_with_bus(
@@ -37,7 +40,24 @@ async def _execute_with_bus(
         input_payload=dict(input_payload or {}),
         metadata=dict(metadata or {}),
     )
-    return await bus.execute(request)
+    result = await bus.execute(request)
+
+    if session_id and execution_type in {"task", "skill", "subagent"}:
+        try:
+            from src.runtime.progressive_context import apply_progressive_context_after_turn
+
+            await apply_progressive_context_after_turn(
+                session_id=session_id,
+                model=None,
+            )
+        except Exception:
+            logger.warning(
+                "Best-effort progressive context commit failed",
+                extra={"session_id": session_id, "execution_type": execution_type},
+                exc_info=True,
+            )
+
+    return result
 
 
 async def execute_chat_orchestration(

--- a/src/runtime/chat_orchestration_adapter.py
+++ b/src/runtime/chat_orchestration_adapter.py
@@ -42,7 +42,7 @@ async def _execute_with_bus(
     )
     result = await bus.execute(request)
 
-    if session_id and execution_type in {"task", "skill", "subagent"}:
+    if session_id and execution_type in {"task", "skill", "subagent", "event"}:
         try:
             from src.runtime.progressive_context import apply_progressive_context_after_turn
 

--- a/src/runtime/chat_orchestration_adapter.py
+++ b/src/runtime/chat_orchestration_adapter.py
@@ -11,6 +11,28 @@ from src.runtime.contracts import ExecutionResult
 logger = logging.getLogger(__name__)
 
 
+def _resolve_effective_model(*, input_payload: Dict[str, Any], metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    resolved_metadata = dict(metadata or {})
+    resolved_payload = dict(input_payload or {})
+    kwargs = resolved_payload.get("kwargs")
+    kwargs = kwargs if isinstance(kwargs, dict) else {}
+    llm_kwargs = kwargs.get("llm_kwargs")
+    llm_kwargs = llm_kwargs if isinstance(llm_kwargs, dict) else {}
+
+    candidates = [
+        resolved_metadata.get("resolved_model"),
+        resolved_metadata.get("model"),
+        resolved_payload.get("model"),
+        kwargs.get("model"),
+        kwargs.get("model_name"),
+        llm_kwargs.get("model"),
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return None
+
+
 async def _execute_with_bus(
     *,
     request_id: Optional[str],
@@ -45,10 +67,14 @@ async def _execute_with_bus(
     if session_id and execution_type in {"task", "skill", "subagent", "event"}:
         try:
             from src.runtime.progressive_context import apply_progressive_context_after_turn
+            effective_model = _resolve_effective_model(
+                input_payload=dict(input_payload or {}),
+                metadata=dict(metadata or {}),
+            )
 
             await apply_progressive_context_after_turn(
                 session_id=session_id,
-                model=None,
+                model=effective_model,
             )
         except Exception:
             logger.warning(

--- a/src/runtime/context_summary.py
+++ b/src/runtime/context_summary.py
@@ -1,0 +1,285 @@
+"""Deterministic context-state extraction and summary helpers."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Sequence
+
+from src.utils.truncate import truncate
+
+_PREVIEW_LIMIT = 240
+_SUMMARY_LIMIT = 320
+_NEXT_STEP_FALLBACK = "Continue from the latest state and preserve prior constraints."
+_CONSTRAINT_KEYWORDS = ("must", "should", "need to", "do not", "don't", "不要", "不能", "必须")
+_DECISION_HINTS = ("decide", "decided", "decision", "we will", "chosen", "选择", "决定", "采用")
+_OPEN_LOOP_HINTS = ("todo", "follow up", "pending", "next", "blocker", "wait", "待办", "后续", "未完成", "需要")
+
+
+def _truncate(value: str, limit: int) -> str:
+    return truncate(value, limit) if value else ""
+
+
+def _msg_attr(message: Any, key: str, default: Any = None) -> Any:
+    if isinstance(message, dict):
+        return message.get(key, default)
+    return getattr(message, key, default)
+
+
+def _iter_sentences(text: str) -> Iterable[str]:
+    for sentence in re.split(r"[\n\.。!！?？]", text or ""):
+        candidate = sentence.strip()
+        if candidate:
+            yield candidate
+
+
+def safe_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        parts: List[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+            elif isinstance(item, str) and item.strip():
+                parts.append(item.strip())
+        return " ".join(parts).strip()
+    return str(value or "").strip()
+
+
+def extract_objective(messages: Sequence[Any]) -> str:
+    first_user = ""
+    latest_user = ""
+    for msg in messages:
+        if _msg_attr(msg, "role", "") != "user":
+            continue
+        text = safe_text(_msg_attr(msg, "content", ""))
+        if not text:
+            continue
+        if not first_user:
+            first_user = text
+        latest_user = text
+    return _truncate(first_user or latest_user, _PREVIEW_LIMIT)
+
+
+def extract_constraints(messages: Sequence[Any]) -> list[str]:
+    constraints: List[str] = []
+    for msg in reversed(list(messages)):
+        if _msg_attr(msg, "role", "") != "user":
+            continue
+        text = safe_text(_msg_attr(msg, "content", ""))
+        if not text:
+            continue
+        for sentence in _iter_sentences(text):
+            lower = sentence.lower()
+            if any(keyword in lower or keyword in sentence for keyword in _CONSTRAINT_KEYWORDS):
+                normalized = _truncate(sentence, 140)
+                if normalized and normalized not in constraints:
+                    constraints.append(normalized)
+                    if len(constraints) >= 5:
+                        return constraints
+    return constraints
+
+
+def extract_current_state(messages: Sequence[Any]) -> str:
+    for msg in reversed(list(messages)):
+        if _msg_attr(msg, "role", "") == "assistant":
+            text = safe_text(_msg_attr(msg, "content", ""))
+            if text:
+                return _truncate(text, 220)
+    for msg in reversed(list(messages)):
+        if _msg_attr(msg, "role", "") == "tool":
+            text = safe_text(_msg_attr(msg, "content", ""))
+            if text:
+                return _truncate(f"Latest tool result: {text}", 220)
+    return ""
+
+
+def extract_next_step(messages: Sequence[Any]) -> str:
+    for msg in reversed(list(messages)):
+        if _msg_attr(msg, "role", "") != "assistant":
+            continue
+        text = safe_text(_msg_attr(msg, "content", ""))
+        if not text:
+            continue
+        lowered = text.lower()
+        if any(token in lowered for token in ("next", "continue", "please", "run", "check", "verify", "then", "should")):
+            return _truncate(text, 180)
+    return _NEXT_STEP_FALLBACK
+
+
+def extract_decisions(messages: Sequence[Any]) -> list[str]:
+    decisions: List[str] = []
+    for msg in reversed(list(messages)):
+        if _msg_attr(msg, "role", "") not in {"assistant", "user"}:
+            continue
+        text = safe_text(_msg_attr(msg, "content", ""))
+        if not text:
+            continue
+        for sentence in _iter_sentences(text):
+            lower = sentence.lower()
+            if any(hint in lower or hint in sentence for hint in _DECISION_HINTS):
+                normalized = _truncate(sentence, 140)
+                if normalized and normalized not in decisions:
+                    decisions.append(normalized)
+                    if len(decisions) >= 5:
+                        return decisions
+    return decisions
+
+
+def extract_open_loops(messages: Sequence[Any]) -> list[str]:
+    open_loops: List[str] = []
+    for msg in reversed(list(messages)):
+        if _msg_attr(msg, "role", "") not in {"assistant", "user"}:
+            continue
+        text = safe_text(_msg_attr(msg, "content", ""))
+        if not text:
+            continue
+        for sentence in _iter_sentences(text):
+            lower = sentence.lower()
+            if "?" in sentence or any(hint in lower or hint in sentence for hint in _OPEN_LOOP_HINTS):
+                normalized = _truncate(sentence, 140)
+                if normalized and normalized not in open_loops:
+                    open_loops.append(normalized)
+                    if len(open_loops) >= 5:
+                        return open_loops
+    return open_loops
+
+
+def _merge_unique(prior_values: Any, current_values: Any, *, limit: int = 5) -> list[str]:
+    merged: List[str] = []
+    for raw in list(prior_values or []) + list(current_values or []):
+        text = _truncate(str(raw or "").strip(), 160)
+        if text and text not in merged:
+            merged.append(text)
+            if len(merged) >= limit:
+                break
+    return merged
+
+
+def _is_weaker_objective(current: str, prior: str) -> bool:
+    if not prior:
+        return False
+    if not current:
+        return True
+    current_clean = current.strip()
+    prior_clean = prior.strip()
+    if len(current_clean) < 12 <= len(prior_clean):
+        return True
+    if len(current_clean) * 2 < len(prior_clean):
+        return True
+    return False
+
+
+def merge_context_state(
+    prior_context_state: dict | None,
+    current_context_state: dict | None,
+    *,
+    compaction_level: str,
+    source_message_count: int,
+    recent_count: int,
+) -> dict:
+    prior = dict(prior_context_state or {})
+    current = dict(current_context_state or {})
+
+    prior_objective = _truncate(str(prior.get("objective") or "").strip(), _PREVIEW_LIMIT)
+    current_objective = _truncate(str(current.get("objective") or "").strip(), _PREVIEW_LIMIT)
+    objective = prior_objective if _is_weaker_objective(current_objective, prior_objective) else current_objective
+
+    next_step = _truncate(str(current.get("next_step") or "").strip(), 180)
+    if not next_step or next_step == _NEXT_STEP_FALLBACK:
+        next_step = _truncate(str(prior.get("next_step") or "").strip(), 180) or _NEXT_STEP_FALLBACK
+
+    merged = {
+        "version": "context.v1",
+        "compaction_level": compaction_level,
+        "objective": objective,
+        "current_state": _truncate(str(current.get("current_state") or prior.get("current_state") or "").strip(), 220),
+        "next_step": next_step,
+        "constraints": _merge_unique(prior.get("constraints"), current.get("constraints"), limit=5),
+        "decisions": _merge_unique(prior.get("decisions"), current.get("decisions"), limit=5),
+        "open_loops": _merge_unique(prior.get("open_loops"), current.get("open_loops"), limit=5),
+        "source_message_count": source_message_count,
+        "recent_window_count": recent_count,
+        "last_compacted_at": datetime.now(timezone.utc).isoformat() if compaction_level in {"micro", "full"} else None,
+    }
+    merged["summary"] = build_structured_summary(merged)
+    merged["recovery_context_message"] = build_recovery_context_message(merged)
+    return merged
+
+
+def build_structured_summary(context_state: dict) -> str:
+    lines = ["Context summary:"]
+    objective = _truncate(str(context_state.get("objective") or "").strip(), 200)
+    current_state = _truncate(str(context_state.get("current_state") or "").strip(), 220)
+    constraints = "; ".join(_merge_unique([], context_state.get("constraints"), limit=5))
+    decisions = "; ".join(_merge_unique([], context_state.get("decisions"), limit=5))
+    open_loops = "; ".join(_merge_unique([], context_state.get("open_loops"), limit=5))
+    next_step = _truncate(str(context_state.get("next_step") or "").strip(), 180)
+
+    if objective:
+        lines.append(f"- Objective: {objective}")
+    if current_state:
+        lines.append(f"- Current state: {current_state}")
+    if constraints:
+        lines.append(f"- Constraints: {constraints}")
+    if decisions:
+        lines.append(f"- Decisions: {decisions}")
+    if open_loops:
+        lines.append(f"- Open loops: {open_loops}")
+    if next_step:
+        lines.append(f"- Next step: {next_step}")
+
+    if len(lines) == 1:
+        lines.append("- Current state: Context state refreshed.")
+    return _truncate("\n".join(lines), _SUMMARY_LIMIT)
+
+
+def build_recovery_context_message(context_state: dict) -> str:
+    lines = ["Recovered context:"]
+    objective = _truncate(str(context_state.get("objective") or "").strip(), 200)
+    current_state = _truncate(str(context_state.get("current_state") or "").strip(), 220)
+    constraints = "; ".join(_merge_unique([], context_state.get("constraints"), limit=5))
+    open_loops = "; ".join(_merge_unique([], context_state.get("open_loops"), limit=5))
+    next_step = _truncate(str(context_state.get("next_step") or "").strip(), 180)
+
+    if objective:
+        lines.append(f"- Objective: {objective}")
+    if current_state:
+        lines.append(f"- Current state: {current_state}")
+    if constraints:
+        lines.append(f"- Constraints: {constraints}")
+    if open_loops:
+        lines.append(f"- Open loops: {open_loops}")
+    if next_step:
+        lines.append(f"- Next step: {next_step}")
+
+    lines.append("Continue from this state without discarding prior constraints.")
+    return _truncate("\n".join(lines), 420)
+
+
+def build_context_state_from_messages(
+    messages: Sequence[Any],
+    *,
+    prior_context_state: dict | None = None,
+    compaction_level: str = "none",
+    source_message_count: int = 0,
+    recent_count: int = 5,
+) -> dict:
+    current = {
+        "objective": extract_objective(messages),
+        "current_state": extract_current_state(messages),
+        "next_step": extract_next_step(messages),
+        "constraints": extract_constraints(messages),
+        "decisions": extract_decisions(messages),
+        "open_loops": extract_open_loops(messages),
+    }
+    return merge_context_state(
+        prior_context_state,
+        current,
+        compaction_level=compaction_level,
+        source_message_count=source_message_count,
+        recent_count=recent_count,
+    )

--- a/src/runtime/portal_session_metadata_client.py
+++ b/src/runtime/portal_session_metadata_client.py
@@ -29,6 +29,10 @@ _CONTROL_PLANE_METADATA_KEYS = {
     "portal_workflow_rule_id",
     "portal_task_source",
     "shared_context_ref",
+    "context_compaction_level",
+    "context_objective_preview",
+    "context_summary_preview",
+    "context_next_step_preview",
 }
 
 

--- a/src/runtime/progressive_context.py
+++ b/src/runtime/progressive_context.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import logging
-import re
-from typing import Any, Dict, List, Optional, Sequence, Set
+from typing import Any, Dict, List, Sequence, Set
 
 from src.agents.compaction import (
     AgentMessage,
@@ -16,17 +15,14 @@ from src.agents.compaction import (
     resolve_context_window_tokens,
 )
 from src.config import config
+from src.runtime.context_summary import (
+    build_context_state_from_messages,
+    build_recovery_context_message,
+)
 from src.sessions.manager import session_manager
 from src.utils.truncate import truncate
 
 logger = logging.getLogger(__name__)
-
-_PREVIEW_LIMIT = 240
-_SUMMARY_LIMIT = 320
-_NEXT_STEP_FALLBACK = "Continue from the latest state and preserve prior constraints."
-_CONSTRAINT_KEYWORDS = ("must", "should", "need to", "do not", "don't", "不要", "不能", "必须")
-_DECISION_HINTS = ("decide", "decided", "decision", "we will", "chosen", "选择", "决定", "采用")
-_OPEN_LOOP_HINTS = ("todo", "follow up", "pending", "next", "blocker", "wait", "待办", "后续", "未完成", "需要")
 
 
 def _to_agent_messages(messages: List[Dict[str, Any]]) -> List[AgentMessage]:
@@ -46,10 +42,7 @@ def _to_agent_messages(messages: List[Dict[str, Any]]) -> List[AgentMessage]:
 def _to_dict_messages(messages: Sequence[AgentMessage]) -> List[Dict[str, Any]]:
     result: List[Dict[str, Any]] = []
     for msg in messages:
-        item: Dict[str, Any] = {
-            "role": msg.role,
-            "content": msg.content,
-        }
+        item: Dict[str, Any] = {"role": msg.role, "content": msg.content}
         if msg.timestamp:
             item["timestamp"] = msg.timestamp
         if msg.tool_calls:
@@ -58,26 +51,6 @@ def _to_dict_messages(messages: Sequence[AgentMessage]) -> List[Dict[str, Any]]:
             item["tool_call_id"] = msg.tool_use_id
         result.append(item)
     return result
-
-
-def _safe_text(value: Any) -> str:
-    if isinstance(value, str):
-        return value.strip()
-    if isinstance(value, list):
-        parts: List[str] = []
-        for item in value:
-            if isinstance(item, dict):
-                text = item.get("text")
-                if isinstance(text, str) and text.strip():
-                    parts.append(text.strip())
-            elif isinstance(item, str) and item.strip():
-                parts.append(item.strip())
-        return " ".join(parts).strip()
-    return str(value or "").strip()
-
-
-def _truncate(value: str, limit: int) -> str:
-    return truncate(value, limit) if value else ""
 
 
 def _collect_protected_tool_chain_ids(messages: Sequence[AgentMessage], recent_count: int) -> Set[str]:
@@ -117,12 +90,12 @@ def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) 
             continue
 
         if msg.role == "tool":
-            content_text = _safe_text(msg.content)
+            content_text = str(msg.content or "").strip()
             if msg.tool_use_id and msg.tool_use_id in protected_tool_chain_ids:
                 compacted.append(msg)
                 continue
             if idx not in keep_tool_indices and len(content_text) > 800:
-                preview = _truncate(content_text, 240)
+                preview = truncate(content_text, 240)
                 compacted.append(
                     AgentMessage(
                         role="tool",
@@ -140,12 +113,12 @@ def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) 
             if call_ids.intersection(protected_tool_chain_ids):
                 compacted.append(msg)
                 continue
-            content_text = _safe_text(msg.content)
+            content_text = str(msg.content or "").strip()
             if len(content_text) > 1200:
                 compacted.append(
                     AgentMessage(
                         role="assistant",
-                        content=_truncate(content_text, 320),
+                        content=truncate(content_text, 320),
                         timestamp=msg.timestamp,
                         tool_calls=msg.tool_calls,
                         tool_use_id=msg.tool_use_id,
@@ -156,212 +129,6 @@ def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) 
         compacted.append(msg)
 
     return fix_tool_call_consistency(compacted)
-
-
-def _extract_objective(messages: Sequence[AgentMessage]) -> str:
-    first_user = ""
-    latest_user = ""
-    for msg in messages:
-        if msg.role != "user":
-            continue
-        text = _safe_text(msg.content)
-        if not text:
-            continue
-        if not first_user:
-            first_user = text
-        latest_user = text
-    return _truncate(first_user or latest_user, _PREVIEW_LIMIT)
-
-
-def _extract_constraints(messages: Sequence[AgentMessage]) -> List[str]:
-    constraints: List[str] = []
-    for msg in reversed(messages):
-        if msg.role != "user":
-            continue
-        text = _safe_text(msg.content)
-        if not text:
-            continue
-        for sentence in re.split(r"[\n\.。!！?？]", text):
-            candidate = sentence.strip()
-            if not candidate:
-                continue
-            lower = candidate.lower()
-            if any(keyword in lower or keyword in candidate for keyword in _CONSTRAINT_KEYWORDS):
-                normalized = _truncate(candidate, 140)
-                if normalized and normalized not in constraints:
-                    constraints.append(normalized)
-                    if len(constraints) >= 5:
-                        return constraints
-    return constraints
-
-
-def _extract_current_state(messages: Sequence[AgentMessage]) -> str:
-    for msg in reversed(messages):
-        if msg.role == "assistant":
-            text = _safe_text(msg.content)
-            if text:
-                return _truncate(text, 220)
-    for msg in reversed(messages):
-        if msg.role == "tool":
-            text = _safe_text(msg.content)
-            if text:
-                return _truncate(f"Latest tool result: {text}", 220)
-    return ""
-
-
-def _extract_next_step(messages: Sequence[AgentMessage]) -> str:
-    for msg in reversed(messages):
-        if msg.role != "assistant":
-            continue
-        assistant_text = _safe_text(msg.content)
-        if not assistant_text:
-            continue
-        lowered = assistant_text.lower()
-        if any(token in lowered for token in ("next", "continue", "please", "run", "check", "verify", "then", "should")):
-            return _truncate(assistant_text, 180)
-    return _NEXT_STEP_FALLBACK
-
-
-def _extract_decisions(messages: Sequence[AgentMessage]) -> List[str]:
-    decisions: List[str] = []
-    for msg in reversed(messages):
-        if msg.role not in {"assistant", "user"}:
-            continue
-        text = _safe_text(msg.content)
-        if not text:
-            continue
-        for sentence in re.split(r"[\n\.。!！?？]", text):
-            candidate = sentence.strip()
-            if not candidate:
-                continue
-            lowered = candidate.lower()
-            if any(hint in lowered or hint in candidate for hint in _DECISION_HINTS):
-                normalized = _truncate(candidate, 140)
-                if normalized and normalized not in decisions:
-                    decisions.append(normalized)
-                    if len(decisions) >= 5:
-                        return decisions
-    return decisions
-
-
-def _extract_open_loops(messages: Sequence[AgentMessage]) -> List[str]:
-    open_loops: List[str] = []
-    for msg in reversed(messages):
-        if msg.role not in {"assistant", "user"}:
-            continue
-        text = _safe_text(msg.content)
-        if not text:
-            continue
-        for sentence in re.split(r"[\n\.。!！?？]", text):
-            candidate = sentence.strip()
-            if not candidate:
-                continue
-            lowered = candidate.lower()
-            if "?" in candidate or any(hint in lowered or hint in candidate for hint in _OPEN_LOOP_HINTS):
-                normalized = _truncate(candidate, 140)
-                if normalized and normalized not in open_loops:
-                    open_loops.append(normalized)
-                    if len(open_loops) >= 5:
-                        return open_loops
-    return open_loops
-
-
-def _is_weaker_objective(current: str, prior: str) -> bool:
-    if not prior:
-        return False
-    if not current:
-        return True
-    if len(current.strip()) < 12 <= len(prior.strip()):
-        return True
-    if len(current.strip()) * 2 < len(prior.strip()):
-        return True
-    return False
-
-
-def _merge_unique(prior_values: Any, current_values: Any, *, limit: int = 5) -> List[str]:
-    merged: List[str] = []
-    for raw in list(prior_values or []) + list(current_values or []):
-        text = _truncate(str(raw or "").strip(), 160)
-        if text and text not in merged:
-            merged.append(text)
-            if len(merged) >= limit:
-                break
-    return merged
-
-
-def _build_structured_summary(context_state: Dict[str, Any]) -> str:
-    lines = ["Context summary:"]
-    objective = _truncate(str(context_state.get("objective") or "").strip(), 200)
-    current_state = _truncate(str(context_state.get("current_state") or "").strip(), 220)
-    constraints = "; ".join(_merge_unique([], context_state.get("constraints"), limit=5))
-    decisions = "; ".join(_merge_unique([], context_state.get("decisions"), limit=5))
-    open_loops = "; ".join(_merge_unique([], context_state.get("open_loops"), limit=5))
-    next_step = _truncate(str(context_state.get("next_step") or "").strip(), 180)
-
-    if objective:
-        lines.append(f"- Objective: {objective}")
-    if current_state:
-        lines.append(f"- Current state: {current_state}")
-    if constraints:
-        lines.append(f"- Constraints: {constraints}")
-    if decisions:
-        lines.append(f"- Decisions: {decisions}")
-    if open_loops:
-        lines.append(f"- Open loops: {open_loops}")
-    if next_step:
-        lines.append(f"- Next step: {next_step}")
-
-    if len(lines) == 1:
-        lines.append("- Current state: Context state refreshed.")
-    return _truncate("\n".join(lines), _SUMMARY_LIMIT)
-
-
-def _merge_prior_and_current_context_state(
-    *,
-    prior_context_state: Dict[str, Any],
-    current_context_state: Dict[str, Any],
-    compaction_level: str,
-    source_message_count: int,
-    recent_count: int,
-) -> Dict[str, Any]:
-    prior_objective = _truncate(str(prior_context_state.get("objective") or "").strip(), _PREVIEW_LIMIT)
-    current_objective = _truncate(str(current_context_state.get("objective") or "").strip(), _PREVIEW_LIMIT)
-    objective = prior_objective if _is_weaker_objective(current_objective, prior_objective) else current_objective
-
-    next_step = _truncate(str(current_context_state.get("next_step") or "").strip(), 180)
-    if not next_step or next_step == _NEXT_STEP_FALLBACK:
-        prior_next = _truncate(str(prior_context_state.get("next_step") or "").strip(), 180)
-        next_step = prior_next or _NEXT_STEP_FALLBACK
-
-    merged: Dict[str, Any] = {
-        "version": "context.v1",
-        "compaction_level": compaction_level,
-        "objective": objective,
-        "current_state": _truncate(
-            str(current_context_state.get("current_state") or prior_context_state.get("current_state") or "").strip(),
-            220,
-        ),
-        "next_step": next_step,
-        "constraints": _merge_unique(prior_context_state.get("constraints"), current_context_state.get("constraints")),
-        "decisions": _merge_unique(prior_context_state.get("decisions"), current_context_state.get("decisions")),
-        "open_loops": _merge_unique(prior_context_state.get("open_loops"), current_context_state.get("open_loops")),
-        "source_message_count": source_message_count,
-        "recent_window_count": recent_count,
-        "last_compacted_at": datetime.now(timezone.utc).isoformat() if compaction_level in {"micro", "full"} else None,
-    }
-    merged["summary"] = _build_structured_summary(merged)
-    return merged
-
-
-def _build_current_context_state(messages: Sequence[AgentMessage]) -> Dict[str, Any]:
-    return {
-        "objective": _extract_objective(messages),
-        "current_state": _extract_current_state(messages),
-        "next_step": _extract_next_step(messages),
-        "constraints": _extract_constraints(messages),
-        "decisions": _extract_decisions(messages),
-        "open_loops": _extract_open_loops(messages),
-    }
 
 
 def _resolve_stage_thresholds(*, stage: str, context_window: int, hard_threshold: int) -> tuple[int, int]:
@@ -375,7 +142,7 @@ def _resolve_stage_thresholds(*, stage: str, context_window: int, hard_threshold
 def _build_synthetic_summary_message(context_state: Dict[str, Any]) -> AgentMessage:
     return AgentMessage(
         role="system",
-        content=_build_structured_summary(context_state),
+        content=str(context_state.get("summary") or "Context summary:"),
         timestamp=datetime.now(timezone.utc).isoformat(),
     )
 
@@ -385,7 +152,6 @@ def _select_recent_window_for_full(messages: Sequence[AgentMessage], recent_coun
         return []
     start = max(0, len(messages) - max(1, recent_count))
     selected = list(messages[start:])
-
     required_tool_ids = {msg.tool_use_id for msg in selected if msg.role == "tool" and msg.tool_use_id}
     if required_tool_ids:
         for msg in messages[:start]:
@@ -398,14 +164,29 @@ def _select_recent_window_for_full(messages: Sequence[AgentMessage], recent_coun
     return fix_tool_call_consistency(selected)
 
 
+def _annotate_context_state(
+    context_state: Dict[str, Any],
+    *,
+    summary_source: str,
+    history_from_count: int,
+    history_to_count: int,
+) -> Dict[str, Any]:
+    annotated = dict(context_state)
+    annotated["summary_source"] = summary_source
+    annotated["history_compacted_from_count"] = history_from_count
+    annotated["history_compacted_to_count"] = history_to_count
+    annotated["recovery_context_message"] = build_recovery_context_message(annotated)
+    return annotated
+
+
 def build_portal_context_preview(context_state: dict | None) -> dict:
     if not isinstance(context_state, dict):
         return {}
     preview = {
         "context_compaction_level": context_state.get("compaction_level"),
-        "context_objective_preview": _truncate(str(context_state.get("objective") or ""), 140),
-        "context_summary_preview": _truncate(str(context_state.get("summary") or ""), 180),
-        "context_next_step_preview": _truncate(str(context_state.get("next_step") or ""), 140),
+        "context_objective_preview": truncate(str(context_state.get("objective") or ""), 140),
+        "context_summary_preview": truncate(str(context_state.get("summary") or ""), 180),
+        "context_next_step_preview": truncate(str(context_state.get("next_step") or ""), 140),
     }
     return {key: value for key, value in preview.items() if value not in (None, "")}
 
@@ -428,16 +209,17 @@ async def prepare_progressive_messages(
             logger.warning("Failed to load prior context_state", exc_info=True)
 
     source_messages = _to_agent_messages(messages)
+    source_count = len(source_messages)
+
     if not source_messages:
-        current_context = _build_current_context_state(source_messages)
-        merged_state = _merge_prior_and_current_context_state(
+        state = build_context_state_from_messages(
+            source_messages,
             prior_context_state=prior_context_state,
-            current_context_state=current_context,
             compaction_level="none",
             source_message_count=0,
             recent_count=recent_count,
         )
-        return [], merged_state
+        return [], _annotate_context_state(state, summary_source="none", history_from_count=0, history_to_count=0)
 
     context_window = resolve_context_window_tokens(model)
     configured_threshold = normalize_compaction_threshold(config.llm.get("compaction_threshold", 0.8), 0.8)
@@ -450,13 +232,15 @@ async def prepare_progressive_messages(
     current_tokens = estimate_messages_tokens(source_messages)
     compaction_level = "none"
     prepared_messages = list(source_messages)
+    summary_source = "none"
 
     if current_tokens > soft_threshold:
         micro_messages = _micro_compact_messages(source_messages, recent_count=recent_count)
-        micro_tokens = estimate_messages_tokens(micro_messages)
         prepared_messages = micro_messages
         compaction_level = "micro"
+        summary_source = "micro"
 
+        micro_tokens = estimate_messages_tokens(micro_messages)
         if micro_tokens > hard_threshold:
             full_messages, _stats = await compact_messages(
                 messages=micro_messages,
@@ -465,41 +249,53 @@ async def prepare_progressive_messages(
                 recent_count=recent_count,
             )
             compaction_level = "full"
-            recent_window = _select_recent_window_for_full(full_messages, recent_count)
-            current_context_for_full = _build_current_context_state(full_messages)
-            merged_for_full = _merge_prior_and_current_context_state(
+            summary_source = "full"
+
+            source_state = build_context_state_from_messages(
+                source_messages,
                 prior_context_state=prior_context_state,
-                current_context_state=current_context_for_full,
                 compaction_level=compaction_level,
-                source_message_count=len(source_messages),
+                source_message_count=source_count,
                 recent_count=recent_count,
             )
-            synthetic_summary_message = _build_synthetic_summary_message(merged_for_full)
+            recent_window = _select_recent_window_for_full(full_messages, recent_count)
+            synthetic_summary_message = _build_synthetic_summary_message(source_state)
             prepared_messages = fix_tool_call_consistency([synthetic_summary_message] + recent_window)
 
-    current_context = _build_current_context_state(prepared_messages)
-    merged_state = _merge_prior_and_current_context_state(
-        prior_context_state=prior_context_state,
-        current_context_state=current_context,
-        compaction_level=compaction_level,
-        source_message_count=len(source_messages),
-        recent_count=recent_count,
-    )
-
-    if stage == "post_turn":
-        # Post-turn state should reflect latest run completion, regardless of compaction path.
-        latest_context = _build_current_context_state(source_messages)
-        merged_state = _merge_prior_and_current_context_state(
-            prior_context_state=merged_state,
-            current_context_state=latest_context,
+    if compaction_level == "full":
+        merged_state = build_context_state_from_messages(
+            source_messages,
+            prior_context_state=prior_context_state,
             compaction_level=compaction_level,
-            source_message_count=len(source_messages),
+            source_message_count=source_count,
+            recent_count=recent_count,
+        )
+    else:
+        merged_state = build_context_state_from_messages(
+            prepared_messages,
+            prior_context_state=prior_context_state,
+            compaction_level=compaction_level,
+            source_message_count=source_count,
             recent_count=recent_count,
         )
 
-    if compaction_level == "none":
-        return list(messages), merged_state
-    return _to_dict_messages(prepared_messages), merged_state
+    if stage == "post_turn":
+        merged_state = build_context_state_from_messages(
+            source_messages,
+            prior_context_state=merged_state,
+            compaction_level=compaction_level,
+            source_message_count=source_count,
+            recent_count=recent_count,
+        )
+
+    final_messages = list(messages) if compaction_level == "none" else _to_dict_messages(prepared_messages)
+    annotated_state = _annotate_context_state(
+        merged_state,
+        summary_source=summary_source,
+        history_from_count=source_count,
+        history_to_count=len(final_messages),
+    )
+    return final_messages, annotated_state
 
 
 async def apply_progressive_context_after_turn(

--- a/src/runtime/progressive_context.py
+++ b/src/runtime/progressive_context.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime, timezone
+import logging
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set
 
 from src.agents.compaction import (
     AgentMessage,
@@ -19,19 +19,14 @@ from src.config import config
 from src.sessions.manager import session_manager
 from src.utils.truncate import truncate
 
+logger = logging.getLogger(__name__)
 
 _PREVIEW_LIMIT = 240
 _SUMMARY_LIMIT = 320
 _NEXT_STEP_FALLBACK = "Continue from the latest state and preserve prior constraints."
 _CONSTRAINT_KEYWORDS = ("must", "should", "need to", "do not", "don't", "不要", "不能", "必须")
-
-
-@dataclass
-class ProgressivePreparation:
-    messages: List[Dict[str, Any]]
-    context_state: Dict[str, Any]
-    history_changed: bool
-    full_summary: Optional[str] = None
+_DECISION_HINTS = ("decide", "decided", "decision", "we will", "chosen", "选择", "决定", "采用")
+_OPEN_LOOP_HINTS = ("todo", "follow up", "pending", "next", "blocker", "wait", "待办", "后续", "未完成", "需要")
 
 
 def _to_agent_messages(messages: List[Dict[str, Any]]) -> List[AgentMessage]:
@@ -48,7 +43,7 @@ def _to_agent_messages(messages: List[Dict[str, Any]]) -> List[AgentMessage]:
     ]
 
 
-def _to_dict_messages(messages: List[AgentMessage]) -> List[Dict[str, Any]]:
+def _to_dict_messages(messages: Sequence[AgentMessage]) -> List[Dict[str, Any]]:
     result: List[Dict[str, Any]] = []
     for msg in messages:
         item: Dict[str, Any] = {
@@ -85,6 +80,27 @@ def _truncate(value: str, limit: int) -> str:
     return truncate(value, limit) if value else ""
 
 
+def _collect_protected_tool_chain_ids(messages: Sequence[AgentMessage], recent_count: int) -> Set[str]:
+    protected: Set[str] = set()
+    if not messages:
+        return protected
+
+    tail = list(messages[-max(1, recent_count + 2):])
+    for msg in tail:
+        if msg.role == "tool" and msg.tool_use_id:
+            protected.add(msg.tool_use_id)
+    for msg in reversed(tail):
+        if msg.role != "assistant" or not msg.tool_calls:
+            continue
+        for call in msg.tool_calls:
+            call_id = str(call.get("id") or "").strip()
+            if call_id:
+                protected.add(call_id)
+        if protected:
+            break
+    return protected
+
+
 def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) -> List[AgentMessage]:
     if not messages:
         return messages
@@ -92,6 +108,7 @@ def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) 
     keep_message_start = max(0, len(messages) - max(1, recent_count))
     tool_indices = [idx for idx, msg in enumerate(messages) if msg.role == "tool"]
     keep_tool_indices = set(tool_indices[-4:])
+    protected_tool_chain_ids = _collect_protected_tool_chain_ids(messages, recent_count)
 
     compacted: List[AgentMessage] = []
     for idx, msg in enumerate(messages):
@@ -101,6 +118,9 @@ def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) 
 
         if msg.role == "tool":
             content_text = _safe_text(msg.content)
+            if msg.tool_use_id and msg.tool_use_id in protected_tool_chain_ids:
+                compacted.append(msg)
+                continue
             if idx not in keep_tool_indices and len(content_text) > 800:
                 preview = _truncate(content_text, 240)
                 compacted.append(
@@ -116,6 +136,10 @@ def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) 
             continue
 
         if msg.role == "assistant" and msg.tool_calls:
+            call_ids = {str(tc.get("id") or "").strip() for tc in msg.tool_calls if tc.get("id")}
+            if call_ids.intersection(protected_tool_chain_ids):
+                compacted.append(msg)
+                continue
             content_text = _safe_text(msg.content)
             if len(content_text) > 1200:
                 compacted.append(
@@ -134,14 +158,22 @@ def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) 
     return fix_tool_call_consistency(compacted)
 
 
-def _extract_objective(messages: List[AgentMessage]) -> str:
-    user_texts = [_safe_text(m.content) for m in messages if m.role == "user" and _safe_text(m.content)]
-    if not user_texts:
-        return ""
-    return _truncate(user_texts[0] or user_texts[-1], _PREVIEW_LIMIT)
+def _extract_objective(messages: Sequence[AgentMessage]) -> str:
+    first_user = ""
+    latest_user = ""
+    for msg in messages:
+        if msg.role != "user":
+            continue
+        text = _safe_text(msg.content)
+        if not text:
+            continue
+        if not first_user:
+            first_user = text
+        latest_user = text
+    return _truncate(first_user or latest_user, _PREVIEW_LIMIT)
 
 
-def _extract_constraints(messages: List[AgentMessage]) -> List[str]:
+def _extract_constraints(messages: Sequence[AgentMessage]) -> List[str]:
     constraints: List[str] = []
     for msg in reversed(messages):
         if msg.role != "user":
@@ -163,58 +195,207 @@ def _extract_constraints(messages: List[AgentMessage]) -> List[str]:
     return constraints
 
 
-def _extract_latest_assistant_preview(messages: List[AgentMessage]) -> str:
+def _extract_current_state(messages: Sequence[AgentMessage]) -> str:
     for msg in reversed(messages):
         if msg.role == "assistant":
             text = _safe_text(msg.content)
             if text:
-                return _truncate(text, 160)
+                return _truncate(text, 220)
+    for msg in reversed(messages):
+        if msg.role == "tool":
+            text = _safe_text(msg.content)
+            if text:
+                return _truncate(f"Latest tool result: {text}", 220)
     return ""
 
 
-def _extract_next_step(messages: List[AgentMessage]) -> str:
-    assistant_text = _extract_latest_assistant_preview(messages)
-    if assistant_text:
+def _extract_next_step(messages: Sequence[AgentMessage]) -> str:
+    for msg in reversed(messages):
+        if msg.role != "assistant":
+            continue
+        assistant_text = _safe_text(msg.content)
+        if not assistant_text:
+            continue
         lowered = assistant_text.lower()
-        if any(token in lowered for token in ("next", "continue", "please", "run", "check", "verify", "then")):
+        if any(token in lowered for token in ("next", "continue", "please", "run", "check", "verify", "then", "should")):
             return _truncate(assistant_text, 180)
     return _NEXT_STEP_FALLBACK
 
 
-def _build_summary(messages: List[AgentMessage], *, objective: str, full_summary: Optional[str]) -> str:
-    if full_summary:
-        return _truncate(full_summary, _SUMMARY_LIMIT)
-    assistant_preview = _extract_latest_assistant_preview(messages)
-    tool_count = sum(1 for msg in messages if msg.role == "tool")
-    parts = [part for part in [objective, assistant_preview] if part]
-    if tool_count:
-        parts.append(f"Tool interactions: {tool_count}.")
-    if not parts:
-        return "Conversation context state updated."
-    return _truncate(" | ".join(parts), _SUMMARY_LIMIT)
+def _extract_decisions(messages: Sequence[AgentMessage]) -> List[str]:
+    decisions: List[str] = []
+    for msg in reversed(messages):
+        if msg.role not in {"assistant", "user"}:
+            continue
+        text = _safe_text(msg.content)
+        if not text:
+            continue
+        for sentence in re.split(r"[\n\.。!！?？]", text):
+            candidate = sentence.strip()
+            if not candidate:
+                continue
+            lowered = candidate.lower()
+            if any(hint in lowered or hint in candidate for hint in _DECISION_HINTS):
+                normalized = _truncate(candidate, 140)
+                if normalized and normalized not in decisions:
+                    decisions.append(normalized)
+                    if len(decisions) >= 5:
+                        return decisions
+    return decisions
 
 
-def _build_context_state(
+def _extract_open_loops(messages: Sequence[AgentMessage]) -> List[str]:
+    open_loops: List[str] = []
+    for msg in reversed(messages):
+        if msg.role not in {"assistant", "user"}:
+            continue
+        text = _safe_text(msg.content)
+        if not text:
+            continue
+        for sentence in re.split(r"[\n\.。!！?？]", text):
+            candidate = sentence.strip()
+            if not candidate:
+                continue
+            lowered = candidate.lower()
+            if "?" in candidate or any(hint in lowered or hint in candidate for hint in _OPEN_LOOP_HINTS):
+                normalized = _truncate(candidate, 140)
+                if normalized and normalized not in open_loops:
+                    open_loops.append(normalized)
+                    if len(open_loops) >= 5:
+                        return open_loops
+    return open_loops
+
+
+def _is_weaker_objective(current: str, prior: str) -> bool:
+    if not prior:
+        return False
+    if not current:
+        return True
+    if len(current.strip()) < 12 <= len(prior.strip()):
+        return True
+    if len(current.strip()) * 2 < len(prior.strip()):
+        return True
+    return False
+
+
+def _merge_unique(prior_values: Any, current_values: Any, *, limit: int = 5) -> List[str]:
+    merged: List[str] = []
+    for raw in list(prior_values or []) + list(current_values or []):
+        text = _truncate(str(raw or "").strip(), 160)
+        if text and text not in merged:
+            merged.append(text)
+            if len(merged) >= limit:
+                break
+    return merged
+
+
+def _build_structured_summary(context_state: Dict[str, Any]) -> str:
+    lines = ["Context summary:"]
+    objective = _truncate(str(context_state.get("objective") or "").strip(), 200)
+    current_state = _truncate(str(context_state.get("current_state") or "").strip(), 220)
+    constraints = "; ".join(_merge_unique([], context_state.get("constraints"), limit=5))
+    decisions = "; ".join(_merge_unique([], context_state.get("decisions"), limit=5))
+    open_loops = "; ".join(_merge_unique([], context_state.get("open_loops"), limit=5))
+    next_step = _truncate(str(context_state.get("next_step") or "").strip(), 180)
+
+    if objective:
+        lines.append(f"- Objective: {objective}")
+    if current_state:
+        lines.append(f"- Current state: {current_state}")
+    if constraints:
+        lines.append(f"- Constraints: {constraints}")
+    if decisions:
+        lines.append(f"- Decisions: {decisions}")
+    if open_loops:
+        lines.append(f"- Open loops: {open_loops}")
+    if next_step:
+        lines.append(f"- Next step: {next_step}")
+
+    if len(lines) == 1:
+        lines.append("- Current state: Context state refreshed.")
+    return _truncate("\n".join(lines), _SUMMARY_LIMIT)
+
+
+def _merge_prior_and_current_context_state(
     *,
-    source_messages: List[AgentMessage],
-    prepared_messages: List[AgentMessage],
+    prior_context_state: Dict[str, Any],
+    current_context_state: Dict[str, Any],
     compaction_level: str,
+    source_message_count: int,
     recent_count: int,
-    full_summary: Optional[str] = None,
 ) -> Dict[str, Any]:
-    objective = _extract_objective(prepared_messages or source_messages)
-    summary = _build_summary(prepared_messages, objective=objective, full_summary=full_summary)
-    return {
+    prior_objective = _truncate(str(prior_context_state.get("objective") or "").strip(), _PREVIEW_LIMIT)
+    current_objective = _truncate(str(current_context_state.get("objective") or "").strip(), _PREVIEW_LIMIT)
+    objective = prior_objective if _is_weaker_objective(current_objective, prior_objective) else current_objective
+
+    next_step = _truncate(str(current_context_state.get("next_step") or "").strip(), 180)
+    if not next_step or next_step == _NEXT_STEP_FALLBACK:
+        prior_next = _truncate(str(prior_context_state.get("next_step") or "").strip(), 180)
+        next_step = prior_next or _NEXT_STEP_FALLBACK
+
+    merged: Dict[str, Any] = {
         "version": "context.v1",
         "compaction_level": compaction_level,
         "objective": objective,
-        "summary": summary,
-        "next_step": _extract_next_step(prepared_messages),
-        "constraints": _extract_constraints(prepared_messages),
-        "source_message_count": len(source_messages),
+        "current_state": _truncate(
+            str(current_context_state.get("current_state") or prior_context_state.get("current_state") or "").strip(),
+            220,
+        ),
+        "next_step": next_step,
+        "constraints": _merge_unique(prior_context_state.get("constraints"), current_context_state.get("constraints")),
+        "decisions": _merge_unique(prior_context_state.get("decisions"), current_context_state.get("decisions")),
+        "open_loops": _merge_unique(prior_context_state.get("open_loops"), current_context_state.get("open_loops")),
+        "source_message_count": source_message_count,
         "recent_window_count": recent_count,
         "last_compacted_at": datetime.now(timezone.utc).isoformat() if compaction_level in {"micro", "full"} else None,
     }
+    merged["summary"] = _build_structured_summary(merged)
+    return merged
+
+
+def _build_current_context_state(messages: Sequence[AgentMessage]) -> Dict[str, Any]:
+    return {
+        "objective": _extract_objective(messages),
+        "current_state": _extract_current_state(messages),
+        "next_step": _extract_next_step(messages),
+        "constraints": _extract_constraints(messages),
+        "decisions": _extract_decisions(messages),
+        "open_loops": _extract_open_loops(messages),
+    }
+
+
+def _resolve_stage_thresholds(*, stage: str, context_window: int, hard_threshold: int) -> tuple[int, int]:
+    if stage == "tool_loop":
+        soft = int(context_window * 0.60)
+        hard = min(hard_threshold, int(context_window * 0.75))
+        return soft, max(soft + 1, hard)
+    return int(context_window * 0.65), hard_threshold
+
+
+def _build_synthetic_summary_message(context_state: Dict[str, Any]) -> AgentMessage:
+    return AgentMessage(
+        role="system",
+        content=_build_structured_summary(context_state),
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def _select_recent_window_for_full(messages: Sequence[AgentMessage], recent_count: int) -> List[AgentMessage]:
+    if not messages:
+        return []
+    start = max(0, len(messages) - max(1, recent_count))
+    selected = list(messages[start:])
+
+    required_tool_ids = {msg.tool_use_id for msg in selected if msg.role == "tool" and msg.tool_use_id}
+    if required_tool_ids:
+        for msg in messages[:start]:
+            if msg.role != "assistant" or not msg.tool_calls:
+                continue
+            call_ids = {str(tc.get("id") or "").strip() for tc in msg.tool_calls if tc.get("id")}
+            if call_ids.intersection(required_tool_ids):
+                selected.insert(0, msg)
+                break
+    return fix_tool_call_consistency(selected)
 
 
 def build_portal_context_preview(context_state: dict | None) -> dict:
@@ -237,57 +418,88 @@ async def prepare_progressive_messages(
     stage: str,
     recent_count: int = 5,
 ) -> tuple[list[dict], dict]:
-    del session_id, stage
+    prior_context_state: Dict[str, Any] = {}
+    if session_id:
+        try:
+            prior = await session_manager.get_context_state(session_id)
+            if isinstance(prior, dict):
+                prior_context_state = dict(prior)
+        except Exception:
+            logger.warning("Failed to load prior context_state", exc_info=True)
+
     source_messages = _to_agent_messages(messages)
     if not source_messages:
-        context_state = _build_context_state(
-            source_messages=[],
-            prepared_messages=[],
+        current_context = _build_current_context_state(source_messages)
+        merged_state = _merge_prior_and_current_context_state(
+            prior_context_state=prior_context_state,
+            current_context_state=current_context,
             compaction_level="none",
+            source_message_count=0,
             recent_count=recent_count,
         )
-        return [], context_state
+        return [], merged_state
 
     context_window = resolve_context_window_tokens(model)
-    soft_threshold = int(context_window * 0.65)
     configured_threshold = normalize_compaction_threshold(config.llm.get("compaction_threshold", 0.8), 0.8)
-    hard_threshold = int(context_window * configured_threshold)
-    current_tokens = estimate_messages_tokens(source_messages)
-
-    if current_tokens <= soft_threshold:
-        context_state = _build_context_state(
-            source_messages=source_messages,
-            prepared_messages=source_messages,
-            compaction_level="none",
-            recent_count=recent_count,
-        )
-        return list(messages), context_state
-
-    micro_messages = _micro_compact_messages(source_messages, recent_count=recent_count)
-    micro_tokens = estimate_messages_tokens(micro_messages)
-    if micro_tokens <= hard_threshold:
-        context_state = _build_context_state(
-            source_messages=source_messages,
-            prepared_messages=micro_messages,
-            compaction_level="micro",
-            recent_count=recent_count,
-        )
-        return _to_dict_messages(micro_messages), context_state
-
-    full_messages, stats = await compact_messages(
-        messages=micro_messages,
-        max_tokens=hard_threshold,
+    soft_threshold, hard_threshold = _resolve_stage_thresholds(
+        stage=stage,
         context_window=context_window,
+        hard_threshold=int(context_window * configured_threshold),
+    )
+
+    current_tokens = estimate_messages_tokens(source_messages)
+    compaction_level = "none"
+    prepared_messages = list(source_messages)
+
+    if current_tokens > soft_threshold:
+        micro_messages = _micro_compact_messages(source_messages, recent_count=recent_count)
+        micro_tokens = estimate_messages_tokens(micro_messages)
+        prepared_messages = micro_messages
+        compaction_level = "micro"
+
+        if micro_tokens > hard_threshold:
+            full_messages, _stats = await compact_messages(
+                messages=micro_messages,
+                max_tokens=hard_threshold,
+                context_window=context_window,
+                recent_count=recent_count,
+            )
+            compaction_level = "full"
+            recent_window = _select_recent_window_for_full(full_messages, recent_count)
+            current_context_for_full = _build_current_context_state(full_messages)
+            merged_for_full = _merge_prior_and_current_context_state(
+                prior_context_state=prior_context_state,
+                current_context_state=current_context_for_full,
+                compaction_level=compaction_level,
+                source_message_count=len(source_messages),
+                recent_count=recent_count,
+            )
+            synthetic_summary_message = _build_synthetic_summary_message(merged_for_full)
+            prepared_messages = fix_tool_call_consistency([synthetic_summary_message] + recent_window)
+
+    current_context = _build_current_context_state(prepared_messages)
+    merged_state = _merge_prior_and_current_context_state(
+        prior_context_state=prior_context_state,
+        current_context_state=current_context,
+        compaction_level=compaction_level,
+        source_message_count=len(source_messages),
         recent_count=recent_count,
     )
-    context_state = _build_context_state(
-        source_messages=source_messages,
-        prepared_messages=full_messages,
-        compaction_level="full",
-        recent_count=recent_count,
-        full_summary=stats.summary,
-    )
-    return _to_dict_messages(full_messages), context_state
+
+    if stage == "post_turn":
+        # Post-turn state should reflect latest run completion, regardless of compaction path.
+        latest_context = _build_current_context_state(source_messages)
+        merged_state = _merge_prior_and_current_context_state(
+            prior_context_state=merged_state,
+            current_context_state=latest_context,
+            compaction_level=compaction_level,
+            source_message_count=len(source_messages),
+            recent_count=recent_count,
+        )
+
+    if compaction_level == "none":
+        return list(messages), merged_state
+    return _to_dict_messages(prepared_messages), merged_state
 
 
 async def apply_progressive_context_after_turn(
@@ -310,21 +522,7 @@ async def apply_progressive_context_after_turn(
 
     if prepared_messages != history:
         session["history"] = prepared_messages
+        session["updated_at"] = datetime.now().isoformat()
 
-    metadata = session.setdefault("metadata", {})
-    metadata["context_state"] = context_state
-    preview = build_portal_context_preview(context_state)
-    metadata.update(preview)
-
-    summary = context_state.get("summary")
-    if summary:
-        metadata["session_memory_summary"] = summary
-    if context_state.get("compaction_level") == "full" and summary:
-        metadata["compaction_summary"] = summary
-
-    session["updated_at"] = datetime.now().isoformat()
-
-    if session_manager.persistence_enabled:
-        session_manager._schedule_metadata_persist(session_id, session)
-
+    await session_manager.set_context_state(session_id, context_state)
     return context_state

--- a/src/runtime/progressive_context.py
+++ b/src/runtime/progressive_context.py
@@ -1,0 +1,330 @@
+"""Progressive context preparation and durable context state helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.agents.compaction import (
+    AgentMessage,
+    compact_messages,
+    estimate_messages_tokens,
+    fix_tool_call_consistency,
+    normalize_compaction_threshold,
+    resolve_context_window_tokens,
+)
+from src.config import config
+from src.sessions.manager import session_manager
+from src.utils.truncate import truncate
+
+
+_PREVIEW_LIMIT = 240
+_SUMMARY_LIMIT = 320
+_NEXT_STEP_FALLBACK = "Continue from the latest state and preserve prior constraints."
+_CONSTRAINT_KEYWORDS = ("must", "should", "need to", "do not", "don't", "不要", "不能", "必须")
+
+
+@dataclass
+class ProgressivePreparation:
+    messages: List[Dict[str, Any]]
+    context_state: Dict[str, Any]
+    history_changed: bool
+    full_summary: Optional[str] = None
+
+
+def _to_agent_messages(messages: List[Dict[str, Any]]) -> List[AgentMessage]:
+    return [
+        AgentMessage(
+            role=str(msg.get("role") or "user"),
+            content=msg.get("content", ""),
+            timestamp=msg.get("timestamp"),
+            tool_calls=msg.get("tool_calls"),
+            tool_use_id=msg.get("tool_call_id") or msg.get("tool_use_id"),
+        )
+        for msg in messages
+        if isinstance(msg, dict)
+    ]
+
+
+def _to_dict_messages(messages: List[AgentMessage]) -> List[Dict[str, Any]]:
+    result: List[Dict[str, Any]] = []
+    for msg in messages:
+        item: Dict[str, Any] = {
+            "role": msg.role,
+            "content": msg.content,
+        }
+        if msg.timestamp:
+            item["timestamp"] = msg.timestamp
+        if msg.tool_calls:
+            item["tool_calls"] = msg.tool_calls
+        if msg.tool_use_id:
+            item["tool_call_id"] = msg.tool_use_id
+        result.append(item)
+    return result
+
+
+def _safe_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        parts: List[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+            elif isinstance(item, str) and item.strip():
+                parts.append(item.strip())
+        return " ".join(parts).strip()
+    return str(value or "").strip()
+
+
+def _truncate(value: str, limit: int) -> str:
+    return truncate(value, limit) if value else ""
+
+
+def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) -> List[AgentMessage]:
+    if not messages:
+        return messages
+
+    keep_message_start = max(0, len(messages) - max(1, recent_count))
+    tool_indices = [idx for idx, msg in enumerate(messages) if msg.role == "tool"]
+    keep_tool_indices = set(tool_indices[-4:])
+
+    compacted: List[AgentMessage] = []
+    for idx, msg in enumerate(messages):
+        if idx >= keep_message_start:
+            compacted.append(msg)
+            continue
+
+        if msg.role == "tool":
+            content_text = _safe_text(msg.content)
+            if idx not in keep_tool_indices and len(content_text) > 800:
+                preview = _truncate(content_text, 240)
+                compacted.append(
+                    AgentMessage(
+                        role="tool",
+                        content=f"[tool_result compacted | original_chars={len(content_text)}] {preview}",
+                        timestamp=msg.timestamp,
+                        tool_use_id=msg.tool_use_id,
+                    )
+                )
+                continue
+            compacted.append(msg)
+            continue
+
+        if msg.role == "assistant" and msg.tool_calls:
+            content_text = _safe_text(msg.content)
+            if len(content_text) > 1200:
+                compacted.append(
+                    AgentMessage(
+                        role="assistant",
+                        content=_truncate(content_text, 320),
+                        timestamp=msg.timestamp,
+                        tool_calls=msg.tool_calls,
+                        tool_use_id=msg.tool_use_id,
+                    )
+                )
+                continue
+
+        compacted.append(msg)
+
+    return fix_tool_call_consistency(compacted)
+
+
+def _extract_objective(messages: List[AgentMessage]) -> str:
+    user_texts = [_safe_text(m.content) for m in messages if m.role == "user" and _safe_text(m.content)]
+    if not user_texts:
+        return ""
+    return _truncate(user_texts[0] or user_texts[-1], _PREVIEW_LIMIT)
+
+
+def _extract_constraints(messages: List[AgentMessage]) -> List[str]:
+    constraints: List[str] = []
+    for msg in reversed(messages):
+        if msg.role != "user":
+            continue
+        text = _safe_text(msg.content)
+        if not text:
+            continue
+        for sentence in re.split(r"[\n\.。!！?？]", text):
+            candidate = sentence.strip()
+            if not candidate:
+                continue
+            lower = candidate.lower()
+            if any(keyword in lower or keyword in candidate for keyword in _CONSTRAINT_KEYWORDS):
+                normalized = _truncate(candidate, 140)
+                if normalized and normalized not in constraints:
+                    constraints.append(normalized)
+                    if len(constraints) >= 5:
+                        return constraints
+    return constraints
+
+
+def _extract_latest_assistant_preview(messages: List[AgentMessage]) -> str:
+    for msg in reversed(messages):
+        if msg.role == "assistant":
+            text = _safe_text(msg.content)
+            if text:
+                return _truncate(text, 160)
+    return ""
+
+
+def _extract_next_step(messages: List[AgentMessage]) -> str:
+    assistant_text = _extract_latest_assistant_preview(messages)
+    if assistant_text:
+        lowered = assistant_text.lower()
+        if any(token in lowered for token in ("next", "continue", "please", "run", "check", "verify", "then")):
+            return _truncate(assistant_text, 180)
+    return _NEXT_STEP_FALLBACK
+
+
+def _build_summary(messages: List[AgentMessage], *, objective: str, full_summary: Optional[str]) -> str:
+    if full_summary:
+        return _truncate(full_summary, _SUMMARY_LIMIT)
+    assistant_preview = _extract_latest_assistant_preview(messages)
+    tool_count = sum(1 for msg in messages if msg.role == "tool")
+    parts = [part for part in [objective, assistant_preview] if part]
+    if tool_count:
+        parts.append(f"Tool interactions: {tool_count}.")
+    if not parts:
+        return "Conversation context state updated."
+    return _truncate(" | ".join(parts), _SUMMARY_LIMIT)
+
+
+def _build_context_state(
+    *,
+    source_messages: List[AgentMessage],
+    prepared_messages: List[AgentMessage],
+    compaction_level: str,
+    recent_count: int,
+    full_summary: Optional[str] = None,
+) -> Dict[str, Any]:
+    objective = _extract_objective(prepared_messages or source_messages)
+    summary = _build_summary(prepared_messages, objective=objective, full_summary=full_summary)
+    return {
+        "version": "context.v1",
+        "compaction_level": compaction_level,
+        "objective": objective,
+        "summary": summary,
+        "next_step": _extract_next_step(prepared_messages),
+        "constraints": _extract_constraints(prepared_messages),
+        "source_message_count": len(source_messages),
+        "recent_window_count": recent_count,
+        "last_compacted_at": datetime.now(timezone.utc).isoformat() if compaction_level in {"micro", "full"} else None,
+    }
+
+
+def build_portal_context_preview(context_state: dict | None) -> dict:
+    if not isinstance(context_state, dict):
+        return {}
+    preview = {
+        "context_compaction_level": context_state.get("compaction_level"),
+        "context_objective_preview": _truncate(str(context_state.get("objective") or ""), 140),
+        "context_summary_preview": _truncate(str(context_state.get("summary") or ""), 180),
+        "context_next_step_preview": _truncate(str(context_state.get("next_step") or ""), 140),
+    }
+    return {key: value for key, value in preview.items() if value not in (None, "")}
+
+
+async def prepare_progressive_messages(
+    *,
+    messages: list[dict],
+    model: str | None,
+    session_id: str,
+    stage: str,
+    recent_count: int = 5,
+) -> tuple[list[dict], dict]:
+    del session_id, stage
+    source_messages = _to_agent_messages(messages)
+    if not source_messages:
+        context_state = _build_context_state(
+            source_messages=[],
+            prepared_messages=[],
+            compaction_level="none",
+            recent_count=recent_count,
+        )
+        return [], context_state
+
+    context_window = resolve_context_window_tokens(model)
+    soft_threshold = int(context_window * 0.65)
+    configured_threshold = normalize_compaction_threshold(config.llm.get("compaction_threshold", 0.8), 0.8)
+    hard_threshold = int(context_window * configured_threshold)
+    current_tokens = estimate_messages_tokens(source_messages)
+
+    if current_tokens <= soft_threshold:
+        context_state = _build_context_state(
+            source_messages=source_messages,
+            prepared_messages=source_messages,
+            compaction_level="none",
+            recent_count=recent_count,
+        )
+        return list(messages), context_state
+
+    micro_messages = _micro_compact_messages(source_messages, recent_count=recent_count)
+    micro_tokens = estimate_messages_tokens(micro_messages)
+    if micro_tokens <= hard_threshold:
+        context_state = _build_context_state(
+            source_messages=source_messages,
+            prepared_messages=micro_messages,
+            compaction_level="micro",
+            recent_count=recent_count,
+        )
+        return _to_dict_messages(micro_messages), context_state
+
+    full_messages, stats = await compact_messages(
+        messages=micro_messages,
+        max_tokens=hard_threshold,
+        context_window=context_window,
+        recent_count=recent_count,
+    )
+    context_state = _build_context_state(
+        source_messages=source_messages,
+        prepared_messages=full_messages,
+        compaction_level="full",
+        recent_count=recent_count,
+        full_summary=stats.summary,
+    )
+    return _to_dict_messages(full_messages), context_state
+
+
+async def apply_progressive_context_after_turn(
+    *,
+    session_id: str,
+    model: str | None,
+) -> dict:
+    if not session_id:
+        return {}
+
+    session = await session_manager.get_session(session_id)
+    history = list(session.get("history") or [])
+    prepared_messages, context_state = await prepare_progressive_messages(
+        messages=history,
+        model=model,
+        session_id=session_id,
+        stage="post_turn",
+        recent_count=5,
+    )
+
+    if prepared_messages != history:
+        session["history"] = prepared_messages
+
+    metadata = session.setdefault("metadata", {})
+    metadata["context_state"] = context_state
+    preview = build_portal_context_preview(context_state)
+    metadata.update(preview)
+
+    summary = context_state.get("summary")
+    if summary:
+        metadata["session_memory_summary"] = summary
+    if context_state.get("compaction_level") == "full" and summary:
+        metadata["compaction_summary"] = summary
+
+    session["updated_at"] = datetime.now().isoformat()
+
+    if session_manager.persistence_enabled:
+        session_manager._schedule_metadata_persist(session_id, session)
+
+    return context_state

--- a/src/runtime/progressive_context.py
+++ b/src/runtime/progressive_context.py
@@ -164,6 +164,33 @@ def _select_recent_window_for_full(messages: Sequence[AgentMessage], recent_coun
     return fix_tool_call_consistency(selected)
 
 
+def _trim_full_compaction_result_to_budget(
+    *,
+    summary_message: AgentMessage,
+    recent_window: Sequence[AgentMessage],
+    hard_threshold: int,
+) -> List[AgentMessage]:
+    trimmed_recent_window = list(recent_window)
+    candidate = fix_tool_call_consistency([summary_message] + trimmed_recent_window)
+    if estimate_messages_tokens(candidate) <= hard_threshold:
+        return candidate
+
+    while trimmed_recent_window:
+        trimmed_recent_window = trimmed_recent_window[1:]
+        candidate = fix_tool_call_consistency([summary_message] + trimmed_recent_window)
+        if estimate_messages_tokens(candidate) <= hard_threshold:
+            return candidate
+
+    shortened_summary = AgentMessage(
+        role=summary_message.role,
+        content=truncate(str(summary_message.content or ""), 220),
+        timestamp=summary_message.timestamp,
+        tool_calls=summary_message.tool_calls,
+        tool_use_id=summary_message.tool_use_id,
+    )
+    return fix_tool_call_consistency([shortened_summary])
+
+
 def _annotate_context_state(
     context_state: Dict[str, Any],
     *,
@@ -260,7 +287,11 @@ async def prepare_progressive_messages(
             )
             recent_window = _select_recent_window_for_full(full_messages, recent_count)
             synthetic_summary_message = _build_synthetic_summary_message(source_state)
-            prepared_messages = fix_tool_call_consistency([synthetic_summary_message] + recent_window)
+            prepared_messages = _trim_full_compaction_result_to_budget(
+                summary_message=synthetic_summary_message,
+                recent_window=recent_window,
+                hard_threshold=hard_threshold,
+            )
 
     if compaction_level == "full":
         merged_state = build_context_state_from_messages(

--- a/src/runtime/recovery_pipeline.py
+++ b/src/runtime/recovery_pipeline.py
@@ -245,6 +245,7 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
         has_context_objective = bool(str((context_state or {}).get("objective") or "").strip())
         has_context_next_step = bool(str((context_state or {}).get("next_step") or "").strip())
         context_summary_preview = str((context_state or {}).get("summary") or "").strip()
+        recovery_context_message = _extract_recovery_context_message(context_state)
         # runtime_state = active recoverable execution state
         # reconstructed_state = lightweight derived restore/reconcile hints, including compaction/memory
         reconstructed_state = {
@@ -261,6 +262,7 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
             "has_context_objective": has_context_objective,
             "has_context_next_step": has_context_next_step,
             "context_summary_preview": context_summary_preview,
+            "recovery_context_message": recovery_context_message,
             "needs_recovery_reconcile": any(
                 (
                     has_pending_delegations,
@@ -433,9 +435,6 @@ def _find_compaction_summary(metadata: dict, history: list[dict]) -> Optional[di
 
 
 def _find_session_memory_summary(metadata: dict, history: list[dict]) -> Optional[dict]:
-    context_state = _extract_context_state(metadata)
-    if isinstance(context_state, dict) and str(context_state.get("summary") or "").strip():
-        return {"source": "metadata", "key": "context_state.summary"}
     if isinstance(metadata, dict):
         for key in ("session_memory_summary", "session_memory_file", "session_memory_saved_at"):
             value = metadata.get(key)
@@ -463,6 +462,21 @@ def _extract_context_state(metadata: Dict[str, Any]) -> Optional[Dict[str, Any]]
     if isinstance(context_state, dict):
         return dict(context_state)
     return None
+
+
+def _extract_recovery_context_message(context_state: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not isinstance(context_state, dict):
+        return None
+    existing = str(context_state.get("recovery_context_message") or "").strip()
+    if existing:
+        return existing
+    try:
+        from src.runtime.context_summary import build_recovery_context_message
+
+        generated = build_recovery_context_message(context_state)
+        return generated or None
+    except Exception:
+        return None
 
 
 def _safe_string(value: Any) -> Optional[str]:

--- a/src/runtime/recovery_pipeline.py
+++ b/src/runtime/recovery_pipeline.py
@@ -128,6 +128,7 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
                     "has_last_execution_id": bool(last_execution_id),
                     "has_compaction_summary": bool(snapshot.reconstructed_state.get("has_compaction_summary")),
                     "has_session_memory_summary": bool(snapshot.reconstructed_state.get("has_session_memory_summary")),
+                    "has_context_state": bool(snapshot.reconstructed_state.get("has_context_state")),
                     "needs_recovery_reconcile": bool(snapshot.reconstructed_state.get("needs_recovery_reconcile")),
                     "warning_count": len(warnings),
                 },
@@ -154,6 +155,7 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
             "has_last_execution_id": bool(hydration.last_execution_id),
             "has_compaction_summary": bool(hydration.reconstructed_state.get("has_compaction_summary")),
             "has_session_memory_summary": bool(hydration.reconstructed_state.get("has_session_memory_summary")),
+            "has_context_state": bool(hydration.reconstructed_state.get("has_context_state")),
             "needs_recovery_reconcile": bool(hydration.reconstructed_state.get("needs_recovery_reconcile")),
             "warning_count": len(hydration.warnings),
         }
@@ -223,20 +225,23 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
         pending_tool_tasks = await self._safe_pending_tool_tasks(session_id, runtime_warnings)
         active_subagents = await self._safe_active_subagents(session_id, runtime_warnings)
         pending_delegations = metadata.get("pending_delegations") if isinstance(metadata.get("pending_delegations"), list) else []
-        compaction_summary = _find_compaction_summary(session.get("history") or [])
+        compaction_summary = _find_compaction_summary(metadata, session.get("history") or [])
         session_memory_summary = _find_session_memory_summary(metadata, session.get("history") or [])
+        context_state = _extract_context_state(metadata)
         runtime_state = {
             "active_skill_session": active_skill_session,
             "last_execution_id": last_execution_id,
             "pending_tool_tasks": pending_tool_tasks,
             "active_subagents": active_subagents,
             "pending_delegations": list(pending_delegations),
+            "context_state": context_state,
         }
         has_pending_tool_tasks = bool(pending_tool_tasks)
         has_active_subagents = bool(active_subagents)
         has_pending_delegations = bool(pending_delegations)
         has_compaction_summary = compaction_summary is not None
         has_session_memory_summary = session_memory_summary is not None
+        has_context_state = context_state is not None
         # runtime_state = active recoverable execution state
         # reconstructed_state = lightweight derived restore/reconcile hints, including compaction/memory
         reconstructed_state = {
@@ -248,6 +253,8 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
             "has_pending_delegations": has_pending_delegations,
             "has_compaction_summary": has_compaction_summary,
             "has_session_memory_summary": has_session_memory_summary,
+            "has_context_state": has_context_state,
+            "context_compaction_level": context_state.get("compaction_level") if isinstance(context_state, dict) else None,
             "needs_recovery_reconcile": any(
                 (
                     has_pending_delegations,
@@ -255,6 +262,7 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
                     has_active_subagents,
                     has_compaction_summary,
                     has_session_memory_summary,
+                    has_context_state,
                 )
             ),
             "has_shared_context_ref": _has_shared_context_ref(metadata),
@@ -311,6 +319,7 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
                         "has_pending_delegations": bool(pending_delegations),
                         "has_compaction_summary": has_compaction_summary,
                         "has_session_memory_summary": has_session_memory_summary,
+                        "has_context_state": has_context_state,
                         "needs_recovery_reconcile": reconstructed_state["needs_recovery_reconcile"],
                         "warning_count": len(runtime_warnings),
                     },
@@ -396,7 +405,14 @@ def _has_materialized_context_ref(metadata: Dict[str, Any]) -> bool:
     return False
 
 
-def _find_compaction_summary(history: list[dict]) -> Optional[dict]:
+def _find_compaction_summary(metadata: dict, history: list[dict]) -> Optional[dict]:
+    context_state = _extract_context_state(metadata)
+    if isinstance(context_state, dict) and context_state.get("compaction_level") == "full":
+        summary = str(context_state.get("summary") or "").strip()
+        if summary:
+            return {"source": "metadata", "key": "context_state.summary", "summary": summary}
+    if isinstance(metadata, dict) and metadata.get("compaction_summary"):
+        return {"source": "metadata", "key": "compaction_summary"}
     for item in history:
         if not isinstance(item, dict):
             continue
@@ -409,6 +425,9 @@ def _find_compaction_summary(history: list[dict]) -> Optional[dict]:
 
 
 def _find_session_memory_summary(metadata: dict, history: list[dict]) -> Optional[dict]:
+    context_state = _extract_context_state(metadata)
+    if isinstance(context_state, dict) and str(context_state.get("summary") or "").strip():
+        return {"source": "metadata", "key": "context_state.summary"}
     if isinstance(metadata, dict):
         for key in ("session_memory_summary", "session_memory_file", "session_memory_saved_at"):
             value = metadata.get(key)
@@ -426,6 +445,15 @@ def _find_session_memory_summary(metadata: dict, history: list[dict]) -> Optiona
             marker = item.get("session_memory_summary")
             if marker:
                 return dict(item)
+    return None
+
+
+def _extract_context_state(metadata: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not isinstance(metadata, dict):
+        return None
+    context_state = metadata.get("context_state")
+    if isinstance(context_state, dict):
+        return dict(context_state)
     return None
 
 

--- a/src/runtime/recovery_pipeline.py
+++ b/src/runtime/recovery_pipeline.py
@@ -242,6 +242,9 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
         has_compaction_summary = compaction_summary is not None
         has_session_memory_summary = session_memory_summary is not None
         has_context_state = context_state is not None
+        has_context_objective = bool(str((context_state or {}).get("objective") or "").strip())
+        has_context_next_step = bool(str((context_state or {}).get("next_step") or "").strip())
+        context_summary_preview = str((context_state or {}).get("summary") or "").strip()
         # runtime_state = active recoverable execution state
         # reconstructed_state = lightweight derived restore/reconcile hints, including compaction/memory
         reconstructed_state = {
@@ -255,6 +258,9 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
             "has_session_memory_summary": has_session_memory_summary,
             "has_context_state": has_context_state,
             "context_compaction_level": context_state.get("compaction_level") if isinstance(context_state, dict) else None,
+            "has_context_objective": has_context_objective,
+            "has_context_next_step": has_context_next_step,
+            "context_summary_preview": context_summary_preview,
             "needs_recovery_reconcile": any(
                 (
                     has_pending_delegations,
@@ -320,6 +326,8 @@ class DefaultRecoveryPipeline(RecoveryPipeline):
                         "has_compaction_summary": has_compaction_summary,
                         "has_session_memory_summary": has_session_memory_summary,
                         "has_context_state": has_context_state,
+                        "has_context_objective": has_context_objective,
+                        "has_context_next_step": has_context_next_step,
                         "needs_recovery_reconcile": reconstructed_state["needs_recovery_reconcile"],
                         "warning_count": len(runtime_warnings),
                     },

--- a/src/runtime/triggered_event_task.py
+++ b/src/runtime/triggered_event_task.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from src.agents.core import agent
+from src.agents.core import agent, run_chat_execution
 from src.channels.confluence import confluence_channel
 from src.channels.github import github_channel
 from src.channels.jira import jira_channel
@@ -18,7 +18,13 @@ def _require(payload: Dict[str, Any], key: str) -> Any:
 
 
 async def _run_agent_response(message: str, session_id: str) -> str:
-    result = await agent.process(message=message, session_id=session_id)
+    result = await run_chat_execution(
+        agent=agent,
+        message=message,
+        session_id=session_id,
+        user_name="triggered-event",
+        track_usage=False,
+    )
     response_text = str(result.get("response") or result.get("output") or "").strip()
     if not response_text:
         raise RuntimeError("Agent returned empty response for triggered event")

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -558,6 +558,33 @@ class SessionManager:
         session["updated_at"] = datetime.now().isoformat()
         self._schedule_metadata_persist(session_id, session)
 
+    async def get_context_state(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get durable progressive context state from session metadata."""
+        if not session_id:
+            return None
+        session = await self.get_session(session_id)
+        metadata = session.get("metadata", {})
+        if not isinstance(metadata, dict):
+            return None
+        context_state = metadata.get("context_state")
+        if isinstance(context_state, dict):
+            return dict(context_state)
+        return None
+
+    async def set_context_state(self, session_id: str, context_state: Dict[str, Any]) -> None:
+        """Persist durable progressive context state and preview metadata keys."""
+        if not session_id or not isinstance(context_state, dict):
+            return
+        session = await self.get_session(session_id)
+        metadata = session.setdefault("metadata", {})
+        metadata["context_state"] = dict(context_state)
+        metadata["context_compaction_level"] = context_state.get("compaction_level")
+        metadata["context_objective_preview"] = truncate(str(context_state.get("objective") or ""), 140)
+        metadata["context_summary_preview"] = truncate(str(context_state.get("summary") or ""), 180)
+        metadata["context_next_step_preview"] = truncate(str(context_state.get("next_step") or ""), 140)
+        session["updated_at"] = datetime.now().isoformat()
+        self._schedule_metadata_persist(session_id, session)
+
     async def add_pending_delegation(self, session_id: str, delegation_record: Dict[str, Any]) -> None:
         """Add a lightweight pending delegation record to session metadata."""
         if not session_id or not isinstance(delegation_record, dict):

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -687,6 +687,7 @@ class SessionManager:
             "warnings": list(hydration.warnings),
             "runtime_events": list(hydration.runtime_events),
             "metadata": dict(hydration.metadata),
+            "recovery_context_message": hydration.reconstructed_state.get("recovery_context_message"),
         }
 
     async def clear_history(self, session_id: str) -> None:

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -590,8 +590,6 @@ class SessionManager:
         summary_preview = truncate(str(context_state.get("summary") or ""), 180)
         _set_or_remove("context_summary_preview", summary_preview)
         _set_or_remove("context_next_step_preview", truncate(str(context_state.get("next_step") or ""), 140))
-
-        _set_or_remove("session_memory_summary", summary_preview)
         if context_state.get("compaction_level") == "full" and summary_preview:
             metadata["compaction_summary"] = summary_preview
         else:

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -578,10 +578,25 @@ class SessionManager:
         session = await self.get_session(session_id)
         metadata = session.setdefault("metadata", {})
         metadata["context_state"] = dict(context_state)
-        metadata["context_compaction_level"] = context_state.get("compaction_level")
-        metadata["context_objective_preview"] = truncate(str(context_state.get("objective") or ""), 140)
-        metadata["context_summary_preview"] = truncate(str(context_state.get("summary") or ""), 180)
-        metadata["context_next_step_preview"] = truncate(str(context_state.get("next_step") or ""), 140)
+
+        def _set_or_remove(key: str, value: Optional[str]) -> None:
+            if value in (None, ""):
+                metadata.pop(key, None)
+            else:
+                metadata[key] = value
+
+        _set_or_remove("context_compaction_level", context_state.get("compaction_level"))
+        _set_or_remove("context_objective_preview", truncate(str(context_state.get("objective") or ""), 140))
+        summary_preview = truncate(str(context_state.get("summary") or ""), 180)
+        _set_or_remove("context_summary_preview", summary_preview)
+        _set_or_remove("context_next_step_preview", truncate(str(context_state.get("next_step") or ""), 140))
+
+        _set_or_remove("session_memory_summary", summary_preview)
+        if context_state.get("compaction_level") == "full" and summary_preview:
+            metadata["compaction_summary"] = summary_preview
+        else:
+            metadata.pop("compaction_summary", None)
+
         session["updated_at"] = datetime.now().isoformat()
         self._schedule_metadata_persist(session_id, session)
 

--- a/tests/test_chat_orchestration_adapter.py
+++ b/tests/test_chat_orchestration_adapter.py
@@ -97,3 +97,59 @@ async def test_execute_with_bus_best_effort_failure_does_not_fail_result(monkeyp
 
     assert out is result
     assert out.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_execute_with_bus_non_chat_uses_model_from_metadata(monkeypatch):
+    result = make_execution_result(request_id="r4", status="success", output_payload={"ok": True})
+    bus = _Bus(result)
+    calls = []
+
+    monkeypatch.setattr("src.runtime.chat_orchestration_adapter.build_default_execution_bus", lambda execute_tool_func=None: bus)
+
+    async def _commit(*, session_id, model):
+        calls.append((session_id, model))
+
+    monkeypatch.setattr("src.runtime.progressive_context.apply_progressive_context_after_turn", _commit)
+
+    out = await _execute_with_bus(
+        request_id="r4",
+        source_type="task",
+        source_ref="ref",
+        execution_type="task",
+        session_id="s4",
+        context_ref=None,
+        input_payload={},
+        metadata={"model": "gpt-4.1-mini"},
+    )
+
+    assert out is result
+    assert calls == [("s4", "gpt-4.1-mini")]
+
+
+@pytest.mark.asyncio
+async def test_execute_with_bus_non_chat_uses_model_from_nested_kwargs(monkeypatch):
+    result = make_execution_result(request_id="r5", status="success", output_payload={"ok": True})
+    bus = _Bus(result)
+    calls = []
+
+    monkeypatch.setattr("src.runtime.chat_orchestration_adapter.build_default_execution_bus", lambda execute_tool_func=None: bus)
+
+    async def _commit(*, session_id, model):
+        calls.append((session_id, model))
+
+    monkeypatch.setattr("src.runtime.progressive_context.apply_progressive_context_after_turn", _commit)
+
+    out = await _execute_with_bus(
+        request_id="r5",
+        source_type="task",
+        source_ref="ref",
+        execution_type="task",
+        session_id="s5",
+        context_ref=None,
+        input_payload={"kwargs": {"llm_kwargs": {"model": "gpt-4o-mini"}}},
+        metadata={},
+    )
+
+    assert out is result
+    assert calls == [("s5", "gpt-4o-mini")]

--- a/tests/test_chat_orchestration_adapter.py
+++ b/tests/test_chat_orchestration_adapter.py
@@ -1,0 +1,99 @@
+import pytest
+
+from src.runtime.chat_orchestration_adapter import _execute_with_bus
+from src.runtime.contracts import make_execution_result
+
+
+class _Bus:
+    def __init__(self, result):
+        self._result = result
+
+    def register_handler(self, _type, _handler):
+        return None
+
+    async def execute(self, _request):
+        return self._result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("execution_type", ["task", "skill", "subagent"])
+async def test_execute_with_bus_non_chat_commits_progressive_context(monkeypatch, execution_type):
+    result = make_execution_result(request_id="r1", status="success", output_payload={"ok": True})
+    bus = _Bus(result)
+    calls = []
+
+    monkeypatch.setattr("src.runtime.chat_orchestration_adapter.build_default_execution_bus", lambda execute_tool_func=None: bus)
+
+    async def _commit(*, session_id, model):
+        calls.append((session_id, model))
+
+    monkeypatch.setattr("src.runtime.progressive_context.apply_progressive_context_after_turn", _commit)
+
+    out = await _execute_with_bus(
+        request_id="r1",
+        source_type="task",
+        source_ref="ref",
+        execution_type=execution_type,
+        session_id="s1",
+        context_ref=None,
+        input_payload={},
+        metadata={},
+    )
+
+    assert out is result
+    assert calls == [("s1", None)]
+
+
+@pytest.mark.asyncio
+async def test_execute_with_bus_chat_does_not_duplicate_progressive_context_commit(monkeypatch):
+    result = make_execution_result(request_id="r2", status="success", output_payload={"ok": True})
+    bus = _Bus(result)
+    calls = []
+
+    monkeypatch.setattr("src.runtime.chat_orchestration_adapter.build_default_execution_bus", lambda execute_tool_func=None: bus)
+
+    async def _commit(*, session_id, model):
+        calls.append((session_id, model))
+
+    monkeypatch.setattr("src.runtime.progressive_context.apply_progressive_context_after_turn", _commit)
+
+    out = await _execute_with_bus(
+        request_id="r2",
+        source_type="chat",
+        source_ref="ref",
+        execution_type="chat",
+        session_id="s2",
+        context_ref=None,
+        input_payload={},
+        metadata={},
+    )
+
+    assert out is result
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_with_bus_best_effort_failure_does_not_fail_result(monkeypatch):
+    result = make_execution_result(request_id="r3", status="success", output_payload={"ok": True})
+    bus = _Bus(result)
+
+    monkeypatch.setattr("src.runtime.chat_orchestration_adapter.build_default_execution_bus", lambda execute_tool_func=None: bus)
+
+    async def _commit(*, session_id, model):
+        raise RuntimeError("commit failed")
+
+    monkeypatch.setattr("src.runtime.progressive_context.apply_progressive_context_after_turn", _commit)
+
+    out = await _execute_with_bus(
+        request_id="r3",
+        source_type="task",
+        source_ref="ref",
+        execution_type="task",
+        session_id="s3",
+        context_ref=None,
+        input_payload={},
+        metadata={},
+    )
+
+    assert out is result
+    assert out.status == "success"

--- a/tests/test_chat_orchestration_adapter.py
+++ b/tests/test_chat_orchestration_adapter.py
@@ -16,7 +16,7 @@ class _Bus:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("execution_type", ["task", "skill", "subagent"])
+@pytest.mark.parametrize("execution_type", ["task", "skill", "subagent", "event"])
 async def test_execute_with_bus_non_chat_commits_progressive_context(monkeypatch, execution_type):
     result = make_execution_result(request_id="r1", status="success", output_payload={"ok": True})
     bus = _Bus(result)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -16,6 +16,7 @@ from src.agents.compaction import (
     prune_history_for_context_share,
     resolve_context_window_tokens,
     normalize_compaction_threshold,
+    generate_summary,
     BASE_CHUNK_RATIO,
     MIN_CHUNK_RATIO,
     SAFETY_MARGIN,
@@ -638,3 +639,19 @@ class TestFixToolCallConsistency:
         assert len(result) == 1
         # Since call_abc has no tool response, tool_calls should be None
         assert result[0].tool_calls is None
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_returns_structured_context_summary():
+    messages = [
+        AgentMessage(role="user", content="Objective: finish migration safely. We must avoid downtime."),
+        AgentMessage(role="assistant", content="Decision: we will run phased rollout."),
+        AgentMessage(role="assistant", content="Next, verify canary metrics."),
+    ]
+
+    summary = await generate_summary(messages)
+
+    assert "Context summary:" in summary
+    assert "Objective:" in summary
+    assert "Next step:" in summary
+    assert "User asked about" not in summary

--- a/tests/test_gateway_server_progressive_context.py
+++ b/tests/test_gateway_server_progressive_context.py
@@ -1,0 +1,62 @@
+import pytest
+
+from src.gateway.server import Gateway, handle_jira_message
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_handle_jira_message_uses_run_chat_execution(monkeypatch):
+    captured = {}
+
+    async def _fake_run_chat_execution(**kwargs):
+        captured.update(kwargs)
+        return {"response": "jira-ok"}
+
+    monkeypatch.setattr("src.gateway.server.run_chat_execution", _fake_run_chat_execution)
+
+    response = await handle_jira_message(
+        message="hello",
+        session_id="jira-session",
+        user_name="jira-user",
+        issue_key="ENG-1",
+    )
+
+    assert response == "jira-ok"
+    assert captured["message"] == "hello"
+    assert captured["session_id"] == "jira-session"
+    assert captured["user_name"] == "jira-user"
+
+
+@pytest.mark.asyncio
+async def test_handle_test_message_uses_run_chat_execution(monkeypatch):
+    captured = {}
+
+    async def _fake_run_chat_execution(**kwargs):
+        captured.update(kwargs)
+        return {"response": "test-ok", "usage": {"prompt_tokens": 1}}
+
+    monkeypatch.setattr("src.gateway.server.run_chat_execution", _fake_run_chat_execution)
+
+    fake_request = _FakeRequest({
+        "message": "ping",
+        "session_id": "http-session",
+        "reasoning_replay": True,
+    })
+
+    response = await Gateway.handle_test_message(object(), fake_request)
+    payload = response.text
+
+    assert response.status == 200
+    assert "test-ok" in payload
+    assert "http-session" in payload
+    assert captured["message"] == "ping"
+    assert captured["session_id"] == "http-session"
+    assert captured["user_name"] == "http-tester"
+    assert captured["reasoning_replay"] is True

--- a/tests/test_portal_session_metadata_client.py
+++ b/tests/test_portal_session_metadata_client.py
@@ -187,3 +187,25 @@ def test_extract_session_metadata_publish_fields_prefers_latest_runtime_event():
     assert extracted["latest_event_state"] == "success"
     assert extracted["snapshot_version"] == "snap-1"
     assert extracted["metadata"]["portal_task_id"] == "pt-1"
+
+
+def test_build_session_metadata_payload_preserves_context_preview_keys():
+    payload = build_session_metadata_payload(
+        last_execution_id="exec-ctx",
+        latest_event_type="chat.completed",
+        latest_event_state="success",
+        snapshot_version="phase3.v1",
+        runtime_events=[],
+        metadata={
+            "context_compaction_level": "micro",
+            "context_objective_preview": "Ship progressive context",
+            "context_summary_preview": "Conversation compacted",
+            "context_next_step_preview": "Proceed with verification",
+        },
+    )
+
+    metadata_json = payload.get("metadata_json", "")
+    assert "context_compaction_level" in metadata_json
+    assert "context_objective_preview" in metadata_json
+    assert "context_summary_preview" in metadata_json
+    assert "context_next_step_preview" in metadata_json

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -1,0 +1,132 @@
+import pytest
+
+from src.runtime import progressive_context
+from src.runtime.progressive_context import (
+    build_portal_context_preview,
+    prepare_progressive_messages,
+)
+
+
+@pytest.mark.asyncio
+async def test_prepare_progressive_messages_under_soft_threshold(monkeypatch):
+    messages = [
+        {"role": "user", "content": "Plan a deployment"},
+        {"role": "assistant", "content": "Sure, I can help."},
+    ]
+
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", lambda msgs: 300)
+
+    prepared, state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id="s1",
+        stage="pre_request",
+    )
+
+    assert prepared == messages
+    assert state["compaction_level"] == "none"
+    assert state["version"] == "context.v1"
+
+
+@pytest.mark.asyncio
+async def test_prepare_progressive_messages_micro_compacts_old_tool_messages(monkeypatch):
+    large_tool = "x" * 1800
+    messages = [
+        {"role": "user", "content": "Start"},
+        {"role": "assistant", "content": "Calling tools", "tool_calls": [{"id": "tc-1", "function": {"name": "a", "arguments": "{}"}}]},
+        {"role": "tool", "content": large_tool, "tool_call_id": "tc-1", "timestamp": "2026-01-01T00:00:00Z"},
+        {"role": "assistant", "content": "Still working"},
+        {
+            "role": "assistant",
+            "content": "More tools",
+            "tool_calls": [
+                {"id": "tc-2", "function": {"name": "b", "arguments": "{}"}},
+                {"id": "tc-3", "function": {"name": "c", "arguments": "{}"}},
+                {"id": "tc-4", "function": {"name": "d", "arguments": "{}"}},
+                {"id": "tc-5", "function": {"name": "e", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "content": "recent-1", "tool_call_id": "tc-2"},
+        {"role": "tool", "content": "recent-2", "tool_call_id": "tc-3"},
+        {"role": "tool", "content": "recent-3", "tool_call_id": "tc-4"},
+        {"role": "tool", "content": "recent-4", "tool_call_id": "tc-5"},
+        {"role": "assistant", "content": "Final"},
+    ]
+
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
+
+    def _estimate(msgs):
+        if any("[tool_result compacted" in str(m.content) for m in msgs):
+            return 750
+        return 700
+
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", _estimate)
+
+    prepared, state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id="s1",
+        stage="pre_request",
+    )
+
+    old_tool = next(item for item in prepared if item.get("tool_call_id") == "tc-1")
+    assert "[tool_result compacted" in old_tool["content"]
+    assert old_tool["tool_call_id"] == "tc-1"
+    newest_tool = next(item for item in prepared if item.get("tool_call_id") == "tc-5")
+    assert newest_tool["content"] == "recent-4"
+    assert state["compaction_level"] == "micro"
+
+
+@pytest.mark.asyncio
+async def test_prepare_progressive_messages_full_compaction_fallback(monkeypatch):
+    messages = [
+        {"role": "user", "content": "We must finish migration safely."},
+        {"role": "assistant", "content": "Acknowledged"},
+        {"role": "tool", "content": "y" * 3000, "tool_call_id": "tc-1"},
+        {"role": "assistant", "content": "Processing"},
+        {"role": "assistant", "content": "Next, validate outputs."},
+    ]
+
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
+
+    def _estimate(msgs):
+        return 900
+
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", _estimate)
+
+    async def _compact_messages(**kwargs):
+        return kwargs["messages"][-2:], type("Stats", (), {"summary": "Compacted summary"})()
+
+    monkeypatch.setattr(progressive_context, "compact_messages", _compact_messages)
+
+    prepared, state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id="s1",
+        stage="tool_loop",
+    )
+
+    assert len(prepared) == 2
+    assert state["compaction_level"] == "full"
+    assert state["summary"]
+
+
+def test_build_portal_context_preview_returns_preview_keys_only():
+    preview = build_portal_context_preview(
+        {
+            "compaction_level": "micro",
+            "objective": "Do the thing",
+            "summary": "A concise summary",
+            "next_step": "Continue",
+            "constraints": ["must be safe"],
+            "version": "context.v1",
+        }
+    )
+
+    assert preview == {
+        "context_compaction_level": "micro",
+        "context_objective_preview": "Do the thing",
+        "context_summary_preview": "A concise summary",
+        "context_next_step_preview": "Continue",
+    }

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -98,6 +98,44 @@ async def test_prepare_progressive_messages_full_compaction_adds_structured_summ
     assert state["compaction_level"] == "full"
     assert prepared[0]["role"] == "system"
     assert str(prepared[0]["content"]).startswith("Context summary:")
+    assert state["summary_source"] == "full"
+    assert state["history_compacted_from_count"] == len(messages)
+    assert state["history_compacted_to_count"] == len(prepared)
+    assert state["recovery_context_message"].startswith("Recovered context:")
+
+
+@pytest.mark.asyncio
+async def test_prepare_progressive_messages_full_compaction_keeps_earliest_objective(monkeypatch):
+    messages = [
+        {"role": "user", "content": "Primary objective: migrate the billing service with zero downtime."},
+        {"role": "assistant", "content": "Understood."},
+        {"role": "tool", "content": "z" * 5000, "tool_call_id": "tc-1"},
+        {"role": "assistant", "content": "Working on it."},
+        {"role": "assistant", "content": "Next, validate."},
+    ]
+
+    async def _get_context_state(_session_id):
+        return {}
+
+    monkeypatch.setattr(progressive_context.session_manager, "get_context_state", _get_context_state)
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", lambda msgs: 900)
+
+    async def _compact_messages(**kwargs):
+        # Drop earliest user message to mimic aggressive compaction output subset
+        return kwargs["messages"][-2:], type("Stats", (), {"summary": "placeholder"})()
+
+    monkeypatch.setattr(progressive_context, "compact_messages", _compact_messages)
+
+    prepared, state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id="s-obj",
+        stage="tool_loop",
+    )
+
+    assert prepared[0]["role"] == "system"
+    assert "migrate the billing service" in state["objective"].lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -178,6 +178,45 @@ async def test_prepare_progressive_messages_preserves_tool_chain_consistency(mon
     assert state["compaction_level"] in {"micro", "full"}
 
 
+@pytest.mark.asyncio
+async def test_prepare_progressive_messages_full_compaction_final_result_respects_hard_threshold(monkeypatch):
+    messages = [
+        {"role": "user", "content": "Need staged migration plan."},
+        {"role": "assistant", "content": "Acknowledged and starting analysis."},
+        {"role": "assistant", "content": "a" * 900},
+        {"role": "tool", "content": "b" * 900, "tool_call_id": "tc-99"},
+        {"role": "assistant", "content": "c" * 900},
+    ]
+
+    async def _get_context_state(_session_id):
+        return {}
+
+    monkeypatch.setattr(progressive_context.session_manager, "get_context_state", _get_context_state)
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
+
+    def _estimate(msgs):
+        return sum(len(str(m.content or "")) for m in msgs)
+
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", _estimate)
+
+    async def _compact_messages(**kwargs):
+        return kwargs["messages"], type("Stats", (), {"summary": "placeholder"})()
+
+    monkeypatch.setattr(progressive_context, "compact_messages", _compact_messages)
+
+    prepared, state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id="s-budget",
+        stage="tool_loop",
+    )
+
+    assert state["compaction_level"] == "full"
+    assert prepared[0]["role"] == "system"
+    assert _estimate(progressive_context._to_agent_messages(prepared)) <= 750
+    assert state["history_compacted_to_count"] == len(prepared)
+
+
 def test_build_portal_context_preview_returns_preview_keys_only():
     preview = build_portal_context_preview(
         {

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -8,57 +8,121 @@ from src.runtime.progressive_context import (
 
 
 @pytest.mark.asyncio
-async def test_prepare_progressive_messages_under_soft_threshold(monkeypatch):
-    messages = [
-        {"role": "user", "content": "Plan a deployment"},
-        {"role": "assistant", "content": "Sure, I can help."},
-    ]
+async def test_prepare_progressive_messages_merges_prior_objective_when_current_is_missing(monkeypatch):
+    messages = [{"role": "assistant", "content": "I will continue execution."}]
 
+    async def _get_context_state(_session_id):
+        return {
+            "objective": "Build a resilient deployment pipeline with rollback guarantees",
+            "constraints": ["must be idempotent"],
+            "next_step": "Verify migrations",
+        }
+
+    monkeypatch.setattr(progressive_context.session_manager, "get_context_state", _get_context_state)
     monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
-    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", lambda msgs: 300)
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", lambda msgs: 200)
 
     prepared, state = await prepare_progressive_messages(
         messages=messages,
         model="gpt-5-mini",
-        session_id="s1",
+        session_id="s-prior",
         stage="pre_request",
     )
 
     assert prepared == messages
-    assert state["compaction_level"] == "none"
-    assert state["version"] == "context.v1"
+    assert state["objective"].startswith("Build a resilient deployment pipeline")
+    assert "must be idempotent" in state["constraints"]
 
 
 @pytest.mark.asyncio
-async def test_prepare_progressive_messages_micro_compacts_old_tool_messages(monkeypatch):
+async def test_prepare_progressive_messages_stage_aware_thresholds(monkeypatch):
+    messages = [
+        {"role": "user", "content": "Do this"},
+        {"role": "assistant", "content": "Acknowledged"},
+    ]
+
+    async def _get_context_state(_session_id):
+        return {}
+
+    monkeypatch.setattr(progressive_context.session_manager, "get_context_state", _get_context_state)
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", lambda msgs: 620)
+
+    pre_messages, pre_state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id="s-stage",
+        stage="pre_request",
+    )
+    loop_messages, loop_state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id="s-stage",
+        stage="tool_loop",
+    )
+
+    assert pre_state["compaction_level"] == "none"
+    assert pre_messages == messages
+    assert loop_state["compaction_level"] == "micro"
+
+
+@pytest.mark.asyncio
+async def test_prepare_progressive_messages_full_compaction_adds_structured_summary(monkeypatch):
+    messages = [
+        {"role": "user", "content": "We must finish migration safely."},
+        {"role": "assistant", "content": "Decision: we will run phased rollout."},
+        {"role": "tool", "content": "y" * 3000, "tool_call_id": "tc-1"},
+        {"role": "assistant", "content": "Next, validate outputs."},
+        {"role": "assistant", "content": "Pending: verify canary metrics."},
+    ]
+
+    async def _get_context_state(_session_id):
+        return {}
+
+    monkeypatch.setattr(progressive_context.session_manager, "get_context_state", _get_context_state)
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", lambda msgs: 900)
+
+    async def _compact_messages(**kwargs):
+        return kwargs["messages"][-3:], type("Stats", (), {"summary": "placeholder"})()
+
+    monkeypatch.setattr(progressive_context, "compact_messages", _compact_messages)
+
+    prepared, state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id="s-full",
+        stage="tool_loop",
+    )
+
+    assert state["compaction_level"] == "full"
+    assert prepared[0]["role"] == "system"
+    assert str(prepared[0]["content"]).startswith("Context summary:")
+
+
+@pytest.mark.asyncio
+async def test_prepare_progressive_messages_preserves_tool_chain_consistency(monkeypatch):
     large_tool = "x" * 1800
     messages = [
         {"role": "user", "content": "Start"},
-        {"role": "assistant", "content": "Calling tools", "tool_calls": [{"id": "tc-1", "function": {"name": "a", "arguments": "{}"}}]},
-        {"role": "tool", "content": large_tool, "tool_call_id": "tc-1", "timestamp": "2026-01-01T00:00:00Z"},
-        {"role": "assistant", "content": "Still working"},
         {
             "role": "assistant",
-            "content": "More tools",
-            "tool_calls": [
-                {"id": "tc-2", "function": {"name": "b", "arguments": "{}"}},
-                {"id": "tc-3", "function": {"name": "c", "arguments": "{}"}},
-                {"id": "tc-4", "function": {"name": "d", "arguments": "{}"}},
-                {"id": "tc-5", "function": {"name": "e", "arguments": "{}"}},
-            ],
+            "content": "Calling tools",
+            "tool_calls": [{"id": "tc-1", "function": {"name": "a", "arguments": "{}"}}],
         },
-        {"role": "tool", "content": "recent-1", "tool_call_id": "tc-2"},
-        {"role": "tool", "content": "recent-2", "tool_call_id": "tc-3"},
-        {"role": "tool", "content": "recent-3", "tool_call_id": "tc-4"},
-        {"role": "tool", "content": "recent-4", "tool_call_id": "tc-5"},
-        {"role": "assistant", "content": "Final"},
+        {"role": "tool", "content": large_tool, "tool_call_id": "tc-1", "timestamp": "2026-01-01T00:00:00Z"},
+        {"role": "assistant", "content": "Next"},
     ]
 
+    async def _get_context_state(_session_id):
+        return {}
+
+    monkeypatch.setattr(progressive_context.session_manager, "get_context_state", _get_context_state)
     monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
 
     def _estimate(msgs):
         if any("[tool_result compacted" in str(m.content) for m in msgs):
-            return 750
+            return 700
         return 700
 
     monkeypatch.setattr(progressive_context, "estimate_messages_tokens", _estimate)
@@ -66,50 +130,14 @@ async def test_prepare_progressive_messages_micro_compacts_old_tool_messages(mon
     prepared, state = await prepare_progressive_messages(
         messages=messages,
         model="gpt-5-mini",
-        session_id="s1",
-        stage="pre_request",
-    )
-
-    old_tool = next(item for item in prepared if item.get("tool_call_id") == "tc-1")
-    assert "[tool_result compacted" in old_tool["content"]
-    assert old_tool["tool_call_id"] == "tc-1"
-    newest_tool = next(item for item in prepared if item.get("tool_call_id") == "tc-5")
-    assert newest_tool["content"] == "recent-4"
-    assert state["compaction_level"] == "micro"
-
-
-@pytest.mark.asyncio
-async def test_prepare_progressive_messages_full_compaction_fallback(monkeypatch):
-    messages = [
-        {"role": "user", "content": "We must finish migration safely."},
-        {"role": "assistant", "content": "Acknowledged"},
-        {"role": "tool", "content": "y" * 3000, "tool_call_id": "tc-1"},
-        {"role": "assistant", "content": "Processing"},
-        {"role": "assistant", "content": "Next, validate outputs."},
-    ]
-
-    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 1000)
-
-    def _estimate(msgs):
-        return 900
-
-    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", _estimate)
-
-    async def _compact_messages(**kwargs):
-        return kwargs["messages"][-2:], type("Stats", (), {"summary": "Compacted summary"})()
-
-    monkeypatch.setattr(progressive_context, "compact_messages", _compact_messages)
-
-    prepared, state = await prepare_progressive_messages(
-        messages=messages,
-        model="gpt-5-mini",
-        session_id="s1",
+        session_id="s-tool-chain",
         stage="tool_loop",
     )
 
-    assert len(prepared) == 2
-    assert state["compaction_level"] == "full"
-    assert state["summary"]
+    tool_ids = [item.get("tool_call_id") for item in prepared if item.get("role") == "tool"]
+    assert "tc-1" in tool_ids
+    assert any(item.get("tool_calls") for item in prepared if item.get("role") == "assistant")
+    assert state["compaction_level"] in {"micro", "full"}
 
 
 def test_build_portal_context_preview_returns_preview_keys_only():

--- a/tests/test_recovery_pipeline.py
+++ b/tests/test_recovery_pipeline.py
@@ -215,6 +215,34 @@ async def test_recovery_snapshot_includes_compaction_and_session_memory_hints(mo
 
 
 @pytest.mark.asyncio
+async def test_recovery_snapshot_includes_context_state_hints(monkeypatch):
+    class _StubSessionManager:
+        sessions = {
+            "s-context-state": {
+                "history": [{"role": "user", "content": "hi"}],
+                "metadata": {
+                    "context_state": {
+                        "version": "context.v1",
+                        "compaction_level": "micro",
+                        "summary": "Compacted conversation summary",
+                    }
+                },
+            }
+        }
+
+    monkeypatch.setattr("src.sessions.manager.session_manager", _StubSessionManager)
+    monkeypatch.setattr("src.agents.tasks.task_manager.list_task_summaries", lambda session_id=None: [])
+    monkeypatch.setattr("src.agents.subagent.list_active_subagent_summaries", lambda parent_session_id=None: [])
+
+    snapshot = await DefaultRecoveryPipeline().build_snapshot("s-context-state")
+    assert snapshot is not None
+    assert snapshot.runtime_state["context_state"]["version"] == "context.v1"
+    assert snapshot.reconstructed_state["has_context_state"] is True
+    assert snapshot.reconstructed_state["context_compaction_level"] == "micro"
+    assert snapshot.reconstructed_state["needs_recovery_reconcile"] is True
+
+
+@pytest.mark.asyncio
 async def test_recovery_pipeline_hydrates_from_metadata_fallback(monkeypatch):
     class _StubSessionManager:
         sessions = {}

--- a/tests/test_recovery_pipeline.py
+++ b/tests/test_recovery_pipeline.py
@@ -244,6 +244,8 @@ async def test_recovery_snapshot_includes_context_state_hints(monkeypatch):
     assert snapshot.reconstructed_state["has_context_objective"] is True
     assert snapshot.reconstructed_state["has_context_next_step"] is True
     assert snapshot.reconstructed_state["context_summary_preview"] == "Compacted conversation summary"
+    assert "Recovered context:" in snapshot.reconstructed_state["recovery_context_message"]
+    assert snapshot.reconstructed_state["has_session_memory_summary"] is False
     assert snapshot.reconstructed_state["needs_recovery_reconcile"] is True
 
 

--- a/tests/test_recovery_pipeline.py
+++ b/tests/test_recovery_pipeline.py
@@ -224,6 +224,8 @@ async def test_recovery_snapshot_includes_context_state_hints(monkeypatch):
                     "context_state": {
                         "version": "context.v1",
                         "compaction_level": "micro",
+                        "objective": "Keep deployment stable",
+                        "next_step": "Run verification tests",
                         "summary": "Compacted conversation summary",
                     }
                 },
@@ -239,6 +241,9 @@ async def test_recovery_snapshot_includes_context_state_hints(monkeypatch):
     assert snapshot.runtime_state["context_state"]["version"] == "context.v1"
     assert snapshot.reconstructed_state["has_context_state"] is True
     assert snapshot.reconstructed_state["context_compaction_level"] == "micro"
+    assert snapshot.reconstructed_state["has_context_objective"] is True
+    assert snapshot.reconstructed_state["has_context_next_step"] is True
+    assert snapshot.reconstructed_state["context_summary_preview"] == "Compacted conversation summary"
     assert snapshot.reconstructed_state["needs_recovery_reconcile"] is True
 
 

--- a/tests/test_recovery_pipeline.py
+++ b/tests/test_recovery_pipeline.py
@@ -5,6 +5,7 @@ from src.runtime.recovery_pipeline import (
     RecoveryHydrationResult,
     build_default_recovery_pipeline,
 )
+from src.sessions.manager import SessionManager
 
 
 @pytest.mark.asyncio
@@ -318,6 +319,33 @@ async def test_recovery_pipeline_handles_missing_session_safely(monkeypatch):
     assert result.recovered is False
     assert "session_not_found" in result.warnings
     assert any(evt.get("event_type") == "recovery.warning" for evt in result.runtime_events)
+
+
+@pytest.mark.asyncio
+async def test_session_manager_recover_session_state_surfaces_recovery_context_message(monkeypatch):
+    import sys
+    import types
+
+    class _StubPipeline:
+        async def hydrate_session_state(self, session_id: str):
+            return RecoveryHydrationResult(
+                session_id=session_id,
+                recovered=True,
+                snapshot_version="phase3.v1",
+                reconstructed_state={"recovery_context_message": "Recovered context: ..."},
+                runtime_state={},
+                warnings=[],
+                runtime_events=[],
+                metadata={},
+            )
+
+    fake_module = types.ModuleType("src.runtime.recovery_pipeline")
+    fake_module.get_recovery_pipeline = lambda: _StubPipeline()
+    monkeypatch.setitem(sys.modules, "src.runtime.recovery_pipeline", fake_module)
+
+    manager = SessionManager(auto_save=False)
+    recovered = await manager.recover_session_state("sess-recovery")
+    assert recovered["recovery_context_message"] == "Recovered context: ..."
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_memory.py
+++ b/tests/test_session_memory.py
@@ -88,6 +88,39 @@ class TestSaveSessionSummary:
             # Should return None for empty session
             assert result is None
 
+    @pytest.mark.asyncio
+    async def test_save_session_summary_prefers_context_state(self):
+        """When context_state exists, memory summary should use it over heuristic summary."""
+        with patch('src.hooks.session_memory.session_manager') as mock_manager:
+            mock_session = {
+                "history": [
+                    {"role": "user", "content": "Initial objective"},
+                    {"role": "assistant", "content": "Response"},
+                    {"role": "user", "content": "Follow up"},
+                ],
+                "metadata": {
+                    "context_state": {
+                        "objective": "Migrate service safely",
+                        "current_state": "Validation in progress",
+                        "constraints": ["must avoid downtime"],
+                        "next_step": "Run final verification",
+                    }
+                },
+                "channel": "webchat",
+                "created_at": "2026-02-26T12:00:00",
+            }
+            mock_manager.get_session = AsyncMock(return_value=mock_session)
+
+            from src.hooks.session_memory import save_session_summary
+
+            with patch('src.hooks.session_memory.summarize_session', new=AsyncMock(return_value="heuristic summary")) as mock_summarize:
+                with patch('builtins.open', MagicMock()):
+                    with patch('pathlib.Path.mkdir', MagicMock()):
+                        with patch('pathlib.Path.exists', return_value=False):
+                            await save_session_summary("test-session")
+
+            mock_summarize.assert_not_called()
+
 
 class TestBuildSessionEntry:
     """Tests for _build_session_entry"""

--- a/tests/test_skill_mode_compaction.py
+++ b/tests/test_skill_mode_compaction.py
@@ -1,0 +1,31 @@
+import pytest
+
+from src.agents.skill_mode import SkillSession, compact_skill_session_async
+
+
+@pytest.mark.asyncio
+async def test_compact_skill_session_async_uses_max_tokens_not_budget_tokens(monkeypatch):
+    captured = {}
+
+    async def _fake_compact_messages(**kwargs):
+        captured.update(kwargs)
+        return kwargs["messages"], type("Stats", (), {"dropped_messages": 0, "kept_tokens": 100})()
+
+    monkeypatch.setattr("src.agents.compaction.compact_messages", _fake_compact_messages)
+    monkeypatch.setattr("src.agents.compaction.resolve_context_window_tokens", lambda model=None: 64000)
+
+    session = SkillSession(
+        skill_name="demo",
+        original_user_request="help",
+        completed_steps=[
+            {"type": "execute", "result": "x" * 9000, "timestamp": 1},
+            {"type": "execute", "result": "y" * 9000, "timestamp": 2},
+        ],
+    )
+
+    await compact_skill_session_async(session, budget_tokens=100)
+
+    assert "max_tokens" in captured
+    assert captured["max_tokens"] == 100
+    assert "budget_tokens" not in captured
+    assert captured["recent_count"] == 3

--- a/tests/test_subagent_progressive_context.py
+++ b/tests/test_subagent_progressive_context.py
@@ -1,0 +1,31 @@
+import pytest
+
+from src.agents.subagent import SubAgent
+
+
+@pytest.mark.asyncio
+async def test_subagent_run_uses_run_chat_execution(monkeypatch):
+    captured = {}
+
+    async def _fake_run_chat_execution(**kwargs):
+        captured.update(kwargs)
+        return {"response": "subagent-result"}
+
+    monkeypatch.setattr("src.agents.subagent.run_chat_execution", _fake_run_chat_execution)
+
+    subagent = SubAgent(
+        session_key="sub-s1",
+        task="do work",
+        model=None,
+        thinking=None,
+    )
+    subagent._agent = object()
+
+    await subagent._run()
+
+    assert subagent.status == "completed"
+    assert subagent.result == "subagent-result"
+    assert captured["message"] == "do work"
+    assert captured["session_id"] == "sub-s1"
+    assert captured["user_name"] == "sub-s1"
+    assert captured["track_usage"] is False

--- a/tests/test_triggered_event_task.py
+++ b/tests/test_triggered_event_task.py
@@ -7,10 +7,12 @@ async def test_run_triggered_event_task_github_mention_passes_session_id_to_agen
 
     calls = {"agent": 0, "comment": 0}
 
-    async def _fake_process(*, message, session_id):
+    async def _fake_run_chat_execution(*, agent, message, session_id, user_name, track_usage):
         calls["agent"] += 1
         assert session_id == "sess-1"
         assert "GitHub" in message
+        assert user_name == "triggered-event"
+        assert track_usage is False
         return {"response": "ok"}
 
     async def _fake_add_comment(owner, repo, issue_number, body):
@@ -20,7 +22,7 @@ async def test_run_triggered_event_task_github_mention_passes_session_id_to_agen
         assert issue_number == 2
         assert body == "ok"
 
-    monkeypatch.setattr("src.runtime.triggered_event_task.agent.process", _fake_process)
+    monkeypatch.setattr("src.runtime.triggered_event_task.run_chat_execution", _fake_run_chat_execution)
     monkeypatch.setattr("src.runtime.triggered_event_task.github_channel.add_comment", _fake_add_comment)
 
     result = await run_triggered_event_task(
@@ -45,10 +47,12 @@ async def test_run_triggered_event_task_jira_assigned_passes_session_id_to_agent
 
     calls = {"agent": 0, "comment": 0}
 
-    async def _fake_process(*, message, session_id):
+    async def _fake_run_chat_execution(*, agent, message, session_id, user_name, track_usage):
         calls["agent"] += 1
         assert session_id == "sess-2"
         assert "Jira" in message
+        assert user_name == "triggered-event"
+        assert track_usage is False
         return {"response": "looks good"}
 
     async def _fake_add_comment(issue_key, body):
@@ -56,7 +60,7 @@ async def test_run_triggered_event_task_jira_assigned_passes_session_id_to_agent
         assert issue_key == "ENG-1"
         assert body == "looks good"
 
-    monkeypatch.setattr("src.runtime.triggered_event_task.agent.process", _fake_process)
+    monkeypatch.setattr("src.runtime.triggered_event_task.run_chat_execution", _fake_run_chat_execution)
     monkeypatch.setattr("src.runtime.triggered_event_task.jira_channel.add_comment", _fake_add_comment)
 
     result = await run_triggered_event_task(
@@ -81,7 +85,7 @@ async def test_run_triggered_event_task_github_mention_blocked_does_not_writebac
 
     called = {"comment": 0}
 
-    async def _fake_process(*, message, session_id):
+    async def _fake_run_chat_execution(*, agent, message, session_id, user_name, track_usage):
         return {"response": "ok"}
 
     async def _fake_add_comment(*args, **kwargs):
@@ -90,7 +94,7 @@ async def test_run_triggered_event_task_github_mention_blocked_does_not_writebac
     def _blocked_gate(action_id, _kwargs):
         return {"blocked": True, "reason": "policy_blocked", "error": f"capability policy blocked for secondary action: {action_id}"}
 
-    monkeypatch.setattr("src.runtime.triggered_event_task.agent.process", _fake_process)
+    monkeypatch.setattr("src.runtime.triggered_event_task.run_chat_execution", _fake_run_chat_execution)
     monkeypatch.setattr("src.runtime.triggered_event_task.github_channel.add_comment", _fake_add_comment)
 
     result = await run_triggered_event_task(
@@ -118,7 +122,7 @@ async def test_run_triggered_event_task_jira_assigned_blocked_does_not_writeback
 
     called = {"comment": 0}
 
-    async def _fake_process(*, message, session_id):
+    async def _fake_run_chat_execution(*, agent, message, session_id, user_name, track_usage):
         return {"response": "ok"}
 
     async def _fake_add_comment(*args, **kwargs):
@@ -127,7 +131,7 @@ async def test_run_triggered_event_task_jira_assigned_blocked_does_not_writeback
     def _blocked_gate(action_id, _kwargs):
         return {"blocked": True, "reason": "policy_blocked", "error": f"capability policy blocked for secondary action: {action_id}"}
 
-    monkeypatch.setattr("src.runtime.triggered_event_task.agent.process", _fake_process)
+    monkeypatch.setattr("src.runtime.triggered_event_task.run_chat_execution", _fake_run_chat_execution)
     monkeypatch.setattr("src.runtime.triggered_event_task.jira_channel.add_comment", _fake_add_comment)
 
     result = await run_triggered_event_task(
@@ -155,7 +159,7 @@ async def test_run_triggered_event_task_confluence_mention_blocked_does_not_writ
 
     called = {"comment": 0}
 
-    async def _fake_process(*, message, session_id):
+    async def _fake_run_chat_execution(*, agent, message, session_id, user_name, track_usage):
         return {"response": "ok"}
 
     async def _fake_add_comment(*args, **kwargs):
@@ -164,7 +168,7 @@ async def test_run_triggered_event_task_confluence_mention_blocked_does_not_writ
     def _blocked_gate(action_id, _kwargs):
         return {"blocked": True, "reason": "policy_blocked", "error": f"capability policy blocked for secondary action: {action_id}"}
 
-    monkeypatch.setattr("src.runtime.triggered_event_task.agent.process", _fake_process)
+    monkeypatch.setattr("src.runtime.triggered_event_task.run_chat_execution", _fake_run_chat_execution)
     monkeypatch.setattr("src.runtime.triggered_event_task.confluence_channel.add_comment", _fake_add_comment)
 
     result = await run_triggered_event_task(


### PR DESCRIPTION
### Motivation
- Prevent token overflows and preserve conversation intent across turns by centralizing progressive compaction and storing a durable compacted context state in session metadata.
- Make compaction policy runtime-owned (micro-first then full fallback) so pre-request and in-loop compaction reuse the same deterministic rules and produce durable artifacts for recovery and Portal previews.

### Description
- Added a new runtime service `src/runtime/progressive_context.py` that implements the soft/hard threshold policy, deterministic micro compaction targeting old `tool` messages, full compaction fallback via existing `compact_messages()`, `prepare_progressive_messages()`, `apply_progressive_context_after_turn()`, and `build_portal_context_preview()` helpers, and builds the `metadata["context_state"]` shape (`version`, `compaction_level`, `objective`, `summary`, `next_step`, `constraints`, `source_message_count`, `recent_window_count`, `last_compacted_at`).
- Updated `src/agents/core.py` to call `prepare_progressive_messages(...)` for pre-request compaction and inside the tool loop (stage=`tool_loop`), and to call `apply_progressive_context_after_turn(...)` after `run_chat_execution()` and attach the returned `context_state` to the result payload as `result["context_state"]`.
- Extended `src/sessions/manager.py` with `get_context_state(session_id)` and `set_context_state(session_id, context_state)` that mirror preview keys (`context_compaction_level`, `context_objective_preview`, `context_summary_preview`, `context_next_step_preview`) into top-level metadata and schedule async metadata persistence via the existing `_schedule_metadata_persist()`.
- Enhanced `src/runtime/recovery_pipeline.py` to read durable `context_state` from session metadata, surface `has_context_state` and `context_compaction_level` in reconstructed hints, include `context_state` in `runtime_state`, and make `needs_recovery_reconcile` true when context state exists.
- Extended `src/runtime/portal_session_metadata_client.py` allowlist to preserve preview keys when publishing, and updated `src/gateway/webchat.py` to merge the Portal preview (via `build_portal_context_preview(...)` + `session_manager.get_context_state(...)`) into metadata at all `publish_session_metadata(...)` sites (chat non-stream, chat stream, task execution).
- Added tests `tests/test_progressive_context.py` and updates to `tests/test_recovery_pipeline.py` and `tests/test_portal_session_metadata_client.py` covering soft/no compaction, micro compaction behavior, full compaction fallback, Portal preview generation, and recovery pipeline handling of `context_state`.

### Testing
- Ran `pytest tests/test_progressive_context.py -q` and it passed (4 tests passed).
- Ran `pytest tests/test_recovery_pipeline.py -q` and it passed (13 tests passed including new context-state coverage).
- Ran `pytest tests/test_portal_session_metadata_client.py -q` and it passed (9 tests passed including preview-key preservation).
- Ran targeted webchat tests `pytest tests/test_webchat.py -q -k "session_metadata or chat_started or (chat and path)"` to validate publish integration and they passed (4 selected tests passed, others deselected).

One remaining risk: `apply_progressive_context_after_turn()` writes compatibility markers (`session_memory_summary` and `compaction_summary`) as simple summary strings in metadata for compatibility, so downstream consumers that expect richer typed compaction summary objects may require adjustment in a follow-up change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d8d5a594832a869598a4161c7acd)