### PR TITLE
Implement session-level Active Skill Contract and section-aware skill prompt compiler

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -53,7 +53,14 @@ from src.agents.skill_runtime import (
     resolve_prompt_execution_boundary,
 )
 from src.skills.runtime import SkillRuntimeConfig
+from src.skills.active_contract import (
+    build_active_skill_contract,
+    get_contract_skill_name,
+    is_active_skill_contract_usable,
+    is_clear_active_skill_command,
+)
 from src.runtime.chat_orchestration_adapter import execute_tool_or_task_orchestration
+from src.runtime import build_default_execution_bus
 from src.runtime.display_blocks import normalize_display_blocks
 from src.runtime.tool_filtering import (
     extract_tool_name,
@@ -801,39 +808,79 @@ You have access to the following tools. When a user asks you to do something tha
         if not skill_registry._initialized:
             skill_registry.load_skills()
 
-        matched_skills = skill_registry.match_skill(message)
         from src.skills import get_tracer
+
+        existing_active_skill_contract = await session_manager.get_active_skill_session(session_id)
+        if is_clear_active_skill_command(message):
+            await session_manager.set_active_skill_session(session_id, None)
+            set_skill_workdir(None)
+            cleared_message = "Active skill cleared."
+            await self._persist_assistant_message(session_id, cleared_message)
+            return self._build_assistant_result_payload(
+                cleared_message,
+                usage=usage_data,
+                user_message_id=user_message_id,
+            )
+
+        matched_skills = skill_registry.match_skill(message)
+        selected_skill = None
+        activation_reason: Optional[str] = None
+        active_skill_contract: Optional[Dict[str, Any]] = None
+        if matched_skills:
+            selected_skill = matched_skills[0]
+            existing_skill_name = get_contract_skill_name(existing_active_skill_contract)
+            activation_reason = "switched" if existing_skill_name and existing_skill_name != selected_skill.name else "matched"
+        elif is_active_skill_contract_usable(existing_active_skill_contract):
+            continued_skill_name = get_contract_skill_name(existing_active_skill_contract)
+            candidate_skill = skill_registry.get_skill(continued_skill_name)
+            if candidate_skill and not getattr(candidate_skill, "deprecated", False):
+                selected_skill = candidate_skill
+                activation_reason = "continued"
+            else:
+                await session_manager.set_active_skill_session(session_id, None)
 
         # Start execution tracing
         tracer = get_tracer()
         execution_id = tracer.start_execution(
             session_id=session_id,
             user_message=message,
-            matched_skill=matched_skills[0].name if matched_skills else None,
+            matched_skill=selected_skill.name if selected_skill else None,
         )
         
         active_skill_runtime: Optional[SkillRuntimeConfig] = None
 
-        if matched_skills:
-            # Use the best match
-            best_skill = matched_skills[0]
-            logger.info(f"[Skill] Matched skill: {best_skill.name}")
+        if selected_skill:
+            logger.info(f"[Skill] Active skill selected: {selected_skill.name} ({activation_reason})")
             
             # Set skill workdir for exec tool (async-safe via contextvars)
-            set_skill_workdir(best_skill.path or None)
-            if best_skill.path:
-                logger.info(f"[Skill] Workdir: {best_skill.path}")
+            set_skill_workdir(selected_skill.path or None)
+            if selected_skill.path:
+                logger.info(f"[Skill] Workdir: {selected_skill.path}")
 
             active_skill_runtime = skill_registry.get_skill_runtime_config(
-                best_skill,
+                selected_skill,
                 globally_allowed_tool_names=getattr(self, "allowed_tool_names", set()),
             )
-            # Log matched skill
-            tracer.log_tool_call(
-                tool_name="skill_matched",
-                arguments={"skill": best_skill.name},
-                result=f"Matched skill: {best_skill.name}",
+            active_skill_contract = build_active_skill_contract(
+                skill=selected_skill,
+                runtime_config=active_skill_runtime,
+                user_message=message,
+                existing_contract=existing_active_skill_contract,
+                activation_reason=activation_reason or "matched",
             )
+            await session_manager.set_active_skill_session(session_id, active_skill_contract)
+            if activation_reason in {"matched", "switched"}:
+                tracer.log_tool_call(
+                    tool_name="skill_matched",
+                    arguments={"skill": selected_skill.name, "reason": activation_reason},
+                    result=f"Matched skill: {selected_skill.name}",
+                )
+            else:
+                tracer.log_tool_call(
+                    tool_name="skill_contract_continued",
+                    arguments={"skill": selected_skill.name, "reason": activation_reason},
+                    result=f"Continued active skill contract: {selected_skill.name}",
+                )
         else:
             set_skill_workdir(None)
         # ===== END SKILL MATCHING =====
@@ -961,8 +1008,19 @@ You have access to the following tools. When a user asks you to do something tha
                     logger.debug(f"Stream event error: {e}")
         
         # Send skill matched event
-        if matched_skills:
-            send_event("skill_matched", {"skill": matched_skills[0].name})
+        if selected_skill and activation_reason in {"matched", "switched"}:
+            send_event("skill_matched", {"skill": selected_skill.name})
+        if active_skill_contract:
+            send_event(
+                "skill_contract_active",
+                {
+                    "skill": active_skill_contract.get("skill_name"),
+                    "status": active_skill_contract.get("status"),
+                    "reason": active_skill_contract.get("activation_reason"),
+                    "turn_count": active_skill_contract.get("turn_count"),
+                    "skill_hash": active_skill_contract.get("skill_hash"),
+                },
+            )
         if active_skill_runtime:
             verbose_runtime_event = _is_debug_enabled() or bool(config.session.get("verbose_skill_runtime_events", False))
             send_event(
@@ -1259,6 +1317,8 @@ You have access to the following tools. When a user asks you to do something tha
                         },
                         "thinking_events": all_events,
                     }
+                    if active_skill_contract:
+                        chatlog_data["skill_session"] = active_skill_contract
                     chatlog_dir = os.path.join(session_persistence.storage_dir, "chatlogs")
                     os.makedirs(chatlog_dir, exist_ok=True)
                     # Use raw session_id to match webchat.py's approach

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -58,6 +58,7 @@ from src.skills.active_contract import (
     get_contract_skill_name,
     is_active_skill_contract_usable,
     is_clear_active_skill_command,
+    parse_explicit_skill_switch_name,
 )
 from src.runtime.chat_orchestration_adapter import execute_tool_or_task_orchestration
 from src.runtime import build_default_execution_bus
@@ -811,9 +812,48 @@ You have access to the following tools. When a user asks you to do something tha
         from src.skills import get_tracer
 
         existing_active_skill_contract = await session_manager.get_active_skill_session(session_id)
+        
+        def emit_skill_contract_cleared_event(previous_skill_name: str) -> None:
+            if not previous_skill_name:
+                return
+            event_data = _enrich_runtime_event_context(
+                {
+                    "skill": previous_skill_name,
+                    "status": "cleared",
+                    "reason": "user_clear_command",
+                },
+                session_id=session_id,
+                agent_id=self.agent_id,
+            )
+            try:
+                from src.gateway.event_bus import emit_agent_event_sync
+
+                emit_agent_event_sync("skill_contract_cleared", event_data)
+            except Exception as event_error:
+                logger.debug(f"Failed to emit skill_contract_cleared to event bus: {event_error}")
+            if not stream_callback:
+                return
+            try:
+                event = json.dumps({"type": "skill_contract_cleared", **event_data})
+                if hasattr(stream_callback, "put"):
+                    try:
+                        loop = asyncio.get_event_loop()
+                        if loop.is_running():
+                            asyncio.create_task(stream_callback.put(event))
+                        else:
+                            stream_callback.put_nowait(event)
+                    except RuntimeError:
+                        stream_callback.put_nowait(event)
+                else:
+                    stream_callback(event)
+            except Exception as event_error:
+                logger.debug(f"Failed to emit skill_contract_cleared to stream callback: {event_error}")
+
         if is_clear_active_skill_command(message):
+            previous_skill_name = get_contract_skill_name(existing_active_skill_contract)
             await session_manager.set_active_skill_session(session_id, None)
             set_skill_workdir(None)
+            emit_skill_contract_cleared_event(previous_skill_name)
             cleared_message = "Active skill cleared."
             await self._persist_assistant_message(session_id, cleared_message)
             return self._build_assistant_result_payload(
@@ -822,22 +862,40 @@ You have access to the following tools. When a user asks you to do something tha
                 user_message_id=user_message_id,
             )
 
-        matched_skills = skill_registry.match_skill(message)
+        explicit_skill_name = parse_explicit_skill_switch_name(message)
         selected_skill = None
         activation_reason: Optional[str] = None
         active_skill_contract: Optional[Dict[str, Any]] = None
-        if matched_skills:
-            selected_skill = matched_skills[0]
+        if is_active_skill_contract_usable(existing_active_skill_contract):
             existing_skill_name = get_contract_skill_name(existing_active_skill_contract)
-            activation_reason = "switched" if existing_skill_name and existing_skill_name != selected_skill.name else "matched"
-        elif is_active_skill_contract_usable(existing_active_skill_contract):
-            continued_skill_name = get_contract_skill_name(existing_active_skill_contract)
-            candidate_skill = skill_registry.get_skill(continued_skill_name)
-            if candidate_skill and not getattr(candidate_skill, "deprecated", False):
-                selected_skill = candidate_skill
-                activation_reason = "continued"
+            if explicit_skill_name:
+                explicit_skill = skill_registry.get_skill(explicit_skill_name)
+                if explicit_skill and not getattr(explicit_skill, "deprecated", False):
+                    selected_skill = explicit_skill
+                    activation_reason = "switched" if explicit_skill.name != existing_skill_name else "continued"
+                else:
+                    not_found_message = f"Skill not found: {explicit_skill_name}"
+                    await self._persist_assistant_message(session_id, not_found_message)
+                    return self._build_assistant_result_payload(
+                        not_found_message,
+                        usage=usage_data,
+                        user_message_id=user_message_id,
+                    )
             else:
-                await session_manager.set_active_skill_session(session_id, None)
+                continued_skill = skill_registry.get_skill(existing_skill_name)
+                if continued_skill and not getattr(continued_skill, "deprecated", False):
+                    selected_skill = continued_skill
+                    activation_reason = "continued"
+                else:
+                    await session_manager.set_active_skill_session(session_id, None)
+                    set_skill_workdir(None)
+
+        matched_skills = []
+        if selected_skill is None:
+            matched_skills = skill_registry.match_skill(message)
+            if matched_skills:
+                selected_skill = matched_skills[0]
+                activation_reason = "matched"
 
         # Start execution tracing
         tracer = get_tracer()

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -891,6 +891,20 @@ You have access to the following tools. When a user asks you to do something tha
                     set_skill_workdir(None)
 
         matched_skills = []
+        if selected_skill is None and explicit_skill_name:
+            explicit_skill = skill_registry.get_skill(explicit_skill_name)
+            if explicit_skill and not getattr(explicit_skill, "deprecated", False):
+                selected_skill = explicit_skill
+                activation_reason = "matched"
+            else:
+                not_found_message = f"Skill not found: {explicit_skill_name}"
+                await self._persist_assistant_message(session_id, not_found_message)
+                return self._build_assistant_result_payload(
+                    not_found_message,
+                    usage=usage_data,
+                    user_message_id=user_message_id,
+                )
+
         if selected_skill is None:
             matched_skills = skill_registry.match_skill(message)
             if matched_skills:

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -131,6 +131,19 @@ async def _enrich_publish_metadata_with_context_preview(
     preview = build_portal_context_preview(context_state)
     if preview:
         merged.update(preview)
+    active_skill = await session_manager.get_active_skill_session(session_id)
+    if isinstance(active_skill, dict):
+        merged.update(
+            {
+                "active_skill_name": active_skill.get("skill_name") or active_skill.get("skill"),
+                "active_skill_status": active_skill.get("status"),
+                "active_skill_goal": active_skill.get("goal"),
+                "active_skill_hash": active_skill.get("skill_hash"),
+                "active_skill_turn_count": active_skill.get("turn_count"),
+                "active_skill_activation_reason": active_skill.get("activation_reason"),
+                "active_skill_tool_policy_declared": active_skill.get("tool_policy_declared"),
+            }
+        )
     return merged
 
 

--- a/src/runtime/portal_session_metadata_client.py
+++ b/src/runtime/portal_session_metadata_client.py
@@ -33,6 +33,13 @@ _CONTROL_PLANE_METADATA_KEYS = {
     "context_objective_preview",
     "context_summary_preview",
     "context_next_step_preview",
+    "active_skill_name",
+    "active_skill_status",
+    "active_skill_goal",
+    "active_skill_hash",
+    "active_skill_turn_count",
+    "active_skill_activation_reason",
+    "active_skill_tool_policy_declared",
 }
 
 

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -207,10 +207,10 @@ class SessionManager:
 
     @staticmethod
     def _restore_active_skill_session_from_metadata(session: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        """Restore legacy active skill session from metadata if needed.
+        """Restore active skill contract from metadata when present.
 
-        Kept for backward compatibility with persisted historical sessions.
-        Runtime skill execution no longer depends on this field.
+        This supports both current Active Skill Contract state and historical
+        sessions that persisted the same field under metadata.
         """
         active = session.get("active_skill_session")
         if active is not None:
@@ -513,7 +513,7 @@ class SessionManager:
     
 
     async def get_active_skill_session(self, session_id: str) -> Optional[Dict[str, Any]]:
-        """Get legacy active skill session state for a chat session."""
+        """Get the current Active Skill Contract for a chat session, if any."""
         session = await self.get_session(session_id)
         active = session.get("active_skill_session")
         if active:
@@ -526,7 +526,7 @@ class SessionManager:
         return active
 
     async def set_active_skill_session(self, session_id: str, skill_session: Optional[Dict[str, Any]]) -> None:
-        """Set or clear legacy active skill session state for a chat session."""
+        """Set or clear the current Active Skill Contract for a chat session."""
         session = await self.get_session(session_id)
         session["active_skill_session"] = skill_session
         metadata = session.setdefault("metadata", {})

--- a/src/skills/active_contract.py
+++ b/src/skills/active_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -19,6 +20,7 @@ _CLEAR_COMMANDS = {
     "/skill off",
     "/skill done",
 }
+_SKILL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def _utc_now_iso() -> str:
@@ -33,6 +35,34 @@ def _shorten(value: Any, max_len: int) -> str:
 def is_clear_active_skill_command(message: str) -> bool:
     normalized = str(message or "").strip().lower()
     return normalized in _CLEAR_COMMANDS
+
+
+def parse_explicit_skill_switch_name(message: str) -> str:
+    raw = str(message or "").strip()
+    if not raw:
+        return ""
+    if is_clear_active_skill_command(raw):
+        return ""
+
+    lowered = raw.lower()
+    if lowered.startswith("/skill "):
+        remainder = raw[len("/skill ") :].strip()
+        if not remainder:
+            return ""
+        parts = remainder.split()
+        if not parts:
+            return ""
+        command = parts[0].lower()
+        candidate = parts[1] if command in {"switch", "use", "activate"} and len(parts) > 1 else parts[0]
+        candidate = candidate.strip()
+        return candidate if _SKILL_NAME_PATTERN.match(candidate) else ""
+
+    if raw.startswith("/") and not lowered.startswith("/skill"):
+        slash_token = raw.split()[0].strip()
+        candidate = slash_token[1:]
+        return candidate if _SKILL_NAME_PATTERN.match(candidate) else ""
+
+    return ""
 
 
 def get_contract_skill_name(contract: Optional[dict]) -> str:

--- a/src/skills/active_contract.py
+++ b/src/skills/active_contract.py
@@ -1,0 +1,122 @@
+"""Active skill session contract helpers."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from src.skills.runtime import SkillRuntimeConfig
+
+ACTIVE_SKILL_CONTRACT_VERSION = "active_skill_contract.v1"
+
+_FINISHED_STATUSES = {"finished", "completed", "cancelled", "canceled", "done", "cleared"}
+_CLEAR_COMMANDS = {
+    "/skill clear",
+    "/skill exit",
+    "/skill stop",
+    "/skill reset",
+    "/skill off",
+    "/skill done",
+}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _shorten(value: Any, max_len: int) -> str:
+    text = str(value or "").strip()
+    return text[:max_len]
+
+
+def is_clear_active_skill_command(message: str) -> bool:
+    normalized = str(message or "").strip().lower()
+    return normalized in _CLEAR_COMMANDS
+
+
+def get_contract_skill_name(contract: Optional[dict]) -> str:
+    if not isinstance(contract, dict):
+        return ""
+    return str(contract.get("skill_name") or contract.get("skill") or "").strip()
+
+
+def is_active_skill_contract_usable(contract: Optional[dict]) -> bool:
+    if not isinstance(contract, dict):
+        return False
+    skill_name = get_contract_skill_name(contract)
+    if not skill_name:
+        return False
+    status = str(contract.get("status") or "").strip().lower()
+    if status in _FINISHED_STATUSES:
+        return False
+    return True
+
+
+def _build_skill_hash(*, skill: Any) -> str:
+    content = "\n".join(
+        [
+            str(getattr(skill, "name", "") or ""),
+            str(getattr(skill, "version", "") or ""),
+            str(getattr(skill, "description", "") or ""),
+            str(getattr(skill, "body", "") or ""),
+        ]
+    )
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:12]
+
+
+def build_active_skill_contract(
+    *,
+    skill,
+    runtime_config: SkillRuntimeConfig,
+    user_message: str,
+    existing_contract: Optional[dict] = None,
+    activation_reason: str = "matched",
+) -> dict:
+    now = _utc_now_iso()
+    existing = existing_contract if isinstance(existing_contract, dict) else {}
+
+    current_skill_name = str(runtime_config.skill_name or "").strip()
+    existing_skill_name = get_contract_skill_name(existing)
+    same_skill = bool(existing_skill_name and existing_skill_name == current_skill_name)
+
+    prior_turn_count = existing.get("turn_count") if same_skill else None
+    try:
+        prior_turn_count_int = int(prior_turn_count)
+    except (TypeError, ValueError):
+        prior_turn_count_int = 0
+
+    original_request = (
+        _shorten(existing.get("original_user_request", ""), 2000)
+        if same_skill and existing.get("original_user_request")
+        else _shorten(user_message, 2000)
+    )
+    goal = (
+        _shorten(existing.get("goal", ""), 500)
+        if same_skill and existing.get("goal")
+        else _shorten(user_message, 500)
+    )
+    created_at = str(existing.get("created_at") or "").strip() if same_skill else ""
+
+    return {
+        "schema_version": ACTIVE_SKILL_CONTRACT_VERSION,
+        "skill_name": current_skill_name,
+        "skill_version": str(getattr(skill, "version", "") or ""),
+        "skill_hash": _build_skill_hash(skill=skill),
+        "status": "active",
+        "activation_reason": str(activation_reason or "matched"),
+        "original_user_request": original_request,
+        "goal": goal,
+        "last_user_message": _shorten(user_message, 1000),
+        "turn_count": prior_turn_count_int + 1 if same_skill else 1,
+        "allowed_tools": list(runtime_config.allowed_tools or []),
+        "tool_policy_declared": bool(runtime_config.tool_policy_declared),
+        "task_tools": list(runtime_config.task_tools or []),
+        "model_override": runtime_config.model_override,
+        "hooks": list(runtime_config.hooks or []),
+        "workdir": runtime_config.workdir,
+        "references": list(runtime_config.references or []),
+        "prompt_contract_summary": _shorten(runtime_config.prompt_blocks.developer_instructions, 2000),
+        "created_at": created_at or now,
+        "updated_at": now,
+    }

--- a/src/skills/active_contract.py
+++ b/src/skills/active_contract.py
@@ -53,7 +53,12 @@ def parse_explicit_skill_switch_name(message: str) -> str:
         if not parts:
             return ""
         command = parts[0].lower()
-        candidate = parts[1] if command in {"switch", "use", "activate"} and len(parts) > 1 else parts[0]
+        if command in {"switch", "use", "activate"}:
+            if len(parts) < 2:
+                return ""
+            candidate = parts[1]
+        else:
+            candidate = parts[0]
         candidate = candidate.strip()
         return candidate if _SKILL_NAME_PATTERN.match(candidate) else ""
 

--- a/src/skills/runtime.py
+++ b/src/skills/runtime.py
@@ -72,7 +72,9 @@ _PRIORITY_SECTION_ORDER = [
     "steps",
     "instructions",
 ]
-_HIGH_PRIORITY_TRUNCATABLE_HEADINGS = {"output contract", "reference usage", "constraints", "rules", "tool policy"}
+_CRITICAL_SECTION_KEYWORDS = {"output contract", "reference usage", "constraints", "rules", "tool policy"}
+_MIN_CRITICAL_SECTION_CHARS = 300
+_MAX_INTRO_SECTION_CHARS = 1200
 _SECTION_TRUNCATED_NOTE = "[Section truncated due to skill contract budget.]"
 
 _SKILL_CONTRACT_TRUNCATED_NOTE = (
@@ -138,24 +140,72 @@ def compile_skill_prompt_contract(skill: Skill, *, max_chars: int = 12000) -> st
     compiled_parts: List[str] = []
     used_chars = 0
     truncated = False
+    pending_critical_sections = [section for section in ordered_sections if _is_critical_section(section)]
+    critical_sections_added = 0
+
     for section in ordered_sections:
         section_text = section["text"]
         if not section_text:
             continue
         joiner = "\n\n" if compiled_parts else ""
-        available = max_chars - used_chars - len(joiner)
-        if available <= 0:
+        heading = str(section.get("heading", ""))
+        is_intro = not heading
+        is_critical = _is_critical_section(section)
+        is_low_priority_process = _is_low_priority_process_section(section)
+
+        remaining_critical_count = len(pending_critical_sections) - (1 if is_critical else 0)
+        reserve_for_remaining = remaining_critical_count * _MIN_CRITICAL_SECTION_CHARS
+        available_total = max_chars - used_chars - len(joiner)
+        available_for_this = available_total - reserve_for_remaining
+        if is_critical and available_for_this <= 0:
+            available_for_this = max(0, available_total)
+
+        if available_total <= 0 or available_for_this <= 0:
             truncated = True
-            continue
-        if len(section_text) <= available:
-            compiled_parts.append(f"{joiner}{section_text}" if joiner else section_text)
-            used_chars += len(joiner) + len(section_text)
+            if is_critical and available_total > 0:
+                minimal_text = _truncate_section_text(
+                    section_text,
+                    available_total,
+                    preserve_heading=True,
+                    max_body_chars=max(80, available_total // 3),
+                )
+                if minimal_text:
+                    compiled_parts.append(f"{joiner}{minimal_text}" if joiner else minimal_text)
+                    used_chars += len(joiner) + len(minimal_text)
+                    critical_sections_added += 1
+                    pending_critical_sections = [item for item in pending_critical_sections if item is not section]
             continue
 
-        heading = str(section["heading"] or "")
-        rank = int(section["rank"])
-        if rank < len(_PRIORITY_SECTION_ORDER) and _PRIORITY_SECTION_ORDER[rank] in _HIGH_PRIORITY_TRUNCATABLE_HEADINGS:
-            truncated_text = _truncate_section_text(section_text, available)
+        if is_intro:
+            section_text = _limit_intro_section_text(section_text, cap=_MAX_INTRO_SECTION_CHARS)
+
+        if len(section_text) <= available_for_this:
+            compiled_parts.append(f"{joiner}{section_text}" if joiner else section_text)
+            used_chars += len(joiner) + len(section_text)
+            if is_critical:
+                critical_sections_added += 1
+                pending_critical_sections = [item for item in pending_critical_sections if item is not section]
+            continue
+
+        if is_critical:
+            truncated_text = _truncate_section_text(
+                section_text,
+                available_for_this,
+                preserve_heading=True,
+                max_body_chars=max(120, available_for_this // 2),
+            )
+            if truncated_text:
+                compiled_parts.append(f"{joiner}{truncated_text}" if joiner else truncated_text)
+                used_chars += len(joiner) + len(truncated_text)
+                critical_sections_added += 1
+                pending_critical_sections = [item for item in pending_critical_sections if item is not section]
+                truncated = True
+                continue
+        elif is_low_priority_process and critical_sections_added < len([s for s in ordered_sections if _is_critical_section(s)]):
+            truncated = True
+            continue
+        elif not is_low_priority_process:
+            truncated_text = _truncate_section_text(section_text, available_for_this, preserve_heading=False, max_body_chars=available_for_this)
             if truncated_text:
                 compiled_parts.append(f"{joiner}{truncated_text}" if joiner else truncated_text)
                 used_chars += len(joiner) + len(truncated_text)
@@ -181,7 +231,13 @@ def _section_priority_rank(heading: str) -> int:
     return len(_PRIORITY_SECTION_ORDER) + 10
 
 
-def _truncate_section_text(section_text: str, available: int) -> str:
+def _truncate_section_text(
+    section_text: str,
+    available: int,
+    *,
+    preserve_heading: bool = False,
+    max_body_chars: Optional[int] = None,
+) -> str:
     if available <= 0:
         return ""
     if len(section_text) <= available:
@@ -191,7 +247,44 @@ def _truncate_section_text(section_text: str, available: int) -> str:
     keep_len = available - len(_SECTION_TRUNCATED_NOTE) - 1
     if keep_len <= 0:
         return section_text[:available].rstrip()
+    if preserve_heading:
+        lines = section_text.splitlines()
+        heading_line = lines[0] if lines else ""
+        body_text = "\n".join(lines[1:]).strip()
+        heading_with_newline = f"{heading_line}\n" if heading_line else ""
+        remaining_for_body = keep_len - len(heading_with_newline)
+        if max_body_chars is not None:
+            remaining_for_body = min(remaining_for_body, max_body_chars)
+        if remaining_for_body <= 0:
+            minimal = heading_line[:keep_len].rstrip() if heading_line else section_text[:keep_len].rstrip()
+            return f"{minimal}\n{_SECTION_TRUNCATED_NOTE}"
+        body_part = body_text[:remaining_for_body].rstrip()
+        combined = f"{heading_with_newline}{body_part}".rstrip()
+        return f"{combined}\n{_SECTION_TRUNCATED_NOTE}"
+    truncated_body = section_text[:keep_len].rstrip()
+    return f"{truncated_body}\n{_SECTION_TRUNCATED_NOTE}"
+
+
+def _limit_intro_section_text(section_text: str, *, cap: int) -> str:
+    if cap <= 0 or len(section_text) <= cap:
+        return section_text
+    if cap <= len(_SECTION_TRUNCATED_NOTE) + 1:
+        return section_text[:cap].rstrip()
+    keep_len = cap - len(_SECTION_TRUNCATED_NOTE) - 1
     return f"{section_text[:keep_len].rstrip()}\n{_SECTION_TRUNCATED_NOTE}"
+
+
+def _is_critical_section(section: dict) -> bool:
+    rank = int(section.get("rank", len(_PRIORITY_SECTION_ORDER) + 10))
+    return rank < len(_PRIORITY_SECTION_ORDER) and _PRIORITY_SECTION_ORDER[rank] in _CRITICAL_SECTION_KEYWORDS
+
+
+def _is_low_priority_process_section(section: dict) -> bool:
+    rank = int(section.get("rank", len(_PRIORITY_SECTION_ORDER) + 10))
+    if rank >= len(_PRIORITY_SECTION_ORDER):
+        return False
+    keyword = _PRIORITY_SECTION_ORDER[rank]
+    return keyword in {"workflow", "process", "steps", "instructions"}
 
 
 def _append_contract_truncation_note(compiled: str, *, max_chars: int) -> str:

--- a/src/skills/runtime.py
+++ b/src/skills/runtime.py
@@ -58,20 +58,22 @@ class SkillRuntimeConfig:
     references: List[str] = field(default_factory=list)
 
 
-_PRIORITY_SKILL_SECTION_KEYWORDS = (
+_PRIORITY_SECTION_ORDER = [
     "output contract",
     "reference usage",
     "constraints",
     "rules",
+    "tool policy",
+    "acceptance",
+    "quality",
     "strategy",
     "workflow",
     "process",
     "steps",
     "instructions",
-    "tool policy",
-    "quality",
-    "acceptance",
-)
+]
+_HIGH_PRIORITY_TRUNCATABLE_HEADINGS = {"output contract", "reference usage", "constraints", "rules", "tool policy"}
+_SECTION_TRUNCATED_NOTE = "[Section truncated due to skill contract budget.]"
 
 _SKILL_CONTRACT_TRUNCATED_NOTE = (
     "[Skill contract truncated: retained priority sections such as output contract, constraints, "
@@ -90,54 +92,117 @@ def compile_skill_prompt_contract(skill: Skill, *, max_chars: int = 12000) -> st
 
     lines = body.splitlines()
     section_pattern = re.compile(r"^\s{0,3}(#{1,6})\s+(.*\S)\s*$")
-    sections: List[dict] = []
+    parsed_sections: List[dict] = []
     current_lines: List[str] = []
     current_heading = ""
 
     for line in lines:
         match = section_pattern.match(line)
         if match:
-            sections.append({"heading": current_heading, "lines": current_lines})
+            parsed_sections.append({"heading": current_heading, "lines": current_lines})
             current_heading = match.group(2).strip().lower()
             current_lines = [line]
             continue
         current_lines.append(line)
-    sections.append({"heading": current_heading, "lines": current_lines})
+    parsed_sections.append({"heading": current_heading, "lines": current_lines})
 
-    intro_sections = [section for section in sections if not section.get("heading")]
-    heading_sections = [section for section in sections if section.get("heading")]
-    if heading_sections:
-        intro_sections.append(heading_sections[0])
-        heading_sections = heading_sections[1:]
-
-    priority_sections = []
-    remaining_sections = []
-    for section in heading_sections:
+    intro_sections: List[dict] = []
+    remaining_sections: List[dict] = []
+    for index, section in enumerate(parsed_sections):
+        if not section.get("lines"):
+            continue
+        normalized = "\n".join(line.rstrip() for line in section.get("lines", [])).strip("\n")
+        if not normalized:
+            continue
         heading = str(section.get("heading", ""))
-        if any(keyword in heading for keyword in _PRIORITY_SKILL_SECTION_KEYWORDS):
-            priority_sections.append(section)
+        record = {
+            "heading": heading,
+            "text": normalized,
+            "rank": _section_priority_rank(heading),
+            "index": index,
+        }
+        if not heading:
+            intro_sections.append(record)
         else:
-            remaining_sections.append(section)
+            remaining_sections.append(record)
 
-    ordered_sections = intro_sections + priority_sections + remaining_sections
-    compiled = "\n\n".join(
-        "\n".join(line.rstrip() for line in section.get("lines", [])).strip("\n")
-        for section in ordered_sections
-        if section.get("lines")
-    ).strip()
-    if len(compiled) <= max_chars:
+    if remaining_sections:
+        intro_sections.append(remaining_sections[0])
+        remaining_sections = remaining_sections[1:]
+
+    priority_sections = [section for section in remaining_sections if section["rank"] < len(_PRIORITY_SECTION_ORDER)]
+    non_priority_sections = [section for section in remaining_sections if section["rank"] >= len(_PRIORITY_SECTION_ORDER)]
+    priority_sections.sort(key=lambda section: (section["rank"], section["index"]))
+    ordered_sections = intro_sections + priority_sections + non_priority_sections
+
+    compiled_parts: List[str] = []
+    used_chars = 0
+    truncated = False
+    for section in ordered_sections:
+        section_text = section["text"]
+        if not section_text:
+            continue
+        joiner = "\n\n" if compiled_parts else ""
+        available = max_chars - used_chars - len(joiner)
+        if available <= 0:
+            truncated = True
+            continue
+        if len(section_text) <= available:
+            compiled_parts.append(f"{joiner}{section_text}" if joiner else section_text)
+            used_chars += len(joiner) + len(section_text)
+            continue
+
+        heading = str(section["heading"] or "")
+        rank = int(section["rank"])
+        if rank < len(_PRIORITY_SECTION_ORDER) and _PRIORITY_SECTION_ORDER[rank] in _HIGH_PRIORITY_TRUNCATABLE_HEADINGS:
+            truncated_text = _truncate_section_text(section_text, available)
+            if truncated_text:
+                compiled_parts.append(f"{joiner}{truncated_text}" if joiner else truncated_text)
+                used_chars += len(joiner) + len(truncated_text)
+                truncated = True
+                continue
+        truncated = True
+
+    compiled = "".join(compiled_parts).strip()
+    if not truncated:
         return compiled
+    if not compiled:
+        return _SKILL_CONTRACT_TRUNCATED_NOTE[:max_chars].strip()
+    return _append_contract_truncation_note(compiled, max_chars=max_chars)
 
-    truncated = compiled[:max_chars].rstrip()
+
+def _section_priority_rank(heading: str) -> int:
+    heading_text = str(heading or "").strip().lower()
+    if not heading_text:
+        return len(_PRIORITY_SECTION_ORDER) + 10
+    for idx, keyword in enumerate(_PRIORITY_SECTION_ORDER):
+        if keyword in heading_text:
+            return idx
+    return len(_PRIORITY_SECTION_ORDER) + 10
+
+
+def _truncate_section_text(section_text: str, available: int) -> str:
+    if available <= 0:
+        return ""
+    if len(section_text) <= available:
+        return section_text
+    if available <= len(_SECTION_TRUNCATED_NOTE) + 1:
+        return section_text[:available].rstrip()
+    keep_len = available - len(_SECTION_TRUNCATED_NOTE) - 1
+    if keep_len <= 0:
+        return section_text[:available].rstrip()
+    return f"{section_text[:keep_len].rstrip()}\n{_SECTION_TRUNCATED_NOTE}"
+
+
+def _append_contract_truncation_note(compiled: str, *, max_chars: int) -> str:
     note = _SKILL_CONTRACT_TRUNCATED_NOTE
-    if len(note) + 1 >= max_chars:
-        return truncated
-    if len(truncated) + len(note) + 1 <= max_chars:
-        return f"{truncated}\n{note}"
-    keep = max_chars - len(note) - 1
-    if keep <= 0:
-        return truncated
-    return f"{compiled[:keep].rstrip()}\n{note}"
+    combined = f"{compiled}\n{note}"
+    if len(combined) <= max_chars:
+        return combined
+    available = max_chars - len(note) - 1
+    if available <= 0:
+        return compiled[:max_chars].rstrip()
+    return f"{compiled[:available].rstrip()}\n{note}"
 
 
 def summarize_skill_references(skill: Skill) -> List[str]:

--- a/src/skills/runtime.py
+++ b/src/skills/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, List, Optional, Set
@@ -55,6 +56,88 @@ class SkillRuntimeConfig:
     workdir: str = ""
     prompt_blocks: SkillPromptBlocks = field(default_factory=SkillPromptBlocks)
     references: List[str] = field(default_factory=list)
+
+
+_PRIORITY_SKILL_SECTION_KEYWORDS = (
+    "output contract",
+    "reference usage",
+    "constraints",
+    "rules",
+    "strategy",
+    "workflow",
+    "process",
+    "steps",
+    "instructions",
+    "tool policy",
+    "quality",
+    "acceptance",
+)
+
+_SKILL_CONTRACT_TRUNCATED_NOTE = (
+    "[Skill contract truncated: retained priority sections such as output contract, constraints, "
+    "reference usage, and workflow.]"
+)
+
+
+def compile_skill_prompt_contract(skill: Skill, *, max_chars: int = 12000) -> str:
+    body = (skill.body or "").strip()
+    if not body:
+        return ""
+    if max_chars <= 0:
+        max_chars = 12000
+    if len(body) <= max_chars:
+        return body
+
+    lines = body.splitlines()
+    section_pattern = re.compile(r"^\s{0,3}(#{1,6})\s+(.*\S)\s*$")
+    sections: List[dict] = []
+    current_lines: List[str] = []
+    current_heading = ""
+
+    for line in lines:
+        match = section_pattern.match(line)
+        if match:
+            sections.append({"heading": current_heading, "lines": current_lines})
+            current_heading = match.group(2).strip().lower()
+            current_lines = [line]
+            continue
+        current_lines.append(line)
+    sections.append({"heading": current_heading, "lines": current_lines})
+
+    intro_sections = [section for section in sections if not section.get("heading")]
+    heading_sections = [section for section in sections if section.get("heading")]
+    if heading_sections:
+        intro_sections.append(heading_sections[0])
+        heading_sections = heading_sections[1:]
+
+    priority_sections = []
+    remaining_sections = []
+    for section in heading_sections:
+        heading = str(section.get("heading", ""))
+        if any(keyword in heading for keyword in _PRIORITY_SKILL_SECTION_KEYWORDS):
+            priority_sections.append(section)
+        else:
+            remaining_sections.append(section)
+
+    ordered_sections = intro_sections + priority_sections + remaining_sections
+    compiled = "\n\n".join(
+        "\n".join(line.rstrip() for line in section.get("lines", [])).strip("\n")
+        for section in ordered_sections
+        if section.get("lines")
+    ).strip()
+    if len(compiled) <= max_chars:
+        return compiled
+
+    truncated = compiled[:max_chars].rstrip()
+    note = _SKILL_CONTRACT_TRUNCATED_NOTE
+    if len(note) + 1 >= max_chars:
+        return truncated
+    if len(truncated) + len(note) + 1 <= max_chars:
+        return f"{truncated}\n{note}"
+    keep = max_chars - len(note) - 1
+    if keep <= 0:
+        return truncated
+    return f"{compiled[:keep].rstrip()}\n{note}"
 
 
 def summarize_skill_references(skill: Skill) -> List[str]:
@@ -125,13 +208,18 @@ def build_skill_prompt_blocks(
         allowed_tools_text = "all currently available tools"
     task_tools_text = ", ".join(effective_task_tools) if effective_task_tools else "none"
     system_rules = (
-        f"Active skill: {skill.name}. Runtime policy: only use allowed tools ({allowed_tools_text}). "
+        f"Active skill: {skill.name}.\n"
+        "You are operating under this active skill contract until the user explicitly clears or switches skill.\n"
+        "Stay within the skill's instructions, constraints, output contract, reference usage, and allowed tool policy.\n"
+        "If the user request conflicts with the active skill, ask whether to clear/switch the skill instead of silently ignoring it.\n"
+        "Do not invent tool results, references, or external facts that were not provided.\n"
+        f"Runtime policy: only use allowed tools ({allowed_tools_text}).\n"
         f"Task-capable tools: {task_tools_text}."
     )
 
     strategy = "\n".join(f"- {item}" for item in (skill.strategy or []))
     body = (skill.body or "").strip()
-    body_compact = "\n".join(line.rstrip() for line in body.splitlines()[:40]).strip()
+    body_compact = compile_skill_prompt_contract(skill)
 
     developer_parts = [
         f"Skill: {skill.name}",

--- a/src/skills/runtime.py
+++ b/src/skills/runtime.py
@@ -177,7 +177,10 @@ def compile_skill_prompt_contract(skill: Skill, *, max_chars: int = 12000) -> st
             continue
 
         if is_intro:
-            section_text = _limit_intro_section_text(section_text, cap=_MAX_INTRO_SECTION_CHARS)
+            limited_intro_text = _limit_intro_section_text(section_text, cap=_MAX_INTRO_SECTION_CHARS)
+            if limited_intro_text != section_text:
+                truncated = True
+            section_text = limited_intro_text
 
         if len(section_text) <= available_for_this:
             compiled_parts.append(f"{joiner}{section_text}" if joiner else section_text)

--- a/tests/test_portal_session_metadata_client.py
+++ b/tests/test_portal_session_metadata_client.py
@@ -209,3 +209,33 @@ def test_build_session_metadata_payload_preserves_context_preview_keys():
     assert "context_objective_preview" in metadata_json
     assert "context_summary_preview" in metadata_json
     assert "context_next_step_preview" in metadata_json
+
+
+def test_build_session_metadata_payload_preserves_active_skill_preview_keys():
+    payload = build_session_metadata_payload(
+        last_execution_id="exec-skill",
+        latest_event_type="chat.completed",
+        latest_event_state="success",
+        snapshot_version=None,
+        runtime_events=[],
+        metadata={
+            "active_skill_name": "review-pull-request",
+            "active_skill_status": "active",
+            "active_skill_goal": "Review PR #12",
+            "active_skill_hash": "abc123",
+            "active_skill_turn_count": 2,
+            "active_skill_activation_reason": "continued",
+            "active_skill_tool_policy_declared": True,
+            "active_skill_session": {"should": "not-pass"},
+        },
+    )
+
+    metadata_json = payload.get("metadata_json", "")
+    assert "active_skill_name" in metadata_json
+    assert "active_skill_status" in metadata_json
+    assert "active_skill_goal" in metadata_json
+    assert "active_skill_hash" in metadata_json
+    assert "active_skill_turn_count" in metadata_json
+    assert "active_skill_activation_reason" in metadata_json
+    assert "active_skill_tool_policy_declared" in metadata_json
+    assert "active_skill_session" not in metadata_json

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -17,6 +17,7 @@ from src.skills.runtime import (
     attach_skill_references,
     assemble_effective_prompt,
     build_skill_runtime_config,
+    compile_skill_prompt_contract,
     summarize_skill_references,
 )
 from src.agents.skill_mode import generate_initial_skill_plan
@@ -47,6 +48,7 @@ class _SessionManager:
     def __init__(self):
         self.messages = []
         self.active_skill_session = None
+        self.active_skill_sessions = {}
 
     async def add_message(self, session_id, role, content, extra=None, wait_for_save=False):
         self.messages.append({"role": role, "content": content, **(extra or {})})
@@ -56,10 +58,15 @@ class _SessionManager:
         return list(self.messages)
 
     async def get_active_skill_session(self, session_id):
-        return self.active_skill_session
+        if session_id in self.active_skill_sessions:
+            return self.active_skill_sessions.get(session_id)
+        if not self.active_skill_sessions:
+            return self.active_skill_session
+        return None
 
     async def set_active_skill_session(self, session_id, skill_session):
         self.active_skill_session = skill_session
+        self.active_skill_sessions[session_id] = skill_session
 
 
 @pytest.fixture
@@ -247,6 +254,34 @@ def test_skill_contract_compiler_preserves_late_output_contract():
     instructions = runtime_config.prompt_blocks.developer_instructions
     assert "Output contract" in instructions
     assert "Reference usage" in instructions
+
+
+def test_skill_contract_compiler_preserves_priority_sections_when_truncated():
+    body = (
+        "# Huge Skill\n"
+        "Intro\n\n"
+        "## Workflow\n"
+        + ("workflow filler\n" * 2000)
+        + "\n## Output contract\n- Must return exact schema\n\n## Reference usage\n- Cite only provided references\n"
+    )
+    skill = SimpleNamespace(
+        name="huge-skill",
+        description="desc",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body=body,
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+    )
+
+    compiled = compile_skill_prompt_contract(skill, max_chars=2500)
+    assert "Output contract" in compiled
+    assert "Reference usage" in compiled
+    assert "Skill contract truncated" in compiled
+    assert len(compiled) <= 2600
 
 
 @pytest.mark.asyncio
@@ -585,7 +620,172 @@ async def test_active_skill_contract_continues_without_rematch(monkeypatch, base
 
 
 @pytest.mark.asyncio
-async def test_clear_active_skill_command_clears_contract_without_llm(monkeypatch, base_agent):
+async def test_active_skill_contract_does_not_soft_switch_on_ordinary_match(monkeypatch, base_agent):
+    agent, sess = base_agent
+    review_skill = SimpleNamespace(
+        name="review-pull-request",
+        description="review",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Review instructions",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+    create_skill = SimpleNamespace(
+        name="create-pull-request",
+        description="create",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Create instructions",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+    sess.active_skill_session = {
+        "schema_version": "active_skill_contract.v1",
+        "skill_name": "review-pull-request",
+        "status": "active",
+        "turn_count": 1,
+    }
+
+    class _Registry:
+        _initialized = True
+
+        def match_skill(self, message):
+            if "ordinary message that matches create" in message:
+                return [create_skill]
+            return []
+
+        def get_skill(self, name):
+            if name == review_skill.name:
+                return review_skill
+            if name == create_skill.name:
+                return create_skill
+            return None
+
+        def get_skill_runtime_config(self, skill, globally_allowed_tool_names=None):
+            return build_skill_runtime_config(skill, globally_allowed_tool_names=globally_allowed_tool_names)
+
+    monkeypatch.setattr("src.skills.skill_registry", _Registry())
+    captured_prompts = []
+
+    async def fake_responses(**kwargs):
+        captured_prompts.append(kwargs.get("system_prompt", ""))
+        return {"content": "done", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("ordinary message that matches create", session_id="s1")
+    assert result["response"] == "done"
+    assert captured_prompts
+    assert "Active skill: review-pull-request" in captured_prompts[0]
+    assert "Active skill: create-pull-request" not in captured_prompts[0]
+    assert sess.active_skill_session["skill_name"] == "review-pull-request"
+    assert sess.active_skill_session["activation_reason"] == "continued"
+
+
+@pytest.mark.asyncio
+async def test_active_skill_contract_switches_only_on_explicit_skill_command(monkeypatch, base_agent):
+    agent, sess = base_agent
+    review_skill = SimpleNamespace(
+        name="review-pull-request",
+        description="review",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Review instructions",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+    create_skill = SimpleNamespace(
+        name="create-pull-request",
+        description="create",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Create instructions",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+    sess.active_skill_session = {
+        "schema_version": "active_skill_contract.v1",
+        "skill_name": "review-pull-request",
+        "status": "active",
+        "turn_count": 1,
+    }
+
+    monkeypatch.setattr(
+        "src.skills.skill_registry",
+        SimpleNamespace(
+            _initialized=True,
+            load_skills=lambda: None,
+            match_skill=lambda *_: [],
+            get_skill=lambda name: create_skill if name == "create-pull-request" else (review_skill if name == "review-pull-request" else None),
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(
+                s, globally_allowed_tool_names=globally_allowed_tool_names
+            ),
+        ),
+    )
+    captured_prompts = []
+
+    async def fake_responses(**kwargs):
+        captured_prompts.append(kwargs.get("system_prompt", ""))
+        return {"content": "done", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("/skill switch create-pull-request", session_id="s1")
+    assert result["response"] == "done"
+    assert "Active skill: create-pull-request" in captured_prompts[0]
+    assert sess.active_skill_session["skill_name"] == "create-pull-request"
+    assert sess.active_skill_session["activation_reason"] == "switched"
+
+
+@pytest.mark.asyncio
+async def test_active_skill_contract_unknown_explicit_switch_returns_without_llm(monkeypatch, base_agent):
+    agent, sess = base_agent
+    sess.active_skill_session = {
+        "schema_version": "active_skill_contract.v1",
+        "skill_name": "review-pull-request",
+        "status": "active",
+        "turn_count": 1,
+    }
+    monkeypatch.setattr(
+        "src.skills.skill_registry",
+        SimpleNamespace(
+            _initialized=True,
+            load_skills=lambda: None,
+            match_skill=lambda *_: [],
+            get_skill=lambda *_: None,
+            get_skill_runtime_config=lambda *args, **kwargs: None,
+        ),
+    )
+
+    async def fake_responses(**kwargs):
+        raise AssertionError("llm_client.responses should not be called for unknown explicit skill switch")
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("/skill switch missing-skill", session_id="s1")
+    assert "Skill not found: missing-skill" in result["response"]
+    assert sess.active_skill_session["skill_name"] == "review-pull-request"
+
+
+@pytest.mark.asyncio
+async def test_clear_active_skill_command_emits_cleared_event_without_llm(monkeypatch, base_agent):
     agent, sess = base_agent
     sess.active_skill_session = {"skill_name": "runtime-skill", "status": "active"}
     monkeypatch.setattr(
@@ -604,9 +804,16 @@ async def test_clear_active_skill_command_clears_contract_without_llm(monkeypatc
 
     monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
 
-    result = await agent.process("/skill clear", session_id="s1")
+    events = []
+
+    def stream_callback(event_json: str):
+        events.append(event_json)
+
+    result = await agent.process("/skill clear", session_id="s1", stream_callback=stream_callback)
     assert result["response"] == "Active skill cleared."
     assert sess.active_skill_session is None
+    assert any('"type": "skill_contract_cleared"' in item for item in events)
+    assert any('"skill": "runtime-skill"' in item for item in events)
 
 
 @pytest.mark.asyncio

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -284,6 +284,79 @@ def test_skill_contract_compiler_preserves_priority_sections_when_truncated():
     assert len(compiled) <= 2600
 
 
+def test_skill_contract_compiler_preserves_reference_usage_when_output_contract_is_huge():
+    body = (
+        "# Huge Skill\n"
+        "Intro\n\n"
+        "## Output contract\n"
+        + ("schema detail line\n" * 1000)
+        + "\n## Reference usage\n"
+        "- Cite only provided references\n"
+        "- Do not invent external facts\n\n"
+        "## Constraints\n"
+        "- Stay within provided context\n"
+    )
+    skill = SimpleNamespace(
+        name="huge-output-contract",
+        description="desc",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body=body,
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+    )
+
+    compiled = compile_skill_prompt_contract(skill, max_chars=2500)
+
+    assert "Output contract" in compiled
+    assert "Reference usage" in compiled
+    assert "Cite only provided references" in compiled
+    assert "Constraints" in compiled
+    assert "Skill contract truncated" in compiled
+    assert len(compiled) <= 2600
+
+
+def test_skill_contract_compiler_preserves_all_critical_headings_under_tight_budget():
+    body = (
+        "# Huge Skill\n"
+        + ("intro filler\n" * 200)
+        + "\n## Output contract\n"
+        + ("output filler\n" * 300)
+        + "\n## Reference usage\n"
+        + ("reference filler\n" * 300)
+        + "\n## Constraints\n"
+        + ("constraint filler\n" * 300)
+        + "\n## Rules\n"
+        + ("rule filler\n" * 300)
+        + "\n## Tool policy\n"
+        + ("tool policy filler\n" * 300)
+        + "\n## Workflow\n"
+        + ("workflow filler\n" * 1000)
+    )
+    skill = SimpleNamespace(
+        name="tight-budget-skill",
+        description="desc",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body=body,
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+    )
+
+    compiled = compile_skill_prompt_contract(skill, max_chars=3500)
+
+    for heading in ["Output contract", "Reference usage", "Constraints", "Rules", "Tool policy"]:
+        assert heading in compiled
+    assert "Skill contract truncated" in compiled
+    assert len(compiled) <= 3600
+
+
 @pytest.mark.asyncio
 async def test_generate_initial_skill_plan_routes_through_execution_bus(monkeypatch):
     skill = SimpleNamespace(name="demo", description="demo desc", strategy=[], path="")

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -357,6 +357,28 @@ def test_skill_contract_compiler_preserves_all_critical_headings_under_tight_bud
     assert len(compiled) <= 3600
 
 
+def test_skill_contract_compiler_marks_overall_truncated_when_intro_only_body_is_capped():
+    body = "intro line\n" * 2000
+    skill = SimpleNamespace(
+        name="intro-only-huge-skill",
+        description="desc",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body=body,
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+    )
+
+    compiled = compile_skill_prompt_contract(skill, max_chars=12000)
+
+    assert "Section truncated due to skill contract budget" in compiled
+    assert "Skill contract truncated" in compiled
+    assert len(compiled) <= 12000
+
+
 @pytest.mark.asyncio
 async def test_generate_initial_skill_plan_routes_through_execution_bus(monkeypatch):
     skill = SimpleNamespace(name="demo", description="demo desc", strategy=[], path="")

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -46,6 +46,7 @@ class _Tracer:
 class _SessionManager:
     def __init__(self):
         self.messages = []
+        self.active_skill_session = None
 
     async def add_message(self, session_id, role, content, extra=None, wait_for_save=False):
         self.messages.append({"role": role, "content": content, **(extra or {})})
@@ -53,6 +54,12 @@ class _SessionManager:
 
     async def get_history(self, session_id):
         return list(self.messages)
+
+    async def get_active_skill_session(self, session_id):
+        return self.active_skill_session
+
+    async def set_active_skill_session(self, session_id, skill_session):
+        self.active_skill_session = skill_session
 
 
 @pytest.fixture
@@ -212,30 +219,58 @@ def test_create_pull_request_runtime_config_contains_expected_blocks():
     assert ("STEP 1" in instructions) or ("Phase 1" in instructions)
 
 
+def test_skill_contract_compiler_preserves_late_output_contract():
+    filler = "\n".join(f"- filler line {idx}" for idx in range(1, 65))
+    long_body = (
+        "# Runtime Skill\n"
+        "Intro text.\n\n"
+        "## Workflow\n"
+        f"{filler}\n\n"
+        "## Output contract\n"
+        "- Provide final checklist.\n\n"
+        "## Reference usage\n"
+        "- Cite provided references only.\n"
+    )
+    skill = SimpleNamespace(
+        name="long-skill",
+        description="desc",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body=long_body,
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+    )
+    runtime_config = build_skill_runtime_config(skill)
+    instructions = runtime_config.prompt_blocks.developer_instructions
+    assert "Output contract" in instructions
+    assert "Reference usage" in instructions
+
+
 @pytest.mark.asyncio
 async def test_generate_initial_skill_plan_routes_through_execution_bus(monkeypatch):
     skill = SimpleNamespace(name="demo", description="demo desc", strategy=[], path="")
 
-    class _FakeBus:
-        def __init__(self):
-            self.requests = []
+    calls = {"count": 0, "kwargs": None}
 
-        def register_handler(self, execution_type, handler):
-            self._handler = handler
+    async def _fake_execute_skill_orchestration(**kwargs):
+        calls["count"] += 1
+        calls["kwargs"] = kwargs
+        return SimpleNamespace(
+            status="success",
+            output_payload={"goal": "g", "steps": [{"id": "1", "type": "execute", "title": "t"}], "usage": {}},
+        )
 
-        async def execute(self, request):
-            self.requests.append(request)
-            return type("R", (), {"status": "success", "output_payload": {"goal": "g", "steps": [{"id": "1", "type": "execute", "title": "t"}], "usage": {}}})()
-
-    fake_bus = _FakeBus()
-    monkeypatch.setattr("src.runtime.build_default_execution_bus", lambda *args, **kwargs: fake_bus)
+    monkeypatch.setattr("src.runtime.chat_orchestration_adapter.execute_skill_orchestration", _fake_execute_skill_orchestration)
 
     goal, steps, usage = await generate_initial_skill_plan(skill, "do work", return_usage=False)
     assert goal == "g"
     assert steps[0]["id"] == "1"
     assert usage == {}
-    assert fake_bus.requests
-    assert fake_bus.requests[0].execution_type == "skill"
+    assert calls["count"] == 1
+    assert calls["kwargs"]["source_ref"] == "skill_mode.generate_initial_skill_plan"
 
     goal2, steps2, usage2 = await generate_initial_skill_plan(skill, "do work", return_usage=True)
     assert goal2 == "g"
@@ -270,14 +305,10 @@ async def test_generate_initial_skill_plan_falls_back_to_direct_on_bus_error(mon
 async def test_generate_initial_skill_plan_normalizes_malformed_payload(monkeypatch):
     skill = SimpleNamespace(name="demo", description="demo desc", strategy=[], path="")
 
-    class _FakeBus:
-        def register_handler(self, execution_type, handler):
-            self._handler = handler
+    async def _fake_execute_skill_orchestration(**kwargs):
+        return SimpleNamespace(status="success", output_payload={"goal": "", "steps": []})
 
-        async def execute(self, request):
-            return type("R", (), {"status": "success", "output_payload": {"goal": "", "steps": []}})()
-
-    monkeypatch.setattr("src.runtime.build_default_execution_bus", lambda *args, **kwargs: _FakeBus())
+    monkeypatch.setattr("src.runtime.chat_orchestration_adapter.execute_skill_orchestration", _fake_execute_skill_orchestration)
     goal, steps, usage = await generate_initial_skill_plan(skill, "do work")
     assert goal == "demo desc"
     assert steps  # fallback from _normalize_plan should not be empty
@@ -482,6 +513,100 @@ async def test_matched_skill_does_not_route_to_legacy_skill_mode(monkeypatch, ba
 
     result = await agent.process("runtime test", session_id="s1")
     assert result["response"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_active_skill_contract_continues_without_rematch(monkeypatch, base_agent):
+    agent, sess = base_agent
+    matched_skill = SimpleNamespace(
+        name="runtime-skill",
+        description="d",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Follow runtime contract instructions.",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+
+    class _Registry:
+        _initialized = True
+
+        def __init__(self):
+            self.match_calls = 0
+
+        def match_skill(self, *_args, **_kwargs):
+            self.match_calls += 1
+            if self.match_calls == 1:
+                return [matched_skill]
+            return []
+
+        def get_skill(self, name):
+            if name == matched_skill.name:
+                return matched_skill
+            return None
+
+        def get_skill_runtime_config(self, skill, globally_allowed_tool_names=None):
+            return build_skill_runtime_config(skill, globally_allowed_tool_names=globally_allowed_tool_names)
+
+    monkeypatch.setattr("src.skills.skill_registry", _Registry())
+
+    captured_system_prompts = []
+
+    async def fake_responses(**kwargs):
+        captured_system_prompts.append(kwargs.get("system_prompt", ""))
+        return {"content": "done", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    async def fail_start(*args, **kwargs):
+        raise AssertionError("legacy _start_skill_mode should not be called")
+
+    async def fail_continue(*args, **kwargs):
+        raise AssertionError("legacy _continue_skill_mode should not be called")
+
+    monkeypatch.setattr(agent, "_start_skill_mode", fail_start)
+    monkeypatch.setattr(agent, "_continue_skill_mode", fail_continue)
+
+    first = await agent.process("runtime test", session_id="s1")
+    second = await agent.process("continue", session_id="s1")
+
+    assert first["response"] == "done"
+    assert second["response"] == "done"
+    assert len(captured_system_prompts) == 2
+    assert "Active skill: runtime-skill" in captured_system_prompts[1]
+    assert "Skill Developer Instructions" in captured_system_prompts[1]
+    assert "Follow runtime contract instructions." in captured_system_prompts[1]
+    assert isinstance(sess.active_skill_session, dict)
+    assert sess.active_skill_session.get("turn_count", 0) >= 2
+
+
+@pytest.mark.asyncio
+async def test_clear_active_skill_command_clears_contract_without_llm(monkeypatch, base_agent):
+    agent, sess = base_agent
+    sess.active_skill_session = {"skill_name": "runtime-skill", "status": "active"}
+    monkeypatch.setattr(
+        "src.skills.skill_registry",
+        SimpleNamespace(
+            _initialized=True,
+            load_skills=lambda: None,
+            match_skill=lambda *_: [],
+            get_skill=lambda *_: None,
+            get_skill_runtime_config=lambda *args, **kwargs: None,
+        ),
+    )
+
+    async def fake_responses(**kwargs):
+        raise AssertionError("llm_client.responses should not be called for /skill clear")
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("/skill clear", session_id="s1")
+    assert result["response"] == "Active skill cleared."
+    assert sess.active_skill_session is None
 
 
 @pytest.mark.asyncio
@@ -1226,15 +1351,14 @@ def test_review_pull_request_backward_compatible_skill_command_invocation():
 
 @pytest.mark.asyncio
 async def test_core_tool_bus_helper_returns_tool_result_compatible_shape(monkeypatch):
-    class _FakeBus:
-        async def execute(self, request):
-            return make_execution_result(
-                request_id=request.request_id,
-                status="success",
-                output_payload={"success": True, "content": "tool-ok", "error": None},
-            )
+    async def _fake_execute_tool_or_task_orchestration(**kwargs):
+        return make_execution_result(
+            request_id="req-1",
+            status="success",
+            output_payload={"success": True, "content": "tool-ok", "error": None},
+        )
 
-    monkeypatch.setattr("src.agents.core.build_default_execution_bus", lambda *args, **kwargs: _FakeBus())
+    monkeypatch.setattr("src.agents.core.execute_tool_or_task_orchestration", _fake_execute_tool_or_task_orchestration)
     result = await _execute_tool_via_runtime_bus(
         session_id="s1",
         tool_name="demo_tool",
@@ -1252,19 +1376,15 @@ async def test_core_tool_bus_helper_returns_tool_result_compatible_shape(monkeyp
 async def test_core_tool_bus_helper_builds_bus_without_stale_execute_direct_kwarg(monkeypatch):
     captured_kwargs = {}
 
-    class _FakeBus:
-        async def execute(self, request):
-            return make_execution_result(
-                request_id=request.request_id,
-                status="success",
-                output_payload={"success": True, "content": "ok"},
-            )
-
-    def _fake_build_default_execution_bus(*args, **kwargs):
+    async def _fake_execute_tool_or_task_orchestration(**kwargs):
         captured_kwargs.update(kwargs)
-        return _FakeBus()
+        return make_execution_result(
+            request_id="req-2",
+            status="success",
+            output_payload={"success": True, "content": "ok"},
+        )
 
-    monkeypatch.setattr("src.agents.core.build_default_execution_bus", _fake_build_default_execution_bus)
+    monkeypatch.setattr("src.agents.core.execute_tool_or_task_orchestration", _fake_execute_tool_or_task_orchestration)
     await _execute_tool_via_runtime_bus(
         session_id="s1",
         tool_name="demo_tool",
@@ -1273,6 +1393,7 @@ async def test_core_tool_bus_helper_builds_bus_without_stale_execute_direct_kwar
         source_ref="test",
     )
 
+    assert "execute_tool_func" in captured_kwargs
     assert "execute_direct" not in captured_kwargs
 
 

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -828,6 +828,88 @@ async def test_active_skill_contract_switches_only_on_explicit_skill_command(mon
 
 
 @pytest.mark.asyncio
+async def test_explicit_skill_use_starts_skill_without_existing_contract(monkeypatch, base_agent):
+    agent, sess = base_agent
+
+    review_skill = SimpleNamespace(
+        name="review-pull-request",
+        description="review",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Review instructions",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+
+    monkeypatch.setattr(
+        "src.skills.skill_registry",
+        SimpleNamespace(
+            _initialized=True,
+            load_skills=lambda: None,
+            match_skill=lambda *_: [],
+            get_skill=lambda name: review_skill if name == "review-pull-request" else None,
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(
+                s, globally_allowed_tool_names=globally_allowed_tool_names
+            ),
+        ),
+    )
+
+    captured_prompts = []
+
+    async def fake_responses(**kwargs):
+        captured_prompts.append(kwargs.get("system_prompt", ""))
+        return {"content": "done", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("/skill use review-pull-request", session_id="s1")
+
+    assert result["response"] == "done"
+    assert "Active skill: review-pull-request" in captured_prompts[0]
+    assert sess.active_skill_session["skill_name"] == "review-pull-request"
+    assert sess.active_skill_session["activation_reason"] == "matched"
+
+
+@pytest.mark.asyncio
+async def test_explicit_skill_activate_unknown_without_existing_contract_returns_without_llm(monkeypatch, base_agent):
+    agent, sess = base_agent
+
+    monkeypatch.setattr(
+        "src.skills.skill_registry",
+        SimpleNamespace(
+            _initialized=True,
+            load_skills=lambda: None,
+            match_skill=lambda *_: [],
+            get_skill=lambda *_: None,
+            get_skill_runtime_config=lambda *args, **kwargs: None,
+        ),
+    )
+
+    async def fake_responses(**kwargs):
+        raise AssertionError("llm_client.responses should not be called for unknown explicit skill command")
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("/skill activate missing-skill", session_id="s1")
+
+    assert "Skill not found: missing-skill" in result["response"]
+    assert sess.active_skill_session is None
+
+
+def test_parse_explicit_skill_switch_name_requires_name_for_switch_use_activate():
+    from src.skills.active_contract import parse_explicit_skill_switch_name
+
+    assert parse_explicit_skill_switch_name("/skill switch") == ""
+    assert parse_explicit_skill_switch_name("/skill use") == ""
+    assert parse_explicit_skill_switch_name("/skill activate") == ""
+    assert parse_explicit_skill_switch_name("/skill use review-pull-request") == "review-pull-request"
+
+
+@pytest.mark.asyncio
 async def test_active_skill_contract_unknown_explicit_switch_returns_without_llm(monkeypatch, base_agent):
     agent, sess = base_agent
     sess.active_skill_session = {


### PR DESCRIPTION
### Motivation

- Persist a matched prompt-skill as a session-level `active_skill_session` so subsequent user messages (like “continue”) keep running under the same skill contract instead of only applying the skill for a single turn.  
- Prevent re-introducing legacy `skill_mode` execution paths and keep runtime skill behavior unified in the agent loop.  
- Fix the existing prompt truncation bug that sliced the skill body to the first 40 lines and thereby lost late sections such as `## Output contract` and `## Reference usage`.

### Description

- Added a small helper module `src/skills/active_contract.py` providing `ACTIVE_SKILL_CONTRACT_VERSION`, `is_clear_active_skill_command`, `get_contract_skill_name`, `is_active_skill_contract_usable`, and `build_active_skill_contract` to construct compact session contracts (no full prompt text) including `turn_count`, `goal`, `skill_hash`, `prompt_contract_summary`, timestamps, and tool-policy preview fields.  
- Replaced fixed "first 40 lines" truncation in `src/skills/runtime.py` with a section-aware compiler `compile_skill_prompt_contract()` that preserves intro + priority sections (`output contract`, `reference usage`, `constraints`, `workflow`, etc.), truncates by character limit if needed, and appends a truncation note; and strengthened `system_rules` to enforce active contract semantics in the LLM system prompt.  
- Updated agent matching loop in `src/agents/core.py` to: read `existing_active_skill_contract` from `session_manager.get_active_skill_session(session_id)` before matching; clear and return immediately on explicit `/skill clear` commands without calling the LLM; select `matched / switched / continued` activation reasons; build and persist the active contract via `build_active_skill_contract(...)`; ensure `get_effective_skill_runtime_prompt(...)` still receives `active_skill_runtime` each round so LLM keeps the contract; emit new `skill_contract_active` events and use `skill_contract_continued` log for continuations; avoid calling legacy `_start_skill_mode()` / `_continue_skill_mode()`.  
- Added compact active-skill preview enrichment to Portal metadata in `src/gateway/webchat.py` and allowed those keys in `src/runtime/portal_session_metadata_client.py` control-plane keys, while explicitly avoiding publishing the full `active_skill_session` object to Portal.  
- Persisted `skill_session` into intermediate local chatlog saves in `src/agents/core.py` (local chatlogs only) to aid recovery and debugging.  
- Tests and test-support updates: updated the test fake `_SessionManager` to implement `get_active_skill_session`/`set_active_skill_session`; added `tests/test_skill_runtime_refactor.py` tests `test_skill_contract_compiler_preserves_late_output_contract`, `test_active_skill_contract_continues_without_rematch`, and `test_clear_active_skill_command_clears_contract_without_llm`; and added `tests/test_portal_session_metadata_client.py::test_build_session_metadata_payload_preserves_active_skill_preview_keys` to validate Portal payload keys.  

### Testing

- Ran unit tests for the change set: `pytest tests/test_skill_runtime_refactor.py tests/test_portal_session_metadata_client.py -q`, and broader validation `pytest tests/test_session_manager.py tests/test_recovery_pipeline.py -q`, and all tests passed.  
- New/updated tests executed include `test_skill_contract_compiler_preserves_late_output_contract`, `test_active_skill_contract_continues_without_rematch`, `test_clear_active_skill_command_clears_contract_without_llm`, and `test_build_session_metadata_payload_preserves_active_skill_preview_keys`, and they passed.  
- Verified legacy behavior constraints: the existing `test_matched_skill_does_not_route_to_legacy_skill_mode` still passes under the new flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e367b7d678832ab7f544c18c99bad4)