### PR TITLE
Respect Jira/Confluence tool outputs: increase default feedback limit and make core-level truncation per-tool

### DIFF
--- a/src/agents/compaction.py
+++ b/src/agents/compaction.py
@@ -54,21 +54,26 @@ class AgentMessage:
         timestamp: Optional[int] = None,
         tool_calls: Optional[List[Dict]] = None,
         tool_use_id: Optional[str] = None,
+        tool_name: Optional[str] = None,
     ):
         self.role = role
         self.content = content
         self.timestamp = timestamp or int(__import__("time").time())
         self.tool_calls = tool_calls
         self.tool_use_id = tool_use_id
+        self.tool_name = tool_name
     
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        data = {
             "role": self.role,
             "content": self.content,
             "timestamp": self.timestamp,
             "tool_calls": self.tool_calls,
             "tool_use_id": self.tool_use_id,
         }
+        if self.tool_name:
+            data["tool_name"] = self.tool_name
+        return data
     
     @classmethod
     def from_dict(cls, data: Dict) -> "AgentMessage":
@@ -78,6 +83,7 @@ class AgentMessage:
             timestamp=data.get("timestamp"),
             tool_calls=data.get("tool_calls"),
             tool_use_id=data.get("tool_use_id"),
+            tool_name=data.get("tool_name"),
         )
     
     def __repr__(self) -> str:
@@ -644,6 +650,7 @@ def fix_tool_call_consistency(messages: List[AgentMessage]) -> List[AgentMessage
                 timestamp=msg.timestamp,
                 tool_calls=valid_calls if valid_calls else None,
                 tool_use_id=msg.tool_use_id,
+                tool_name=getattr(msg, "tool_name", None),
             ))
         elif msg.role == "tool":
             # Keep only tool responses whose tool_use_id appears in some assistant.tool_calls

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -159,11 +159,35 @@ def get_skill_workdir() -> Optional[str]:
 
 _DEBUG_ENABLED = None  # Lazy initialization
 _TOOL_RESULT_GOVERNANCE_ATTR = "_governance"
+DEFAULT_TOOL_FEEDBACK_MAX_LENGTH = 8000
+UNBOUNDED_TOOL_FEEDBACK_PREFIXES = ("jira_", "confluence_")
 
 
-def _tool_feedback_text(value: Any, max_length: int = 4000) -> str:
-    """Build bounded tool feedback text for next-round LLM input only."""
-    return truncate_with_count(str(value), max_length)
+def _is_unbounded_tool_feedback(tool_name: Optional[str]) -> bool:
+    """Return True when tool feedback should skip core truncation."""
+    return bool(tool_name) and tool_name.startswith(UNBOUNDED_TOOL_FEEDBACK_PREFIXES)
+
+
+def _tool_feedback_text(
+    value: Any,
+    max_length: Optional[int] = DEFAULT_TOOL_FEEDBACK_MAX_LENGTH,
+) -> str:
+    """Build bounded tool feedback text for next-round LLM input only.
+
+    max_length <= 0 or None means no core-level truncation.
+    """
+    text = str(value)
+    if not text:
+        return "(empty)"
+    if max_length is None or max_length <= 0:
+        return text
+    return truncate_with_count(text, max_length)
+
+
+def _tool_feedback_text_for_tool(tool_name: Optional[str], value: Any) -> str:
+    """Build tool feedback for the next LLM call using per-tool truncation policy."""
+    max_length = None if _is_unbounded_tool_feedback(tool_name) else DEFAULT_TOOL_FEEDBACK_MAX_LENGTH
+    return _tool_feedback_text(value, max_length=max_length)
 
 
 def _is_debug_enabled() -> bool:
@@ -1260,6 +1284,19 @@ You have access to the following tools. When a user asks you to do something tha
         # Convert messages to input_items for Responses API
         def _to_input_items(msgs):
             items = []
+            tool_names_by_call_id = {}
+
+            def _feedback_output_for_message(msg: Dict[str, Any], content: Any) -> str:
+                if not content:
+                    return ""
+                call_id = msg.get("tool_call_id", "")
+                tool_name = (
+                    msg.get("tool_name")
+                    or msg.get("name")
+                    or tool_names_by_call_id.get(call_id)
+                )
+                return _tool_feedback_text_for_tool(tool_name, content)
+
             for msg in msgs:
                 role = msg.get("role", "user")
                 
@@ -1270,7 +1307,7 @@ You have access to the following tools. When a user asks you to do something tha
                     items.append({
                         "type": "function_call_output",
                         "call_id": tool_call_id,
-                        "output": _tool_feedback_text(content) if content else "",
+                        "output": _feedback_output_for_message(msg, content),
                     })
                     continue
                 
@@ -1294,6 +1331,8 @@ You have access to the following tools. When a user asks you to do something tha
                         name = func.get("name", "")
                         args = func.get("arguments", {})
                         args_str = args if isinstance(args, str) else json.dumps(args)
+                        if call_id and name:
+                            tool_names_by_call_id[call_id] = name
                         items.append({
                             "type": "function_call",
                             "call_id": call_id,
@@ -1308,7 +1347,7 @@ You have access to the following tools. When a user asks you to do something tha
                     items.append({
                         "type": "function_call_output",
                         "call_id": tool_call_id,
-                        "output": _tool_feedback_text(content) if content else "",
+                        "output": _feedback_output_for_message(msg, content),
                     })
                     continue
                 
@@ -1795,8 +1834,9 @@ You have access to the following tools. When a user asks you to do something tha
                         loop_messages.append(
                             {
                                 "role": "tool",
-                                "content": _tool_feedback_text(deny_result),
+                                "content": _tool_feedback_text_for_tool(tool_name, deny_result),
                                 "tool_call_id": call_id,
+                                "tool_name": tool_name,
                             }
                         )
                         executed_tool_results.append((tool_name, deny_result))
@@ -1830,8 +1870,9 @@ You have access to the following tools. When a user asks you to do something tha
                     loop_messages.append(
                         {
                             "role": "tool",
-                            "content": _tool_feedback_text(short_result),
+                            "content": _tool_feedback_text_for_tool(tool_name, short_result),
                             "tool_call_id": call_id,
+                            "tool_name": tool_name,
                         }
                     )
                     send_event("tool_result", {
@@ -1913,8 +1954,9 @@ You have access to the following tools. When a user asks you to do something tha
                 # The tool result naturally comes after the assistant message in the iteration order.
                 tool_result_msg = {
                     "role": "tool",
-                    "content": _tool_feedback_text(tool_result),
+                    "content": _tool_feedback_text_for_tool(tool_name, tool_result),
                     "tool_call_id": call_id,
+                    "tool_name": tool_name,
                 }
                 
                 # Append tool result to end of loop_messages
@@ -2438,7 +2480,7 @@ You have access to the following tools. When a user asks you to do something tha
                         args=normalized_args,
                         source_ref="agents.core.skill_mode_loop",
                     )
-                    output_text = _tool_feedback_text(tool_result)
+                    output_text = _tool_feedback_text_for_tool(tool_name, tool_result)
                     logger.debug(f"[SkillMode] [TOOL_RESULT] tool={tool_name}, result length={len(output_text)}, preview={safe_preview(output_text, 200)}")
                 except Exception as tool_exc:
                     output_text = f"Error: Tool '{tool_name}' failed with {tool_exc}"

--- a/src/confluence/__init__.py
+++ b/src/confluence/__init__.py
@@ -566,7 +566,7 @@ def get_tools_schemas() -> list:
                         },
                         "max_chars": {
                             "type": "integer",
-                            "description": "Maximum characters to return (avoid token overflow)"
+                            "description": "Optional explicit response shortening. Leave unset for full Confluence page content; do not set unless the user explicitly asks for a shortened response."
                         }
                     },
                     "required": ["page_id"]
@@ -590,7 +590,7 @@ def get_tools_schemas() -> list:
                         },
                         "max_chars": {
                             "type": "integer",
-                            "description": "Maximum characters to return (avoid token overflow)"
+                            "description": "Optional explicit response shortening. Leave unset for full Confluence page content; do not set unless the user explicitly asks for a shortened response."
                         }
                     },
                     "required": ["url"]

--- a/src/confluence/__init__.py
+++ b/src/confluence/__init__.py
@@ -206,7 +206,7 @@ async def confluence_get_page(
     Args:
         page_id: Page ID
         format: "markdown" (default) or "storage"
-        max_chars: Maximum characters to return (avoid token overflow)
+        max_chars: Optional explicit response shortening. Leave None for full Confluence page content.
     """
     try:
         if not confluence_channel.is_configured():
@@ -253,7 +253,7 @@ async def confluence_get_page_by_url(
     Args:
         url: Full Confluence page URL
         format: "markdown" (default) or "storage"
-        max_chars: Maximum characters to return
+        max_chars: Optional explicit response shortening. Leave None for full Confluence page content.
     """
     try:
         page_id = _extract_page_id_from_url(url)

--- a/src/confluence/adapter.py
+++ b/src/confluence/adapter.py
@@ -64,7 +64,7 @@ class ConfluenceFormatAdapter:
         Args:
             page_id: Page ID
             format: "markdown" (default) or "storage"
-            max_chars: Limit response length (avoid token overflow)
+            max_chars: Optional explicit response shortening. Leave None for full Confluence page content.
             
         Returns:
             Page content in requested format
@@ -98,7 +98,7 @@ class ConfluenceFormatAdapter:
         Args:
             url: Full Confluence page URL
             format: "markdown" (default) or "storage"
-            max_chars: Limit response length
+            max_chars: Optional explicit response shortening. Leave None for full Confluence page content.
             
         Returns:
             Page content in requested format

--- a/src/jira/__init__.py
+++ b/src/jira/__init__.py
@@ -118,7 +118,7 @@ async def jira_get_issue(
     Args:
         issue_key: Jira issue key (e.g., 'PROJ-123')
         format: Output format - "markdown" (default), "wiki", or "raw"
-        max_chars: Maximum characters to return
+        max_chars: Optional explicit response shortening. Leave None for full Jira issue content.
         max_comments: Maximum number of comments to include
         include_fields: Fields to include (default: summary, status, description, comments)
         include_comments: Whether to include comments
@@ -183,7 +183,7 @@ async def jira_get_issue_by_url(
     Args:
         url: Full Jira issue URL (e.g., https://company.atlassian.net/browse/PROJ-123)
         format: Output format - "markdown" (default), "wiki", or "raw"
-        max_chars: Maximum characters to return
+        max_chars: Optional explicit response shortening. Leave None for full Jira issue content.
         max_comments: Maximum number of comments to include
         include_fields: Fields to include
         include_comments: Whether to include comments

--- a/src/jira/__init__.py
+++ b/src/jira/__init__.py
@@ -413,7 +413,7 @@ def _get_all_schemas() -> list:
                         },
                         "max_chars": {
                             "type": "integer",
-                            "description": "Maximum characters to return"
+                            "description": "Optional explicit response shortening. Leave unset for full Jira issue content; do not set when generating requirements/features unless the user explicitly asks for a shortened response."
                         },
                         "max_comments": {
                             "type": "integer",
@@ -455,7 +455,10 @@ def _get_all_schemas() -> list:
                             "default": "markdown",
                             "description": "Output format: markdown, wiki, or raw"
                         },
-                        "max_chars": {"type": "integer", "description": "Maximum characters to return"},
+                        "max_chars": {
+                            "type": "integer",
+                            "description": "Optional explicit response shortening. Leave unset for full Jira issue content; do not set when generating requirements/features unless the user explicitly asks for a shortened response."
+                        },
                         "max_comments": {"type": "integer", "description": "Maximum comments to include", "default": 5},
                         "include_comments": {"type": "boolean", "description": "Include comments", "default": True},
                         "include_attachment_urls": {

--- a/src/jira/adapter.py
+++ b/src/jira/adapter.py
@@ -65,7 +65,7 @@ class JiraFormatAdapter:
         Args:
             issue_key: Jira issue key (e.g., 'PROJ-123')
             format: Output format - "markdown" (default), "wiki", or "raw"
-            max_chars: Maximum characters to return
+            max_chars: Optional explicit response shortening. Leave None for full Jira issue content.
             max_comments: Maximum number of comments to include
             include_fields: Fields to include (default: summary, status, description, comments)
             include_comments: Whether to include comments

--- a/src/runtime/progressive_context.py
+++ b/src/runtime/progressive_context.py
@@ -33,6 +33,7 @@ def _to_agent_messages(messages: List[Dict[str, Any]]) -> List[AgentMessage]:
             timestamp=msg.get("timestamp"),
             tool_calls=msg.get("tool_calls"),
             tool_use_id=msg.get("tool_call_id") or msg.get("tool_use_id"),
+            tool_name=msg.get("tool_name"),
         )
         for msg in messages
         if isinstance(msg, dict)
@@ -49,6 +50,8 @@ def _to_dict_messages(messages: Sequence[AgentMessage]) -> List[Dict[str, Any]]:
             item["tool_calls"] = msg.tool_calls
         if msg.tool_use_id:
             item["tool_call_id"] = msg.tool_use_id
+        if getattr(msg, "tool_name", None):
+            item["tool_name"] = msg.tool_name
         result.append(item)
     return result
 
@@ -102,6 +105,7 @@ def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) 
                         content=f"[tool_result compacted | original_chars={len(content_text)}] {preview}",
                         timestamp=msg.timestamp,
                         tool_use_id=msg.tool_use_id,
+                        tool_name=getattr(msg, "tool_name", None),
                     )
                 )
                 continue
@@ -122,6 +126,7 @@ def _micro_compact_messages(messages: List[AgentMessage], *, recent_count: int) 
                         timestamp=msg.timestamp,
                         tool_calls=msg.tool_calls,
                         tool_use_id=msg.tool_use_id,
+                        tool_name=getattr(msg, "tool_name", None),
                     )
                 )
                 continue
@@ -187,6 +192,7 @@ def _trim_full_compaction_result_to_budget(
         timestamp=summary_message.timestamp,
         tool_calls=summary_message.tool_calls,
         tool_use_id=summary_message.tool_use_id,
+        tool_name=getattr(summary_message, "tool_name", None),
     )
     return fix_tool_call_consistency([shortened_summary])
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -655,3 +655,46 @@ async def test_generate_summary_returns_structured_context_summary():
     assert "Objective:" in summary
     assert "Next step:" in summary
     assert "User asked about" not in summary
+
+
+def test_agent_message_preserves_tool_name_metadata():
+    from src.agents.compaction import AgentMessage
+
+    msg = AgentMessage(
+        role="tool",
+        content="result",
+        timestamp=12345,
+        tool_use_id="call_1",
+        tool_name="jira_get_issue",
+    )
+
+    data = msg.to_dict()
+    assert data["tool_name"] == "jira_get_issue"
+
+    restored = AgentMessage.from_dict(data)
+    assert restored.tool_name == "jira_get_issue"
+    assert restored.tool_use_id == "call_1"
+
+
+def test_fix_tool_call_consistency_preserves_tool_name_metadata_on_rebuilt_messages():
+    from src.agents.compaction import AgentMessage, fix_tool_call_consistency
+
+    messages = [
+        AgentMessage(
+            role="assistant",
+            content="Calling Jira",
+            tool_calls=[{"id": "call_1", "function": {"name": "jira_get_issue", "arguments": "{}"}}],
+            tool_name="jira_get_issue",
+        ),
+        AgentMessage(
+            role="tool",
+            content="full jira content",
+            tool_use_id="call_1",
+            tool_name="jira_get_issue",
+        ),
+    ]
+
+    result = fix_tool_call_consistency(messages)
+
+    assert result[0].tool_name == "jira_get_issue"
+    assert result[1].tool_name == "jira_get_issue"

--- a/tests/test_confluence_markdown.py
+++ b/tests/test_confluence_markdown.py
@@ -251,6 +251,7 @@ class TestToolSchemas:
         props = get_page_schema["function"]["parameters"]["properties"]
         
         assert "max_chars" in props
+        assert "Leave unset for full Confluence page content" in props["max_chars"]["description"]
     
     def test_create_page_schema_has_body_format(self):
         """Test confluence_create_page schema includes body_format parameter."""

--- a/tests/test_confluence_markdown.py
+++ b/tests/test_confluence_markdown.py
@@ -252,6 +252,16 @@ class TestToolSchemas:
         
         assert "max_chars" in props
         assert "Leave unset for full Confluence page content" in props["max_chars"]["description"]
+
+    def test_confluence_get_page_by_url_schema_max_chars_description_prefers_unset_default(self):
+        from src.confluence import get_tools_schemas
+
+        schemas = get_tools_schemas()
+        schema = next(s for s in schemas if s["function"]["name"] == "confluence_get_page_by_url")
+        desc = schema["function"]["parameters"]["properties"]["max_chars"]["description"]
+
+        assert "Leave unset for full Confluence page content" in desc
+        assert "do not set unless the user explicitly asks" in desc
     
     def test_create_page_schema_has_body_format(self):
         """Test confluence_create_page schema includes body_format parameter."""

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -127,6 +127,26 @@ def test_tool_feedback_text_for_non_jira_confluence_uses_default_8000_limit():
     assert len(output) < len(long_value)
 
 
+def test_unbounded_tool_feedback_prefix_policy_is_prefix_based():
+    from src.agents import core
+
+    assert core._is_unbounded_tool_feedback("jira_get_issue") is True
+    assert core._is_unbounded_tool_feedback("jira_future_bundle") is True
+    assert core._is_unbounded_tool_feedback("confluence_get_page") is True
+    assert core._is_unbounded_tool_feedback("confluence_future_tool") is True
+    assert core._is_unbounded_tool_feedback("github_get_pull_request") is False
+    assert core._is_unbounded_tool_feedback("") is False
+    assert core._is_unbounded_tool_feedback(None) is False
+
+
+def test_tool_feedback_text_allows_explicit_unbounded_max_length():
+    from src.agents import core
+
+    value = "A" * 20000
+    assert core._tool_feedback_text(value, max_length=None) == value
+    assert core._tool_feedback_text(value, max_length=0) == value
+
+
 def test_agent_process_source_uses_per_tool_feedback_policy_for_all_tool_feedback_paths():
     from src.agents import core
 

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -84,36 +84,65 @@ def test_tool_feedback_text_preserves_short_text():
     assert "chars hidden" not in core._tool_feedback_text(value)
 
 
-def test_tool_feedback_text_truncates_long_text_with_count():
+def test_tool_feedback_text_truncates_long_text_with_count_at_default_8000():
     from src.agents import core
 
-    long_value = "A" * 5005
+    long_value = "A" * 9005
     output = core._tool_feedback_text(long_value)
 
-    assert output.startswith("A" * 20)
-    assert "chars hidden" in output
+    assert output.startswith("A" * 8000)
+    assert "1005 chars hidden" in output
     assert len(output) < len(long_value)
 
 
-def test_agent_process_source_uses_tool_feedback_text_for_all_tool_feedback_paths():
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "jira_get_issue",
+        "jira_get_issue_by_url",
+        "jira_search",
+        "confluence_get_page",
+        "confluence_get_page_by_url",
+        "confluence_get_comments",
+    ],
+)
+def test_tool_feedback_text_for_jira_and_confluence_is_unbounded(tool_name):
+    from src.agents import core
+
+    long_value = "A" * 20000
+    output = core._tool_feedback_text_for_tool(tool_name, long_value)
+
+    assert output == long_value
+    assert "chars hidden" not in output
+
+
+def test_tool_feedback_text_for_non_jira_confluence_uses_default_8000_limit():
+    from src.agents import core
+
+    long_value = "A" * 9005
+    output = core._tool_feedback_text_for_tool("github_get_pull_request", long_value)
+
+    assert output.startswith("A" * 8000)
+    assert "1005 chars hidden" in output
+    assert len(output) < len(long_value)
+
+
+def test_agent_process_source_uses_per_tool_feedback_policy_for_all_tool_feedback_paths():
     from src.agents import core
 
     process_source = inspect.getsource(core.Agent.process)
     module_source = inspect.getsource(core)
 
     # Agent.process should cover deny / short-circuit / normal tool result feedback.
-    assert process_source.count("_tool_feedback_text(") >= 3
+    assert process_source.count("_tool_feedback_text_for_tool(") >= 3
     # Module-level coverage also includes skill mode function_call_output feedback.
-    assert module_source.count("_tool_feedback_text(") >= 4
+    assert module_source.count("_tool_feedback_text_for_tool(") >= 4
 
 
-def test_to_input_items_source_bounds_historical_function_call_output_content():
+def test_to_input_items_source_uses_per_tool_feedback_policy():
     from src.agents import core
 
     module_source = inspect.getsource(core)
-    expected = '"output": _tool_feedback_text(content) if content else ""'
-
-    # Historical tool feedback can flow through two branches in _to_input_items:
-    # 1) role == "tool" with tool_call_id
-    # 2) generic fallback with tool_call_id
-    assert module_source.count(expected) >= 2
+    assert '"output": _tool_feedback_text(content) if content else ""' not in module_source
+    assert "_tool_feedback_text_for_tool(" in module_source
+    assert "tool_names_by_call_id" in module_source

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -31,6 +31,17 @@ def test_jira_get_issue_schema_max_chars_description_prefers_unset_default():
     assert "Leave unset for full Jira issue content" in max_chars_desc
 
 
+def test_jira_get_issue_by_url_schema_max_chars_description_prefers_unset_default():
+    from src.jira import get_tools_schemas
+
+    schemas = get_tools_schemas()
+    schema = next(s for s in schemas if s["function"]["name"] == "jira_get_issue_by_url")
+    desc = schema["function"]["parameters"]["properties"]["max_chars"]["description"]
+
+    assert "Leave unset for full Jira issue content" in desc
+    assert "do not set when generating requirements/features" in desc
+
+
 @pytest.mark.asyncio
 async def test_jira_update_issue_summary_only(mock_jira_channel):
     """Test jira_update_issue with summary only"""

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -21,6 +21,16 @@ async def test_jira_update_issue(mock_jira_channel):
     assert "updated successfully" in result or "Error" in result
 
 
+def test_jira_get_issue_schema_max_chars_description_prefers_unset_default():
+    from src.jira import get_tools_schemas
+
+    schemas = get_tools_schemas()
+    get_issue_schema = next(s for s in schemas if s["function"]["name"] == "jira_get_issue")
+    max_chars_desc = get_issue_schema["function"]["parameters"]["properties"]["max_chars"]["description"]
+
+    assert "Leave unset for full Jira issue content" in max_chars_desc
+
+
 @pytest.mark.asyncio
 async def test_jira_update_issue_summary_only(mock_jira_channel):
     """Test jira_update_issue with summary only"""

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -327,3 +327,20 @@ def test_build_portal_context_preview_returns_preview_keys_only():
         "context_summary_preview": "A concise summary",
         "context_next_step_preview": "Continue",
     }
+
+
+def test_progressive_context_dict_roundtrip_preserves_tool_name():
+    messages = [
+        {
+            "role": "tool",
+            "content": "full jira content",
+            "tool_call_id": "call_1",
+            "tool_name": "jira_get_issue",
+        }
+    ]
+
+    agent_messages = progressive_context._to_agent_messages(messages)
+    restored = progressive_context._to_dict_messages(agent_messages)
+
+    assert restored[0]["tool_name"] == "jira_get_issue"
+    assert restored[0]["tool_call_id"] == "call_1"


### PR DESCRIPTION
### Motivation
- Agent Core was automatically truncating all tool outputs to 4000 chars before feeding them back to the LLM, which caused Jira/Confluence content (ACs, page bodies) to be cut unexpectedly.
- The intent is to keep protective truncation for noisy tools while allowing Jira/Confluence tools to pass full content by default and raise the core default limit to reduce unnecessary truncation.

### Description
- Introduced module-level constants `DEFAULT_TOOL_FEEDBACK_MAX_LENGTH = 8000` and `UNBOUNDED_TOOL_FEEDBACK_PREFIXES = ("jira_", "confluence_")` and added per-tool helpers `
`_is_unbounded_tool_feedback`
`, `
`_tool_feedback_text`
` and `
`_tool_feedback_text_for_tool`
` in `src/agents/core.py` to implement per-tool truncation policy (Jira/Confluence unbounded; others default to 8000).
- Replaced the old `_tool_feedback_text(..., max_length=4000)` implementation with the new logic and preserved the `(empty)` behavior for empty content.
- Fixed `_to_input_items()` to build a `call_id -> tool_name` mapping and use a `_feedback_output_for_message` helper so historical `function_call_output` items use `
`_tool_feedback_text_for_tool`
` (removing the legacy fixed second-pass truncation).
- Updated the agent tool-result append paths (deny, short-circuit, normal) to use `
`_tool_feedback_text_for_tool(tool_name, ...)`
` and to include `"tool_name": tool_name` metadata on appended tool messages for reliable identification in the next conversion step.
- Applied the same per-tool policy to skill-mode tool feedback so skill-mode function call outputs also respect Jira/Confluence passthrough.
- Updated Jira and Confluence tool schema `max_chars` descriptions in `src/jira/__init__.py` and `src/confluence/__init__.py` to clarify it is an optional explicit shortening flag and should be left unset for full content.
- Updated tests to reflect the new default and behavior: `tests/test_core_runtime_boundary.py`, `tests/test_confluence_markdown.py`, and `tests/test_jira_tools.py` were adjusted/extended to assert the 8000 default, Jira/Confluence passthrough, and the updated schema descriptions.

### Testing
- Ran `pytest tests/test_core_runtime_boundary.py` and all tests passed (17 passed).
- Ran `pytest tests/test_confluence_markdown.py` and `pytest tests/test_jira_tools.py` and all tests passed.
- Performed a quick runtime sanity check with a Python snippet exercising `
`_tool_feedback_text_for_tool`
` for normal, Jira, and Confluence outputs, which printed `OK` (assertions passed).

Unresolved risk: allowing full Jira/Confluence content into LLM context increases token usage and may affect prompt size/cost in long documents; this is an intentional trade-off to avoid inadvertent truncation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5803b4580832a9827be6bb82579fe)