### PR TITLE
Append terminal post-turn context_snapshot runtime event after chat execution

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -137,6 +137,92 @@ def _build_runtime_event_record(event_type: str, event_data: Dict[str, Any]) -> 
         "ts": datetime.utcnow().isoformat() + "Z",
     }
 
+
+def _is_meaningful_context_state(value: Any) -> bool:
+    if not isinstance(value, dict) or not value:
+        return False
+
+    text_fields = (
+        "objective",
+        "summary",
+        "current_state",
+        "next_step",
+        "recovery_context_message",
+        "compaction_level",
+    )
+    for field in text_fields:
+        field_value = value.get(field)
+        if isinstance(field_value, str) and field_value.strip():
+            return True
+
+    list_fields = ("constraints", "decisions", "open_loops")
+    for field in list_fields:
+        field_value = value.get(field)
+        if isinstance(field_value, list) and field_value:
+            for item in field_value:
+                if str(item).strip():
+                    return True
+
+    budget = value.get("budget")
+    if isinstance(budget, dict):
+        for budget_value in budget.values():
+            if budget_value not in (None, "", [], {}):
+                return True
+
+    return False
+
+
+def _build_terminal_context_snapshot_event(
+    *,
+    context_state: Dict[str, Any],
+    session_id: str,
+    agent_id: Optional[str],
+    request_id: Optional[str],
+    status: str,
+) -> Optional[Dict[str, Any]]:
+    if not _is_meaningful_context_state(context_state):
+        return None
+
+    budget = context_state.get("budget") if isinstance(context_state.get("budget"), dict) else {}
+    event_data = {
+        "stage": "post_turn",
+        "terminal": True,
+        "state": status,
+        "message": "Final context snapshot",
+        "summary": "Final context snapshot",
+        "context_state": context_state,
+        "budget": budget,
+    }
+    enriched_event_data = _enrich_runtime_event_context(
+        event_data,
+        session_id=session_id,
+        agent_id=agent_id,
+        request_id=request_id,
+    )
+    return _build_runtime_event_record("context_snapshot", enriched_event_data)
+
+
+def _has_terminal_post_turn_context_snapshot(events: Any) -> bool:
+    if not isinstance(events, list):
+        return False
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type") or event.get("event_type")
+        if event_type != "context_snapshot":
+            continue
+        data_payload = event.get("data") if isinstance(event.get("data"), dict) else {}
+        detail_payload = event.get("detail_payload") if isinstance(event.get("detail_payload"), dict) else {}
+        stage = data_payload.get("stage")
+        if stage is None:
+            stage = detail_payload.get("stage")
+        terminal = data_payload.get("terminal")
+        if terminal is None:
+            terminal = detail_payload.get("terminal")
+        if stage == "post_turn" and terminal is True:
+            return True
+    return False
+
 # Context variable for skill workdir - async-safe
 _skill_workdir: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar('skill_workdir', default=None)
 
@@ -2856,6 +2942,23 @@ async def run_chat_execution(
     )
     if isinstance(result, dict):
         result["context_state"] = context_state
+        if _is_meaningful_context_state(context_state):
+            runtime_events = result.get("runtime_events")
+            if not isinstance(runtime_events, list):
+                runtime_events = []
+                result["runtime_events"] = runtime_events
+
+            if not _has_terminal_post_turn_context_snapshot(runtime_events):
+                status = "failed" if result.get("error") else "completed"
+                terminal_context_event = _build_terminal_context_snapshot_event(
+                    context_state=context_state,
+                    session_id=session_id,
+                    agent_id=getattr(agent, "agent_id", None),
+                    request_id=request_id,
+                    status=status,
+                )
+                if terminal_context_event:
+                    runtime_events.append(terminal_context_event)
         if request_id:
             result.setdefault("request_id", request_id)
     return result

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -2941,6 +2941,12 @@ async def run_chat_execution(
         model=getattr(agent, "model", None),
     )
     if isinstance(result, dict):
+        effective_request_id = request_id
+        if not effective_request_id:
+            candidate_request_id = result.get("request_id")
+            if candidate_request_id:
+                effective_request_id = str(candidate_request_id)
+
         result["context_state"] = context_state
         if _is_meaningful_context_state(context_state):
             runtime_events = result.get("runtime_events")
@@ -2954,13 +2960,13 @@ async def run_chat_execution(
                     context_state=context_state,
                     session_id=session_id,
                     agent_id=getattr(agent, "agent_id", None),
-                    request_id=request_id,
+                    request_id=effective_request_id,
                     status=status,
                 )
                 if terminal_context_event:
                     runtime_events.append(terminal_context_event)
-        if request_id:
-            result.setdefault("request_id", request_id)
+        if effective_request_id:
+            result.setdefault("request_id", effective_request_id)
     return result
 
 

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -219,7 +219,10 @@ def _has_terminal_post_turn_context_snapshot(events: Any) -> bool:
         terminal = data_payload.get("terminal")
         if terminal is None:
             terminal = detail_payload.get("terminal")
-        if stage == "post_turn" and terminal is True:
+        context_state = data_payload.get("context_state")
+        if not _is_meaningful_context_state(context_state):
+            context_state = detail_payload.get("context_state")
+        if stage == "post_turn" and terminal is True and _is_meaningful_context_state(context_state):
             return True
     return False
 

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -166,3 +166,87 @@ def test_to_input_items_source_uses_per_tool_feedback_policy():
     assert '"output": _tool_feedback_text(content) if content else ""' not in module_source
     assert "_tool_feedback_text_for_tool(" in module_source
     assert "tool_names_by_call_id" in module_source
+
+
+def test_is_meaningful_context_state_rules():
+    from src.agents import core
+
+    assert core._is_meaningful_context_state({}) is False
+    assert core._is_meaningful_context_state({"objective": ""}) is False
+    assert core._is_meaningful_context_state({"objective": "Ship final snapshot"}) is True
+    assert core._is_meaningful_context_state({"constraints": [""]}) is False
+    assert core._is_meaningful_context_state({"constraints": ["must preserve context"]}) is True
+    assert core._is_meaningful_context_state({"budget": {"usage_percent": 42.0}}) is True
+
+
+def test_build_terminal_context_snapshot_event_builds_standard_event():
+    from src.agents import core
+
+    event = core._build_terminal_context_snapshot_event(
+        context_state={"summary": "Final summary", "budget": {"usage_percent": 42.0}},
+        session_id="s-1",
+        agent_id="agent-1",
+        request_id="req-1",
+        status="completed",
+    )
+
+    assert event is not None
+    assert event["type"] == "context_snapshot"
+    assert event["event_type"] == "context_snapshot"
+    assert event["state"] == "completed"
+    assert event["session_id"] == "s-1"
+    assert event["request_id"] == "req-1"
+    assert event["agent_id"] == "agent-1"
+    assert event["data"]["stage"] == "post_turn"
+    assert event["data"]["terminal"] is True
+    assert event["data"]["context_state"]["summary"] == "Final summary"
+    assert event["data"]["budget"]["usage_percent"] == 42.0
+    assert event["detail_payload"]["terminal"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_chat_execution_appends_terminal_context_snapshot(monkeypatch):
+    from src.agents import core
+
+    class _FakeAgent:
+        model = "gpt-5-mini"
+        agent_id = "agent-1"
+
+        async def process(self, **kwargs):
+            return {
+                "response": "ok",
+                "runtime_events": [
+                    {
+                        "type": "execution.started",
+                        "event_type": "execution.started",
+                        "data": {"message": "started"},
+                    }
+                ],
+            }
+
+    async def _fake_apply_progressive_context_after_turn(*, session_id, model):
+        assert session_id == "s-1"
+        assert model == "gpt-5-mini"
+        return {"summary": "Final context", "budget": {"usage_percent": 12.5}}
+
+    monkeypatch.setattr(core, "apply_progressive_context_after_turn", _fake_apply_progressive_context_after_turn)
+
+    result = await core.run_chat_execution(
+        _FakeAgent(),
+        message="hello",
+        session_id="s-1",
+        request_id="req-1",
+    )
+
+    assert result["context_state"]["summary"] == "Final context"
+    assert result["request_id"] == "req-1"
+    assert result["runtime_events"][0]["type"] == "execution.started"
+    terminal_events = [
+        event
+        for event in result["runtime_events"]
+        if event.get("type") == "context_snapshot"
+        and (event.get("data") or {}).get("stage") == "post_turn"
+        and (event.get("data") or {}).get("terminal") is True
+    ]
+    assert len(terminal_events) == 1
+    assert terminal_events[0]["data"]["context_state"]["summary"] == "Final context"

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -250,3 +250,137 @@ async def test_run_chat_execution_appends_terminal_context_snapshot(monkeypatch)
     ]
     assert len(terminal_events) == 1
     assert terminal_events[0]["data"]["context_state"]["summary"] == "Final context"
+
+
+@pytest.mark.asyncio
+async def test_run_chat_execution_does_not_duplicate_existing_terminal_context_snapshot(monkeypatch):
+    from src.agents import core
+
+    class _FakeAgent:
+        model = "gpt-5-mini"
+        agent_id = "agent-1"
+
+        async def process(self, **kwargs):
+            return {
+                "response": "ok",
+                "runtime_events": [
+                    {
+                        "type": "context_snapshot",
+                        "event_type": "context_snapshot",
+                        "data": {
+                            "stage": "post_turn",
+                            "terminal": True,
+                            "context_state": {"summary": "Existing final context"},
+                        },
+                        "detail_payload": {
+                            "stage": "post_turn",
+                            "terminal": True,
+                        },
+                    }
+                ],
+            }
+
+    async def _fake_apply_progressive_context_after_turn(*, session_id, model):
+        return {"summary": "New final context", "budget": {"usage_percent": 12.5}}
+
+    monkeypatch.setattr(core, "apply_progressive_context_after_turn", _fake_apply_progressive_context_after_turn)
+
+    result = await core.run_chat_execution(
+        _FakeAgent(),
+        message="hello",
+        session_id="s-1",
+    )
+
+    terminal_events = [
+        event
+        for event in result["runtime_events"]
+        if event.get("type") == "context_snapshot"
+        and (event.get("data") or {}).get("stage") == "post_turn"
+        and (event.get("data") or {}).get("terminal") is True
+    ]
+    assert len(terminal_events) == 1
+    assert terminal_events[0]["data"]["context_state"]["summary"] == "Existing final context"
+    assert result["context_state"]["summary"] == "New final context"
+
+
+@pytest.mark.asyncio
+async def test_run_chat_execution_does_not_append_terminal_context_snapshot_for_empty_context(monkeypatch):
+    from src.agents import core
+
+    class _FakeAgent:
+        model = "gpt-5-mini"
+        agent_id = "agent-1"
+
+        async def process(self, **kwargs):
+            return {
+                "response": "ok",
+                "runtime_events": [
+                    {
+                        "type": "execution.started",
+                        "event_type": "execution.started",
+                        "data": {"message": "started"},
+                    }
+                ],
+            }
+
+    async def _fake_apply_progressive_context_after_turn(*, session_id, model):
+        return {}
+
+    monkeypatch.setattr(core, "apply_progressive_context_after_turn", _fake_apply_progressive_context_after_turn)
+
+    result = await core.run_chat_execution(
+        _FakeAgent(),
+        message="hello",
+        session_id="s-1",
+    )
+
+    assert result["context_state"] == {}
+    terminal_events = [
+        event
+        for event in result["runtime_events"]
+        if event.get("type") == "context_snapshot"
+        and (event.get("data") or {}).get("stage") == "post_turn"
+        and (event.get("data") or {}).get("terminal") is True
+    ]
+    assert terminal_events == []
+
+
+@pytest.mark.asyncio
+async def test_run_chat_execution_uses_result_request_id_fallback_for_terminal_event(monkeypatch):
+    from src.agents import core
+
+    class _FakeAgent:
+        model = "gpt-5-mini"
+        agent_id = "agent-1"
+
+        async def process(self, **kwargs):
+            assert kwargs.get("request_id") is None
+            return {
+                "request_id": "req-from-result",
+                "response": "ok",
+                "runtime_events": [],
+            }
+
+    async def _fake_apply_progressive_context_after_turn(*, session_id, model):
+        return {"summary": "Final context"}
+
+    monkeypatch.setattr(core, "apply_progressive_context_after_turn", _fake_apply_progressive_context_after_turn)
+
+    result = await core.run_chat_execution(
+        _FakeAgent(),
+        message="hello",
+        session_id="s-1",
+    )
+
+    assert result["request_id"] == "req-from-result"
+    terminal_events = [
+        event
+        for event in result["runtime_events"]
+        if event.get("type") == "context_snapshot"
+        and (event.get("data") or {}).get("stage") == "post_turn"
+        and (event.get("data") or {}).get("terminal") is True
+    ]
+    assert len(terminal_events) == 1
+    assert terminal_events[0]["request_id"] == "req-from-result"
+    assert terminal_events[0]["data"]["request_id"] == "req-from-result"
+    assert terminal_events[0]["detail_payload"]["request_id"] == "req-from-result"

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -384,3 +384,60 @@ async def test_run_chat_execution_uses_result_request_id_fallback_for_terminal_e
     assert terminal_events[0]["request_id"] == "req-from-result"
     assert terminal_events[0]["data"]["request_id"] == "req-from-result"
     assert terminal_events[0]["detail_payload"]["request_id"] == "req-from-result"
+
+
+@pytest.mark.asyncio
+async def test_run_chat_execution_appends_when_existing_terminal_snapshot_has_no_meaningful_context(monkeypatch):
+    from src.agents import core
+
+    class _FakeAgent:
+        model = "gpt-5-mini"
+        agent_id = "agent-1"
+
+        async def process(self, **kwargs):
+            return {
+                "response": "ok",
+                "runtime_events": [
+                    {
+                        "type": "context_snapshot",
+                        "event_type": "context_snapshot",
+                        "data": {
+                            "stage": "post_turn",
+                            "terminal": True,
+                            "context_state": {},
+                        },
+                        "detail_payload": {
+                            "stage": "post_turn",
+                            "terminal": True,
+                        },
+                    }
+                ],
+            }
+
+    async def _fake_apply_progressive_context_after_turn(*, session_id, model):
+        return {
+            "summary": "Real final context",
+            "next_step": "Render final snapshot",
+            "budget": {"usage_percent": 20.0},
+        }
+
+    monkeypatch.setattr(core, "apply_progressive_context_after_turn", _fake_apply_progressive_context_after_turn)
+
+    result = await core.run_chat_execution(
+        _FakeAgent(),
+        message="hello",
+        session_id="s-1",
+        request_id="req-1",
+    )
+
+    terminal_events = [
+        event
+        for event in result["runtime_events"]
+        if event.get("type") == "context_snapshot"
+        and (event.get("data") or {}).get("stage") == "post_turn"
+        and (event.get("data") or {}).get("terminal") is True
+    ]
+
+    assert len(terminal_events) == 2
+    assert terminal_events[-1]["data"]["context_state"]["summary"] == "Real final context"
+    assert terminal_events[-1]["data"]["request_id"] == "req-1"


### PR DESCRIPTION
### Motivation
- Ensure the Portal can persist and show the final EFP runtime `context_state` by emitting a terminal `context_snapshot` event after chat execution completes. 
- Avoid relying only on in-loop snapshots so the timeline/persisted panels do not end up empty when the final context is only returned on the response payload.

### Description
- Added module-level helpers in `src/agents/core.py`: `_is_meaningful_context_state(...)` to detect whether a `context_state` is significant, `_build_terminal_context_snapshot_event(...)` to construct a terminal `context_snapshot` reusing `_enrich_runtime_event_context` and `_build_runtime_event_record`, and `_has_terminal_post_turn_context_snapshot(...)` to detect existing terminal post-turn snapshots and avoid duplicates. 
- Updated `run_chat_execution(...)` to call `apply_progressive_context_after_turn(...)`, keep `result["context_state"]`, and append a terminal `context_snapshot` to `result["runtime_events"]` when the final context is meaningful; it initializes `runtime_events` when missing, preserves existing events, and computes `status` as `failed` if `result.get("error")` else `completed`.
- The terminal event includes `session_id`, `agent_id`, `request_id`, `data.stage == "post_turn"`, `data.terminal == True`, `data.context_state`, and `data.budget` when present, and does not expose hidden model reasoning.

### Testing
- Added unit tests in `tests/test_core_runtime_boundary.py` for `_is_meaningful_context_state`, `_build_terminal_context_snapshot_event`, and `run_chat_execution` append behavior that preserves existing runtime events. 
- Ran `pytest tests/test_core_runtime_boundary.py tests/test_webchat_request_id_contract.py tests/test_progressive_context.py` and all tests passed. 
- Verified `run_chat_execution(...)` still returns `context_state`, retains prior `runtime_events`, and appends exactly one terminal `context_snapshot` when appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e595fc254c832a9794f7340c62b300)