### PR TITLE
Fix null-safe parsing for Responses API optional objects

### DIFF
--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -148,6 +148,13 @@ def _sanitize_headers(headers: Dict[str, str]) -> Dict[str, str]:
 
 
 
+def _dict_or_empty(value: Any) -> Dict[str, Any]:
+    """Return a dict for optional API objects that may be omitted or explicitly null."""
+    return value if isinstance(value, dict) else {}
+
+
+
+
 def _convert_messages_to_input_items(messages: List[Dict]) -> List[Dict]:
     """Convert Chat-style messages to Responses API input_items format."""
     items = []
@@ -644,12 +651,12 @@ class OpenAIProvider(BaseProvider):
                     "name": item.get("name", ""),
                     "arguments": item.get("arguments", {}),
                 })
-        incomplete_reason = data.get("incomplete_details", {}).get("reason")
+        incomplete_reason = _dict_or_empty(data.get("incomplete_details")).get("reason")
 
         # Prioritize function_call: if there are function_calls/tool_calls_compat, return directly to the upper layer
         if not content.strip():
             # Assign all return fields in advance to ensure robustness
-            usage_data = data.get("usage", {})
+            usage_data = _dict_or_empty(data.get("usage"))
             prompt_tokens = usage_data.get("input_tokens", 0)
             completion_tokens = usage_data.get("output_tokens", 0)
             if prompt_tokens == 0:
@@ -708,7 +715,7 @@ class OpenAIProvider(BaseProvider):
                         "details": {
                             "incomplete_reason": "max_output_tokens",
                             "max_output_tokens": payload.get("max_output_tokens"),
-                            "request_estimated_tokens": data.get("usage", {}).get("input_tokens"),
+                            "request_estimated_tokens": usage_data.get("input_tokens"),
                             "suggestion": "Context was compacted but model output still reached max_output_tokens; split generation or write artifacts/files instead of emitting all content in chat.",
                         },
                         "status_code": 500,
@@ -718,7 +725,7 @@ class OpenAIProvider(BaseProvider):
             return {"error": {"message": "Copilot API returned empty message. Please try rephrasing your prompt or check your input.", "type": "empty_response", "code": "empty_message"}}
 
         # Calculate usage
-        usage_data = data.get("usage", {})
+        usage_data = _dict_or_empty(data.get("usage"))
         prompt_tokens = usage_data.get("input_tokens", 0)
         completion_tokens = usage_data.get("output_tokens", 0)
         
@@ -1072,12 +1079,12 @@ class GitHubCopilotProvider(BaseProvider):
                     "arguments": item.get("arguments", {}),
                 })
 
-        incomplete_reason = data.get("incomplete_details", {}).get("reason")
+        incomplete_reason = _dict_or_empty(data.get("incomplete_details")).get("reason")
 
         # Priority: handle function_call first. If there are function_calls/tool_calls_compat, return directly to the upper layer.
         if not content.strip():
             # Pre-assign all return fields in advance to ensure robustness
-            usage_data = data.get("usage", {})
+            usage_data = _dict_or_empty(data.get("usage"))
             prompt_tokens = usage_data.get("input_tokens", 0)
             completion_tokens = usage_data.get("output_tokens", 0)
             if prompt_tokens == 0:
@@ -1136,7 +1143,7 @@ class GitHubCopilotProvider(BaseProvider):
                         "details": {
                             "incomplete_reason": "max_output_tokens",
                             "max_output_tokens": payload.get("max_output_tokens"),
-                            "request_estimated_tokens": data.get("usage", {}).get("input_tokens"),
+                            "request_estimated_tokens": usage_data.get("input_tokens"),
                             "suggestion": "Context was compacted but model output still reached max_output_tokens; split generation or write artifacts/files instead of emitting all content in chat.",
                         },
                         "status_code": 500,
@@ -1146,7 +1153,7 @@ class GitHubCopilotProvider(BaseProvider):
             return {"error": {"message": "Copilot API returned empty message. Please try rephrasing your prompt or check your input.", "type": "empty_response", "code": "empty_message"}}
 
         # Calculate usage
-        usage_data = data.get("usage", {})
+        usage_data = _dict_or_empty(data.get("usage"))
         prompt_tokens = usage_data.get("input_tokens", 0)
         completion_tokens = usage_data.get("output_tokens", 0)
         

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -467,6 +467,77 @@ class TestResponsesAPI:
         assert result["error"]["details"]["incomplete_reason"] == "max_output_tokens"
 
     @pytest.mark.asyncio
+    async def test_openai_responses_allows_null_optional_response_objects(self, openai_provider):
+        mock_response = MockResponse({
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "ok"}],
+                }
+            ],
+            "incomplete_details": None,
+            "usage": None,
+        })
+        mock_client = MockHttpClient(mock_response)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await openai_provider.responses(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+
+        assert result["content"] == "ok"
+        assert "error" not in result
+        assert result["usage"]["prompt_tokens"] > 0
+        assert result["usage"]["completion_tokens"] > 0
+
+    @pytest.mark.asyncio
+    async def test_github_copilot_responses_allows_null_optional_response_objects(
+        self,
+        github_copilot_provider,
+    ):
+        mock_response = MockResponse({
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "ok"}],
+                }
+            ],
+            "incomplete_details": None,
+            "usage": None,
+        })
+        mock_client = MockHttpClient(mock_response)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await github_copilot_provider.responses(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+
+        assert result["content"] == "ok"
+        assert "error" not in result
+        assert result["usage"]["prompt_tokens"] > 0
+        assert result["usage"]["completion_tokens"] > 0
+
+    @pytest.mark.asyncio
+    async def test_github_copilot_responses_empty_output_with_null_incomplete_details_returns_empty_response(
+        self,
+        github_copilot_provider,
+    ):
+        mock_response = MockResponse({
+            "output": [],
+            "incomplete_details": None,
+            "usage": None,
+        })
+        mock_client = MockHttpClient(mock_response)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await github_copilot_provider.responses(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+
+        assert result["error"]["type"] == "empty_response"
+        assert result["error"]["code"] == "empty_message"
+
+    @pytest.mark.asyncio
     async def test_openai_responses_partial_content_with_max_output_tokens_returns_warning(self, openai_provider):
         mock_response = MockResponse({
             "output": [{"type": "message", "content": [{"type": "output_text", "text": "partial"}]}],


### PR DESCRIPTION
### Motivation
- Prevent runtime AttributeError when Responses API returns optional objects explicitly set to `null` (e.g. `"incomplete_details": null` or `"usage": null`) which caused `NoneType` to be accessed with `.get()`.
- Keep the fix narrowly scoped to the runtime Responses parser to avoid touching Portal, ExecutionBus, webchat handler, or swallowing real errors.

### Description
- Add a small helper `def _dict_or_empty(value: Any) -> Dict[str, Any]` in `src/agents/llm.py` (placed after `_sanitize_headers`) that returns the input if it's a `dict` or `{}` otherwise.
- Update both `OpenAIProvider.responses` and `GitHubCopilotProvider.responses` in `src/agents/llm.py` to read optional objects null-safely by replacing `data.get("incomplete_details", {}).get("reason")` with `_dict_or_empty(data.get("incomplete_details")).get("reason")` and by replacing `usage_data = data.get("usage", {})` with `usage_data = _dict_or_empty(data.get("usage"))`.
- Replace direct occurrences of `data.get("usage", {}).get("input_tokens")` in truncated error details with `usage_data.get("input_tokens")` to avoid unsafe chained `.get()` on `None`.
- Add three regression tests to `tests/test_llm_client.py::TestResponsesAPI` to verify that: OpenAI and GitHub Copilot providers tolerate `incomplete_details: None` and `usage: None` without raising, and GitHub Copilot returns an `empty_response` (structured error) when `output` is empty and `incomplete_details` is `None`.
- Files modified: `src/agents/llm.py` and `tests/test_llm_client.py`; no other files changed.
- The change does not add broad `try/except`, does not alter provider URLs/headers/model selection/payload/tool conversion/usage tracker behavior, and preserves existing behaviors around `function_call`, `max_output_tokens` truncation, partial content handling, and usage fallback estimation.

### Testing
- Verified grep checks ensuring no remaining unsafe pattern: `data.get("incomplete_details", {}).get("reason")` no longer exists in `src/agents/llm.py`.
- Ran targeted tests: `python -m pytest tests/test_llm_client.py::TestResponsesAPI -q` — result: 14 passed.
- Ran full provider tests: `python -m pytest tests/test_llm_client.py -q` — result: 52 passed.
- Ran broader suite: `python -m pytest tests/test_webchat.py tests/test_execution_bus.py -q` — result: 1 failing test (`test_execution_bus_uses_injected_execute_tool_callable_for_tool_and_task`) unrelated to these LLM parser changes; remaining tests passed (255 passed, 1 warning, 1 failure). 

Notes / Scope
- Modified files list and concrete changes: `src/agents/llm.py` (added `_dict_or_empty`, replaced unsafe `.get()` patterns for `incomplete_details` and `usage`, reused `usage_data` in truncated details) and `tests/test_llm_client.py` (added three regression tests).
- Confirmed no changes were made to Portal, `ExecutionBus`, `webchat.py`, or `agents/core.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65ca5669c832a83b87474ec41d2f5)