### PR TITLE
Project recent large assistant outputs; fallback projection + MobileX output guard

### DIFF
--- a/skills/mobilex-test-cases-generator/skill.md
+++ b/skills/mobilex-test-cases-generator/skill.md
@@ -21,12 +21,13 @@ tools:
 strategy:
   - "1. Parse Jira ticket(s) - supports single or multiple (e.g., EFP-123 or EFP-123,EFP-456)"
   - "2. Call jira_get_issue_by_url to fetch each ticket's details"
-  - "3. After getting result, respond with [FINISH] + summary of what was fetched"
-  - "4. Include in [FINISH]: summary, description (key points), acceptance criteria"
-  - "5. Wait for user confirmation before generating test code"
-  - "6. After confirmation, generate test scenarios (scenario outline + examples)"
-  - "7. Generate Cucumber feature file + Step Definitions + Java implementations"
-  - "8. Commit code to GitHub"
+  - "3. After Jira fetch, respond with [FINISH] + summary/description(key points)/acceptance criteria only (no Gherkin/code)"
+  - "4. Wait for user confirmation before generation"
+  - "5. Generate phase 1 scenario manifest only"
+  - "6. Generate phase 2 feature file only"
+  - "7. Generate phase 3 step definitions only"
+  - "8. Generate phase 4+ Java drivers one file at a time"
+  - "9. Commit only after files are written and user confirms"
 output_format: markdown
 ---
 
@@ -34,18 +35,23 @@ output_format: markdown
 
 Generate mobile automation test cases from Jira tickets.
 
+## Hard Output Constraints
+
+- Never generate full multi-file Java implementation in one response.
+- Never dump all generated artifacts in chat; use file/write tools when a repository target is known.
+- Never repeat previously generated Gherkin in full; summarize prior output and continue from the next phase.
+- Always produce one file/phase at a time and keep each chat response bounded (target under ~8000 characters).
+- If no repository target is available, return a concise manifest and ask the user which next phase/file to generate.
+- Commit only after files are actually written and user confirmation is received.
+
 ## Overview
 
-1. **Jira Parsing** - Fetch requirement details from Jira (summary, description, AC, comments)
-2. **Scenario Generation** - Generate test scenarios covering requirements (Gherkin/Cucumber)
-3. **Code Generation** - Create complete test code:
-   - Cucumber Feature files
-   - Java Step Definitions
-   - Java DeviceStepDriver Interface
-   - Common Implementation
-   - iOS Implementation
-   - Android Implementation
-4. **Git Commit** - Commit code to GitHub
+1. **Jira Parsing (phase 0)** - Fetch requirement details from Jira (summary, key description points, AC) and stop with `[FINISH]`. Do not generate Gherkin/code yet.
+2. **Scenario Manifest (phase 1)** - After user says continue, provide scenario manifest / feature outline only.
+3. **Feature File (phase 2)** - Generate only the `.feature` file content.
+4. **Step Definitions (phase 3)** - Generate only step definition file(s).
+5. **Driver Implementations (phase 4+)** - Generate interfaces/implementations one file at a time (common, iOS, Android).
+6. **Git Commit (final)** - Commit only after files are written and user confirms.
 
 ## Output File Structure
 
@@ -131,8 +137,8 @@ public interface DeviceStepDriver {
 2. **Confirm Info** → Display summary + AC, user confirms/supplements
 3. **Generate Scenarios** → Create feature draft
 4. **Review Scenarios** → User confirms or modifies scenarios
-5. **Generate Code** → One-click generate complete test code
-6. **Submit Code** → Git push + PR link
+5. **Generate Code** → Continue phase-by-phase and file-by-file
+6. **Submit Code** → Git push + PR link only after explicit user confirmation
 
 ## Notes
 

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -430,7 +430,8 @@ def _is_projected_feedback(text: str) -> bool:
     if value.startswith("[large source tool result projected]"):
         return "context_ref: ctx://context/" in value
     if (
-        value.startswith("[old tool output compacted")
+        value.startswith("[assistant output compacted")
+        or value.startswith("[old tool output compacted")
         or value.startswith("[old assistant output compacted")
         or value.startswith("[assistant tool-call content compacted")
         or value.startswith("[assistant skill content compacted")
@@ -592,6 +593,33 @@ def _should_project_assistant_context(content_text: str) -> bool:
         len(text) > DEFAULT_TOOL_FEEDBACK_MAX_LENGTH
         or "```" in text
         or re.search(r"\b(Feature:|Scenario:|Scenario Outline:|class\s+\w+|def\s+\w+)\b", text) is not None
+    )
+
+
+def _large_generation_output_guard(
+    active_skill_runtime: Optional[Any],
+    selected_skill: Optional[Any],
+    active_skill_contract: Optional[Dict[str, Any]],
+) -> str:
+    skill_name = (
+        getattr(active_skill_runtime, "skill_name", None)
+        or getattr(selected_skill, "name", None)
+        or (active_skill_contract or {}).get("skill_name")
+    )
+    normalized = str(skill_name or "").strip().lower()
+    guarded_skills = {
+        "mobilex-test-cases-generator",
+        "java_cucumber_generator",
+        "java-cucumber-generator",
+        "mobilex-test-generator",
+    }
+    if normalized not in guarded_skills:
+        return ""
+    return (
+        "Large generation output guard: For this skill, never emit all generated files or complete multi-file "
+        "implementations in a single chat response. Produce one bounded phase at a time. Prefer writing "
+        "artifacts/files via tools when a repository target is available. In chat, return a concise manifest, "
+        "file paths, and the next recommended step. Keep chat output under 8000 characters."
     )
 
 
@@ -764,7 +792,21 @@ def build_responses_input_items(messages: List[Dict[str, Any]], *, session_id: O
             if role == "user":
                 items.append({"role": role, "content": [{"type": "input_text", "text": str(content)}]})
             else:
-                items.append({"role": role, "content": str(content)})
+                content_text = str(content)
+                if role == "assistant":
+                    if _is_projected_feedback(content_text):
+                        items.append({"role": role, "content": content_text})
+                    elif _should_project_assistant_context(content_text):
+                        content_text = project_skill_assistant_content_for_input_items(
+                            content_text,
+                            session_id=session_id,
+                            round_num=0,
+                        )
+                        items.append({"role": role, "content": content_text})
+                    else:
+                        items.append({"role": role, "content": content_text})
+                else:
+                    items.append({"role": role, "content": content_text})
 
     return items
 
@@ -2053,6 +2095,13 @@ You have access to the following tools. When a user asks you to do something tha
                 tools=loop_tools,
                 reasoning_replay=enable_reasoning,
             )
+            large_generation_guard = _large_generation_output_guard(
+                active_skill_runtime=active_skill_runtime,
+                selected_skill=selected_skill,
+                active_skill_contract=active_skill_contract,
+            )
+            if large_generation_guard:
+                llm_kwargs["system_prompt"] = ((llm_kwargs.get("system_prompt") or "") + "\n\n" + large_generation_guard).strip()
             if effective_model:
                 llm_kwargs["model"] = effective_model
             
@@ -2062,7 +2111,7 @@ You have access to the following tools. When a user asks you to do something tha
 
             request_estimated_tokens = estimate_llm_request_tokens(
                 input_items=input_items,
-                system_prompt=effective_system_prompt or "",
+                system_prompt=llm_kwargs.get("system_prompt", "") or "",
                 tools=loop_tools or [],
             )
             loop_budget = resolve_prompt_budget(stage="tool_loop", model=effective_model)
@@ -2088,7 +2137,7 @@ You have access to the following tools. When a user asks you to do something tha
                 llm_kwargs["input_items"] = input_items
                 request_estimated_tokens = estimate_llm_request_tokens(
                     input_items=input_items,
-                    system_prompt=effective_system_prompt or "",
+                    system_prompt=llm_kwargs.get("system_prompt", "") or "",
                     tools=loop_tools or [],
                 )
             if request_estimated_tokens > int(loop_budget.get("prompt_budget_tokens", 0) or 0):
@@ -2097,7 +2146,7 @@ You have access to the following tools. When a user asks you to do something tha
                 llm_kwargs["input_items"] = input_items
                 request_estimated_tokens = estimate_llm_request_tokens(
                     input_items=input_items,
-                    system_prompt=effective_system_prompt or "",
+                    system_prompt=llm_kwargs.get("system_prompt", "") or "",
                     tools=loop_tools or [],
                 )
             if isinstance(loop_context_state, dict):
@@ -2124,7 +2173,7 @@ You have access to the following tools. When a user asks you to do something tha
                 return attach_runtime_events(error_response)
             if request_estimated_tokens > prompt_budget_tokens:
                 llm_kwargs["system_prompt"] = (
-                    (effective_system_prompt or "")
+                    (llm_kwargs.get("system_prompt") or "")
                     + "\n\nBudget guard: Do not emit all generated files in chat. "
                     "Write artifacts/files via tools when possible; otherwise output a concise manifest and ask to continue file-by-file."
                 )
@@ -3023,12 +3072,19 @@ You have access to the following tools. When a user asks you to do something tha
                 "reasoning_replay": False,
                 "provider": _normalize_provider_key(provider),
             }
+            large_generation_guard = _large_generation_output_guard(
+                active_skill_runtime=skill_runtime_config,
+                selected_skill=skill,
+                active_skill_contract=skill_state if isinstance(skill_state, dict) else None,
+            )
+            if large_generation_guard:
+                llm_kwargs["system_prompt"] = ((llm_kwargs.get("system_prompt") or "") + "\n\n" + large_generation_guard).strip()
             if self.model:
                 llm_kwargs["model"] = self.model
 
             request_estimated_tokens = estimate_llm_request_tokens(
                 input_items=input_items,
-                system_prompt=system_prompt or "",
+                system_prompt=llm_kwargs.get("system_prompt", "") or "",
                 tools=available_tools or [],
             )
             loop_budget = resolve_prompt_budget(stage="skill_generation", model=llm_kwargs.get("model"))
@@ -3051,10 +3107,14 @@ You have access to the following tools. When a user asks you to do something tha
                 system_prompt = _build_skill_mode_system_prompt(skill, skill_session)
                 input_items = degrade_projected_context_sources_in_responses_input_items(input_items)
                 llm_kwargs["system_prompt"] = system_prompt
+                if large_generation_guard:
+                    llm_kwargs["system_prompt"] = (
+                        (llm_kwargs.get("system_prompt") or "") + "\n\n" + large_generation_guard
+                    ).strip()
                 llm_kwargs["input_items"] = input_items
                 request_estimated_tokens = estimate_llm_request_tokens(
                     input_items=input_items,
-                    system_prompt=system_prompt or "",
+                    system_prompt=llm_kwargs.get("system_prompt", "") or "",
                     tools=available_tools or [],
                 )
                 skill_request_budget.update(

--- a/src/runtime/progressive_context.py
+++ b/src/runtime/progressive_context.py
@@ -208,6 +208,21 @@ def _looks_artifact_like(text: str) -> bool:
     return any(marker in sample for marker in markers)
 
 
+def _is_already_projected_feedback(text: str) -> bool:
+    value = str(text or "").lstrip()
+    marker_prefixes = (
+        "[assistant output compacted",
+        "[old assistant output compacted",
+        "[assistant tool-call content compacted",
+        "[assistant skill content compacted",
+        "[old tool output compacted",
+        "[large source tool result projected]",
+    )
+    if not value.startswith(marker_prefixes):
+        return False
+    return "ctx://context/" in value
+
+
 def _project_large_history_messages(
     messages: List[AgentMessage],
     *,
@@ -233,6 +248,42 @@ def _project_large_history_messages(
     projected: List[AgentMessage] = []
     for idx, msg in enumerate(messages):
         text = str(msg.content or "")
+        if msg.role == "assistant" and not msg.tool_calls:
+            if _is_already_projected_feedback(text):
+                projected.append(msg)
+                continue
+            artifact_like = _looks_artifact_like(text)
+            artifact_limit = int(old_assistant_cfg.get("artifact_like_max_chars", 3000) or 3000)
+            assistant_plain_limit = artifact_limit if artifact_like else assistant_limit
+            if len(text) > assistant_plain_limit:
+                ref = put_text(
+                    session_id=session_id,
+                    kind="assistant_output",
+                    source_id=f"assistant_{idx}",
+                    title="assistant_output",
+                    content=text,
+                    metadata={"stage": stage, "recent_tail": idx >= keep_start, "artifact_like": artifact_like},
+                )
+                refs.append(ref)
+                summary = _extract_deterministic_assistant_summary(text, summary_max_chars=summary_max)
+                compact = (
+                    f"[assistant output compacted | original_chars={len(text)} | ref={ref}]\n"
+                    f"Summary:\n{summary}\n\n"
+                    f"Full assistant output is available through context_read_ref(ref=\"{ref}\")."
+                )
+                saved += max(0, len(text) - len(compact))
+                projected_assistant += 1
+                projected.append(
+                    AgentMessage(
+                        role="assistant",
+                        content=compact,
+                        timestamp=msg.timestamp,
+                        tool_calls=msg.tool_calls,
+                        tool_use_id=msg.tool_use_id,
+                        tool_name=getattr(msg, "tool_name", None),
+                    )
+                )
+                continue
         if msg.role == "assistant" and msg.tool_calls:
             assistant_tool_limit = int(old_assistant_cfg.get("artifact_like_max_chars", assistant_limit) or assistant_limit)
             if not _looks_artifact_like(text):
@@ -268,18 +319,6 @@ def _project_large_history_messages(
                 continue
         if idx >= keep_start:
             projected.append(msg)
-            continue
-        if msg.role == "assistant" and not msg.tool_calls and len(text) > assistant_limit:
-            ref = put_text(session_id=session_id, kind="assistant_output", source_id=f"assistant_{idx}", title="assistant_output", content=text, metadata={"stage": stage})
-            refs.append(ref)
-            summary = _extract_deterministic_assistant_summary(text, summary_max_chars=summary_max)
-            compact = (
-                f"[old assistant output compacted | original_chars={len(text)} | ref={ref}]\n"
-                f"Summary:\n{summary}\n\nFull original assistant output is available in the session transcript/context blob."
-            )
-            saved += max(0, len(text) - len(compact))
-            projected_assistant += 1
-            projected.append(AgentMessage(role="assistant", content=compact, timestamp=msg.timestamp, tool_calls=msg.tool_calls, tool_use_id=msg.tool_use_id, tool_name=getattr(msg, "tool_name", None)))
             continue
         if msg.role == "tool" and msg.tool_use_id and msg.tool_use_id in protected_tool_chain_ids:
             projected.append(msg)

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -298,6 +298,98 @@ def test_build_responses_input_items_keeps_already_projected_assistant_tool_call
     assert "[assistant skill content compacted" not in assistant_item["content"]
 
 
+def test_build_responses_input_items_projects_plain_assistant_large_gherkin():
+    from src.agents import core
+
+    long_gherkin = "@MMGFX-13887\nFeature: OCO TP\n" + ("\nScenario: L\nGiven a\nWhen b\nThen c" * 3000)
+    messages = [
+        {"role": "assistant", "content": long_gherkin},
+        {"role": "user", "content": "continue"},
+    ]
+    items = core.build_responses_input_items(messages, session_id="s-plain")
+    assistant_item = next(item for item in items if item.get("role") == "assistant")
+    assert assistant_item["content"] != long_gherkin
+    assert "ctx://context/" in assistant_item["content"]
+    assert "[assistant skill content compacted" in assistant_item["content"]
+    assert long_gherkin[:200] not in assistant_item["content"]
+
+
+def test_build_responses_input_items_keeps_already_projected_plain_assistant_unchanged():
+    from src.agents import core
+
+    projected = (
+        "[assistant output compacted | original_chars=20000 | ref=ctx://context/s/assistant_output/aaaaaaaaaaaa]\n"
+        "Summary:\nFeature: X"
+    )
+    messages = [{"role": "assistant", "content": projected}]
+    items = core.build_responses_input_items(messages, session_id="s")
+    assistant_item = next(item for item in items if item.get("role") == "assistant")
+    assert assistant_item["content"] == projected
+
+
+def test_mobilex_large_generation_output_guard_is_unconditional_in_tool_loop_and_skill_mode():
+    from src.agents import core
+
+    process_source = inspect.getsource(core.Agent.process)
+    continue_source = inspect.getsource(core.Agent._continue_skill_mode)
+    assert "_large_generation_output_guard(" in process_source
+    assert "_large_generation_output_guard(" in continue_source
+    assert "Large generation output guard:" in inspect.getsource(core._large_generation_output_guard)
+
+
+def test_mobilex_skill_prompt_contains_hard_output_constraints():
+    from pathlib import Path
+
+    skill_text = Path("skills/mobilex-test-cases-generator/skill.md").read_text(encoding="utf-8")
+    assert "## Hard Output Constraints" in skill_text
+    assert "Never generate full multi-file Java implementation in one response." in skill_text
+    assert "one file at a time" in skill_text
+
+
+def test_mobilex_continuation_regression_shape_projects_plain_assistant_and_jira():
+    from src.agents import core
+
+    long_gherkin = "@MMGFX-13887\nFeature: OCO TP\n" + ("\nScenario: L\nGiven a\nWhen b\nThen c" * 3000)
+    long_jira = (
+        "# MMGFX-13887: OCO\n## Description\n"
+        + ("noise\n" * 3500)
+        + "## Acceptance Criteria\n- ac1\n- ac2\n"
+    )
+    messages = [
+        {"role": "assistant", "content": long_gherkin},
+        {"role": "user", "content": "continue"},
+        {
+            "role": "assistant",
+            "content": "calling jira",
+            "tool_calls": [{"id": "call_1", "function": {"name": "jira_get_issue", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "tool_name": "jira_get_issue", "content": long_jira},
+    ]
+
+    raw_items = [
+        {"role": "assistant", "content": long_gherkin},
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+        {"role": "assistant", "content": "calling jira"},
+        {"type": "function_call", "call_id": "call_1", "name": "jira_get_issue", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_1", "output": long_jira},
+    ]
+    raw_tokens = core.estimate_llm_request_tokens(raw_items, "", [])
+
+    items = core.build_responses_input_items(messages, session_id="s-regress")
+    new_tokens = core.estimate_llm_request_tokens(items, "", [])
+    assistant_item = next(item for item in items if item.get("role") == "assistant" and isinstance(item.get("content"), str))
+    tool_output_item = next(item for item in items if item.get("type") == "function_call_output")
+    function_call = next(item for item in items if item.get("type") == "function_call")
+
+    assert long_gherkin[:200] not in assistant_item["content"]
+    assert "ctx://context/" in assistant_item["content"]
+    assert "context_ref: ctx://context/" in tool_output_item["output"]
+    assert "context_read_ref(" in tool_output_item["output"]
+    assert long_jira[:500] not in tool_output_item["output"]
+    assert new_tokens < raw_tokens
+    assert tool_output_item["call_id"] == function_call["call_id"]
+
+
 def test_degrade_projected_context_sources_in_responses_input_items_preserves_call_id():
     from src.agents import core
 

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -1,6 +1,8 @@
 import pytest
+import re
 
 from src.runtime import progressive_context
+from src.context_blob_store import read_ref
 from src.runtime.progressive_context import (
     build_portal_context_preview,
     degrade_projected_context_sources,
@@ -483,6 +485,44 @@ async def test_projects_large_assistant_with_tool_calls_even_when_recent(monkeyp
     assert "ctx://context/" in assistant["content"]
     assert assistant["tool_calls"][0]["id"] == "call_1"
     assert assistant["tool_calls"][0]["function"]["name"] == "jira_get_issue_by_url"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["pre_request", "tool_loop"])
+async def test_projects_recent_plain_assistant_artifact_like_content(monkeypatch, stage):
+    huge = "@MMGFX-13887\nFeature: OCO Order Input Page - Take Profit\n" + ("\nScenario: S\nGiven x\nWhen y\nThen z" * 3000)
+    messages = [
+        {"role": "user", "content": "/mobilex-test-generator"},
+        {"role": "assistant", "content": "Need Jira URL first."},
+        {"role": "user", "content": "https://jira.local/browse/MMGFX-13887"},
+        {"role": "assistant", "content": huge},
+        {"role": "user", "content": "continue"},
+    ]
+
+    async def _get_context_state(_session_id):
+        return {}
+
+    monkeypatch.setattr(progressive_context.session_manager, "get_context_state", _get_context_state)
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 200000)
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", lambda msgs: 100)
+
+    prepared, state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id=f"s-recent-plain-{stage}",
+        stage=stage,
+        recent_count=5,
+    )
+
+    assistant = next(m for m in prepared if m["role"] == "assistant" and "compacted" in str(m.get("content", "")))
+    assert huge not in assistant["content"]
+    assert "ctx://context/" in assistant["content"]
+    assert "[assistant output compacted" in assistant["content"]
+    ref = re.search(r"ref=(ctx://context/[^\s\]]+)", assistant["content"]).group(1)
+    restored = read_ref(ref, session_id=f"s-recent-plain-{stage}", max_chars=len(huge) + 1000)
+    assert restored == huge
+    assert state["budget"]["projected_old_assistant_messages"] >= 1
+    assert messages[3]["content"] == huge
 
 
 def test_degrade_projected_context_sources_keeps_ref_and_call_id():


### PR DESCRIPTION
### Motivation

- A recent production continuation hit max_output_tokens because a very large plain assistant response (large Gherkin/code) in the protected recent tail was sent verbatim to the LLM on the next request.
- The system must project large assistant artifact-like outputs even when they are in the recent tail, and also add a safety guard for large-generation skills so the model does not attempt to dump multi-file outputs in a single response.

### Description

- Project recent plain assistant artifacts: added `_is_already_projected_feedback()` and a pre-tail projection branch in `_project_large_history_messages()` to store full assistant outputs in `context_blob_store` and replace model-facing messages with a deterministic summary + `ctx://context/...` ref (marker: `[assistant output compacted ...]`).
- Fallback projection at response boundary: extended `build_responses_input_items()` to detect plain assistant messages (no `tool_calls`) and apply projection via `project_skill_assistant_content_for_input_items()` when `_should_project_assistant_context()` returns true while preserving already-projected markers.
- Large-generation output guard: added `_large_generation_output_guard()` and inject the guard unconditionally into the `system_prompt` for tool-loop and skill-mode LLM calls when an active skill matches mobile/large-generation names (including `mobilex-test-cases-generator`).
- MobileX skill contract tightened: updated `skills/mobilex-test-cases-generator/skill.md` with a `## Hard Output Constraints` section and an explicit phased, file-by-file workflow to avoid encouraging single-response multi-file dumps.
- Tests: added/updated unit tests to cover recent-tail projection of plain assistant artifact-like content, the fallback projection in the responses builder, the unconditional large-generation guard, and a regression test that reproduces the exact continuation shape (assistant large body + Jira tool result + function_call consistency).
- Preservation and safety: raw session history is unchanged, Jira/Confluence tool schemas were not altered (no `max_chars` exposed), and no UNBOUNDED feedback prefixes were reintroduced; projection remains model-facing only with full content available via `ctx://context` refs.

### Testing

- Static checks: `python -m compileall -q src tests` succeeded.
- Focused test runs (all succeeded):
  - `pytest tests/test_progressive_context.py -q` → 20 passed, 1 warning.
  - `pytest tests/test_core_runtime_boundary.py -q` → 49 passed, 1 warning.
  - `pytest tests/test_skill_mode_termination.py -q` → 24 passed, 1 warning.
  - `pytest tests/test_llm_client.py -q` → 49 passed, 1 warning.
  - `pytest tests/test_llm_tools_filtering.py -q` → 17 passed, 1 warning.
  - `pytest tests/test_context_blob_store.py -q` → 3 passed, 1 warning.
  - `pytest tests/test_jira_tools.py tests/test_confluence_tools.py -q` → 26 passed, 1 warning.
  - `pytest tests/test_confluence_markdown.py -q` → 23 passed, 1 warning.
- Full test run: `pytest -q` failed during collection in this environment with 7 import errors (missing `src.gateway.server` / `src.gateway.webchat` modules); these collection errors are unrelated to the context-projection changes and block running the entire suite here.

Files changed

- src/runtime/progressive_context.py (added pre-tail assistant projection and helper)
- src/agents/core.py (fallback projection in `build_responses_input_items`, `_is_projected_feedback` marker update, `_large_generation_output_guard`, injection points in tool-loop and skill-mode)
- skills/mobilex-test-cases-generator/skill.md (Hard Output Constraints and phased workflow)
- tests/test_progressive_context.py (added recent-tail assistant projection tests)
- tests/test_core_runtime_boundary.py (added build_responses_input_items and regression tests)

Confirmations

1. Recent plain assistant large content is projected (including when it falls inside the recent-tail window): YES — implemented and covered by tests for `pre_request` and `tool_loop`.
2. `build_responses_input_items` includes a final/fallback projection for plain assistant large content: YES — implemented and tested.
3. MobileX receives an unconditional output-size guard injected into system prompts for tool-loop and skill-mode LLM calls: YES — helper added and injected unconditionally for guarded skills.
4. MobileX skill prompt is staged/file-first and includes hard output constraints: YES — `skills/mobilex-test-cases-generator/skill.md` updated.
5. Jira/Confluence schemas were not altered to expose `max_chars`: YES — schema tests still pass and no schema exposure was changed.
6. No unbounded Jira/Confluence feedback prefixes were reintroduced: YES — grep/coverage confirms no `UNBOUNDED_TOOL_FEEDBACK_PREFIXES` and large-source projection remains prefix-based with `ctx://context` refs.

If you want, I can (a) open a follow-up PR to expand the guarded-skills set or make the guard configurable, or (b) run the full test matrix in an environment that includes the gateway modules so we can validate the complete test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b3fab41c832a872481073e737a71)