### PR TITLE
Add EFP observability counters for assistant projection and output guards

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -250,9 +250,14 @@ def _merge_request_budget_into_context_state(
         "max_output_tokens",
         "request_over_budget",
         "projected_old_assistant_messages",
+        "projected_recent_assistant_messages",
+        "projected_plain_assistant_messages",
         "projected_old_tool_messages",
         "projection_chars_saved",
+        "assistant_projection_chars_saved",
         "context_blob_refs_created",
+        "output_size_guard_applied",
+        "large_generation_guard_applied",
         "request_budget_stage",
     ):
         if key in latest_request_budget:
@@ -517,6 +522,8 @@ def _safe_request_budget_fields(budget: Optional[Dict[str, Any]]) -> Dict[str, A
         "max_prompt_tokens",
         "max_output_tokens",
         "request_over_budget",
+        "output_size_guard_applied",
+        "large_generation_guard_applied",
     )
     safe = {key: budget.get(key) for key in keys if key in budget}
     stage = budget.get("request_budget_stage")
@@ -2102,6 +2109,7 @@ You have access to the following tools. When a user asks you to do something tha
             )
             if large_generation_guard:
                 llm_kwargs["system_prompt"] = ((llm_kwargs.get("system_prompt") or "") + "\n\n" + large_generation_guard).strip()
+            large_generation_guard_applied = bool(large_generation_guard)
             if effective_model:
                 llm_kwargs["model"] = effective_model
             
@@ -2124,6 +2132,8 @@ You have access to the following tools. When a user asks you to do something tha
                 budget_state["safety_margin_tokens"] = loop_budget.get("safety_margin_tokens")
                 budget_state["max_prompt_tokens"] = loop_budget.get("max_prompt_tokens")
                 budget_state["request_over_budget"] = request_estimated_tokens > prompt_budget_tokens if prompt_budget_tokens else False
+                budget_state["large_generation_guard_applied"] = large_generation_guard_applied
+                budget_state["output_size_guard_applied"] = large_generation_guard_applied
             if request_estimated_tokens > int(loop_budget.get("prompt_budget_tokens", 0) or 0):
                 loop_messages, loop_context_state = await prepare_progressive_messages(
                     messages=loop_messages,
@@ -2159,6 +2169,8 @@ You have access to the following tools. When a user asks you to do something tha
                 budget_state["max_prompt_tokens"] = loop_budget.get("max_prompt_tokens")
                 budget_state["max_output_tokens"] = loop_budget.get("max_output_tokens")
                 budget_state["request_over_budget"] = request_estimated_tokens > prompt_budget_tokens if prompt_budget_tokens else False
+                budget_state["large_generation_guard_applied"] = large_generation_guard_applied
+                budget_state["output_size_guard_applied"] = large_generation_guard_applied
                 budget_state["request_budget_stage"] = "tool_loop"
                 latest_request_budget = dict(budget_state)
                 emit_context_snapshot("tool_loop_budget", loop_context_state, iteration=iteration)
@@ -3079,6 +3091,7 @@ You have access to the following tools. When a user asks you to do something tha
             )
             if large_generation_guard:
                 llm_kwargs["system_prompt"] = ((llm_kwargs.get("system_prompt") or "") + "\n\n" + large_generation_guard).strip()
+            large_generation_guard_applied = bool(large_generation_guard)
             if self.model:
                 llm_kwargs["model"] = self.model
 
@@ -3099,6 +3112,8 @@ You have access to the following tools. When a user asks you to do something tha
                 "max_prompt_tokens": loop_budget.get("max_prompt_tokens"),
                 "max_output_tokens": loop_budget.get("max_output_tokens"),
                 "request_over_budget": request_estimated_tokens > prompt_budget_tokens if prompt_budget_tokens else False,
+                "large_generation_guard_applied": large_generation_guard_applied,
+                "output_size_guard_applied": large_generation_guard_applied,
                 "request_budget_stage": "skill_generation",
                 "stage": "skill_generation",
             }

--- a/src/runtime/progressive_context.py
+++ b/src/runtime/progressive_context.py
@@ -243,7 +243,10 @@ def _project_large_history_messages(
     protected_tool_chain_ids = _collect_protected_tool_chain_ids(messages, recent_count)
     refs: List[str] = []
     saved = 0
+    assistant_saved = 0
     projected_assistant = 0
+    projected_recent_assistant = 0
+    projected_plain_assistant = 0
     projected_tool = 0
     projected: List[AgentMessage] = []
     for idx, msg in enumerate(messages):
@@ -272,7 +275,11 @@ def _project_large_history_messages(
                     f"Full assistant output is available through context_read_ref(ref=\"{ref}\")."
                 )
                 saved += max(0, len(text) - len(compact))
+                assistant_saved += max(0, len(text) - len(compact))
                 projected_assistant += 1
+                projected_plain_assistant += 1
+                if idx >= keep_start:
+                    projected_recent_assistant += 1
                 projected.append(
                     AgentMessage(
                         role="assistant",
@@ -305,6 +312,7 @@ def _project_large_history_messages(
                     f"Tool calls are preserved below; full assistant text is available through context_read_ref(ref=\"{ref}\")."
                 )
                 saved += max(0, len(text) - len(compact))
+                assistant_saved += max(0, len(text) - len(compact))
                 projected_assistant += 1
                 projected.append(
                     AgentMessage(
@@ -342,8 +350,11 @@ def _project_large_history_messages(
     return projected, {
         "changed": projected != messages,
         "projected_old_assistant_messages": projected_assistant,
+        "projected_recent_assistant_messages": projected_recent_assistant,
+        "projected_plain_assistant_messages": projected_plain_assistant,
         "projected_old_tool_messages": projected_tool,
         "projection_chars_saved": saved,
+        "assistant_projection_chars_saved": assistant_saved,
         "context_blob_refs_created": refs,
     }
 
@@ -535,8 +546,11 @@ def _build_context_budget(
         budget.update(
             {
                 "projected_old_assistant_messages": projection_stats.get("projected_old_assistant_messages", 0),
+                "projected_recent_assistant_messages": projection_stats.get("projected_recent_assistant_messages", 0),
+                "projected_plain_assistant_messages": projection_stats.get("projected_plain_assistant_messages", 0),
                 "projected_old_tool_messages": projection_stats.get("projected_old_tool_messages", 0),
                 "projection_chars_saved": projection_stats.get("projection_chars_saved", 0),
+                "assistant_projection_chars_saved": projection_stats.get("assistant_projection_chars_saved", 0),
                 "context_blob_refs_created": projection_stats.get("context_blob_refs_created", []),
             }
         )
@@ -577,8 +591,13 @@ def build_portal_context_preview(context_state: dict | None) -> dict:
                 "context_max_prompt_tokens": budget.get("max_prompt_tokens"),
                 "context_max_output_tokens": budget.get("max_output_tokens"),
                 "context_projection_chars_saved": budget.get("projection_chars_saved"),
+                "context_assistant_projection_chars_saved": budget.get("assistant_projection_chars_saved"),
                 "context_projected_old_assistant_messages": budget.get("projected_old_assistant_messages"),
+                "context_projected_recent_assistant_messages": budget.get("projected_recent_assistant_messages"),
+                "context_projected_plain_assistant_messages": budget.get("projected_plain_assistant_messages"),
                 "context_projected_old_tool_messages": budget.get("projected_old_tool_messages"),
+                "context_output_size_guard_applied": budget.get("output_size_guard_applied"),
+                "context_large_generation_guard_applied": budget.get("large_generation_guard_applied"),
                 "context_context_blob_refs_created": (
                     len(budget.get("context_blob_refs_created"))
                     if isinstance(budget.get("context_blob_refs_created"), list)

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -551,13 +551,39 @@ def test_merge_request_budget_into_context_state_merges_safe_fields():
 
     merged = core._merge_request_budget_into_context_state(
         {"budget": {"existing": 1}},
-        {"request_estimated_tokens": 123, "request_over_budget": True, "stage": "skill_finalizer", "ignored_key": "x"},
+        {
+            "request_estimated_tokens": 123,
+            "request_over_budget": True,
+            "stage": "skill_finalizer",
+            "large_generation_guard_applied": True,
+            "output_size_guard_applied": True,
+            "ignored_key": "x",
+        },
     )
     assert merged["budget"]["existing"] == 1
     assert merged["budget"]["request_estimated_tokens"] == 123
     assert merged["budget"]["request_over_budget"] is True
+    assert merged["budget"]["large_generation_guard_applied"] is True
+    assert merged["budget"]["output_size_guard_applied"] is True
     assert merged["budget"]["request_budget_stage"] == "skill_finalizer"
     assert "ignored_key" not in merged["budget"]
+
+
+def test_safe_request_budget_fields_includes_guard_flags():
+    from src.agents import core
+
+    safe = core._safe_request_budget_fields(
+        {
+            "request_estimated_tokens": 10,
+            "large_generation_guard_applied": True,
+            "output_size_guard_applied": True,
+            "prompt": "do-not-include",
+        }
+    )
+    assert safe["request_estimated_tokens"] == 10
+    assert safe["large_generation_guard_applied"] is True
+    assert safe["output_size_guard_applied"] is True
+    assert "prompt" not in safe
 
 
 def test_agent_process_source_attaches_runtime_events_for_early_budget_and_llm_errors():
@@ -573,6 +599,14 @@ def test_continue_skill_mode_source_merges_budget_into_llm_errors():
 
     source = inspect.getsource(core.Agent._continue_skill_mode)
     assert "_merge_budget_into_error_details(error_response, skill_request_budget)" in source
+
+
+def test_agent_process_source_records_large_generation_guard_budget_fields():
+    from src.agents import core
+
+    source = inspect.getsource(core.Agent.process)
+    assert 'budget_state["large_generation_guard_applied"] = large_generation_guard_applied' in source
+    assert 'budget_state["output_size_guard_applied"] = large_generation_guard_applied' in source
 
 
 def test_is_meaningful_context_state_rules():

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -348,9 +348,14 @@ def test_build_portal_context_preview_includes_request_budget_fields():
                 "max_prompt_tokens": 32000,
                 "max_output_tokens": 64000,
                 "projection_chars_saved": 12345,
+                "assistant_projection_chars_saved": 6789,
                 "projected_old_assistant_messages": 2,
+                "projected_recent_assistant_messages": 1,
+                "projected_plain_assistant_messages": 1,
                 "projected_old_tool_messages": 3,
                 "context_blob_refs_created": ["ctx://context/a", "ctx://context/b"],
+                "output_size_guard_applied": True,
+                "large_generation_guard_applied": True,
                 "request_over_budget": True,
                 "request_budget_stage": "skill_finalizer",
             },
@@ -365,8 +370,13 @@ def test_build_portal_context_preview_includes_request_budget_fields():
     assert preview["context_max_prompt_tokens"] == 32000
     assert preview["context_max_output_tokens"] == 64000
     assert preview["context_projection_chars_saved"] == 12345
+    assert preview["context_assistant_projection_chars_saved"] == 6789
     assert preview["context_projected_old_assistant_messages"] == 2
+    assert preview["context_projected_recent_assistant_messages"] == 1
+    assert preview["context_projected_plain_assistant_messages"] == 1
     assert preview["context_projected_old_tool_messages"] == 3
+    assert preview["context_output_size_guard_applied"] is True
+    assert preview["context_large_generation_guard_applied"] is True
     assert preview["context_context_blob_refs_created"] == 2
     assert preview["context_request_budget_stage"] == "skill_finalizer"
     assert preview["context_request_over_budget"] is True
@@ -522,7 +532,40 @@ async def test_projects_recent_plain_assistant_artifact_like_content(monkeypatch
     restored = read_ref(ref, session_id=f"s-recent-plain-{stage}", max_chars=len(huge) + 1000)
     assert restored == huge
     assert state["budget"]["projected_old_assistant_messages"] >= 1
+    assert state["budget"]["projected_recent_assistant_messages"] >= 1
+    assert state["budget"]["projected_plain_assistant_messages"] >= 1
+    assert state["budget"]["assistant_projection_chars_saved"] > 0
     assert messages[3]["content"] == huge
+
+
+@pytest.mark.asyncio
+async def test_projects_large_assistant_with_tool_calls_tracks_assistant_saved_not_plain(monkeypatch):
+    huge = "```gherkin\n" + ("\nScenario: S\nGiven x\nWhen y\nThen z" * 2500)
+    messages = [
+        {"role": "assistant", "content": huge, "tool_calls": [{"id": "call_1", "function": {"name": "jira_get_issue", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_1", "tool_name": "jira_get_issue", "content": "short"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    async def _get_context_state(_session_id):
+        return {}
+
+    monkeypatch.setattr(progressive_context.session_manager, "get_context_state", _get_context_state)
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 200000)
+    monkeypatch.setattr(progressive_context, "estimate_messages_tokens", lambda msgs: 100)
+
+    prepared, state = await prepare_progressive_messages(
+        messages=messages,
+        model="gpt-5-mini",
+        session_id="s-assistant-tool-saved",
+        stage="tool_loop",
+        recent_count=5,
+    )
+
+    assistant = next(m for m in prepared if m["role"] == "assistant")
+    assert "[assistant tool-call content compacted" in assistant["content"]
+    assert state["budget"]["assistant_projection_chars_saved"] > 0
+    assert state["budget"]["projected_plain_assistant_messages"] == 0
 
 
 def test_degrade_projected_context_sources_keeps_ref_and_call_id():

--- a/tests/test_skill_mode_termination.py
+++ b/tests/test_skill_mode_termination.py
@@ -39,6 +39,7 @@ async def run_replay_case(
     initial_session=None,
     capture_llm_kwargs=None,
     tracer_factory=None,
+    skill_name="lookup",
 ):
     from src.agents import core as core_mod
 
@@ -74,10 +75,10 @@ async def run_replay_case(
     tracer_provider = tracer_factory or (lambda: FakeTracer())
     monkeypatch.setattr("src.skills.get_tracer", tracer_provider)
 
-    skill = SimpleNamespace(name="lookup", description="search issue", path="", tools=[], strategy=[])
+    skill = SimpleNamespace(name=skill_name, description="search issue", path="", tools=[], strategy=[])
     agent = make_agent()
 
-    skill_session = initial_session or SkillSession(skill_name="lookup", original_user_request=message)
+    skill_session = initial_session or SkillSession(skill_name=skill_name, original_user_request=message)
     result = await agent._continue_skill_mode(
         message=message,
         session_id="s-replay",
@@ -619,6 +620,8 @@ async def test_continue_skill_mode_error_response_includes_skill_generation_budg
         responses=[{"error": {"message": "boom", "type": "llm_error"}}],
     )
     assert result["request_budget"].get("request_budget_stage") == "skill_generation"
+    assert result["request_budget"].get("large_generation_guard_applied") is False
+    assert result["request_budget"].get("output_size_guard_applied") is False
 
 
 @pytest.mark.asyncio
@@ -652,3 +655,16 @@ async def test_continue_skill_mode_over_budget_error_includes_skill_generation_s
     assert result["details"]["request_budget_stage"] == "skill_generation"
     assert result["details"]["stage"] == "skill_generation"
     assert result["request_budget"]["request_budget_stage"] == "skill_generation"
+
+
+@pytest.mark.asyncio
+async def test_continue_skill_mode_mobilex_budget_marks_large_generation_guard_applied(monkeypatch):
+    result, _snapshots, _calls = await run_replay_case(
+        monkeypatch,
+        responses=[{"error": {"message": "boom", "type": "llm_error"}}],
+        skill_name="mobilex-test-cases-generator",
+    )
+
+    assert result["request_budget"].get("request_budget_stage") == "skill_generation"
+    assert result["request_budget"].get("large_generation_guard_applied") is True
+    assert result["request_budget"].get("output_size_guard_applied") is True


### PR DESCRIPTION
### Motivation
- Surface safe, scalar diagnostics so Portal can confirm when assistant-projection and output-guard logic actually ran without changing projection behavior or exposing raw blobs or secrets.

### Description
- Populate per-assistant projection counters and saved-chars in `_project_large_history_messages()` by adding `projected_recent_assistant_messages`, `projected_plain_assistant_messages`, and `assistant_projection_chars_saved`, while keeping legacy projection fields intact, and thread them through `projection_stats`. (`src/runtime/progressive_context.py`)
- Add the new projection fields into the context budget assembly in `_build_context_budget()` and expose flattened preview keys in `build_portal_context_preview()` as `context_projected_recent_assistant_messages`, `context_projected_plain_assistant_messages`, and `context_assistant_projection_chars_saved`, plus guard flags `context_output_size_guard_applied` and `context_large_generation_guard_applied`. (`src/runtime/progressive_context.py`)
- Record whether the large-generation / output-size guard was applied by setting `large_generation_guard_applied` and `output_size_guard_applied` in both the main Agent tool-loop request budgets and skill-mode `skill_request_budget`. (`src/agents/core.py`)
- Extend safe budget propagation allowlist so the guard booleans and new projection counters flow into sanitized error details and merged context-state budgets via `_safe_request_budget_fields()` and `_merge_request_budget_into_context_state()`. (`src/agents/core.py`)
- Tests updated/added to validate the above behaviors and to ensure assistant+tool-call projection accounting differs from plain-assistant accounting. (tests under `tests/`) 

Files changed
- `src/runtime/progressive_context.py`
- `src/agents/core.py`
- `tests/test_progressive_context.py`
- `tests/test_core_runtime_boundary.py`
- `tests/test_skill_mode_termination.py`

### Testing
- Ran `python -m compileall -q src tests` and unit tests listed below in this environment.
- `pytest tests/test_progressive_context.py -q` — 21 passed (1 warning).
- `pytest tests/test_core_runtime_boundary.py -q` — 51 passed (1 warning).
- `pytest tests/test_skill_mode_termination.py -q` — 25 passed (1 warning).
- `pytest tests/test_llm_client.py -q` — 52 passed (1 warning).
- `pytest tests/test_llm_tools_filtering.py -q` — 17 passed (1 warning).
- `pytest tests/test_context_blob_store.py -q` — 3 passed (1 warning).
- `pytest tests/test_jira_tools.py tests/test_confluence_tools.py -q` — 26 passed (1 warning).
- `pytest tests/test_confluence_markdown.py -q` — 23 passed (1 warning).
- `pytest -q` (full test run) — FAILED during collection: 7 errors due to missing gateway modules in this environment (examples: `ModuleNotFoundError: No module named 'src.gateway.server'`, `ModuleNotFoundError: No module named 'src.gateway.webchat'`), so global test collection could not complete here.
- Portal-side tests/paths were not runnable in this checkout (`app/...` and portal test files are absent), so portal verification steps were not executed locally and reported as file-not-found.

Confirmations
1. `projected_recent_assistant_messages` is populated (new projection stats returned from `_project_large_history_messages()`).
2. `projected_plain_assistant_messages` is populated (plain-assistant projections increment this counter).
3. `assistant_projection_chars_saved` is populated (chars-saved accounting for assistant projections, including assistant+tool_calls cases).
4. `large_generation_guard_applied` and `output_size_guard_applied` are recorded in request budgets in both main loop and skill-mode budgets when the guard text is applied.
5. EFP flat Portal preview (`build_portal_context_preview()`) emits the new fields (`context_projected_recent_assistant_messages`, `context_projected_plain_assistant_messages`, `context_assistant_projection_chars_saved`, `context_output_size_guard_applied`, `context_large_generation_guard_applied`).
6. Portal UI verification could not be executed here because `app/` and Portal tests are not present in this checkout, but the flat preview keys were added so Portal (which already supports these fields) can display them without receiving raw prompt/payload/Jira/context blob content.
7. Functional behavior and contracts were preserved: projection behavior unchanged (recent plain assistant projection still runs), Jira/Confluence `max_chars` exposure unchanged, no reintroduction of any unbounded-prefix constants, and raw ctx:// blob contents remain only referenced by ref (not sent in full).

If you want, I can open a follow-up PR for the Portal repo (or run its tests) once the Portal tree is available in this environment to validate rendering and templates end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6baffb7a4832a85e7d3719c27e2e6)