### PR TITLE
Harden tool dispatch/session scoping and staged generation state checks

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -23,7 +23,7 @@ llm:
   # OpenAI Configuration
   api_base: "https://api.openai.com/v1"
   api_key: "YOUR_OPENAI_API_KEY"
-  model: "gpt-3.5-turbo"
+  model: "gpt-5.4-mini"
   
   # Or GitHub Copilot Configuration
   # provider: "github_copilot"
@@ -38,30 +38,40 @@ llm:
   # model: "claude-sonnet-4-20250514"  # or claude-haiku-4-20250514, claude-opus-4-20250514
   
   max_tokens: 64000
+  model_limits:
+    gpt-5.4-mini:
+      max_context_window_tokens: 264000
+      max_prompt_tokens: 128000
+      max_output_tokens: 64000
   temperature: 0.7
   max_retries: 3
   retry_delay: 1
   context_budget:
     default:
-      max_prompt_tokens: 50000
-      reserved_output_tokens: 8000
-      safety_margin_tokens: 4000
+      max_prompt_tokens: 128000
+      reserved_output_tokens: 64000
+      safety_margin_tokens: 8000
     pre_request:
-      max_prompt_tokens: 50000
-      reserved_output_tokens: 8000
-      safety_margin_tokens: 4000
+      max_prompt_tokens: 128000
+      reserved_output_tokens: 64000
+      safety_margin_tokens: 8000
     tool_loop:
-      max_prompt_tokens: 32000
-      reserved_output_tokens: 16000
-      safety_margin_tokens: 4000
+      max_prompt_tokens: 128000
+      reserved_output_tokens: 64000
+      safety_margin_tokens: 8000
     skill_generation:
-      max_prompt_tokens: 28000
-      reserved_output_tokens: 24000
-      safety_margin_tokens: 4000
+      max_prompt_tokens: 128000
+      reserved_output_tokens: 64000
+      safety_margin_tokens: 8000
     tool_loop_aggressive:
-      max_prompt_tokens: 24000
-      reserved_output_tokens: 24000
-      safety_margin_tokens: 4000
+      max_prompt_tokens: 96000
+      reserved_output_tokens: 64000
+      safety_margin_tokens: 8000
+  output_controller:
+    max_chat_output_tokens: 60000
+    chars_per_token_estimate: 4
+    max_chat_output_chars: null
+    oversized_output_strategy: "save_and_manifest"
   context_projection:
     recent_protected_messages: 6
     jira_confluence:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -39,8 +39,28 @@ llm:
   
   max_tokens: 64000
   model_limits:
-    gpt-5.4-mini:
+    gpt-4o:
+      max_context_window_tokens: 128000
+      max_prompt_tokens: 64000
+      max_output_tokens: 16384
+    gpt-4.1:
+      max_context_window_tokens: 128000
+      max_prompt_tokens: 128000
+      max_output_tokens: 16384
+    gpt-5-mini:
       max_context_window_tokens: 264000
+      max_prompt_tokens: 128000
+      max_output_tokens: 64000
+    gpt-5.3-codex:
+      max_context_window_tokens: 400000
+      max_prompt_tokens: 272000
+      max_output_tokens: 128000
+    gpt-5.4-mini:
+      max_context_window_tokens: 400000
+      max_prompt_tokens: 272000
+      max_output_tokens: 128000
+    gemini-2.5-pro:
+      max_context_window_tokens: 128000
       max_prompt_tokens: 128000
       max_output_tokens: 64000
   temperature: 0.7
@@ -48,27 +68,27 @@ llm:
   retry_delay: 1
   context_budget:
     default:
-      max_prompt_tokens: 128000
-      reserved_output_tokens: 64000
+      max_prompt_tokens: 272000
+      reserved_output_tokens: 128000
       safety_margin_tokens: 8000
     pre_request:
-      max_prompt_tokens: 128000
-      reserved_output_tokens: 64000
+      max_prompt_tokens: 272000
+      reserved_output_tokens: 128000
       safety_margin_tokens: 8000
     tool_loop:
-      max_prompt_tokens: 128000
-      reserved_output_tokens: 64000
+      max_prompt_tokens: 272000
+      reserved_output_tokens: 128000
       safety_margin_tokens: 8000
     skill_generation:
-      max_prompt_tokens: 128000
-      reserved_output_tokens: 64000
+      max_prompt_tokens: 272000
+      reserved_output_tokens: 128000
       safety_margin_tokens: 8000
     tool_loop_aggressive:
-      max_prompt_tokens: 96000
-      reserved_output_tokens: 64000
+      max_prompt_tokens: 200000
+      reserved_output_tokens: 128000
       safety_margin_tokens: 8000
   output_controller:
-    max_chat_output_tokens: 60000
+    max_chat_output_tokens: 120000
     chars_per_token_estimate: 4
     max_chat_output_chars: null
     oversized_output_strategy: "save_and_manifest"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -37,7 +37,8 @@ llm:
   # api_key: "${ANTHROPIC_API_KEY}"  # Set ANTHROPIC_API_KEY env var
   # model: "claude-sonnet-4-20250514"  # or claude-haiku-4-20250514, claude-opus-4-20250514
   
-  max_tokens: 64000
+  max_tokens: 128000
+  allow_lower_max_tokens_than_model_limit: false
   model_limits:
     gpt-4o:
       max_context_window_tokens: 128000

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -597,6 +597,11 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
         page_id = kwargs.get("page_id", "")
         result = await confluence_module.confluence_get_comments(page_id, _session_id=kwargs.get("_session_id"))
         return ToolResult(success="Error" not in result, content=result)
+
+    elif name == "jira_get_comments":
+        issue_key = kwargs.get("issue_key", "")
+        result = await jira_module.jira_get_comments(issue_key, _session_id=kwargs.get("_session_id"))
+        return ToolResult(success="Error" not in str(result), content=str(result))
     
     elif name == "confluence_add_comment":
         page_id = kwargs.get("page_id", "")
@@ -623,7 +628,11 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
     elif name == "confluence_get_page_children":
         page_id = kwargs.get("page_id", "")
         limit = kwargs.get("limit", 10)
-        result = await confluence_module.confluence_get_page_children(page_id, limit)
+        result = await confluence_module.confluence_get_page_children(
+            page_id,
+            limit,
+            _session_id=kwargs.get("_session_id"),
+        )
         return ToolResult(success="Error" not in result, content=result)
     
     elif name == "confluence_get_page_history":

--- a/src/agents/compaction.py
+++ b/src/agents/compaction.py
@@ -29,6 +29,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from src.utils.truncate import truncate
 from src.runtime.context_summary import build_context_state_from_messages, build_structured_summary
+from src.config import resolve_model_limits
 
 logger = logging.getLogger(__name__)
 
@@ -804,6 +805,10 @@ def resolve_context_window_tokens(model: Optional[str] = None) -> int:
     Returns:
         Context window size
     """
+    limits = resolve_model_limits(model)
+    if limits.get("max_context_window_tokens"):
+        return int(limits["max_context_window_tokens"])
+
     # Default context windows
     context_windows = {
         # GPT-4 series
@@ -812,6 +817,7 @@ def resolve_context_window_tokens(model: Optional[str] = None) -> int:
         "gpt-4o": 128000,
         "gpt-4o-mini": 128000,
         # GPT-5 series
+        "gpt-5.4-mini": 264000,
         "gpt-5": 200000,
         "gpt-5-mini": 200000,
         "gpt-5-pro": 200000,

--- a/src/agents/compaction.py
+++ b/src/agents/compaction.py
@@ -820,14 +820,16 @@ def resolve_context_window_tokens(model: Optional[str] = None) -> int:
         "gpt-4o": 128000,
         "gpt-4o-mini": 128000,
         # GPT-5 series
-        "gpt-5.4-mini": 264000,
+        "gpt-5.4-mini": 400000,
+        "gpt-5.3-codex": 400000,
         "gpt-5": 200000,
-        "gpt-5-mini": 200000,
+        "gpt-5-mini": 264000,
         "gpt-5-pro": 200000,
         # GPT-3.5
         "gpt-3.5-turbo": 16385,
         # Gemini series (64K context)
-        "gemini-2.5": 200000,
+        "gemini-2.5-pro": 128000,
+        "gemini-2.5": 128000,
         "minimax/MiniMax-M3": 200000,
         "gemini-2.0": 32000,
         "gemini-1.5": 32000,

--- a/src/agents/compaction.py
+++ b/src/agents/compaction.py
@@ -433,7 +433,7 @@ async def summarize_with_fallback(
     summarize_func: Optional[Callable] = None,
     reserve_tokens: int = 1000,
     max_chunk_tokens: int = 4000,
-    context_window: int = 8000,
+    context_window: Optional[int] = None,
     custom_instructions: Optional[str] = None,
     previous_summary: Optional[str] = None,
 ) -> str:
@@ -455,6 +455,7 @@ async def summarize_with_fallback(
     """
     if not messages:
         return previous_summary or DEFAULT_SUMMARY_FALLBACK
+    context_window = int(context_window or resolve_context_window_tokens(None))
     
     # Try full summarization first
     try:
@@ -509,7 +510,7 @@ async def summarize_in_stages(
     summarize_func: Optional[Callable] = None,
     reserve_tokens: int = 1000,
     max_chunk_tokens: int = 4000,
-    context_window: int = 8000,
+    context_window: Optional[int] = None,
     custom_instructions: Optional[str] = None,
     previous_summary: Optional[str] = None,
     parts: Optional[int] = None,
@@ -533,6 +534,7 @@ async def summarize_in_stages(
     """
     if not messages:
         return previous_summary or DEFAULT_SUMMARY_FALLBACK
+    context_window = int(context_window or resolve_context_window_tokens(None))
     
     normalized_parts = normalize_parts(parts or DEFAULT_PARTS, len(messages))
     total_tokens = estimate_messages_tokens(messages)
@@ -721,7 +723,7 @@ async def compact_messages(
     messages: List[AgentMessage],
     max_tokens: int,
     summarize_func: Optional[Callable] = None,
-    context_window: int = 8000,
+    context_window: Optional[int] = None,
     recent_count: int = 3,
 ) -> Tuple[List[AgentMessage], CompactionStats]:
     """Compact messages for token optimization.
@@ -740,6 +742,7 @@ async def compact_messages(
     """
     if not messages:
         return [], CompactionStats()
+    context_window = int(context_window or resolve_context_window_tokens(None))
     
     # Estimate current tokens
     current_tokens = estimate_messages_tokens(messages)

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -1237,7 +1237,9 @@ async def _run_skill_finalizer(
         loop_budget = resolve_prompt_budget(stage="skill_generation", model=model)
         output_boundary = resolve_output_boundary(model)
         prompt_budget_tokens = int(loop_budget.get("prompt_budget_tokens", 0) or 0)
-        configured_max = int(loop_budget.get("max_output_tokens") or config.llm.get("max_tokens", 64000) or 64000)
+        model_max = int(loop_budget.get("max_output_tokens") or 64000)
+        configured_limit = int(config.llm.get("max_tokens", model_max) or model_max)
+        configured_max = min(model_max, configured_limit)
         requested_max = int(max_tokens or configured_max)
         budget_max_tokens = min(requested_max, configured_max)
         items_for_call = items
@@ -2307,7 +2309,9 @@ You have access to the following tools. When a user asks you to do something tha
             )
             loop_budget = resolve_prompt_budget(stage="tool_loop", model=effective_model)
             output_boundary = resolve_output_boundary(effective_model)
-            llm_kwargs["max_tokens"] = int(loop_budget.get("max_output_tokens") or config.llm.get("max_tokens", 64000) or 64000)
+            model_max_tokens = int(loop_budget.get("max_output_tokens") or 64000)
+            configured_limit = int(config.llm.get("max_tokens", model_max_tokens) or model_max_tokens)
+            llm_kwargs["max_tokens"] = min(model_max_tokens, configured_limit)
             if isinstance(loop_context_state, dict):
                 budget_state = loop_context_state.setdefault("budget", {})
                 prompt_budget_tokens = int(loop_budget.get("prompt_budget_tokens", 0) or 0)
@@ -3352,7 +3356,9 @@ You have access to the following tools. When a user asks you to do something tha
             )
             loop_budget = resolve_prompt_budget(stage="skill_generation", model=llm_kwargs.get("model"))
             output_boundary = resolve_output_boundary(llm_kwargs.get("model"))
-            effective_max_tokens = int(loop_budget.get("max_output_tokens") or config.llm.get("max_tokens", 64000) or 64000)
+            model_max_tokens = int(loop_budget.get("max_output_tokens") or 64000)
+            configured_limit = int(config.llm.get("max_tokens", model_max_tokens) or model_max_tokens)
+            effective_max_tokens = min(model_max_tokens, configured_limit)
             llm_kwargs["max_tokens"] = effective_max_tokens
             prompt_budget_tokens = int(loop_budget.get("prompt_budget_tokens", 0) or 0)
             skill_request_budget = {

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -1241,7 +1241,7 @@ async def _run_skill_finalizer(
     track_usage: bool,
     usage_data: Dict[str, Any],
     remaining_llm_budget: int,
-    max_tokens: int = 64000,
+    max_tokens: Optional[int] = None,
 ) -> tuple[FinalizerResult, Dict[str, Any]]:
     raw_output = ""
     fallback_used = False

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -33,7 +33,7 @@ from src.agents.llm import (
 from src.agents.memory import memory_system
 from src.memory.update_manager import MemoryUpdateManager
 from src.agents.thinking import ThinkLevel, normalize_think_level, format_runtime_info
-from src.config import config
+from src.config import config, resolve_output_boundary
 from src.utils.truncate import truncate, truncate_with_count
 from src.utils.redaction import safe_preview, redact_value, sanitize_exception_message
 from src.sessions.manager import session_manager
@@ -646,12 +646,17 @@ def _large_generation_output_guard(
     )
     if not is_generation:
         return ""
+    boundary = resolve_output_boundary(
+        getattr(active_skill_runtime, "model", None) or getattr(selected_skill, "model", None) or config.llm.get("model")
+    )
+    max_chars = int(boundary.get("max_chat_output_chars") or 0)
+    max_tokens = int(boundary.get("max_chat_output_tokens") or 0)
     return (
         "Large generation output guard: Do not emit a complete multi-file implementation or very long generated "
         "artifact in a single chat response. Generate one bounded phase/file at a time. Prefer writing artifacts/files "
         "through tools when available. In chat, return a concise manifest, file paths, and next step. "
-        "Keep response under 8000 characters.\n"
-        "generation_mode=staged\nmax_chat_output_chars=8000\ncurrent_phase=manifest"
+        f"Keep response within resolved output boundary (tokens≈{max_tokens}, chars≈{max_chars}).\n"
+        f"generation_mode=staged\nmax_chat_output_chars={max_chars}\ncurrent_phase=manifest"
     )
 
 
@@ -1230,6 +1235,7 @@ async def _run_skill_finalizer(
         items = list(input_items)
         items.append({"role": "user", "content": [{"type": "input_text", "text": prompt}]})
         loop_budget = resolve_prompt_budget(stage="skill_generation", model=model)
+        output_boundary = resolve_output_boundary(model)
         prompt_budget_tokens = int(loop_budget.get("prompt_budget_tokens", 0) or 0)
         configured_max = int(loop_budget.get("max_output_tokens") or config.llm.get("max_tokens", 64000) or 64000)
         requested_max = int(max_tokens or configured_max)
@@ -1291,7 +1297,7 @@ async def _run_skill_finalizer(
             context_state={"budget": finalizer_request_budget},
             active_skill=None,
             latest_user_text="",
-            max_chat_output_chars=8000,
+            max_chat_output_chars=int(output_boundary.get("max_chat_output_chars") or (int(output_boundary.get("max_chat_output_tokens") or 0) * int(output_boundary.get("chars_per_token_estimate") or 4))),
         )
         skill_session.llm_call_count += 1
         if not result.get("error"):
@@ -2300,6 +2306,8 @@ You have access to the following tools. When a user asks you to do something tha
                 tools=loop_tools or [],
             )
             loop_budget = resolve_prompt_budget(stage="tool_loop", model=effective_model)
+            output_boundary = resolve_output_boundary(effective_model)
+            llm_kwargs["max_tokens"] = int(loop_budget.get("max_output_tokens") or config.llm.get("max_tokens", 64000) or 64000)
             if isinstance(loop_context_state, dict):
                 budget_state = loop_context_state.setdefault("budget", {})
                 prompt_budget_tokens = int(loop_budget.get("prompt_budget_tokens", 0) or 0)
@@ -2314,7 +2322,8 @@ You have access to the following tools. When a user asks you to do something tha
                 budget_state["large_generation_guard_reason"] = "classifier:skill_or_user_generation_request" if large_generation_guard_applied else ""
                 budget_state["generation_mode"] = "staged" if large_generation_guard_applied else "default"
                 budget_state["current_generation_phase"] = "manifest" if large_generation_guard_applied else ""
-                budget_state["max_chat_output_chars"] = 8000
+                budget_state["max_chat_output_tokens"] = output_boundary.get("max_chat_output_tokens")
+                budget_state["max_chat_output_chars"] = output_boundary.get("max_chat_output_chars")
                 budget_state["output_risk_level"] = "high" if large_generation_guard_applied else "normal"
                 budget_state["output_token_limit"] = loop_budget.get("max_output_tokens")
                 budget_state["input_context_usage_percent"] = (
@@ -2356,6 +2365,8 @@ You have access to the following tools. When a user asks you to do something tha
                 budget_state["safety_margin_tokens"] = loop_budget.get("safety_margin_tokens")
                 budget_state["max_prompt_tokens"] = loop_budget.get("max_prompt_tokens")
                 budget_state["max_output_tokens"] = loop_budget.get("max_output_tokens")
+                budget_state["max_chat_output_tokens"] = output_boundary.get("max_chat_output_tokens")
+                budget_state["max_chat_output_chars"] = output_boundary.get("max_chat_output_chars")
                 budget_state["request_over_budget"] = request_estimated_tokens > prompt_budget_tokens if prompt_budget_tokens else False
                 budget_state["large_generation_guard_applied"] = large_generation_guard_applied
                 budget_state["output_size_guard_applied"] = large_generation_guard_applied
@@ -2391,7 +2402,7 @@ You have access to the following tools. When a user asks you to do something tha
                 context_state=loop_context_state if isinstance(loop_context_state, dict) else {"budget": {}},
                 active_skill=selected_skill,
                 latest_user_text=latest_user_text,
-                max_chat_output_chars=_safe_int(raw_max_chat, 8000),
+                max_chat_output_chars=_safe_int(raw_max_chat, int(output_boundary.get("max_chat_output_chars") or (int(output_boundary.get("max_chat_output_tokens") or 0) * int(output_boundary.get("chars_per_token_estimate") or 4)))),
             )
             if isinstance(loop_context_state, dict) and isinstance(loop_context_state.get("budget"), dict):
                 loop_context_state["budget"]["output_controller_applied"] = True
@@ -3340,6 +3351,7 @@ You have access to the following tools. When a user asks you to do something tha
                 tools=available_tools or [],
             )
             loop_budget = resolve_prompt_budget(stage="skill_generation", model=llm_kwargs.get("model"))
+            output_boundary = resolve_output_boundary(llm_kwargs.get("model"))
             effective_max_tokens = int(loop_budget.get("max_output_tokens") or config.llm.get("max_tokens", 64000) or 64000)
             llm_kwargs["max_tokens"] = effective_max_tokens
             prompt_budget_tokens = int(loop_budget.get("prompt_budget_tokens", 0) or 0)
@@ -3356,6 +3368,8 @@ You have access to the following tools. When a user asks you to do something tha
                 "large_generation_guard_reason": "classifier:skill_or_user_generation_request" if large_generation_guard_applied else "",
                 "generation_mode": "staged" if large_generation_guard_applied else "default",
                 "current_generation_phase": "manifest" if large_generation_guard_applied else "",
+                "max_chat_output_tokens": output_boundary.get("max_chat_output_tokens"),
+                "max_chat_output_chars": output_boundary.get("max_chat_output_chars"),
                 "request_budget_stage": "skill_generation",
                 "stage": "skill_generation",
             }
@@ -3411,7 +3425,7 @@ You have access to the following tools. When a user asks you to do something tha
                 context_state={"budget": skill_request_budget},
                 active_skill=skill,
                 latest_user_text=latest_user_text,
-                max_chat_output_chars=8000,
+                max_chat_output_chars=int(output_boundary.get("max_chat_output_chars") or (int(output_boundary.get("max_chat_output_tokens") or 0) * int(output_boundary.get("chars_per_token_estimate") or 4))),
             )
             skill_session.llm_call_count += 1
             turn_state.llm_call_count = skill_session.llm_call_count

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -1325,7 +1325,7 @@ async def _run_skill_finalizer(
             context_state={"budget": finalizer_request_budget},
             active_skill=None,
             latest_user_text="",
-            max_chat_output_chars=int(output_boundary.get("max_chat_output_chars") or (int(output_boundary.get("max_chat_output_tokens") or 0) * int(output_boundary.get("chars_per_token_estimate") or 4))),
+            max_chat_output_chars=None,
         )
         skill_session.llm_call_count += 1
         if not result.get("error"):
@@ -2438,7 +2438,7 @@ You have access to the following tools. When a user asks you to do something tha
                 context_state=loop_context_state if isinstance(loop_context_state, dict) else {"budget": {}},
                 active_skill=selected_skill,
                 latest_user_text=latest_user_text,
-                max_chat_output_chars=_safe_int(raw_max_chat, int(output_boundary.get("max_chat_output_chars") or (int(output_boundary.get("max_chat_output_tokens") or 0) * int(output_boundary.get("chars_per_token_estimate") or 4)))),
+                max_chat_output_chars=raw_max_chat,
             )
             if isinstance(loop_context_state, dict) and isinstance(loop_context_state.get("budget"), dict):
                 loop_context_state["budget"]["output_controller_applied"] = True
@@ -3465,7 +3465,7 @@ You have access to the following tools. When a user asks you to do something tha
                 context_state={"budget": skill_request_budget},
                 active_skill=skill,
                 latest_user_text=latest_user_text,
-                max_chat_output_chars=int(output_boundary.get("max_chat_output_chars") or (int(output_boundary.get("max_chat_output_tokens") or 0) * int(output_boundary.get("chars_per_token_estimate") or 4))),
+                max_chat_output_chars=None,
             )
             skill_session.llm_call_count += 1
             turn_state.llm_call_count = skill_session.llm_call_count

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -233,6 +233,30 @@ def _has_terminal_post_turn_context_snapshot(events: Any) -> bool:
     return False
 
 
+def _resolve_effective_max_tokens(model_max_tokens: int) -> Tuple[int, Dict[str, Any]]:
+    llm_cfg = config.llm if isinstance(config.llm, dict) else {}
+    allow_lower = bool(llm_cfg.get("allow_lower_max_tokens_than_model_limit", False))
+    configured_raw = llm_cfg.get("max_tokens")
+    configured_max_tokens: Optional[int]
+    try:
+        configured_max_tokens = int(configured_raw) if configured_raw is not None else None
+    except Exception:
+        configured_max_tokens = None
+    if configured_max_tokens is not None and configured_max_tokens <= 0:
+        configured_max_tokens = None
+    legacy_ignored = False
+    if configured_max_tokens is not None and configured_max_tokens < int(model_max_tokens) and not allow_lower:
+        effective = int(model_max_tokens)
+        legacy_ignored = True
+    else:
+        effective = min(int(model_max_tokens), int(configured_max_tokens or model_max_tokens))
+    return effective, {
+        "configured_max_tokens": configured_max_tokens,
+        "effective_max_tokens": effective,
+        "legacy_max_tokens_ignored": legacy_ignored,
+    }
+
+
 def _merge_request_budget_into_context_state(
     context_state: Dict[str, Any],
     latest_request_budget: Optional[Dict[str, Any]],
@@ -1238,10 +1262,9 @@ async def _run_skill_finalizer(
         output_boundary = resolve_output_boundary(model)
         prompt_budget_tokens = int(loop_budget.get("prompt_budget_tokens", 0) or 0)
         model_max = int(loop_budget.get("max_output_tokens") or 64000)
-        configured_limit = int(config.llm.get("max_tokens", model_max) or model_max)
-        configured_max = min(model_max, configured_limit)
-        requested_max = int(max_tokens or configured_max)
-        budget_max_tokens = min(requested_max, configured_max)
+        effective_max_tokens, max_token_diag = _resolve_effective_max_tokens(model_max)
+        requested_max = int(max_tokens or effective_max_tokens)
+        budget_max_tokens = min(requested_max, effective_max_tokens)
         items_for_call = items
         request_estimated_tokens = estimate_llm_request_tokens(
             input_items=items_for_call,
@@ -1255,6 +1278,9 @@ async def _run_skill_finalizer(
             "safety_margin_tokens": loop_budget.get("safety_margin_tokens"),
             "max_prompt_tokens": loop_budget.get("max_prompt_tokens"),
             "max_output_tokens": budget_max_tokens,
+            "configured_max_tokens": max_token_diag.get("configured_max_tokens"),
+            "effective_max_tokens": max_token_diag.get("effective_max_tokens"),
+            "legacy_max_tokens_ignored": bool(max_token_diag.get("legacy_max_tokens_ignored")),
             "request_over_budget": request_estimated_tokens > prompt_budget_tokens if prompt_budget_tokens else False,
             "request_budget_stage": "skill_finalizer",
             "stage": "skill_finalizer",
@@ -2310,8 +2336,8 @@ You have access to the following tools. When a user asks you to do something tha
             loop_budget = resolve_prompt_budget(stage="tool_loop", model=effective_model)
             output_boundary = resolve_output_boundary(effective_model)
             model_max_tokens = int(loop_budget.get("max_output_tokens") or 64000)
-            configured_limit = int(config.llm.get("max_tokens", model_max_tokens) or model_max_tokens)
-            llm_kwargs["max_tokens"] = min(model_max_tokens, configured_limit)
+            effective_max_tokens, max_token_diag = _resolve_effective_max_tokens(model_max_tokens)
+            llm_kwargs["max_tokens"] = effective_max_tokens
             if isinstance(loop_context_state, dict):
                 budget_state = loop_context_state.setdefault("budget", {})
                 prompt_budget_tokens = int(loop_budget.get("prompt_budget_tokens", 0) or 0)
@@ -2330,6 +2356,9 @@ You have access to the following tools. When a user asks you to do something tha
                 budget_state["max_chat_output_chars"] = output_boundary.get("max_chat_output_chars")
                 budget_state["output_risk_level"] = "high" if large_generation_guard_applied else "normal"
                 budget_state["output_token_limit"] = loop_budget.get("max_output_tokens")
+                budget_state["configured_max_tokens"] = max_token_diag.get("configured_max_tokens")
+                budget_state["effective_max_tokens"] = max_token_diag.get("effective_max_tokens")
+                budget_state["legacy_max_tokens_ignored"] = bool(max_token_diag.get("legacy_max_tokens_ignored"))
                 budget_state["input_context_usage_percent"] = (
                     (loop_context_state.get("budget") or {}).get("usage_percent")
                     if isinstance(loop_context_state.get("budget"), dict)
@@ -2371,6 +2400,9 @@ You have access to the following tools. When a user asks you to do something tha
                 budget_state["max_output_tokens"] = loop_budget.get("max_output_tokens")
                 budget_state["max_chat_output_tokens"] = output_boundary.get("max_chat_output_tokens")
                 budget_state["max_chat_output_chars"] = output_boundary.get("max_chat_output_chars")
+                budget_state["configured_max_tokens"] = max_token_diag.get("configured_max_tokens")
+                budget_state["effective_max_tokens"] = max_token_diag.get("effective_max_tokens")
+                budget_state["legacy_max_tokens_ignored"] = bool(max_token_diag.get("legacy_max_tokens_ignored"))
                 budget_state["request_over_budget"] = request_estimated_tokens > prompt_budget_tokens if prompt_budget_tokens else False
                 budget_state["large_generation_guard_applied"] = large_generation_guard_applied
                 budget_state["output_size_guard_applied"] = large_generation_guard_applied
@@ -3357,8 +3389,7 @@ You have access to the following tools. When a user asks you to do something tha
             loop_budget = resolve_prompt_budget(stage="skill_generation", model=llm_kwargs.get("model"))
             output_boundary = resolve_output_boundary(llm_kwargs.get("model"))
             model_max_tokens = int(loop_budget.get("max_output_tokens") or 64000)
-            configured_limit = int(config.llm.get("max_tokens", model_max_tokens) or model_max_tokens)
-            effective_max_tokens = min(model_max_tokens, configured_limit)
+            effective_max_tokens, max_token_diag = _resolve_effective_max_tokens(model_max_tokens)
             llm_kwargs["max_tokens"] = effective_max_tokens
             prompt_budget_tokens = int(loop_budget.get("prompt_budget_tokens", 0) or 0)
             skill_request_budget = {
@@ -3368,6 +3399,9 @@ You have access to the following tools. When a user asks you to do something tha
                 "safety_margin_tokens": loop_budget.get("safety_margin_tokens"),
                 "max_prompt_tokens": loop_budget.get("max_prompt_tokens"),
                 "max_output_tokens": loop_budget.get("max_output_tokens"),
+                "configured_max_tokens": max_token_diag.get("configured_max_tokens"),
+                "effective_max_tokens": max_token_diag.get("effective_max_tokens"),
+                "legacy_max_tokens_ignored": bool(max_token_diag.get("legacy_max_tokens_ignored")),
                 "request_over_budget": request_estimated_tokens > prompt_budget_tokens if prompt_budget_tokens else False,
                 "large_generation_guard_applied": large_generation_guard_applied,
                 "output_size_guard_applied": large_generation_guard_applied,

--- a/src/agents/skill_mode.py
+++ b/src/agents/skill_mode.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from src.agents.llm import _normalize_provider_key, llm_client
 from src.runtime.output_controller import call_llm_with_output_control
-from src.config import config
+from src.config import config, resolve_output_boundary
 from src.skills.registry import Skill
 
 logger = logging.getLogger(__name__)
@@ -369,6 +369,7 @@ async def _generate_initial_skill_plan_direct(skill: Skill, user_message: str, m
     }
     if model:
         kwargs["model"] = model
+    output_boundary = resolve_output_boundary(model or kwargs.get("model"))
 
     result, _diag = await call_llm_with_output_control(
         llm_client=llm_client,
@@ -378,7 +379,7 @@ async def _generate_initial_skill_plan_direct(skill: Skill, user_message: str, m
         context_state={"budget": {}},
         active_skill=skill,
         latest_user_text=user_message,
-        max_chat_output_chars=8000,
+        max_chat_output_chars=int(output_boundary.get("max_chat_output_chars") or (int(output_boundary.get("max_chat_output_tokens") or 0) * int(output_boundary.get("chars_per_token_estimate") or 4))),
     )
     content = (result.get("content") or "").strip()
 

--- a/src/agents/skill_mode.py
+++ b/src/agents/skill_mode.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from src.agents.llm import _normalize_provider_key, llm_client
 from src.runtime.output_controller import call_llm_with_output_control
-from src.config import config, resolve_output_boundary
+from src.config import config
 from src.skills.registry import Skill
 
 logger = logging.getLogger(__name__)
@@ -369,7 +369,6 @@ async def _generate_initial_skill_plan_direct(skill: Skill, user_message: str, m
     }
     if model:
         kwargs["model"] = model
-    output_boundary = resolve_output_boundary(model or kwargs.get("model"))
 
     result, _diag = await call_llm_with_output_control(
         llm_client=llm_client,
@@ -379,7 +378,7 @@ async def _generate_initial_skill_plan_direct(skill: Skill, user_message: str, m
         context_state={"budget": {}},
         active_skill=skill,
         latest_user_text=user_message,
-        max_chat_output_chars=int(output_boundary.get("max_chat_output_chars") or (int(output_boundary.get("max_chat_output_tokens") or 0) * int(output_boundary.get("chars_per_token_estimate") or 4))),
+        max_chat_output_chars=None,
     )
     content = (result.get("content") or "").strip()
 

--- a/src/config.py
+++ b/src/config.py
@@ -807,6 +807,7 @@ def resolve_output_boundary(model: Optional[str] = None) -> Dict[str, int | str]
         "max_chat_output_tokens": max_chat_output_tokens,
         "chars_per_token_estimate": chars_per_token,
         "max_chat_output_chars": max_chat_output_chars,
+        "allow_low_max_chat_output_chars": bool(output_cfg.get("allow_low_max_chat_output_chars", False)),
         "configured_max_chat_output_chars": str(configured_chars) if configured_chars is not None else None,
         "legacy_max_chat_output_chars_ignored": legacy_ignored,
         "output_boundary_source": boundary_source,

--- a/src/config.py
+++ b/src/config.py
@@ -696,5 +696,81 @@ class Config:
         return self._config.get("heartbeat", {})
 
 
+DEFAULT_MODEL_LIMITS: Dict[str, Dict[str, int]] = {
+    "gpt-5.4-mini": {
+        "max_context_window_tokens": 264000,
+        "max_prompt_tokens": 128000,
+        "max_output_tokens": 64000,
+    },
+}
+
+
+def _safe_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+        return parsed if parsed > 0 else default
+    except Exception:
+        return default
+
+
+def resolve_model_limits(model: Optional[str] = None) -> Dict[str, int]:
+    llm_cfg = config.llm if isinstance(config.llm, dict) else {}
+    configured_model = str(model or llm_cfg.get("model") or "").strip()
+    configured_limits = llm_cfg.get("model_limits") if isinstance(llm_cfg.get("model_limits"), dict) else {}
+    candidates: Dict[str, Dict[str, int]] = dict(DEFAULT_MODEL_LIMITS)
+    for key, raw in configured_limits.items():
+        if not isinstance(raw, dict):
+            continue
+        candidates[str(key).lower()] = {
+            "max_context_window_tokens": _safe_positive_int(raw.get("max_context_window_tokens"), 264000),
+            "max_prompt_tokens": _safe_positive_int(raw.get("max_prompt_tokens"), 128000),
+            "max_output_tokens": _safe_positive_int(raw.get("max_output_tokens"), _safe_positive_int(llm_cfg.get("max_tokens"), 64000)),
+        }
+
+    selected = candidates.get(configured_model.lower(), {})
+    if not selected and configured_model:
+        model_lower = configured_model.lower()
+        for key in sorted(candidates.keys(), key=len, reverse=True):
+            if key in model_lower:
+                selected = candidates[key]
+                break
+    if not selected:
+        selected = {
+            "max_context_window_tokens": 200000,
+            "max_prompt_tokens": 128000,
+            "max_output_tokens": _safe_positive_int(llm_cfg.get("max_tokens"), 64000),
+        }
+    selected = dict(selected)
+    selected["max_output_tokens"] = _safe_positive_int(selected.get("max_output_tokens"), _safe_positive_int(llm_cfg.get("max_tokens"), 64000))
+    selected["max_prompt_tokens"] = _safe_positive_int(selected.get("max_prompt_tokens"), 128000)
+    selected["max_context_window_tokens"] = _safe_positive_int(selected.get("max_context_window_tokens"), 264000)
+    return selected
+
+
+def resolve_output_boundary(model: Optional[str] = None) -> Dict[str, int | str]:
+    llm_cfg = config.llm if isinstance(config.llm, dict) else {}
+    output_cfg = llm_cfg.get("output_controller") if isinstance(llm_cfg.get("output_controller"), dict) else {}
+    limits = resolve_model_limits(model)
+    max_output_tokens = _safe_positive_int(limits.get("max_output_tokens"), _safe_positive_int(llm_cfg.get("max_tokens"), 64000))
+    configured_chat_tokens = output_cfg.get("max_chat_output_tokens")
+    default_chat_tokens = max(1, int(max_output_tokens * 0.9375))
+    max_chat_output_tokens = _safe_positive_int(configured_chat_tokens, default_chat_tokens)
+    max_chat_output_tokens = min(max_chat_output_tokens, max_output_tokens)
+    chars_per_token = _safe_positive_int(output_cfg.get("chars_per_token_estimate"), 4)
+    configured_chars = output_cfg.get("max_chat_output_chars")
+    if configured_chars in (None, "", "null"):
+        max_chat_output_chars = max_chat_output_tokens * chars_per_token
+    else:
+        max_chat_output_chars = _safe_positive_int(configured_chars, max_chat_output_tokens * chars_per_token)
+    strategy = str(output_cfg.get("oversized_output_strategy") or "save_and_manifest")
+    return {
+        "max_output_tokens": max_output_tokens,
+        "max_chat_output_tokens": max_chat_output_tokens,
+        "chars_per_token_estimate": chars_per_token,
+        "max_chat_output_chars": max_chat_output_chars,
+        "oversized_output_strategy": strategy,
+    }
+
+
 # Global config instance
 config = Config()

--- a/src/config.py
+++ b/src/config.py
@@ -758,16 +758,33 @@ def resolve_output_boundary(model: Optional[str] = None) -> Dict[str, int | str]
     max_chat_output_tokens = min(max_chat_output_tokens, max_output_tokens)
     chars_per_token = _safe_positive_int(output_cfg.get("chars_per_token_estimate"), 4)
     configured_chars = output_cfg.get("max_chat_output_chars")
+    derived_chars = max_chat_output_tokens * chars_per_token
+    min_reasonable_chars = int(derived_chars * 0.25)
+    legacy_ignored = False
+    boundary_source = "model_limits_derived"
     if configured_chars in (None, "", "null"):
-        max_chat_output_chars = max_chat_output_tokens * chars_per_token
+        max_chat_output_chars = derived_chars
     else:
-        max_chat_output_chars = _safe_positive_int(configured_chars, max_chat_output_tokens * chars_per_token)
+        parsed_chars = _safe_positive_int(configured_chars, derived_chars)
+        allow_low = bool(output_cfg.get("allow_low_max_chat_output_chars", False))
+        if parsed_chars < min_reasonable_chars and not allow_low:
+            max_chat_output_chars = derived_chars
+            legacy_ignored = True
+            boundary_source = "model_limits_legacy_override_ignored"
+        else:
+            max_chat_output_chars = parsed_chars
+            boundary_source = "config_override"
     strategy = str(output_cfg.get("oversized_output_strategy") or "save_and_manifest")
     return {
+        "max_context_window_tokens": int(limits.get("max_context_window_tokens") or 264000),
+        "max_prompt_tokens": int(limits.get("max_prompt_tokens") or 128000),
         "max_output_tokens": max_output_tokens,
         "max_chat_output_tokens": max_chat_output_tokens,
         "chars_per_token_estimate": chars_per_token,
         "max_chat_output_chars": max_chat_output_chars,
+        "configured_max_chat_output_chars": str(configured_chars) if configured_chars is not None else None,
+        "legacy_max_chat_output_chars_ignored": legacy_ignored,
+        "output_boundary_source": boundary_source,
         "oversized_output_strategy": strategy,
     }
 

--- a/src/config.py
+++ b/src/config.py
@@ -697,9 +697,34 @@ class Config:
 
 
 DEFAULT_MODEL_LIMITS: Dict[str, Dict[str, int]] = {
-    "gpt-5.4-mini": {
+    "gpt-4o": {
+        "max_context_window_tokens": 128_000,
+        "max_prompt_tokens": 64000,
+        "max_output_tokens": 16384,
+    },
+    "gpt-4.1": {
+        "max_context_window_tokens": 128_000,
+        "max_prompt_tokens": 128_000,
+        "max_output_tokens": 16384,
+    },
+    "gpt-5-mini": {
         "max_context_window_tokens": 264000,
         "max_prompt_tokens": 128000,
+        "max_output_tokens": 64000,
+    },
+    "gpt-5.3-codex": {
+        "max_context_window_tokens": 400000,
+        "max_prompt_tokens": 272000,
+        "max_output_tokens": 128000,
+    },
+    "gpt-5.4-mini": {
+        "max_context_window_tokens": 400000,
+        "max_prompt_tokens": 272000,
+        "max_output_tokens": 128000,
+    },
+    "gemini-2.5-pro": {
+        "max_context_window_tokens": 128_000,
+        "max_prompt_tokens": 128_000,
         "max_output_tokens": 64000,
     },
 }

--- a/src/hooks/file_context/retrieval.py
+++ b/src/hooks/file_context/retrieval.py
@@ -4,6 +4,8 @@ import re
 from collections import defaultdict
 from typing import List, Dict, Set, Tuple
 
+from src.config import config, resolve_model_limits
+
 from .models import Chunk, RetrievalRequest, RetrievalResult
 from .storage import storage
 
@@ -88,6 +90,26 @@ class RetrievalEngine:
         if include_images:
             return chunks
         return [c for c in chunks if c.type != 'image']
+
+    def _resolve_budget_thresholds(self, request: RetrievalRequest) -> Tuple[int, int, int]:
+        """Resolve retrieval thresholds from model prompt limits, with emergency legacy fallback."""
+        llm_cfg = config.llm if isinstance(config.llm, dict) else {}
+        model = str(llm_cfg.get("model") or "").strip()
+        known_model_keys = ("gpt-4o", "gpt-4.1", "gpt-5-mini", "gpt-5.3-codex", "gpt-5.4-mini", "gemini-2.5-pro")
+        model_limits = resolve_model_limits(model or None)
+        prompt_budget = int(model_limits.get("max_prompt_tokens") or 0) if any(k in model.lower() for k in known_model_keys) else 0
+        if prompt_budget <= 0:
+            try:
+                prompt_budget = int(request.max_tokens or 0)
+            except Exception:
+                prompt_budget = 0
+        if prompt_budget <= 0:
+            # Emergency fallback only if model/request budgets are unavailable.
+            return 1000, 4000, 8000
+        direct_threshold = max(1000, min(16000, int(prompt_budget * 0.05)))
+        topk_threshold = max(direct_threshold + 1, min(64000, int(prompt_budget * 0.20)))
+        summarize_threshold = max(topk_threshold + 1, min(128000, int(prompt_budget * 0.50)))
+        return direct_threshold, topk_threshold, summarize_threshold
     
     def retrieve(self, request: RetrievalRequest) -> RetrievalResult:
         """Perform retrieval with budget control."""
@@ -135,11 +157,12 @@ class RetrievalEngine:
         estimated_tokens = self._estimate_tokens(chunks)
         
         # Determine budget status
-        if estimated_tokens < 1000:
+        direct_threshold, topk_threshold, summarize_threshold = self._resolve_budget_thresholds(request)
+        if estimated_tokens < direct_threshold:
             budget_status = "direct"
-        elif estimated_tokens < 4000:
+        elif estimated_tokens < topk_threshold:
             budget_status = "top-k"
-        elif estimated_tokens < 8000:
+        elif estimated_tokens < summarize_threshold:
             budget_status = "summarize"
         else:
             budget_status = "error"

--- a/src/runtime/output_controller.py
+++ b/src/runtime/output_controller.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Tuple
 
 from src.context_blob_store import put_text
-from src.config import resolve_output_boundary
+from src.config import config, resolve_model_limits, resolve_output_boundary
 
 
 def _safe_int(value: Any, default: int) -> int:
@@ -47,6 +47,33 @@ def normalize_chat_output_chars(
     if parsed < min_reasonable and not allow_low:
         return derived, configured_raw is not None, configured_raw
     return parsed, False, configured_raw
+
+
+def resolve_effective_max_tokens_for_model(model: Optional[str]) -> Tuple[int, Dict[str, Any]]:
+    llm_cfg = config.llm if isinstance(config.llm, dict) else {}
+    limits = resolve_model_limits(model)
+    model_max_tokens = int(limits.get("max_output_tokens") or llm_cfg.get("max_tokens") or 64000)
+    configured_raw = llm_cfg.get("max_tokens")
+    configured_max_tokens: Optional[int]
+    try:
+        configured_max_tokens = int(configured_raw) if configured_raw is not None else None
+    except Exception:
+        configured_max_tokens = None
+    if configured_max_tokens is not None and configured_max_tokens <= 0:
+        configured_max_tokens = None
+    allow_lower = bool(llm_cfg.get("allow_lower_max_tokens_than_model_limit", False))
+    legacy_ignored = False
+    if configured_max_tokens is not None and configured_max_tokens < model_max_tokens and not allow_lower:
+        effective_max_tokens = model_max_tokens
+        legacy_ignored = True
+    else:
+        effective_max_tokens = min(model_max_tokens, int(configured_max_tokens or model_max_tokens))
+    return effective_max_tokens, {
+        "configured_max_tokens": configured_max_tokens,
+        "effective_max_tokens": effective_max_tokens,
+        "legacy_max_tokens_ignored": legacy_ignored,
+        "allow_lower_max_tokens_than_model_limit": allow_lower,
+    }
 
 
 def classify_output_risk(user_text: str, active_skill: Any, system_prompt: str, source_state: Optional[Dict[str, Any]] = None) -> str:
@@ -335,7 +362,28 @@ async def call_llm_with_output_control(
     max_chat_output_chars: Optional[int] = None,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     model = str(llm_kwargs.get("model") or "")
+    llm_kwargs = dict(llm_kwargs)
     boundary = resolve_output_boundary(model)
+    effective_max_tokens, max_token_diag = resolve_effective_max_tokens_for_model(model or None)
+    caller_max_tokens_raw = llm_kwargs.get("max_tokens")
+    caller_max_tokens: Optional[int]
+    try:
+        caller_max_tokens = int(caller_max_tokens_raw) if caller_max_tokens_raw is not None else None
+    except Exception:
+        caller_max_tokens = None
+    allow_lower_max_tokens = bool(max_token_diag.get("allow_lower_max_tokens_than_model_limit", False))
+    caller_max_tokens_ignored = False
+    model_token_cap = int(boundary.get("max_output_tokens") or effective_max_tokens)
+    if caller_max_tokens is None:
+        llm_kwargs["max_tokens"] = int(effective_max_tokens)
+    elif caller_max_tokens <= 0:
+        llm_kwargs["max_tokens"] = int(effective_max_tokens)
+        caller_max_tokens_ignored = True
+    elif caller_max_tokens < int(effective_max_tokens) and not allow_lower_max_tokens:
+        llm_kwargs["max_tokens"] = int(effective_max_tokens)
+        caller_max_tokens_ignored = True
+    else:
+        llm_kwargs["max_tokens"] = int(min(caller_max_tokens, model_token_cap))
     budget = context_state.setdefault("budget", {}) if isinstance(context_state, dict) else {}
     fallback_chars, fallback_source = _default_output_chars(model)
     allow_low = bool(boundary.get("allow_low_max_chat_output_chars", False))
@@ -379,6 +427,11 @@ async def call_llm_with_output_control(
     diagnostics["configured_budget_max_chat_output_chars"] = configured_budget_chars
     diagnostics["arg_max_chat_output_chars_ignored"] = arg_ignored
     diagnostics["configured_arg_max_chat_output_chars"] = configured_arg_chars
+    diagnostics["configured_max_tokens"] = max_token_diag.get("configured_max_tokens")
+    diagnostics["effective_max_tokens"] = int(llm_kwargs.get("max_tokens") or effective_max_tokens)
+    diagnostics["legacy_max_tokens_ignored"] = bool(max_token_diag.get("legacy_max_tokens_ignored") or caller_max_tokens_ignored)
+    diagnostics["caller_max_tokens"] = caller_max_tokens
+    diagnostics["caller_max_tokens_ignored"] = caller_max_tokens_ignored
     if isinstance(budget, dict):
         budget["session_id"] = session_id
 
@@ -420,6 +473,11 @@ async def call_llm_with_output_control(
         budget["configured_budget_max_chat_output_chars"] = configured_budget_chars
         budget["output_boundary_source"] = str(boundary.get("output_boundary_source") or fallback_source)
         budget["output_controller_stage"] = stage
+        budget["configured_max_tokens"] = max_token_diag.get("configured_max_tokens")
+        budget["effective_max_tokens"] = int(llm_kwargs.get("max_tokens") or effective_max_tokens)
+        budget["legacy_max_tokens_ignored"] = bool(max_token_diag.get("legacy_max_tokens_ignored") or caller_max_tokens_ignored)
+        budget["caller_max_tokens"] = caller_max_tokens
+        budget["caller_max_tokens_ignored"] = caller_max_tokens_ignored
 
     llm_result = await llm_client.responses(**llm_kwargs)
     llm_result, recovery_info = await recover_max_output_tokens(

--- a/src/runtime/output_controller.py
+++ b/src/runtime/output_controller.py
@@ -18,15 +18,15 @@ def _safe_int(value: Any, default: int) -> int:
         return default
 
 
-def _default_output_chars(model: Optional[str] = None) -> int:
+def _default_output_chars(model: Optional[str] = None) -> Tuple[int, str]:
     boundary = resolve_output_boundary(model)
     chars = int(boundary.get("max_chat_output_chars") or 0)
     if chars > 0:
-        return chars
+        return chars, str(boundary.get("output_boundary_source") or "model_limits_derived")
     tokens = int(boundary.get("max_chat_output_tokens") or 0)
     if tokens > 0:
-        return tokens * int(boundary.get("chars_per_token_estimate") or 4)
-    return 8000
+        return tokens * int(boundary.get("chars_per_token_estimate") or 4), str(boundary.get("output_boundary_source") or "model_limits_derived")
+    return 8000, "emergency_fallback_8000"
 
 
 def classify_output_risk(user_text: str, active_skill: Any, system_prompt: str, source_state: Optional[Dict[str, Any]] = None) -> str:
@@ -163,7 +163,7 @@ def ensure_staged_generation(
     gen["source_digest_chunk_coverage"] = coverage if isinstance(coverage, list) else []
     gen["source_digest_chunk_coverage_count"] = len(gen["source_digest_chunk_coverage"])
     _refresh_generation_done(gen)
-    fallback_chars = _default_output_chars()
+    fallback_chars, _ = _default_output_chars()
     gen["max_chat_output_chars"] = _safe_int(max_chat_output_chars, fallback_chars)
     gen["output_controller_applied"] = True
     gen["output_controller_stage"] = stage
@@ -213,7 +213,7 @@ def _extract_content_text(result: Dict[str, Any]) -> str:
 
 def enforce_chat_output_bound(content: str, *, session_id: str, stage: str, max_chars: Optional[int] = None) -> Tuple[str, Dict[str, Any]]:
     text = str(content or "")
-    fallback_chars = _default_output_chars()
+    fallback_chars, _ = _default_output_chars()
     max_chars = _safe_int(max_chars, fallback_chars)
     if len(text) <= max_chars:
         return text, {"bounded": False, "ref_count": 0}
@@ -308,7 +308,7 @@ async def call_llm_with_output_control(
     model = str(llm_kwargs.get("model") or "")
     boundary = resolve_output_boundary(model)
     budget = context_state.setdefault("budget", {}) if isinstance(context_state, dict) else {}
-    fallback_chars = _default_output_chars(model)
+    fallback_chars, fallback_source = _default_output_chars(model)
     max_chat_output_chars = _safe_int(max_chat_output_chars, fallback_chars)
     if isinstance(budget, dict):
         budget_chars = budget.get("max_chat_output_chars")
@@ -319,6 +319,15 @@ async def call_llm_with_output_control(
             chars_per_token = int(boundary.get("chars_per_token_estimate") or 4)
             max_chat_output_chars = _safe_int(budget_tokens, int(boundary.get("max_chat_output_tokens") or 0)) * chars_per_token
     diagnostics: Dict[str, Any] = {"output_controller_applied": True, "stage": stage}
+    diagnostics["output_boundary_source"] = str(boundary.get("output_boundary_source") or fallback_source)
+    diagnostics["legacy_max_chat_output_chars_ignored"] = bool(boundary.get("legacy_max_chat_output_chars_ignored", False))
+    diagnostics["configured_max_chat_output_chars"] = boundary.get("configured_max_chat_output_chars")
+    diagnostics["max_context_window_tokens"] = int(boundary.get("max_context_window_tokens") or 0)
+    diagnostics["max_prompt_tokens"] = int(boundary.get("max_prompt_tokens") or 0)
+    diagnostics["max_output_tokens"] = int(boundary.get("max_output_tokens") or 0)
+    diagnostics["max_chat_output_tokens"] = int(boundary.get("max_chat_output_tokens") or 0)
+    diagnostics["max_chat_output_chars"] = int(boundary.get("max_chat_output_chars") or max_chat_output_chars)
+    diagnostics["chars_per_token_estimate"] = int(boundary.get("chars_per_token_estimate") or 4)
     if isinstance(budget, dict):
         budget["session_id"] = session_id
 
@@ -350,6 +359,13 @@ async def call_llm_with_output_control(
         budget["output_token_limit"] = int(llm_kwargs.get("max_tokens") or boundary.get("max_output_tokens") or 0)
         budget["max_chat_output_tokens"] = int(boundary.get("max_chat_output_tokens") or 0)
         budget["max_chat_output_chars"] = max_chat_output_chars
+        budget["max_context_window_tokens"] = int(boundary.get("max_context_window_tokens") or 0)
+        budget["max_prompt_tokens"] = int(boundary.get("max_prompt_tokens") or 0)
+        budget["max_output_tokens"] = int(boundary.get("max_output_tokens") or 0)
+        budget["chars_per_token_estimate"] = int(boundary.get("chars_per_token_estimate") or 4)
+        budget["configured_max_chat_output_chars"] = boundary.get("configured_max_chat_output_chars")
+        budget["legacy_max_chat_output_chars_ignored"] = bool(boundary.get("legacy_max_chat_output_chars_ignored", False))
+        budget["output_boundary_source"] = str(boundary.get("output_boundary_source") or fallback_source)
         budget["output_controller_stage"] = stage
 
     llm_result = await llm_client.responses(**llm_kwargs)

--- a/src/runtime/output_controller.py
+++ b/src/runtime/output_controller.py
@@ -92,6 +92,13 @@ def initialize_completion_criteria(gen: Dict[str, Any], *, generation_mode: str)
     return normalized
 
 
+def _refresh_generation_done(gen: Dict[str, Any]) -> bool:
+    status = gen.get("completion_criteria_status")
+    done = bool(isinstance(status, dict) and status and all(bool(v) for v in status.values()))
+    gen["generation_done"] = done
+    return done
+
+
 def mark_phase_complete(gen: Dict[str, Any], phase: str) -> None:
     completed = gen.get("completed_phases")
     if not isinstance(completed, list):
@@ -137,12 +144,13 @@ def ensure_staged_generation(
     refs = gen.get("generated_artifact_refs")
     gen["generated_artifact_refs"] = refs if isinstance(refs, list) else []
     gen["generated_artifact_ref_count"] = len(gen["generated_artifact_refs"])
+    artifacts_by_phase = gen.get("generated_artifacts_by_phase")
+    gen["generated_artifacts_by_phase"] = artifacts_by_phase if isinstance(artifacts_by_phase, dict) else {}
     initialize_completion_criteria(gen, generation_mode="staged")
     coverage = gen.get("source_digest_chunk_coverage")
     gen["source_digest_chunk_coverage"] = coverage if isinstance(coverage, list) else []
     gen["source_digest_chunk_coverage_count"] = len(gen["source_digest_chunk_coverage"])
-    statuses = gen.get("completion_criteria_status")
-    gen["generation_done"] = bool(isinstance(statuses, dict) and statuses and all(bool(v) for v in statuses.values()))
+    _refresh_generation_done(gen)
     gen["max_chat_output_chars"] = _safe_int(max_chat_output_chars, 8000)
     gen["output_controller_applied"] = True
     gen["output_controller_stage"] = stage
@@ -157,9 +165,6 @@ def advance_generation_phase(context_state: Optional[Dict[str, Any]], *, latest_
     if text not in {"continue", "next", "go on", "继续", "继续生成"}:
         return gen
     current = str(gen.get("current_generation_phase") or "manifest")
-    status = gen.get("completion_criteria_status")
-    if isinstance(status, dict) and current == "manifest":
-        status["manifest_prepared"] = True
     mark_phase_complete(gen, current)
     next_phase = next_incomplete_phase(gen)
     gen["current_generation_phase"] = next_phase
@@ -340,6 +345,15 @@ async def call_llm_with_output_control(
 
     content = _extract_content_text(llm_result)
     if content:
+        if isinstance(gen_state, dict):
+            status = gen_state.get("completion_criteria_status")
+            if isinstance(status, dict):
+                phase = str(gen_state.get("current_generation_phase") or "manifest")
+                if phase == "manifest":
+                    status["manifest_prepared"] = True
+                if phase.startswith("phase_"):
+                    status["phase_output_recorded"] = True
+            _refresh_generation_done(gen_state)
         bounded, bound_info = enforce_chat_output_bound(
             content,
             session_id=session_id or "unknown_session",
@@ -367,24 +381,38 @@ async def call_llm_with_output_control(
                     refs.append(ref)
                     gen_state["generated_artifact_refs"] = refs
                     gen_state["generated_artifact_ref_count"] = len(refs)
+                    by_phase = gen_state.get("generated_artifacts_by_phase")
+                    if not isinstance(by_phase, dict):
+                        by_phase = {}
+                    phase = str(gen_state.get("current_generation_phase") or "manifest")
+                    phase_refs = by_phase.get(phase)
+                    if not isinstance(phase_refs, list):
+                        phase_refs = []
+                    phase_refs.append(ref)
+                    by_phase[phase] = phase_refs
+                    gen_state["generated_artifacts_by_phase"] = by_phase
                     coverage = gen_state.get("source_digest_chunk_coverage")
                     if not isinstance(coverage, list):
                         coverage = []
-                    coverage.append(f"{stage}:{gen_state.get('current_generation_phase')}")
+                    coverage.append(f"{stage}:{phase}")
                     gen_state["source_digest_chunk_coverage"] = coverage
                     gen_state["source_digest_chunk_coverage_count"] = len(coverage)
                 status = gen_state.get("completion_criteria_status")
                 if isinstance(status, dict):
                     status["response_bounded"] = True
-                    if str(gen_state.get("current_generation_phase")) == "manifest":
+                    phase = str(gen_state.get("current_generation_phase") or "manifest")
+                    if phase == "manifest":
                         status["manifest_prepared"] = True
-                    if str(gen_state.get("current_generation_phase", "")).startswith("phase_"):
+                    if phase.startswith("phase_"):
                         status["phase_output_recorded"] = True
                 if gen_state.get("generation_mode") == "staged":
                     gen_state["next_phase"] = next_incomplete_phase(gen_state)
+                    if gen_state["next_phase"] == "complete":
+                        gen_state["current_generation_phase"] = "complete"
+                    else:
+                        gen_state["current_generation_phase"] = gen_state["next_phase"]
             gen_state["partial_output_saved"] = bool(recovery_info.get("partial_ref"))
-            status = gen_state.get("completion_criteria_status")
-            gen_state["generation_done"] = bool(isinstance(status, dict) and status and all(bool(v) for v in status.values()))
+            _refresh_generation_done(gen_state)
 
     if isinstance(gen_state, dict):
         diagnostics["generation"] = dict(gen_state)

--- a/src/runtime/output_controller.py
+++ b/src/runtime/output_controller.py
@@ -29,6 +29,26 @@ def _default_output_chars(model: Optional[str] = None) -> Tuple[int, str]:
     return 8000, "emergency_fallback_8000"
 
 
+def normalize_chat_output_chars(
+    candidate: Any,
+    *,
+    boundary: Dict[str, Any],
+    allow_low: bool = False,
+) -> Tuple[int, bool, Optional[str]]:
+    chars_per_token = int(boundary.get("chars_per_token_estimate") or 4)
+    derived = int(boundary.get("max_chat_output_chars") or 0)
+    if derived <= 0:
+        derived = int(boundary.get("max_chat_output_tokens") or 0) * chars_per_token
+    if derived <= 0:
+        derived = 8000
+    configured_raw = None if candidate in (None, "") else str(candidate)
+    parsed = _safe_int(candidate, derived)
+    min_reasonable = max(1, int(derived * 0.25))
+    if parsed < min_reasonable and not allow_low:
+        return derived, configured_raw is not None, configured_raw
+    return parsed, False, configured_raw
+
+
 def classify_output_risk(user_text: str, active_skill: Any, system_prompt: str, source_state: Optional[Dict[str, Any]] = None) -> str:
     text = (str(user_text or "") + " " + str(system_prompt or "")).lower()
     skill_name = str(getattr(active_skill, "name", "") or getattr(active_skill, "skill_name", "")).lower()
@@ -164,7 +184,16 @@ def ensure_staged_generation(
     gen["source_digest_chunk_coverage_count"] = len(gen["source_digest_chunk_coverage"])
     _refresh_generation_done(gen)
     fallback_chars, _ = _default_output_chars()
-    gen["max_chat_output_chars"] = _safe_int(max_chat_output_chars, fallback_chars)
+    boundary = {
+        "max_chat_output_chars": fallback_chars,
+        "chars_per_token_estimate": 4,
+    }
+    normalized_chars, _, _ = normalize_chat_output_chars(
+        max_chat_output_chars,
+        boundary=boundary,
+        allow_low=True,
+    )
+    gen["max_chat_output_chars"] = normalized_chars
     gen["output_controller_applied"] = True
     gen["output_controller_stage"] = stage
     return gen
@@ -309,15 +338,33 @@ async def call_llm_with_output_control(
     boundary = resolve_output_boundary(model)
     budget = context_state.setdefault("budget", {}) if isinstance(context_state, dict) else {}
     fallback_chars, fallback_source = _default_output_chars(model)
-    max_chat_output_chars = _safe_int(max_chat_output_chars, fallback_chars)
+    allow_low = bool(boundary.get("allow_low_max_chat_output_chars", False))
+    max_chat_output_chars, arg_ignored, configured_arg_chars = normalize_chat_output_chars(
+        max_chat_output_chars,
+        boundary=boundary,
+        allow_low=allow_low,
+    )
+    budget_chars_ignored = False
+    configured_budget_chars = None
     if isinstance(budget, dict):
         budget_chars = budget.get("max_chat_output_chars")
         budget_tokens = budget.get("max_chat_output_tokens")
         if budget_chars not in (None, ""):
-            max_chat_output_chars = _safe_int(budget_chars, max_chat_output_chars)
+            max_chat_output_chars, ignored, configured_budget_chars = normalize_chat_output_chars(
+                budget_chars,
+                boundary=boundary,
+                allow_low=allow_low,
+            )
+            budget_chars_ignored = budget_chars_ignored or ignored
         if budget_tokens not in (None, "") and budget.get("max_chat_output_chars") in (None, ""):
             chars_per_token = int(boundary.get("chars_per_token_estimate") or 4)
-            max_chat_output_chars = _safe_int(budget_tokens, int(boundary.get("max_chat_output_tokens") or 0)) * chars_per_token
+            tokens_candidate = _safe_int(budget_tokens, int(boundary.get("max_chat_output_tokens") or 0)) * chars_per_token
+            max_chat_output_chars, ignored, _ = normalize_chat_output_chars(
+                tokens_candidate,
+                boundary=boundary,
+                allow_low=allow_low,
+            )
+            budget_chars_ignored = budget_chars_ignored or ignored
     diagnostics: Dict[str, Any] = {"output_controller_applied": True, "stage": stage}
     diagnostics["output_boundary_source"] = str(boundary.get("output_boundary_source") or fallback_source)
     diagnostics["legacy_max_chat_output_chars_ignored"] = bool(boundary.get("legacy_max_chat_output_chars_ignored", False))
@@ -326,8 +373,12 @@ async def call_llm_with_output_control(
     diagnostics["max_prompt_tokens"] = int(boundary.get("max_prompt_tokens") or 0)
     diagnostics["max_output_tokens"] = int(boundary.get("max_output_tokens") or 0)
     diagnostics["max_chat_output_tokens"] = int(boundary.get("max_chat_output_tokens") or 0)
-    diagnostics["max_chat_output_chars"] = int(boundary.get("max_chat_output_chars") or max_chat_output_chars)
+    diagnostics["max_chat_output_chars"] = max_chat_output_chars
     diagnostics["chars_per_token_estimate"] = int(boundary.get("chars_per_token_estimate") or 4)
+    diagnostics["budget_max_chat_output_chars_ignored"] = budget_chars_ignored
+    diagnostics["configured_budget_max_chat_output_chars"] = configured_budget_chars
+    diagnostics["arg_max_chat_output_chars_ignored"] = arg_ignored
+    diagnostics["configured_arg_max_chat_output_chars"] = configured_arg_chars
     if isinstance(budget, dict):
         budget["session_id"] = session_id
 
@@ -365,6 +416,8 @@ async def call_llm_with_output_control(
         budget["chars_per_token_estimate"] = int(boundary.get("chars_per_token_estimate") or 4)
         budget["configured_max_chat_output_chars"] = boundary.get("configured_max_chat_output_chars")
         budget["legacy_max_chat_output_chars_ignored"] = bool(boundary.get("legacy_max_chat_output_chars_ignored", False))
+        budget["budget_max_chat_output_chars_ignored"] = budget_chars_ignored
+        budget["configured_budget_max_chat_output_chars"] = configured_budget_chars
         budget["output_boundary_source"] = str(boundary.get("output_boundary_source") or fallback_source)
         budget["output_controller_stage"] = stage
 

--- a/src/runtime/output_controller.py
+++ b/src/runtime/output_controller.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Tuple
 
 from src.context_blob_store import put_text
+from src.config import resolve_output_boundary
 
 
 def _safe_int(value: Any, default: int) -> int:
@@ -15,6 +16,17 @@ def _safe_int(value: Any, default: int) -> int:
         return parsed if parsed > 0 else default
     except Exception:
         return default
+
+
+def _default_output_chars(model: Optional[str] = None) -> int:
+    boundary = resolve_output_boundary(model)
+    chars = int(boundary.get("max_chat_output_chars") or 0)
+    if chars > 0:
+        return chars
+    tokens = int(boundary.get("max_chat_output_tokens") or 0)
+    if tokens > 0:
+        return tokens * int(boundary.get("chars_per_token_estimate") or 4)
+    return 8000
 
 
 def classify_output_risk(user_text: str, active_skill: Any, system_prompt: str, source_state: Optional[Dict[str, Any]] = None) -> str:
@@ -34,7 +46,7 @@ def build_output_guard(risk: str, generation_mode: str) -> str:
     return (
         "Large generation output guard: staged mode is enforced. "
         "Return manifest/phase output only; do not emit full multi-file content. "
-        "Keep chat output <= 8000 characters."
+        "Keep chat output concise and split multi-file output across phases."
     )
 
 
@@ -131,7 +143,7 @@ def ensure_staged_generation(
     context_state: Optional[Dict[str, Any]],
     *,
     stage: str,
-    max_chat_output_chars: int,
+    max_chat_output_chars: Optional[int],
 ) -> Dict[str, Any]:
     gen = get_generation_state(context_state)
     completed = gen.get("completed_phases")
@@ -151,7 +163,8 @@ def ensure_staged_generation(
     gen["source_digest_chunk_coverage"] = coverage if isinstance(coverage, list) else []
     gen["source_digest_chunk_coverage_count"] = len(gen["source_digest_chunk_coverage"])
     _refresh_generation_done(gen)
-    gen["max_chat_output_chars"] = _safe_int(max_chat_output_chars, 8000)
+    fallback_chars = _default_output_chars()
+    gen["max_chat_output_chars"] = _safe_int(max_chat_output_chars, fallback_chars)
     gen["output_controller_applied"] = True
     gen["output_controller_stage"] = stage
     return gen
@@ -198,9 +211,10 @@ def _extract_content_text(result: Dict[str, Any]) -> str:
     return ""
 
 
-def enforce_chat_output_bound(content: str, *, session_id: str, stage: str, max_chars: int = 8000) -> Tuple[str, Dict[str, Any]]:
+def enforce_chat_output_bound(content: str, *, session_id: str, stage: str, max_chars: Optional[int] = None) -> Tuple[str, Dict[str, Any]]:
     text = str(content or "")
-    max_chars = _safe_int(max_chars, 8000)
+    fallback_chars = _default_output_chars()
+    max_chars = _safe_int(max_chars, fallback_chars)
     if len(text) <= max_chars:
         return text, {"bounded": False, "ref_count": 0}
     ref = put_text(
@@ -212,12 +226,12 @@ def enforce_chat_output_bound(content: str, *, session_id: str, stage: str, max_
         metadata={"stage": stage},
     )
     bounded = (
-        "Output was too large for one response. Saved full draft to context blob. "
-        "Continuing in staged mode with concise manifest.\n"
-        "ref_count=1\nnext_phase=phase_1\n"
+        "I saved the oversized draft and will continue from the next phase.\n"
+        "Output was too large for one response. Continuing in staged mode with concise manifest.\n"
+        "generated_artifact_ref_count=1\nnext_phase=phase_1\n"
         f"Use context_read_ref(ref=\"{ref}\") if needed."
     )
-    return bounded, {"bounded": True, "ref_count": 1, "ref": ref}
+    return bounded, {"bounded": True, "ref_count": 1, "generated_artifact_ref_count": 1, "ref": ref}
 
 
 async def recover_max_output_tokens(
@@ -266,8 +280,8 @@ async def recover_max_output_tokens(
         return retry_result, info
 
     fallback_text = (
-        "The requested output is too large for one response. I switched to staged generation and "
-        "will continue with manifest-first output."
+        "I saved the oversized draft and will continue from the next phase. "
+        "I switched to staged generation with manifest-first output."
     )
     if partial_ref:
         fallback_text += f"\nRecovered partial output was saved. Use context_read_ref(ref=\"{partial_ref}\") if needed."
@@ -289,11 +303,22 @@ async def call_llm_with_output_control(
     context_state: Optional[Dict[str, Any]],
     active_skill: Any = None,
     latest_user_text: str = "",
-    max_chat_output_chars: int = 8000,
+    max_chat_output_chars: Optional[int] = None,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    max_chat_output_chars = _safe_int(max_chat_output_chars, 8000)
-    diagnostics: Dict[str, Any] = {"output_controller_applied": True, "stage": stage}
+    model = str(llm_kwargs.get("model") or "")
+    boundary = resolve_output_boundary(model)
     budget = context_state.setdefault("budget", {}) if isinstance(context_state, dict) else {}
+    fallback_chars = _default_output_chars(model)
+    max_chat_output_chars = _safe_int(max_chat_output_chars, fallback_chars)
+    if isinstance(budget, dict):
+        budget_chars = budget.get("max_chat_output_chars")
+        budget_tokens = budget.get("max_chat_output_tokens")
+        if budget_chars not in (None, ""):
+            max_chat_output_chars = _safe_int(budget_chars, max_chat_output_chars)
+        if budget_tokens not in (None, "") and budget.get("max_chat_output_chars") in (None, ""):
+            chars_per_token = int(boundary.get("chars_per_token_estimate") or 4)
+            max_chat_output_chars = _safe_int(budget_tokens, int(boundary.get("max_chat_output_tokens") or 0)) * chars_per_token
+    diagnostics: Dict[str, Any] = {"output_controller_applied": True, "stage": stage}
     if isinstance(budget, dict):
         budget["session_id"] = session_id
 
@@ -322,7 +347,9 @@ async def call_llm_with_output_control(
         budget["output_controller_applied"] = True
         budget["output_risk_level"] = risk
         budget["generation_mode"] = generation_mode
-        budget["output_token_limit"] = int(llm_kwargs.get("max_tokens") or 0)
+        budget["output_token_limit"] = int(llm_kwargs.get("max_tokens") or boundary.get("max_output_tokens") or 0)
+        budget["max_chat_output_tokens"] = int(boundary.get("max_chat_output_tokens") or 0)
+        budget["max_chat_output_chars"] = max_chat_output_chars
         budget["output_controller_stage"] = stage
 
     llm_result = await llm_client.responses(**llm_kwargs)
@@ -367,11 +394,11 @@ async def call_llm_with_output_control(
         diagnostics["output_bounding"] = bound_info
         if isinstance(budget, dict):
             budget["output_bounded"] = bool(bound_info.get("bounded"))
-            budget["max_chat_output_chars"] = _safe_int(max_chat_output_chars, 8000)
+            budget["max_chat_output_chars"] = max_chat_output_chars
             budget["oversized_output_saved"] = bool(bound_info.get("bounded"))
             budget["partial_output_saved"] = bool(recovery_info.get("partial_ref"))
         if isinstance(gen_state, dict):
-            gen_state["max_chat_output_chars"] = _safe_int(max_chat_output_chars, 8000)
+            gen_state["max_chat_output_chars"] = max_chat_output_chars
             if bound_info.get("bounded"):
                 ref = bound_info.get("ref")
                 if isinstance(ref, str):

--- a/src/runtime/progressive_context.py
+++ b/src/runtime/progressive_context.py
@@ -15,7 +15,7 @@ from src.agents.compaction import (
     normalize_compaction_threshold,
     resolve_context_window_tokens,
 )
-from src.config import config
+from src.config import config, resolve_model_limits
 from src.runtime.context_summary import (
     build_context_state_from_messages,
     build_recovery_context_message,
@@ -152,11 +152,20 @@ def resolve_prompt_budget(*, stage: str, model: str | None) -> Dict[str, int]:
     default_cfg = budget_cfg.get("default") if isinstance(budget_cfg.get("default"), dict) else {}
     stage_cfg = budget_cfg.get(stage) if isinstance(budget_cfg.get(stage), dict) else {}
     merged = {**default_cfg, **stage_cfg}
+    model_limits = resolve_model_limits(model)
     context_window = int(resolve_context_window_tokens(model))
-    configured_reserved = int(merged.get("reserved_output_tokens", 8000) or 8000)
-    configured_safety = int(merged.get("safety_margin_tokens", 4000) or 4000)
-    max_prompt_tokens = int(merged.get("max_prompt_tokens", 50000) or 50000)
-    actual_max_output_tokens = int(config.llm.get("max_tokens", 64000) or 64000)
+    model_max_prompt_tokens = int(model_limits.get("max_prompt_tokens") or 128000)
+    actual_max_output_tokens = int(model_limits.get("max_output_tokens") or config.llm.get("max_tokens", 64000) or 64000)
+    configured_reserved = int(merged.get("reserved_output_tokens", actual_max_output_tokens) or actual_max_output_tokens)
+    configured_safety = int(merged.get("safety_margin_tokens", 8000) or 8000)
+    configured_max_prompt = merged.get("max_prompt_tokens")
+    max_prompt_tokens = int(configured_max_prompt or model_max_prompt_tokens)
+    if max_prompt_tokens <= 0:
+        max_prompt_tokens = model_max_prompt_tokens
+    allow_lower = bool(merged.get("allow_lower_than_model_limit", False))
+    if max_prompt_tokens < model_max_prompt_tokens and not allow_lower:
+        max_prompt_tokens = model_max_prompt_tokens
+    max_prompt_tokens = min(max_prompt_tokens, model_max_prompt_tokens)
     effective_reserved = min(configured_reserved, actual_max_output_tokens, int(context_window * 0.25))
     effective_safety = min(configured_safety, int(context_window * 0.05))
     context_based_prompt_cap = context_window - effective_reserved - effective_safety

--- a/src/runtime/progressive_context.py
+++ b/src/runtime/progressive_context.py
@@ -166,8 +166,14 @@ def resolve_prompt_budget(*, stage: str, model: str | None) -> Dict[str, int]:
     if max_prompt_tokens < model_max_prompt_tokens and not allow_lower:
         max_prompt_tokens = model_max_prompt_tokens
     max_prompt_tokens = min(max_prompt_tokens, model_max_prompt_tokens)
-    effective_reserved = min(configured_reserved, actual_max_output_tokens, int(context_window * 0.25))
     effective_safety = min(configured_safety, int(context_window * 0.05))
+    reserved_cap = int(context_window * 0.25) if context_window < 10000 else context_window
+    effective_reserved = min(
+        configured_reserved,
+        actual_max_output_tokens,
+        max(1, context_window - effective_safety - 1),
+        max(1, reserved_cap),
+    )
     context_based_prompt_cap = context_window - effective_reserved - effective_safety
     base_prompt = min(max_prompt_tokens, context_based_prompt_cap)
     if context_window < 4000:
@@ -599,6 +605,12 @@ def build_portal_context_preview(context_state: dict | None) -> dict:
                 "context_safety_margin_tokens": budget.get("safety_margin_tokens"),
                 "context_max_prompt_tokens": budget.get("max_prompt_tokens"),
                 "context_max_output_tokens": budget.get("max_output_tokens"),
+                "context_max_context_window_tokens": budget.get("max_context_window_tokens"),
+                "context_max_chat_output_tokens": budget.get("max_chat_output_tokens"),
+                "context_chars_per_token_estimate": budget.get("chars_per_token_estimate"),
+                "context_output_boundary_source": budget.get("output_boundary_source"),
+                "context_legacy_max_chat_output_chars_ignored": budget.get("legacy_max_chat_output_chars_ignored"),
+                "context_configured_max_chat_output_chars": budget.get("configured_max_chat_output_chars"),
                 "context_projection_chars_saved": budget.get("projection_chars_saved"),
                 "context_assistant_projection_chars_saved": budget.get("assistant_projection_chars_saved"),
                 "context_projected_old_assistant_messages": budget.get("projected_old_assistant_messages"),

--- a/src/sessions/pruning.py
+++ b/src/sessions/pruning.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from src.config import config, resolve_model_limits
 from src.sessions.manager import session_manager
 
 logger = logging.getLogger(__name__)
@@ -117,8 +118,24 @@ class SessionPruner:
 class SessionCompactor:
     """Compacts old conversation history into summaries."""
     
-    def __init__(self, max_context_tokens: int = 60000):
-        self.max_context_tokens = max_context_tokens
+    def __init__(self, max_context_tokens: Optional[int] = None, model: Optional[str] = None):
+        self.max_context_tokens = self._resolve_max_context_tokens(max_context_tokens, model=model)
+
+    @staticmethod
+    def _resolve_max_context_tokens(max_context_tokens: Optional[int], model: Optional[str] = None) -> int:
+        try:
+            if max_context_tokens is not None and int(max_context_tokens) > 0:
+                return int(max_context_tokens)
+        except Exception:
+            pass
+        llm_cfg = config.llm if isinstance(config.llm, dict) else {}
+        configured_model = str(model or llm_cfg.get("model") or "").strip()
+        limits = resolve_model_limits(configured_model or None)
+        prompt_tokens = int(limits.get("max_prompt_tokens") or 0)
+        if prompt_tokens > 0:
+            return prompt_tokens
+        # Emergency fallback only when limits cannot be resolved.
+        return 60000
     
     async def compact(
         self,

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -291,8 +291,8 @@ class TestResolveContextWindowTokens:
         """Test GPT-4 Turbo context window."""
         # Update based on actual implementation
         result = resolve_context_window_tokens("gpt-4-turbo")
-        # Should match either gpt-4 or be the actual 128000
-        assert result in [8192, 128000]
+        # Should match either gpt-4 or be the actual 128k
+        assert result in [8192, 128_000]
     
     def test_gpt_3_5_turbo(self):
         """Test GPT-3.5 Turbo context window."""
@@ -307,16 +307,16 @@ class TestResolveContextWindowTokens:
         assert resolve_context_window_tokens("unknown") == 4096
     
     def test_none_model(self):
-        """Test None model returns default."""
-        assert resolve_context_window_tokens(None) == 4096
+        """Test None model resolves to configured model limit."""
+        assert resolve_context_window_tokens(None) >= 128_000
 
     def test_gpt_4o(self):
         """Test GPT-4o context window."""
-        assert resolve_context_window_tokens("gpt-4o") == 128000
+        assert resolve_context_window_tokens("gpt-4o") == 128_000
 
     def test_gpt_4o_mini(self):
         """Test GPT-4o Mini context window."""
-        assert resolve_context_window_tokens("gpt-4o-mini") == 128000
+        assert resolve_context_window_tokens("gpt-4o-mini") == 128_000
 
     def test_gpt_5(self):
         """Test GPT-5 context window."""
@@ -324,7 +324,7 @@ class TestResolveContextWindowTokens:
 
     def test_gpt_5_mini(self):
         """Test GPT-5 Mini context window."""
-        assert resolve_context_window_tokens("gpt-5-mini") == 200000
+        assert resolve_context_window_tokens("gpt-5-mini") == 264000
 
     def test_gpt_5_pro(self):
         """Test GPT-5 Pro context window."""

--- a/tests/test_confluence_tools.py
+++ b/tests/test_confluence_tools.py
@@ -298,6 +298,26 @@ async def test_confluence_get_page_children_is_ledger_aware(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_confluence_get_page_children_uses_active_session(monkeypatch):
+    from src import execute_tool
+    from src.context_tools import context_read_ref
+
+    class _Channel:
+        def is_configured(self): return True
+        async def get_all_page_children_with_ledger(self, page_id, limit=100):
+            return [{"id": "c1", "title": "Child 1"}], {"loaded": 1, "total": 1, "complete": True}
+
+    monkeypatch.setattr("src.confluence.confluence_channel", _Channel())
+    result = await execute_tool("confluence_get_page_children", page_id="123", _session_id="s1")
+    assert result.success is True
+    assert "ctx://context/s1/" in result.content
+    assert "ctx://context/confluence-children-" not in result.content
+    ref = re.search(r"context_ref:\s*(ctx://context/[^\s\"\\]+)", result.content).group(1)
+    read_back = await context_read_ref(ref=ref, _session_id="s1")
+    assert "child" in read_back.lower()
+
+
+@pytest.mark.asyncio
 async def test_confluence_prepare_page_context_descendant_comment_incomplete_propagates(monkeypatch):
     from src.confluence import confluence_prepare_page_context
 
@@ -320,6 +340,7 @@ async def test_confluence_prepare_page_context_descendant_comment_incomplete_pro
     out = await confluence_prepare_page_context("123", include_children=True, _session_id="s-conf-desc")
     assert "descendants_comments_complete: False" in out
     assert "descendants_complete: False" in out
+    assert "source_tree_complete: False" in out
     assert "source_complete: False" in out
 
 
@@ -346,7 +367,61 @@ async def test_confluence_prepare_page_context_descendant_aggregates_complete(mo
     assert "descendants_pages_complete: True" in out
     assert "descendants_comments_complete: True" in out
     assert "descendants_attachments_complete: True" in out
+    assert "descendants_complete: True" in out
     assert "source_tree_complete: True" in out
+
+
+@pytest.mark.asyncio
+async def test_confluence_prepare_page_context_descendant_attachment_incomplete_propagates(monkeypatch):
+    from src.confluence import confluence_prepare_page_context
+
+    class _Channel:
+        def is_configured(self): return True
+        def get_instance_client(self, **kwargs): return self
+        async def get_page(self, page_id):
+            return {"id": page_id, "title": "Page", "space": {"key": "DOC"}, "body": {"storage": {"value": "<p>hello</p>"}}}
+        async def get_all_comments_with_ledger(self, page_id, limit=100):
+            return [], {"loaded": 0, "total": 0, "complete": True}
+        async def get_all_attachments_with_ledger(self, page_id, limit=100):
+            complete = False if page_id == "d1" else True
+            return [], {"loaded": 0, "total": 0, "complete": complete}
+        async def get_all_page_children_with_ledger(self, page_id, limit=100):
+            return [{"id": "c1"}], {"loaded": 1, "total": 1, "complete": True}
+        async def get_all_descendants_with_ledger(self, page_id, limit=100, max_depth=None):
+            return [{"id": "d1", "title": "Desc", "parent_id": page_id, "depth": 1}], {"loaded": 1, "total": 1, "complete": True, "partial_reasons": []}
+
+    monkeypatch.setattr("src.confluence.confluence_channel", _Channel())
+    out = await confluence_prepare_page_context("123", include_children=True, _session_id="s-conf-desc-attach")
+    assert "descendants_attachments_complete: False" in out
+    assert "descendants_complete: False" in out
+    assert "source_complete: False" in out
+
+
+@pytest.mark.asyncio
+async def test_confluence_prepare_page_context_descendant_page_body_missing_propagates(monkeypatch):
+    from src.confluence import confluence_prepare_page_context
+
+    class _Channel:
+        def is_configured(self): return True
+        def get_instance_client(self, **kwargs): return self
+        async def get_page(self, page_id):
+            if page_id == "d1":
+                return {}
+            return {"id": page_id, "title": "Page", "space": {"key": "DOC"}, "body": {"storage": {"value": "<p>hello</p>"}}}
+        async def get_all_comments_with_ledger(self, page_id, limit=100):
+            return [], {"loaded": 0, "total": 0, "complete": True}
+        async def get_all_attachments_with_ledger(self, page_id, limit=100):
+            return [], {"loaded": 0, "total": 0, "complete": True}
+        async def get_all_page_children_with_ledger(self, page_id, limit=100):
+            return [{"id": "c1"}], {"loaded": 1, "total": 1, "complete": True}
+        async def get_all_descendants_with_ledger(self, page_id, limit=100, max_depth=None):
+            return [{"id": "d1", "title": "Desc", "parent_id": page_id, "depth": 1}], {"loaded": 1, "total": 1, "complete": True, "partial_reasons": []}
+
+    monkeypatch.setattr("src.confluence.confluence_channel", _Channel())
+    out = await confluence_prepare_page_context("123", include_children=True, _session_id="s-conf-desc-page")
+    assert "descendants_pages_complete: False" in out
+    assert "descendants_complete: False" in out
+    assert "source_complete: False" in out
 
 
 @pytest.mark.asyncio

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -905,6 +905,97 @@ async def test_output_controller_allows_100k_below_real_boundary():
 
 
 @pytest.mark.asyncio
+async def test_output_controller_injects_effective_max_tokens_when_missing(monkeypatch):
+    from src.config import config
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {"model": "gpt-5.4-mini", "max_tokens": 64000, "allow_lower_max_tokens_than_model_limit": False},
+    )
+    captured = {}
+
+    class _Client:
+        async def responses(self, **kwargs):
+            captured["max_tokens"] = kwargs.get("max_tokens")
+            return {"content": "ok", "tool_calls": [], "function_calls": [], "usage": {}}
+
+    _, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "chat", "tools": [], "model": "gpt-5.4-mini"},
+        session_id="s-max-missing",
+        stage="tool_loop",
+        context_state={"budget": {}},
+        latest_user_text="hi",
+        max_chat_output_chars=None,
+    )
+    assert captured["max_tokens"] == 128000
+    assert diag.get("effective_max_tokens") == 128000
+    assert diag.get("legacy_max_tokens_ignored") is True
+
+
+@pytest.mark.asyncio
+async def test_output_controller_ignores_stale_low_caller_max_tokens_when_not_allowed(monkeypatch):
+    from src.config import config
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {"model": "gpt-5.4-mini", "max_tokens": 64000, "allow_lower_max_tokens_than_model_limit": False},
+    )
+    captured = {}
+
+    class _Client:
+        async def responses(self, **kwargs):
+            captured["max_tokens"] = kwargs.get("max_tokens")
+            return {"content": "ok", "tool_calls": [], "function_calls": [], "usage": {}}
+
+    _, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "chat", "tools": [], "model": "gpt-5.4-mini", "max_tokens": 64000},
+        session_id="s-max-low",
+        stage="tool_loop",
+        context_state={"budget": {}},
+        latest_user_text="hi",
+        max_chat_output_chars=None,
+    )
+    assert captured["max_tokens"] == 128000
+    assert diag.get("caller_max_tokens_ignored") is True
+
+
+@pytest.mark.asyncio
+async def test_output_controller_honors_explicit_allow_lower_max_tokens(monkeypatch):
+    from src.config import config
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {"model": "gpt-5.4-mini", "max_tokens": 64000, "allow_lower_max_tokens_than_model_limit": True},
+    )
+    captured = {}
+
+    class _Client:
+        async def responses(self, **kwargs):
+            captured["max_tokens"] = kwargs.get("max_tokens")
+            return {"content": "ok", "tool_calls": [], "function_calls": [], "usage": {}}
+
+    _, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "chat", "tools": [], "model": "gpt-5.4-mini", "max_tokens": 64000},
+        session_id="s-max-allow-low",
+        stage="tool_loop",
+        context_state={"budget": {}},
+        latest_user_text="hi",
+        max_chat_output_chars=None,
+    )
+    assert captured["max_tokens"] == 64000
+    assert diag.get("caller_max_tokens_ignored") is False
+
+
+@pytest.mark.asyncio
 async def test_output_controller_ignores_stale_budget_max_chat_output_chars(monkeypatch):
     from src.config import config
     from src.runtime.output_controller import call_llm_with_output_control

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -486,7 +486,7 @@ async def test_output_controller_bounds_huge_content_in_staged_mode():
         stage="skill_generation",
         context_state=state,
         latest_user_text="generate all test cases",
-        max_chat_output_chars=240000,
+        max_chat_output_chars=480000,
     )
     assert len(result.get("content") or "") == 50000
     assert "context_read_ref(" not in (result.get("content") or "")
@@ -517,13 +517,35 @@ async def test_output_controller_allows_20k_high_risk_without_oversize_manifest(
     assert diag.get("output_bounding", {}).get("bounded") is False
 
 
-def test_resolve_output_boundary_uses_model_limit_tokens():
-    from src.config import resolve_output_boundary
+def test_resolve_output_boundary_uses_model_limit_tokens(monkeypatch):
+    from src.config import config, resolve_output_boundary
 
+    monkeypatch.setitem(config._config, "llm", {"model": "gpt-5.4-mini", "max_tokens": 128000})
     boundary = resolve_output_boundary("gpt-5.4-mini")
-    assert boundary["max_output_tokens"] == 64000
-    assert boundary["max_chat_output_tokens"] >= 60000
-    assert boundary["max_chat_output_chars"] >= 200000
+    assert boundary["max_output_tokens"] == 128000
+    assert boundary["max_chat_output_tokens"] == 120000
+    assert boundary["max_chat_output_chars"] == 120000 * 4
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_output", "expected_chat_tokens", "expected_chars"),
+    [
+        ("gpt-4o", 16384, 15360, 61440),
+        ("gpt-4.1", 16384, 15360, 61440),
+        ("gpt-5-mini", 64000, 60000, 240000),
+        ("gpt-5.3-codex", 128000, 120000, 480000),
+        ("gpt-5.4-mini", 128000, 120000, 480000),
+        ("gemini-2.5-pro", 64000, 60000, 240000),
+    ],
+)
+def test_resolve_output_boundary_for_authoritative_models(monkeypatch, model, expected_output, expected_chat_tokens, expected_chars):
+    from src.config import config, resolve_output_boundary
+
+    monkeypatch.setitem(config._config, "llm", {"model": model, "max_tokens": expected_output})
+    boundary = resolve_output_boundary(model)
+    assert boundary["max_output_tokens"] == expected_output
+    assert boundary["max_chat_output_tokens"] == expected_chat_tokens
+    assert boundary["max_chat_output_chars"] == expected_chars
 
 
 def test_resolve_output_boundary_ignores_legacy_8k_override(monkeypatch):
@@ -534,19 +556,19 @@ def test_resolve_output_boundary_ignores_legacy_8k_override(monkeypatch):
         "llm",
         {
             "model": "gpt-5.4-mini",
-            "max_tokens": 64000,
+            "max_tokens": 128000,
             "output_controller": {"max_chat_output_chars": 7000, "chars_per_token_estimate": 4},
             "model_limits": {
                 "gpt-5.4-mini": {
-                    "max_context_window_tokens": 264000,
-                    "max_prompt_tokens": 128000,
-                    "max_output_tokens": 64000,
+                    "max_context_window_tokens": 400000,
+                    "max_prompt_tokens": 272000,
+                    "max_output_tokens": 128000,
                 }
             },
         },
     )
     boundary = resolve_output_boundary("gpt-5.4-mini")
-    assert boundary["max_chat_output_chars"] >= 200000
+    assert boundary["max_chat_output_chars"] == 120000 * 4
     assert boundary["legacy_max_chat_output_chars_ignored"] is True
     assert boundary["output_boundary_source"] == "model_limits_legacy_override_ignored"
 
@@ -559,7 +581,7 @@ def test_resolve_output_boundary_allows_low_override_when_explicit(monkeypatch):
         "llm",
         {
                 "model": "gpt-5.4-mini",
-                "max_tokens": 64000,
+                "max_tokens": 128000,
                 "output_controller": {
                 "max_chat_output_chars": 7000,
                 "allow_low_max_chat_output_chars": True,
@@ -567,9 +589,9 @@ def test_resolve_output_boundary_allows_low_override_when_explicit(monkeypatch):
             },
             "model_limits": {
                 "gpt-5.4-mini": {
-                    "max_context_window_tokens": 264000,
-                    "max_prompt_tokens": 128000,
-                    "max_output_tokens": 64000,
+                    "max_context_window_tokens": 400000,
+                    "max_prompt_tokens": 272000,
+                    "max_output_tokens": 128000,
                 }
             },
         },
@@ -587,19 +609,19 @@ def test_resolve_output_boundary_defaults_to_derived_chars(monkeypatch):
         "llm",
         {
             "model": "gpt-5.4-mini",
-            "max_tokens": 64000,
-            "output_controller": {"max_chat_output_tokens": 60000, "chars_per_token_estimate": 4},
+            "max_tokens": 128000,
+            "output_controller": {"max_chat_output_tokens": 120000, "chars_per_token_estimate": 4},
             "model_limits": {
                 "gpt-5.4-mini": {
-                    "max_context_window_tokens": 264000,
-                    "max_prompt_tokens": 128000,
-                    "max_output_tokens": 64000,
+                    "max_context_window_tokens": 400000,
+                    "max_prompt_tokens": 272000,
+                    "max_output_tokens": 128000,
                 }
             },
         },
     )
     boundary = resolve_output_boundary("gpt-5.4-mini")
-    assert boundary["max_chat_output_chars"] == 240000
+    assert boundary["max_chat_output_chars"] == 120000 * 4
 
 
 def test_compaction_context_window_defaults_do_not_assume_8k():
@@ -608,6 +630,14 @@ def test_compaction_context_window_defaults_do_not_assume_8k():
     assert inspect.signature(compaction.summarize_with_fallback).parameters["context_window"].default is None
     assert inspect.signature(compaction.summarize_in_stages).parameters["context_window"].default is None
     assert inspect.signature(compaction.compact_messages).parameters["context_window"].default is None
+
+
+def test_output_controller_default_output_chars_uses_model_limits():
+    from src.runtime.output_controller import _default_output_chars
+
+    chars, source = _default_output_chars("gpt-5.4-mini")
+    assert chars == 120000 * 4
+    assert source != "emergency_fallback_8000"
 
 
 @pytest.mark.asyncio
@@ -717,7 +747,7 @@ async def test_output_controller_tracks_generated_artifacts_by_phase_when_bounde
 
     class _Client:
         async def responses(self, **kwargs):
-            return {"content": "X" * 250000, "tool_calls": [], "function_calls": [], "usage": {}}
+            return {"content": "X" * 500000, "tool_calls": [], "function_calls": [], "usage": {}}
 
     state = {"budget": {}}
     _, diag1 = await call_llm_with_output_control(
@@ -751,7 +781,7 @@ async def test_output_controller_bounds_huge_content_medium_risk():
         stage="tool_loop",
         context_state=state,
         latest_user_text=user_text,
-        max_chat_output_chars=240000,
+        max_chat_output_chars=480000,
     )
     assert len(result.get("content") or "") == 50000
 
@@ -825,7 +855,7 @@ def test_ensure_staged_generation_accepts_none_max_chat_output_chars():
 
     state = {"generation": {}}
     gen = ensure_staged_generation(state, stage="tool_loop", max_chat_output_chars=None)
-    assert gen.get("max_chat_output_chars") >= 200000
+    assert gen.get("max_chat_output_chars") >= 120000 * 4
 
 
 @pytest.mark.asyncio
@@ -844,7 +874,7 @@ async def test_output_controller_bounds_oversized_normal_risk_output():
         stage="tool_loop",
         context_state=state,
         latest_user_text="hello",
-        max_chat_output_chars=240000,
+        max_chat_output_chars=480000,
     )
     assert len(result.get("content") or "") == 50000
     assert diag.get("output_bounding", {}).get("bounded") is False
@@ -857,7 +887,7 @@ async def test_output_controller_bounds_only_when_exceeding_real_boundary():
 
     class _Client:
         async def responses(self, **kwargs):
-            return {"content": "N" * 250000, "tool_calls": [], "function_calls": [], "usage": {}}
+            return {"content": "N" * 500000, "tool_calls": [], "function_calls": [], "usage": {}}
 
     state = {"budget": {}}
     result, diag = await call_llm_with_output_control(

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -567,7 +567,14 @@ async def test_output_controller_generation_done_requires_completion_criteria():
         async def responses(self, **kwargs):
             return {"content": "X" * 50000, "tool_calls": [], "function_calls": [], "usage": {}}
 
-    state = {"budget": {}, "generation": {"completion_criteria": ["manifest_prepared", "phase_output_recorded"], "completion_criteria_status": {"manifest_prepared": False, "phase_output_recorded": False}}}
+    state = {
+        "budget": {},
+        "generation": {
+            "completion_criteria": ["manifest_prepared", "phase_output_recorded"],
+            "completion_criteria_status": {"manifest_prepared": False, "phase_output_recorded": False},
+            "generated_artifact_ref_count": 2,
+        },
+    }
     _, diag1 = await call_llm_with_output_control(
         llm_client=_Client(),
         llm_kwargs={"input_items": [], "system_prompt": "generate implementation", "tools": []},
@@ -587,6 +594,29 @@ async def test_output_controller_generation_done_requires_completion_criteria():
         latest_user_text="continue",
     )
     assert diag2.get("generation_done") is True
+
+
+@pytest.mark.asyncio
+async def test_output_controller_tracks_generated_artifacts_by_phase_when_bounded():
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    class _Client:
+        async def responses(self, **kwargs):
+            return {"content": "X" * 50000, "tool_calls": [], "function_calls": [], "usage": {}}
+
+    state = {"budget": {}}
+    _, diag1 = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "generate implementation", "tools": []},
+        session_id="s-gen-phase",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="generate implementation",
+    )
+    by_phase = diag1.get("generation", {}).get("generated_artifacts_by_phase", {})
+    assert isinstance(by_phase, dict)
+    assert "manifest" in by_phase
+    assert len(by_phase["manifest"]) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -526,6 +526,90 @@ def test_resolve_output_boundary_uses_model_limit_tokens():
     assert boundary["max_chat_output_chars"] >= 200000
 
 
+def test_resolve_output_boundary_ignores_legacy_8k_override(monkeypatch):
+    from src.config import config, resolve_output_boundary
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "model": "gpt-5.4-mini",
+            "max_tokens": 64000,
+            "output_controller": {"max_chat_output_chars": 7000, "chars_per_token_estimate": 4},
+            "model_limits": {
+                "gpt-5.4-mini": {
+                    "max_context_window_tokens": 264000,
+                    "max_prompt_tokens": 128000,
+                    "max_output_tokens": 64000,
+                }
+            },
+        },
+    )
+    boundary = resolve_output_boundary("gpt-5.4-mini")
+    assert boundary["max_chat_output_chars"] >= 200000
+    assert boundary["legacy_max_chat_output_chars_ignored"] is True
+    assert boundary["output_boundary_source"] == "model_limits_legacy_override_ignored"
+
+
+def test_resolve_output_boundary_allows_low_override_when_explicit(monkeypatch):
+    from src.config import config, resolve_output_boundary
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+                "model": "gpt-5.4-mini",
+                "max_tokens": 64000,
+                "output_controller": {
+                "max_chat_output_chars": 7000,
+                "allow_low_max_chat_output_chars": True,
+                "chars_per_token_estimate": 4,
+            },
+            "model_limits": {
+                "gpt-5.4-mini": {
+                    "max_context_window_tokens": 264000,
+                    "max_prompt_tokens": 128000,
+                    "max_output_tokens": 64000,
+                }
+            },
+        },
+    )
+    boundary = resolve_output_boundary("gpt-5.4-mini")
+    assert boundary["max_chat_output_chars"] == 7000
+    assert boundary["legacy_max_chat_output_chars_ignored"] is False
+
+
+def test_resolve_output_boundary_defaults_to_derived_chars(monkeypatch):
+    from src.config import config, resolve_output_boundary
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "model": "gpt-5.4-mini",
+            "max_tokens": 64000,
+            "output_controller": {"max_chat_output_tokens": 60000, "chars_per_token_estimate": 4},
+            "model_limits": {
+                "gpt-5.4-mini": {
+                    "max_context_window_tokens": 264000,
+                    "max_prompt_tokens": 128000,
+                    "max_output_tokens": 64000,
+                }
+            },
+        },
+    )
+    boundary = resolve_output_boundary("gpt-5.4-mini")
+    assert boundary["max_chat_output_chars"] == 240000
+
+
+def test_compaction_context_window_defaults_do_not_assume_8k():
+    from src.agents import compaction
+
+    assert inspect.signature(compaction.summarize_with_fallback).parameters["context_window"].default is None
+    assert inspect.signature(compaction.summarize_in_stages).parameters["context_window"].default is None
+    assert inspect.signature(compaction.compact_messages).parameters["context_window"].default is None
+
+
 @pytest.mark.asyncio
 async def test_output_controller_treats_warning_truncation_as_recovery():
     from src.runtime.output_controller import call_llm_with_output_control
@@ -670,6 +754,28 @@ async def test_output_controller_bounds_huge_content_medium_risk():
         max_chat_output_chars=240000,
     )
     assert len(result.get("content") or "") == 50000
+
+
+@pytest.mark.asyncio
+async def test_output_controller_allows_100k_below_real_boundary():
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    class _Client:
+        async def responses(self, **kwargs):
+            return {"content": "M" * 100000, "tool_calls": [], "function_calls": [], "usage": {}}
+
+    state = {"budget": {}}
+    result, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "chat", "tools": [], "model": "gpt-5.4-mini"},
+        session_id="s-medium-100k",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="generate docs",
+        max_chat_output_chars=None,
+    )
+    assert len(result.get("content") or "") == 100000
+    assert diag.get("output_bounding", {}).get("bounded") is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -54,6 +54,79 @@ def test_agent_process_source_uses_safe_int_for_max_chat_output_chars():
     assert "resolve_output_boundary(effective_model)" in source
 
 
+def test_core_paths_use_effective_max_tokens_helper():
+    from src.agents import core
+
+    module_source = inspect.getsource(core)
+    assert module_source.count("_resolve_effective_max_tokens(") >= 3
+
+
+def test_session_compactor_default_uses_model_prompt_budget(monkeypatch):
+    from src.config import config
+    from src.sessions.pruning import SessionCompactor
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "model": "gpt-5.4-mini",
+            "model_limits": {
+                "gpt-5.4-mini": {
+                    "max_context_window_tokens": 400000,
+                    "max_prompt_tokens": 272000,
+                    "max_output_tokens": 128000,
+                }
+            },
+        },
+    )
+    compactor = SessionCompactor()
+    assert compactor.max_context_tokens >= 264000
+
+
+def test_resolve_effective_max_tokens_ignores_legacy_lower_limit(monkeypatch):
+    from src.agents import core
+    from src.config import config
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {"model": "gpt-5.4-mini", "max_tokens": 64000, "allow_lower_max_tokens_than_model_limit": False},
+    )
+    effective, diag = core._resolve_effective_max_tokens(128000)
+    assert effective == 128000
+    assert diag["configured_max_tokens"] == 64000
+    assert diag["legacy_max_tokens_ignored"] is True
+
+
+def test_resolve_effective_max_tokens_accepts_explicit_lower_override(monkeypatch):
+    from src.agents import core
+    from src.config import config
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {"model": "gpt-5.4-mini", "max_tokens": 64000, "allow_lower_max_tokens_than_model_limit": True},
+    )
+    effective, diag = core._resolve_effective_max_tokens(128000)
+    assert effective == 64000
+    assert diag["configured_max_tokens"] == 64000
+    assert diag["legacy_max_tokens_ignored"] is False
+
+
+def test_resolve_effective_max_tokens_keeps_model_cap_for_smaller_models(monkeypatch):
+    from src.agents import core
+    from src.config import config
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {"model": "gpt-4o", "max_tokens": 128000, "allow_lower_max_tokens_than_model_limit": False},
+    )
+    effective, diag = core._resolve_effective_max_tokens(16384)
+    assert effective == 16384
+    assert diag["legacy_max_tokens_ignored"] is False
+
+
 def test_read_governance_hint_returns_empty_when_missing():
     from src.agents import core
     from src import ToolResult
@@ -806,6 +879,78 @@ async def test_output_controller_allows_100k_below_real_boundary():
     )
     assert len(result.get("content") or "") == 100000
     assert diag.get("output_bounding", {}).get("bounded") is False
+
+
+@pytest.mark.asyncio
+async def test_output_controller_ignores_stale_budget_max_chat_output_chars(monkeypatch):
+    from src.config import config
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "model": "gpt-5.4-mini",
+            "max_tokens": 128000,
+            "allow_lower_max_tokens_than_model_limit": False,
+            "output_controller": {"chars_per_token_estimate": 4},
+        },
+    )
+
+    class _Client:
+        async def responses(self, **kwargs):
+            return {"content": "M" * 50000, "tool_calls": [], "function_calls": [], "usage": {}}
+
+    state = {"budget": {"max_chat_output_chars": 8000}}
+    result, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "chat", "tools": [], "model": "gpt-5.4-mini"},
+        session_id="s-stale-budget",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="normal response",
+        max_chat_output_chars=None,
+    )
+    assert len(result.get("content") or "") == 50000
+    assert diag.get("output_bounding", {}).get("bounded") is False
+    assert diag.get("max_chat_output_chars") == 480000
+    assert diag.get("budget_max_chat_output_chars_ignored") is True
+    assert diag.get("configured_budget_max_chat_output_chars") == "8000"
+
+
+@pytest.mark.asyncio
+async def test_output_controller_allows_low_budget_max_chat_output_chars_when_explicit(monkeypatch):
+    from src.config import config
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "model": "gpt-5.4-mini",
+            "max_tokens": 128000,
+            "output_controller": {"allow_low_max_chat_output_chars": True, "chars_per_token_estimate": 4},
+        },
+    )
+
+    class _Client:
+        async def responses(self, **kwargs):
+            return {"content": "M" * 20000, "tool_calls": [], "function_calls": [], "usage": {}}
+
+    state = {"budget": {"max_chat_output_chars": 8000}}
+    result, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "chat", "tools": [], "model": "gpt-5.4-mini"},
+        session_id="s-allow-low-budget",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="normal response",
+        max_chat_output_chars=None,
+    )
+    assert len(result.get("content") or "") < 1000
+    assert diag.get("output_bounding", {}).get("bounded") is True
+    assert diag.get("max_chat_output_chars") == 8000
+    assert diag.get("budget_max_chat_output_chars_ignored") is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -46,12 +46,12 @@ def test_core_safe_int_handles_none_for_max_chat_output_chars():
     assert core._safe_int("7000", 8000) == 7000
 
 
-def test_agent_process_source_uses_safe_int_for_max_chat_output_chars():
+def test_agent_process_passes_raw_max_chat_output_chars_to_output_controller():
     from src.agents import core
 
     source = inspect.getsource(core.Agent.process)
     assert "raw_max_chat =" in source
-    assert "resolve_output_boundary(effective_model)" in source
+    assert "max_chat_output_chars=raw_max_chat" in source
 
 
 def test_core_paths_use_effective_max_tokens_helper():
@@ -839,6 +839,28 @@ async def test_output_controller_tracks_generated_artifacts_by_phase_when_bounde
 
 
 @pytest.mark.asyncio
+async def test_output_controller_allows_20k_below_real_boundary():
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    class _Client:
+        async def responses(self, **kwargs):
+            return {"content": "M" * 20000, "tool_calls": [], "function_calls": [], "usage": {}}
+
+    state = {"budget": {}}
+    result, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "chat", "tools": [], "model": "gpt-5.4-mini"},
+        session_id="s-medium-20k",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="generate docs",
+        max_chat_output_chars=None,
+    )
+    assert len(result.get("content") or "") == 20000
+    assert diag.get("output_bounding", {}).get("bounded") is False
+
+
+@pytest.mark.asyncio
 async def test_output_controller_bounds_huge_content_medium_risk():
     from src.runtime.output_controller import call_llm_with_output_control
 
@@ -1021,7 +1043,7 @@ async def test_output_controller_accepts_none_max_chat_output_chars():
 
     result, diag = await call_llm_with_output_control(
         llm_client=_Client(),
-        llm_kwargs={"input_items": [], "system_prompt": "simple", "tools": []},
+        llm_kwargs={"input_items": [], "system_prompt": "simple", "tools": [], "model": "gpt-5.4-mini"},
         session_id="s-none-max-chat",
         stage="tool_loop",
         context_state={"budget": {}},
@@ -1030,6 +1052,7 @@ async def test_output_controller_accepts_none_max_chat_output_chars():
     )
     assert len(result.get("content") or "") == 9000
     assert diag.get("output_bounding", {}).get("bounded") is False
+    assert diag.get("max_chat_output_chars") == 480000
 
 
 def test_ensure_staged_generation_accepts_none_max_chat_output_chars():

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -605,6 +605,7 @@ def test_resolve_output_boundary_uses_model_limit_tokens(monkeypatch):
     [
         ("gpt-4o", 16384, 15360, 61440),
         ("gpt-4.1", 16384, 15360, 61440),
+        # 60000 chat-token defaults are valid for 64k-output models (not for gpt-5.4-mini).
         ("gpt-5-mini", 64000, 60000, 240000),
         ("gpt-5.3-codex", 128000, 120000, 480000),
         ("gpt-5.4-mini", 128000, 120000, 480000),
@@ -916,6 +917,42 @@ async def test_output_controller_ignores_stale_budget_max_chat_output_chars(monk
     assert diag.get("max_chat_output_chars") == 480000
     assert diag.get("budget_max_chat_output_chars_ignored") is True
     assert diag.get("configured_budget_max_chat_output_chars") == "8000"
+
+
+@pytest.mark.asyncio
+async def test_output_controller_ignores_stale_arg_max_chat_output_chars(monkeypatch):
+    from src.config import config
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "model": "gpt-5.4-mini",
+            "max_tokens": 128000,
+            "output_controller": {"chars_per_token_estimate": 4},
+        },
+    )
+
+    class _Client:
+        async def responses(self, **kwargs):
+            return {"content": "M" * 50000, "tool_calls": [], "function_calls": [], "usage": {}}
+
+    result, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "chat", "tools": [], "model": "gpt-5.4-mini"},
+        session_id="s-stale-arg",
+        stage="tool_loop",
+        context_state={"budget": {}},
+        latest_user_text="normal response",
+        max_chat_output_chars=8000,
+    )
+    assert len(result.get("content") or "") == 50000
+    assert diag.get("output_bounding", {}).get("bounded") is False
+    assert diag.get("max_chat_output_chars") == 480000
+    assert diag.get("arg_max_chat_output_chars_ignored") is True
+    assert diag.get("configured_arg_max_chat_output_chars") == "8000"
+    assert diag.get("output_boundary_source") != "emergency_fallback_8000"
 
 
 @pytest.mark.asyncio

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -51,7 +51,7 @@ def test_agent_process_source_uses_safe_int_for_max_chat_output_chars():
 
     source = inspect.getsource(core.Agent.process)
     assert "raw_max_chat =" in source
-    assert "max_chat_output_chars=_safe_int(raw_max_chat, 8000)" in source
+    assert "resolve_output_boundary(effective_model)" in source
 
 
 def test_read_governance_hint_returns_empty_when_missing():
@@ -486,13 +486,44 @@ async def test_output_controller_bounds_huge_content_in_staged_mode():
         stage="skill_generation",
         context_state=state,
         latest_user_text="generate all test cases",
-        max_chat_output_chars=8000,
+        max_chat_output_chars=240000,
     )
-    assert len(result.get("content") or "") <= 8000
-    assert "context_read_ref(" in (result.get("content") or "")
-    assert diag.get("output_bounding", {}).get("bounded") is True
-    assert diag.get("generated_artifact_ref_count", 0) >= 1
+    assert len(result.get("content") or "") == 50000
+    assert "context_read_ref(" not in (result.get("content") or "")
+    assert diag.get("output_bounding", {}).get("bounded") is False
     assert diag.get("generation", {}).get("generation_mode") == "staged"
+
+
+@pytest.mark.asyncio
+async def test_output_controller_allows_20k_high_risk_without_oversize_manifest():
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    class _Client:
+        async def responses(self, **kwargs):
+            return {"content": "H" * 20000, "tool_calls": [], "function_calls": [], "usage": {}}
+
+    state = {"budget": {}}
+    result, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "generate implementation", "tools": [], "model": "gpt-5.4-mini"},
+        session_id="s-20k",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="generate full implementation",
+        max_chat_output_chars=None,
+    )
+    assert len(result.get("content") or "") == 20000
+    assert "saved the oversized draft" not in (result.get("content") or "").lower()
+    assert diag.get("output_bounding", {}).get("bounded") is False
+
+
+def test_resolve_output_boundary_uses_model_limit_tokens():
+    from src.config import resolve_output_boundary
+
+    boundary = resolve_output_boundary("gpt-5.4-mini")
+    assert boundary["max_output_tokens"] == 64000
+    assert boundary["max_chat_output_tokens"] >= 60000
+    assert boundary["max_chat_output_chars"] >= 200000
 
 
 @pytest.mark.asyncio
@@ -602,7 +633,7 @@ async def test_output_controller_tracks_generated_artifacts_by_phase_when_bounde
 
     class _Client:
         async def responses(self, **kwargs):
-            return {"content": "X" * 50000, "tool_calls": [], "function_calls": [], "usage": {}}
+            return {"content": "X" * 250000, "tool_calls": [], "function_calls": [], "usage": {}}
 
     state = {"budget": {}}
     _, diag1 = await call_llm_with_output_control(
@@ -636,9 +667,9 @@ async def test_output_controller_bounds_huge_content_medium_risk():
         stage="tool_loop",
         context_state=state,
         latest_user_text=user_text,
-        max_chat_output_chars=8000,
+        max_chat_output_chars=240000,
     )
-    assert len(result.get("content") or "") <= 8000
+    assert len(result.get("content") or "") == 50000
 
 
 @pytest.mark.asyncio
@@ -679,8 +710,8 @@ async def test_output_controller_accepts_none_max_chat_output_chars():
         latest_user_text="Hey",
         max_chat_output_chars=None,
     )
-    assert len(result.get("content") or "") <= 8000
-    assert diag.get("output_bounding", {}).get("bounded") is True
+    assert len(result.get("content") or "") == 9000
+    assert diag.get("output_bounding", {}).get("bounded") is False
 
 
 def test_ensure_staged_generation_accepts_none_max_chat_output_chars():
@@ -688,7 +719,7 @@ def test_ensure_staged_generation_accepts_none_max_chat_output_chars():
 
     state = {"generation": {}}
     gen = ensure_staged_generation(state, stage="tool_loop", max_chat_output_chars=None)
-    assert gen.get("max_chat_output_chars") == 8000
+    assert gen.get("max_chat_output_chars") >= 200000
 
 
 @pytest.mark.asyncio
@@ -707,11 +738,36 @@ async def test_output_controller_bounds_oversized_normal_risk_output():
         stage="tool_loop",
         context_state=state,
         latest_user_text="hello",
-        max_chat_output_chars=8000,
+        max_chat_output_chars=240000,
     )
-    assert len(result.get("content") or "") <= 8000
+    assert len(result.get("content") or "") == 50000
+    assert diag.get("output_bounding", {}).get("bounded") is False
+    assert state["budget"].get("oversized_output_saved") is False
+
+
+@pytest.mark.asyncio
+async def test_output_controller_bounds_only_when_exceeding_real_boundary():
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    class _Client:
+        async def responses(self, **kwargs):
+            return {"content": "N" * 250000, "tool_calls": [], "function_calls": [], "usage": {}}
+
+    state = {"budget": {}}
+    result, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "simple chat reply", "tools": [], "model": "gpt-5.4-mini"},
+        session_id="s-normal-oversized",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="hello",
+        max_chat_output_chars=None,
+    )
+    assert len(result.get("content") or "") < 1000
     assert diag.get("output_bounding", {}).get("bounded") is True
     assert state["budget"].get("oversized_output_saved") is True
+    assert "generated_artifact_ref_count=1" in (result.get("content") or "")
+    assert "next_phase=phase_1" in (result.get("content") or "")
 
 
 def test_core_and_skill_mode_do_not_call_llm_client_responses_directly():

--- a/tests/test_file_context_retrieval.py
+++ b/tests/test_file_context_retrieval.py
@@ -1,0 +1,63 @@
+from src.hooks.file_context.models import Chunk, RetrievalRequest, SessionFileMeta
+from src.hooks.file_context.retrieval import RetrievalEngine
+from src.config import config
+
+
+def _make_chunk(chunk_id: str, content_chars: int = 40000) -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        file_id="f1",
+        session_id="s1",
+        type="paragraph",
+        content="A" * content_chars,
+        source="pymupdf",
+        content_hash=f"h-{chunk_id}",
+    )
+
+
+def test_retrieval_engine_uses_model_aware_thresholds_for_large_models(monkeypatch):
+    engine = RetrievalEngine()
+    chunks = [_make_chunk("c1", 80000), _make_chunk("c2", 200000)]
+    files = [SessionFileMeta(file_id="f1", session_id="s1", filename="doc.md", content_type="text/markdown", parse_status="completed")]
+
+    monkeypatch.setattr("src.hooks.file_context.retrieval.storage.get_session_chunks", lambda _sid: chunks)
+    monkeypatch.setattr("src.hooks.file_context.retrieval.storage.get_session_completed_files", lambda _sid: files)
+    monkeypatch.setattr("src.hooks.file_context.retrieval.storage.get_file_chunks", lambda _fid: chunks)
+
+    original_model = config.llm.get("model")
+    config.llm["model"] = "gpt-5.4-mini"
+    try:
+        # estimated_tokens ~= 20k
+        r1 = engine.retrieve(RetrievalRequest(session_id="s1", query="A", top_k=1))
+        assert r1.estimated_tokens >= 20000
+        assert r1.budget_status in {"top-k", "summarize"}
+
+        # estimated_tokens ~= 50k
+        r2 = engine.retrieve(RetrievalRequest(session_id="s1", query="A", top_k=2))
+        assert r2.estimated_tokens >= 50000
+        assert r2.budget_status in {"top-k", "summarize"}
+    finally:
+        if original_model is None:
+            config.llm.pop("model", None)
+        else:
+            config.llm["model"] = original_model
+
+
+def test_retrieval_engine_fallback_thresholds_for_unknown_model(monkeypatch):
+    engine = RetrievalEngine()
+    chunk = _make_chunk("c1", 36000)  # ~9000 tokens
+    files = [SessionFileMeta(file_id="f1", session_id="s1", filename="doc.md", content_type="text/markdown", parse_status="completed")]
+    monkeypatch.setattr("src.hooks.file_context.retrieval.storage.get_session_chunks", lambda _sid: [chunk])
+    monkeypatch.setattr("src.hooks.file_context.retrieval.storage.get_session_completed_files", lambda _sid: files)
+    monkeypatch.setattr("src.hooks.file_context.retrieval.storage.get_file_chunks", lambda _fid: [chunk])
+
+    original_model = config.llm.get("model")
+    config.llm["model"] = "unknown-model"
+    try:
+        result = engine.retrieve(RetrievalRequest(session_id="s1", query="A", top_k=1, max_tokens=100))
+        assert result.budget_status == "error"
+    finally:
+        if original_model is None:
+            config.llm.pop("model", None)
+        else:
+            config.llm["model"] = original_model

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -49,6 +49,13 @@ def test_jira_preview_tools_not_model_facing():
     assert "export_issues_to_markdown" not in names
 
 
+def test_jira_get_comments_schema_is_model_facing():
+    from src.jira import get_tools_schemas
+
+    names = {s.get("function", {}).get("name") for s in get_tools_schemas()}
+    assert "jira_get_comments" in names
+
+
 @pytest.mark.asyncio
 async def test_jira_update_issue_summary_only(mock_jira_channel):
     """Test jira_update_issue with summary only"""
@@ -379,3 +386,23 @@ async def test_execute_tool_jira_get_issue_by_url_uses_session_scoped_context_re
     ref = re.search(r"context_ref:\s*(ctx://context/[^\s\"\\]+)", result.content).group(1)
     read_back = await context_read_ref(ref=ref, _session_id="s1")
     assert "source bundle" in read_back.lower() or "metadata" in read_back.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_jira_get_comments_dispatches_with_session(monkeypatch):
+    from src import execute_tool
+
+    captured = {}
+
+    async def _fake_jira_get_comments(issue_key, _session_id=None):
+        captured["issue_key"] = issue_key
+        captured["session_id"] = _session_id
+        return "[jira comments bundle prepared]\ncontext_ref: ctx://context/s1/blob-1\ncomments_loaded: 1/1"
+
+    monkeypatch.setattr("src.jira.jira_get_comments", _fake_jira_get_comments)
+    result = await execute_tool("jira_get_comments", issue_key="ABC-1", _session_id="s1")
+    assert result.success is True
+    assert captured["issue_key"] == "ABC-1"
+    assert captured["session_id"] == "s1"
+    assert "[jira comments bundle prepared]" in result.content
+    assert "ctx://context/s1/" in result.content

--- a/tests/test_portal_session_metadata_client.py
+++ b/tests/test_portal_session_metadata_client.py
@@ -221,7 +221,7 @@ def test_build_session_metadata_payload_preserves_context_budget_preview_keys():
         metadata={
             "context_usage_percent": 42.0,
             "context_estimated_tokens": 4200,
-            "context_window_tokens": 128000,
+            "context_window_tokens": 128_000,
             "context_next_compaction_action": "approaching_micro_compaction",
             "context_next_pruning_policy": "Approaching micro-compaction...",
             "context_tokens_until_soft_threshold": 1200,

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -462,6 +462,28 @@ def test_resolve_model_limits_for_gpt_54_mini():
     assert limits["max_output_tokens"] == 64000
 
 
+def test_resolve_context_window_tokens_uses_configured_model_limit(monkeypatch):
+    from src.agents.compaction import resolve_context_window_tokens
+    from src.config import config
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "model": "gpt-5.4-mini",
+            "max_tokens": 64000,
+            "model_limits": {
+                "gpt-5.4-mini": {
+                    "max_context_window_tokens": 264000,
+                    "max_prompt_tokens": 128000,
+                    "max_output_tokens": 64000,
+                }
+            },
+        },
+    )
+    assert resolve_context_window_tokens(None) == 264000
+
+
 @pytest.mark.asyncio
 async def test_projection_runs_before_threshold_checks_and_compacts_old_assistant(monkeypatch):
     old = "Feature: Big\n" + ("\nScenario: very long\nGiven x" * 4000)

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -474,6 +474,23 @@ def test_resolve_prompt_budget_skill_generation_uses_model_limit(monkeypatch):
 @pytest.mark.parametrize(
     ("model", "expected"),
     [
+        ("gpt-5.3-codex", (400000, 272000, 128000, 264000)),
+        ("gpt-5.4-mini", (400000, 272000, 128000, 264000)),
+        ("gpt-5-mini", (264000, 128000, 64000, 128000)),
+        ("gpt-4o", (128000, 64000, 16384, 64000)),
+    ],
+)
+def test_resolve_prompt_budget_respects_authoritative_model_table(model, expected):
+    budget = progressive_context.resolve_prompt_budget(stage="tool_loop", model=model)
+    assert budget["context_window_tokens"] == expected[0]
+    assert budget["max_prompt_tokens"] == expected[1]
+    assert budget["max_output_tokens"] == expected[2]
+    assert budget["prompt_budget_tokens"] == expected[3]
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
         ("gpt-4o", (128000, 64000, 16384)),
         ("gpt-4.1", (128000, 128000, 16384)),
         ("gpt-5-mini", (264000, 128000, 64000)),

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -396,7 +396,15 @@ def test_build_portal_context_preview_includes_source_and_generation_diagnostics
                 "generation_mode": "staged",
                 "current_generation_phase": "manifest",
                 "output_risk_level": "high",
-                "max_chat_output_chars": 240000,
+                "max_chat_output_chars": 120000 * 4,
+                "max_chat_output_tokens": 120000,
+                "max_context_window_tokens": 400000,
+                "max_prompt_tokens": 272000,
+                "max_output_tokens": 128000,
+                "output_boundary_source": "model_limits_derived",
+                "legacy_max_chat_output_chars_ignored": True,
+                "configured_max_chat_output_chars": "7000",
+                "chars_per_token_estimate": 4,
                 "max_output_recovery_applied": True,
             },
             "source": {
@@ -417,6 +425,10 @@ def test_build_portal_context_preview_includes_source_and_generation_diagnostics
     assert preview["context_source_complete"] is True
     assert preview["context_output_risk_level"] == "high"
     assert preview["context_source_digest_chunk_count"] == 4
+    assert preview["context_max_chat_output_tokens"] == 120000
+    assert preview["context_max_chat_output_chars"] == 120000 * 4
+    assert preview["context_max_context_window_tokens"] == 400000
+    assert preview["context_output_boundary_source"] == "model_limits_derived"
 
 
 def test_progressive_context_dict_roundtrip_preserves_tool_name():
@@ -437,29 +449,46 @@ def test_progressive_context_dict_roundtrip_preserves_tool_name():
 
 
 def test_resolve_prompt_budget_caps_large_context_window(monkeypatch):
-    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 264000)
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 400000)
     budget = progressive_context.resolve_prompt_budget(stage="tool_loop", model="gpt-5.4-mini")
-    assert budget["context_window_tokens"] == 264000
-    assert budget["max_prompt_tokens"] == 128000
-    assert budget["max_output_tokens"] == 64000
-    assert budget["prompt_budget_tokens"] == 128000
-    assert budget["reserved_output_tokens"] == 64000
+    assert budget["context_window_tokens"] == 400000
+    assert budget["max_prompt_tokens"] == 272000
+    assert budget["max_output_tokens"] == 128000
+    assert budget["reserved_output_tokens"] == 128000
+    assert budget["safety_margin_tokens"] == 8000
+    assert budget["prompt_budget_tokens"] == min(
+        budget["max_prompt_tokens"],
+        budget["context_window_tokens"] - budget["reserved_output_tokens"] - budget["safety_margin_tokens"],
+    )
+    assert budget["prompt_budget_tokens"] == 264000
 
 
 def test_resolve_prompt_budget_skill_generation_uses_model_limit(monkeypatch):
-    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 264000)
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 400000)
     budget = progressive_context.resolve_prompt_budget(stage="skill_generation", model="gpt-5.4-mini")
-    assert budget["max_prompt_tokens"] == 128000
-    assert budget["prompt_budget_tokens"] == 128000
+    assert budget["max_prompt_tokens"] == 272000
+    assert budget["max_output_tokens"] == 128000
+    assert budget["prompt_budget_tokens"] == 264000
 
 
-def test_resolve_model_limits_for_gpt_54_mini():
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("gpt-4o", (128000, 64000, 16384)),
+        ("gpt-4.1", (128000, 128000, 16384)),
+        ("gpt-5-mini", (264000, 128000, 64000)),
+        ("gpt-5.3-codex", (400000, 272000, 128000)),
+        ("gpt-5.4-mini", (400000, 272000, 128000)),
+        ("gemini-2.5-pro", (128000, 128000, 64000)),
+    ],
+)
+def test_resolve_model_limits_for_authoritative_models(model, expected):
     from src.config import resolve_model_limits
 
-    limits = resolve_model_limits("gpt-5.4-mini")
-    assert limits["max_context_window_tokens"] == 264000
-    assert limits["max_prompt_tokens"] == 128000
-    assert limits["max_output_tokens"] == 64000
+    limits = resolve_model_limits(model)
+    assert limits["max_context_window_tokens"] == expected[0]
+    assert limits["max_prompt_tokens"] == expected[1]
+    assert limits["max_output_tokens"] == expected[2]
 
 
 def test_resolve_context_window_tokens_uses_configured_model_limit(monkeypatch):
@@ -474,14 +503,29 @@ def test_resolve_context_window_tokens_uses_configured_model_limit(monkeypatch):
             "max_tokens": 64000,
             "model_limits": {
                 "gpt-5.4-mini": {
-                    "max_context_window_tokens": 264000,
-                    "max_prompt_tokens": 128000,
-                    "max_output_tokens": 64000,
+                    "max_context_window_tokens": 400000,
+                    "max_prompt_tokens": 272000,
+                    "max_output_tokens": 128000,
                 }
             },
         },
     )
-    assert resolve_context_window_tokens(None) == 264000
+    assert resolve_context_window_tokens(None) == 400000
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_window"),
+    [
+        ("gpt-5.4-mini", 400000),
+        ("gpt-5.3-codex", 400000),
+        ("gpt-5-mini", 264000),
+        ("gemini-2.5-pro", 128000),
+    ],
+)
+def test_resolve_context_window_tokens_known_models(model, expected_window):
+    from src.agents.compaction import resolve_context_window_tokens
+
+    assert resolve_context_window_tokens(model) == expected_window
 
 
 @pytest.mark.asyncio

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -335,6 +335,7 @@ def test_build_portal_context_preview_returns_preview_keys_only():
 
 
 def test_build_portal_context_preview_includes_request_budget_fields():
+    # Synthetic passthrough fixture for preview serialization coverage; values are not runtime model limits.
     preview = build_portal_context_preview(
         {
             "compaction_level": "projection",
@@ -474,10 +475,12 @@ def test_resolve_prompt_budget_skill_generation_uses_model_limit(monkeypatch):
 @pytest.mark.parametrize(
     ("model", "expected"),
     [
+        ("gpt-4o", (128000, 64000, 16384, 64000)),
+        ("gpt-4.1", (128000, 128000, 16384, 105216)),
         ("gpt-5.3-codex", (400000, 272000, 128000, 264000)),
         ("gpt-5.4-mini", (400000, 272000, 128000, 264000)),
         ("gpt-5-mini", (264000, 128000, 64000, 128000)),
-        ("gpt-4o", (128000, 64000, 16384, 64000)),
+        ("gemini-2.5-pro", (128000, 128000, 64000, 57600)),
     ],
 )
 def test_resolve_prompt_budget_respects_authoritative_model_table(model, expected):

--- a/tests/test_progressive_context.py
+++ b/tests/test_progressive_context.py
@@ -396,7 +396,7 @@ def test_build_portal_context_preview_includes_source_and_generation_diagnostics
                 "generation_mode": "staged",
                 "current_generation_phase": "manifest",
                 "output_risk_level": "high",
-                "max_chat_output_chars": 8000,
+                "max_chat_output_chars": 240000,
                 "max_output_recovery_applied": True,
             },
             "source": {
@@ -437,10 +437,29 @@ def test_progressive_context_dict_roundtrip_preserves_tool_name():
 
 
 def test_resolve_prompt_budget_caps_large_context_window(monkeypatch):
-    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 200000)
-    budget = progressive_context.resolve_prompt_budget(stage="tool_loop", model="gpt-5-mini")
-    assert budget["prompt_budget_tokens"] == 32000
-    assert budget["reserved_output_tokens"] == 16000
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 264000)
+    budget = progressive_context.resolve_prompt_budget(stage="tool_loop", model="gpt-5.4-mini")
+    assert budget["context_window_tokens"] == 264000
+    assert budget["max_prompt_tokens"] == 128000
+    assert budget["max_output_tokens"] == 64000
+    assert budget["prompt_budget_tokens"] == 128000
+    assert budget["reserved_output_tokens"] == 64000
+
+
+def test_resolve_prompt_budget_skill_generation_uses_model_limit(monkeypatch):
+    monkeypatch.setattr(progressive_context, "resolve_context_window_tokens", lambda model: 264000)
+    budget = progressive_context.resolve_prompt_budget(stage="skill_generation", model="gpt-5.4-mini")
+    assert budget["max_prompt_tokens"] == 128000
+    assert budget["prompt_budget_tokens"] == 128000
+
+
+def test_resolve_model_limits_for_gpt_54_mini():
+    from src.config import resolve_model_limits
+
+    limits = resolve_model_limits("gpt-5.4-mini")
+    assert limits["max_context_window_tokens"] == 264000
+    assert limits["max_prompt_tokens"] == 128000
+    assert limits["max_output_tokens"] == 64000
 
 
 @pytest.mark.asyncio

--- a/tests/test_skill_mode_termination.py
+++ b/tests/test_skill_mode_termination.py
@@ -369,6 +369,48 @@ async def test_run_skill_finalizer_uses_passed_max_tokens(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_skill_finalizer_omitted_max_tokens_uses_model_limit(monkeypatch):
+    from src.agents import core as core_mod
+
+    captured = {}
+    original_max = core_mod.config.llm.get("max_tokens")
+    original_allow_lower = core_mod.config.llm.get("allow_lower_max_tokens_than_model_limit")
+    core_mod.config.llm["max_tokens"] = 64000
+    core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = False
+
+    async def fake_responses(**kwargs):
+        captured["max_tokens"] = kwargs.get("max_tokens")
+        return {"content": "[FINISH]\ndone", "usage": {}}
+
+    monkeypatch.setattr(core_mod, "llm_client", SimpleNamespace(responses=fake_responses))
+    try:
+        result, _usage = await core_mod._run_skill_finalizer(
+            input_items=[{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            system_prompt="sys",
+            provider="openai",
+            model="gpt-5.4-mini",
+            skill_session=SkillSession(skill_name="lookup", original_user_request="x"),
+            track_usage=False,
+            usage_data={},
+            remaining_llm_budget=1,
+            max_tokens=None,
+        )
+    finally:
+        if original_max is None:
+            core_mod.config.llm.pop("max_tokens", None)
+        else:
+            core_mod.config.llm["max_tokens"] = original_max
+        if original_allow_lower is None:
+            core_mod.config.llm.pop("allow_lower_max_tokens_than_model_limit", None)
+        else:
+            core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = original_allow_lower
+
+    assert result.state == "succeeded"
+    assert captured["max_tokens"] == 128000
+    assert result.request_budget.get("legacy_max_tokens_ignored") is True
+
+
+@pytest.mark.asyncio
 async def test_run_skill_finalizer_ignores_legacy_lower_config_cap_by_default(monkeypatch):
     from src.agents import core as core_mod
 
@@ -448,6 +490,7 @@ async def test_run_skill_finalizer_honors_explicit_lower_config_cap(monkeypatch)
 
     assert result.state == "succeeded"
     assert captured["max_tokens"] == 2048
+    assert result.request_budget.get("legacy_max_tokens_ignored") is False
 
 
 @pytest.mark.asyncio
@@ -470,6 +513,7 @@ async def test_run_skill_finalizer_aborts_when_request_over_budget(monkeypatch):
         core_mod,
         "resolve_prompt_budget",
         lambda **kwargs: {
+            # Synthetic low-budget fixture: explicitly legacy/over-budget path test.
             "prompt_budget_tokens": 28000,
             "max_output_tokens": 4096,
             "reserved_output_tokens": 1000,
@@ -549,6 +593,7 @@ async def test_continue_skill_mode_finalizer_abort_includes_finalizer_request_bu
         core_mod,
         "resolve_prompt_budget",
         lambda **kwargs: {
+            # Synthetic low-budget fixture for explicit over-budget/finalizer abort behavior.
             "prompt_budget_tokens": 28000,
             "max_output_tokens": 4096,
             "reserved_output_tokens": 1000,
@@ -678,12 +723,14 @@ async def test_continue_skill_mode_over_budget_error_includes_skill_generation_s
     monkeypatch.setattr(
         core_mod,
         "estimate_llm_request_tokens",
+        # Synthetic over-budget request size fixture; not a model-limit expectation.
         lambda **kwargs: 60000,
     )
     monkeypatch.setattr(
         core_mod,
         "resolve_prompt_budget",
         lambda **kwargs: {
+            # Synthetic low-budget fixture for context-budget-exceeded path testing.
             "prompt_budget_tokens": 28000,
             "max_output_tokens": 4096,
             "reserved_output_tokens": 1000,

--- a/tests/test_skill_mode_termination.py
+++ b/tests/test_skill_mode_termination.py
@@ -369,12 +369,14 @@ async def test_run_skill_finalizer_uses_passed_max_tokens(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_run_skill_finalizer_caps_to_config_when_config_smaller(monkeypatch):
+async def test_run_skill_finalizer_ignores_legacy_lower_config_cap_by_default(monkeypatch):
     from src.agents import core as core_mod
 
     captured = {}
     original_max = core_mod.config.llm.get("max_tokens")
+    original_allow_lower = core_mod.config.llm.get("allow_lower_max_tokens_than_model_limit")
     core_mod.config.llm["max_tokens"] = 2048
+    core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = False
 
     async def fake_responses(**kwargs):
         captured["max_tokens"] = kwargs.get("max_tokens")
@@ -398,6 +400,51 @@ async def test_run_skill_finalizer_caps_to_config_when_config_smaller(monkeypatc
             core_mod.config.llm.pop("max_tokens", None)
         else:
             core_mod.config.llm["max_tokens"] = original_max
+        if original_allow_lower is None:
+            core_mod.config.llm.pop("allow_lower_max_tokens_than_model_limit", None)
+        else:
+            core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = original_allow_lower
+
+    assert result.state == "succeeded"
+    assert captured["max_tokens"] == 4096
+
+
+@pytest.mark.asyncio
+async def test_run_skill_finalizer_honors_explicit_lower_config_cap(monkeypatch):
+    from src.agents import core as core_mod
+
+    captured = {}
+    original_max = core_mod.config.llm.get("max_tokens")
+    original_allow_lower = core_mod.config.llm.get("allow_lower_max_tokens_than_model_limit")
+    core_mod.config.llm["max_tokens"] = 2048
+    core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = True
+
+    async def fake_responses(**kwargs):
+        captured["max_tokens"] = kwargs.get("max_tokens")
+        return {"content": "[FINISH]\ndone", "usage": {}}
+
+    monkeypatch.setattr(core_mod, "llm_client", SimpleNamespace(responses=fake_responses))
+    try:
+        result, _usage = await core_mod._run_skill_finalizer(
+            input_items=[{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            system_prompt="sys",
+            provider="openai",
+            model="gpt-5-mini",
+            skill_session=SkillSession(skill_name="lookup", original_user_request="x"),
+            track_usage=False,
+            usage_data={},
+            remaining_llm_budget=1,
+            max_tokens=4096,
+        )
+    finally:
+        if original_max is None:
+            core_mod.config.llm.pop("max_tokens", None)
+        else:
+            core_mod.config.llm["max_tokens"] = original_max
+        if original_allow_lower is None:
+            core_mod.config.llm.pop("allow_lower_max_tokens_than_model_limit", None)
+        else:
+            core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = original_allow_lower
 
     assert result.state == "succeeded"
     assert captured["max_tokens"] == 2048

--- a/tests/test_skill_mode_termination.py
+++ b/tests/test_skill_mode_termination.py
@@ -338,7 +338,9 @@ async def test_run_skill_finalizer_uses_passed_max_tokens(monkeypatch):
 
     captured = {}
     original_max = core_mod.config.llm.get("max_tokens")
+    original_allow_lower = core_mod.config.llm.get("allow_lower_max_tokens_than_model_limit")
     core_mod.config.llm["max_tokens"] = 64000
+    core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = True
 
     async def fake_responses(**kwargs):
         captured["max_tokens"] = kwargs.get("max_tokens")
@@ -363,9 +365,54 @@ async def test_run_skill_finalizer_uses_passed_max_tokens(monkeypatch):
             core_mod.config.llm.pop("max_tokens", None)
         else:
             core_mod.config.llm["max_tokens"] = original_max
+        if original_allow_lower is None:
+            core_mod.config.llm.pop("allow_lower_max_tokens_than_model_limit", None)
+        else:
+            core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = original_allow_lower
 
     assert result.state == "succeeded"
     assert captured["max_tokens"] == 4096
+
+
+@pytest.mark.asyncio
+async def test_initial_skill_plan_direct_uses_model_derived_max_tokens(monkeypatch):
+    from src.agents import skill_mode
+
+    captured = {}
+    original_max = skill_mode.config.llm.get("max_tokens")
+    original_allow_lower = skill_mode.config.llm.get("allow_lower_max_tokens_than_model_limit")
+    original_model = skill_mode.config.llm.get("model")
+    skill_mode.config.llm["model"] = "gpt-5.4-mini"
+    skill_mode.config.llm["max_tokens"] = 64000
+    skill_mode.config.llm["allow_lower_max_tokens_than_model_limit"] = False
+
+    async def _fake_responses(**kwargs):
+        captured["max_tokens"] = kwargs.get("max_tokens")
+        return {"content": "{\"goal\":\"g\",\"steps\":[]}", "tool_calls": [], "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr(skill_mode, "llm_client", SimpleNamespace(responses=_fake_responses))
+    try:
+        result = await skill_mode._generate_initial_skill_plan_direct(
+            skill=SimpleNamespace(name="lookup", description="desc", strategy=[], tools=[]),
+            user_message="plan this",
+            model="gpt-5.4-mini",
+        )
+    finally:
+        if original_max is None:
+            skill_mode.config.llm.pop("max_tokens", None)
+        else:
+            skill_mode.config.llm["max_tokens"] = original_max
+        if original_allow_lower is None:
+            skill_mode.config.llm.pop("allow_lower_max_tokens_than_model_limit", None)
+        else:
+            skill_mode.config.llm["allow_lower_max_tokens_than_model_limit"] = original_allow_lower
+        if original_model is None:
+            skill_mode.config.llm.pop("model", None)
+        else:
+            skill_mode.config.llm["model"] = original_model
+
+    assert result.get("goal") == "g"
+    assert captured.get("max_tokens") == 128000
 
 
 @pytest.mark.asyncio
@@ -448,7 +495,7 @@ async def test_run_skill_finalizer_ignores_legacy_lower_config_cap_by_default(mo
             core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = original_allow_lower
 
     assert result.state == "succeeded"
-    assert captured["max_tokens"] == 4096
+    assert captured["max_tokens"] == 64000
 
 
 @pytest.mark.asyncio
@@ -547,7 +594,11 @@ async def test_continue_skill_mode_uses_budget_max_output_tokens_for_llm_calls(m
 
     captured = []
     original_max = core_mod.config.llm.get("max_tokens")
+    original_allow_lower = core_mod.config.llm.get("allow_lower_max_tokens_than_model_limit")
+    original_model = core_mod.config.llm.get("model")
+    core_mod.config.llm["model"] = "gpt-5-mini"
     core_mod.config.llm["max_tokens"] = 4096
+    core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = True
 
     monkeypatch.setattr(
         core_mod,
@@ -571,6 +622,14 @@ async def test_continue_skill_mode_uses_budget_max_output_tokens_for_llm_calls(m
             core_mod.config.llm.pop("max_tokens", None)
         else:
             core_mod.config.llm["max_tokens"] = original_max
+        if original_allow_lower is None:
+            core_mod.config.llm.pop("allow_lower_max_tokens_than_model_limit", None)
+        else:
+            core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = original_allow_lower
+        if original_model is None:
+            core_mod.config.llm.pop("model", None)
+        else:
+            core_mod.config.llm["model"] = original_model
 
     assert captured
     assert captured[0].get("max_tokens") == 4096

--- a/tests/test_skill_mode_termination.py
+++ b/tests/test_skill_mode_termination.py
@@ -577,6 +577,110 @@ async def test_continue_skill_mode_uses_budget_max_output_tokens_for_llm_calls(m
 
 
 @pytest.mark.asyncio
+async def test_continue_skill_mode_uses_model_max_output_tokens_by_default_for_gpt_5_4_mini(monkeypatch):
+    from src.agents import core as core_mod
+
+    captured = []
+    original_max = core_mod.config.llm.get("max_tokens")
+    original_allow_lower = core_mod.config.llm.get("allow_lower_max_tokens_than_model_limit")
+    original_model = core_mod.config.llm.get("model")
+    core_mod.config.llm["model"] = "gpt-5.4-mini"
+    core_mod.config.llm["max_tokens"] = 64000
+    core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = False
+
+    monkeypatch.setattr(
+        core_mod,
+        "resolve_prompt_budget",
+        lambda **kwargs: {
+            "prompt_budget_tokens": 50000,
+            "max_output_tokens": 128000,
+            "reserved_output_tokens": 128000,
+            "safety_margin_tokens": 8000,
+            "max_prompt_tokens": 272000,
+        },
+    )
+    responses = [
+        {"content": "", "function_calls": [], "usage": {}},
+        {"content": "[FINISH]\ndone", "function_calls": [], "usage": {}},
+    ]
+    try:
+        await run_replay_case(
+            monkeypatch,
+            responses=responses,
+            capture_llm_kwargs=captured,
+            message="search issue details",
+        )
+    finally:
+        if original_max is None:
+            core_mod.config.llm.pop("max_tokens", None)
+        else:
+            core_mod.config.llm["max_tokens"] = original_max
+        if original_allow_lower is None:
+            core_mod.config.llm.pop("allow_lower_max_tokens_than_model_limit", None)
+        else:
+            core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = original_allow_lower
+        if original_model is None:
+            core_mod.config.llm.pop("model", None)
+        else:
+            core_mod.config.llm["model"] = original_model
+
+    assert captured
+    assert captured[0].get("max_tokens") == 128000
+
+
+@pytest.mark.asyncio
+async def test_continue_skill_mode_honors_explicit_lower_max_tokens_override(monkeypatch):
+    from src.agents import core as core_mod
+
+    captured = []
+    original_max = core_mod.config.llm.get("max_tokens")
+    original_allow_lower = core_mod.config.llm.get("allow_lower_max_tokens_than_model_limit")
+    original_model = core_mod.config.llm.get("model")
+    core_mod.config.llm["model"] = "gpt-5.4-mini"
+    core_mod.config.llm["max_tokens"] = 64000
+    core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = True
+
+    monkeypatch.setattr(
+        core_mod,
+        "resolve_prompt_budget",
+        lambda **kwargs: {
+            "prompt_budget_tokens": 50000,
+            "max_output_tokens": 128000,
+            "reserved_output_tokens": 128000,
+            "safety_margin_tokens": 8000,
+            "max_prompt_tokens": 272000,
+        },
+    )
+    responses = [
+        {"content": "", "function_calls": [], "usage": {}},
+        {"content": "[FINISH]\ndone", "function_calls": [], "usage": {}},
+    ]
+    try:
+        await run_replay_case(
+            monkeypatch,
+            responses=responses,
+            capture_llm_kwargs=captured,
+            message="search issue details",
+        )
+    finally:
+        if original_max is None:
+            core_mod.config.llm.pop("max_tokens", None)
+        else:
+            core_mod.config.llm["max_tokens"] = original_max
+        if original_allow_lower is None:
+            core_mod.config.llm.pop("allow_lower_max_tokens_than_model_limit", None)
+        else:
+            core_mod.config.llm["allow_lower_max_tokens_than_model_limit"] = original_allow_lower
+        if original_model is None:
+            core_mod.config.llm.pop("model", None)
+        else:
+            core_mod.config.llm["model"] = original_model
+
+    assert captured
+    assert captured[0].get("max_tokens") == 64000
+
+
+@pytest.mark.asyncio
 async def test_continue_skill_mode_finalizer_abort_includes_finalizer_request_budget(monkeypatch):
     from src.agents import core as core_mod
 


### PR DESCRIPTION
### Motivation
- Ensure model-visible tools have runtime dispatch and produce bounded, session-scoped manifests instead of exposing raw source or orphan refs. 
- Prevent raw provider truncation errors and unbounded large outputs from surfacing to users, especially in high-risk/staged generation flows. 
- Make staged generation explicit and recoverable by deriving `generation_done` from explicit completion criteria and tracking artifacts by phase.

### Description
- Add missing `execute_tool` branch for `jira_get_comments` that forwards `_session_id` and returns a bounded manifest string (manifest + `context_ref`) instead of raw comments. 
- Thread `_session_id` through the `confluence_get_page_children` `execute_tool` dispatch so persisted child bundles are stored under the active session. 
- Harden the staged-generation bookkeeping in `src/runtime/output_controller.py` by adding `_refresh_generation_done()`, initializing `generated_artifacts_by_phase`, recording phase-aware artifact refs and coverage when oversized outputs are persisted, and updating completion criteria status only when phase output is actually recorded. 
- Files changed: `src/__init__.py`, `src/runtime/output_controller.py`, `tests/test_jira_tools.py`, `tests/test_confluence_tools.py`, and `tests/test_core_runtime_boundary.py` (tests expanded/added to cover dispatch, session-scoping, descendant completeness, and generation bookkeeping).

### Testing
- Compilation: `python -m compileall -q src tests` completed successfully; targeted module tests were run individually with passing results as follows: `tests/test_jira_tools.py` (26 passed), `tests/test_confluence_tools.py` (28 passed), `tests/test_core_runtime_boundary.py` (73 passed), `tests/test_skill_mode_termination.py` (25 passed), `tests/test_llm_client.py` (52 passed), `tests/test_progressive_context.py` (22 passed), and `tests/test_context_blob_store.py` (3 passed). 
- Full-test run: `pytest -q` failed during collection in this environment because gateway modules are unavailable (`src.gateway.server` / `src.gateway.webchat`), causing collection errors unrelated to these changes. 
- Grep / safety checks: no matches for `UNBOUNDED_TOOL_FEEDBACK_PREFIXES`; `"max_comments"` and `"max_chars"` are not present in Jira/Confluence model-facing schemas; the provider-layer message `"Model output was truncated because max_output_tokens"` exists only in lower-level provider code but the output controller tests verify it is not surfaced to users in high-risk/generation flows. 
- Confirmations: prior `Hey` int(None) boundary remains fixed; `jira_get_comments` now has `execute_tool` dispatch and returns a bounded manifest with `context_ref`; `confluence_get_page_children` execution uses active session-scoped refs; default Jira retrieval remains source-complete without keyword matching; default Confluence retrieval now aggregates descendant completeness honestly; user-facing assistant content is bounded and oversized outputs are persisted and replaced by concise manifests; raw provider `max_output_tokens` fatal messages are not user-facing for high-risk/staged generation; and the generation state machine computes `generation_done` from explicit completion criteria and records artifacts by phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7287931f0832a9bff1c68b20b6071)