### PR TITLE
Improve Server Files download UX and attachment filename stability

### DIFF
--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -2240,10 +2240,13 @@
     }
 
     function updateServerFilesToolbarState() {
+        const downloadBtn = fileExplorerContent.querySelector('#serverFilesDownloadBtn');
         const deleteBtn = fileExplorerContent.querySelector('#serverFilesDeleteBtn');
-        if (!deleteBtn) return;
+        if (!downloadBtn || !deleteBtn) return;
         const count = selectedServerFilePaths.size;
+        downloadBtn.disabled = count === 0;
         deleteBtn.disabled = count === 0;
+        downloadBtn.textContent = count > 0 ? `Download (${count})` : 'Download';
         deleteBtn.textContent = count > 0 ? `Delete (${count})` : 'Delete';
     }
 
@@ -2309,6 +2312,20 @@
         }
     }
 
+    function downloadServerFiles(paths) {
+        if (!paths.length) return;
+        const url = new URL('/api/server-files/download', window.location.origin);
+        paths.forEach(path => url.searchParams.append('paths', path));
+
+        const link = document.createElement('a');
+        link.href = url.toString();
+        link.download = '';
+        link.rel = 'noopener';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+    }
+
     // Show My Uploads (user's uploaded files)
     async function showMyUploads() {
         fileExplorerPanel.classList.add('show');
@@ -2365,6 +2382,7 @@
             pathHtml += `
                 <div class="file-explorer-toolbar" style="display:flex;gap:8px;margin:8px 0 10px 0;">
                     <button type="button" id="serverFilesUploadBtn">Upload</button>
+                    <button type="button" id="serverFilesDownloadBtn" disabled>Download</button>
                     <button type="button" id="serverFilesDeleteBtn" disabled>Delete</button>
                 </div>
             `;
@@ -2385,7 +2403,7 @@
                 <div class="file-explorer-list">
                     ${data.items.map(item => `
                         <div class="file-explorer-item" data-path="${item.path}" data-is-dir="${item.is_dir}">
-                            <input type="checkbox" class="server-file-select" data-path="${item.path}" title="Select for delete" />
+                            <input type="checkbox" class="server-file-select" data-path="${item.path}" title="Select for download/delete" />
                             ${item.is_dir ?
                                 '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>' :
                                 '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>'
@@ -2407,6 +2425,12 @@
             if (deleteBtn) {
                 deleteBtn.addEventListener('click', () => {
                     deleteServerFiles(Array.from(selectedServerFilePaths));
+                });
+            }
+            const downloadBtn = fileExplorerContent.querySelector('#serverFilesDownloadBtn');
+            if (downloadBtn) {
+                downloadBtn.addEventListener('click', () => {
+                    downloadServerFiles(Array.from(selectedServerFilePaths));
                 });
             }
             fileExplorerContent.querySelectorAll('.server-file-select').forEach(checkbox => {

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -15,6 +15,7 @@ import time
 import io
 import mimetypes
 import shutil
+import unicodedata
 import zipfile
 from datetime import datetime
 from pathlib import Path
@@ -1714,7 +1715,8 @@ def _server_file_content_type(path: Path) -> str:
 
 
 def _safe_download_filename(name: str, fallback: str = "server-files") -> str:
-    sanitized = ''.join(ch for ch in name if ch >= ' ' and ch != '\x7f')
+    raw_name = "" if name is None else str(name)
+    sanitized = ''.join(ch for ch in raw_name if not unicodedata.category(ch).startswith("C"))
     sanitized = sanitized.replace('/', '').replace('\\', '').replace('"', "'").strip()
     return sanitized or fallback
 

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -1713,6 +1713,27 @@ def _server_file_content_type(path: Path) -> str:
     return mimetypes.guess_type(str(path))[0] or "application/octet-stream"
 
 
+def _safe_download_filename(name: str, fallback: str = "server-files") -> str:
+    sanitized = ''.join(ch for ch in name if ch >= ' ' and ch != '\x7f')
+    sanitized = sanitized.replace('/', '').replace('\\', '').replace('"', "'").strip()
+    return sanitized or fallback
+
+
+def _attachment_disposition(filename: str) -> str:
+    safe_name = _safe_download_filename(filename, fallback="download")
+    return f'attachment; filename="{safe_name}"'
+
+
+def _server_files_archive_name(paths: List[Path]) -> str:
+    if len(paths) != 1:
+        return "server-files-selection.zip"
+
+    base_name = _safe_download_filename(paths[0].name, fallback="server-files")
+    if base_name.lower().endswith('.zip'):
+        return base_name
+    return f"{base_name}.zip"
+
+
 def _create_server_files_zip(paths: List[Path]) -> bytes:
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
@@ -1995,15 +2016,15 @@ async def api_server_files_download(request: web.Request) -> web.Response:
             file_path = resolved_paths[0]
             response = web.FileResponse(file_path)
             response.content_type = _server_file_content_type(file_path)
-            response.headers['Content-Disposition'] = f'attachment; filename="{file_path.name}"'
+            response.headers['Content-Disposition'] = _attachment_disposition(file_path.name)
             return response
 
         archive = await asyncio.to_thread(_create_server_files_zip, resolved_paths)
-        archive_name = f"{resolved_paths[0].name}.zip" if len(resolved_paths) == 1 else "files.zip"
+        archive_name = _server_files_archive_name(resolved_paths)
         return web.Response(
             body=archive,
             content_type='application/zip',
-            headers={'Content-Disposition': f'attachment; filename="{archive_name}"'},
+            headers={'Content-Disposition': _attachment_disposition(archive_name)},
         )
     except web.HTTPBadRequest as exc:
         return web.json_response({'success': False, **json.loads(exc.text)}, status=400)

--- a/tests/test_webchat_server_files.py
+++ b/tests/test_webchat_server_files.py
@@ -372,9 +372,18 @@ async def test_server_files_download_multiple_paths_uses_selection_zip_name(monk
 
 
 def test_safe_download_filename_sanitizes_control_characters():
-    sanitized = webchat._safe_download_filename('bad"\\r\\nname.txt')
+    sanitized = webchat._safe_download_filename('bad"\r\n\t\x00name.txt')
 
     assert '\"' not in sanitized
     assert "\r" not in sanitized
     assert "\n" not in sanitized
+    assert "\t" not in sanitized
+    assert "\x00" not in sanitized
     assert webchat._safe_download_filename("notes.md") == "notes.md"
+
+
+def test_safe_download_filename_removes_path_separators():
+    assert "/" not in webchat._safe_download_filename("../bad/name.txt")
+    assert "\\" not in webchat._safe_download_filename("bad\\name.txt")
+    assert webchat._safe_download_filename("../bad/name.txt")
+    assert webchat._safe_download_filename("bad\\name.txt")

--- a/tests/test_webchat_server_files.py
+++ b/tests/test_webchat_server_files.py
@@ -312,17 +312,31 @@ async def test_server_files_delete_multiple_paths(monkeypatch, tmp_path):
 @pytest.mark.asyncio
 async def test_server_files_download_single_file(monkeypatch, tmp_path):
     workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
-    file_path = workspace_root / "single.txt"
-    file_path.write_text("one", encoding="utf-8")
+    file_path = workspace_root / "single.md"
+    file_path.write_text("# one", encoding="utf-8")
 
     response = await webchat.api_server_files_download(_Request({"path": str(file_path)}))
 
     assert isinstance(response, web.FileResponse)
-    assert response.headers["Content-Disposition"] == 'attachment; filename="single.txt"'
+    assert response.content_type == "text/markdown"
+    assert response.headers["Content-Disposition"] == 'attachment; filename="single.md"'
 
 
 @pytest.mark.asyncio
-async def test_server_files_download_directory_as_zip(monkeypatch, tmp_path):
+async def test_server_files_download_inline_type_still_forces_attachment(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    file_path = workspace_root / "data.json"
+    file_path.write_text('{\"ok\":true}', encoding="utf-8")
+
+    response = await webchat.api_server_files_download(_Request({"path": str(file_path)}))
+
+    assert isinstance(response, web.FileResponse)
+    assert response.content_type == "application/json"
+    assert response.headers["Content-Disposition"] == 'attachment; filename="data.json"'
+
+
+@pytest.mark.asyncio
+async def test_server_files_download_directory_uses_directory_zip_name(monkeypatch, tmp_path):
     workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
     dir_path = workspace_root / "bundle"
     dir_path.mkdir(parents=True)
@@ -332,6 +346,35 @@ async def test_server_files_download_directory_as_zip(monkeypatch, tmp_path):
 
     assert response.status == 200
     assert response.content_type == "application/zip"
+    assert response.headers["Content-Disposition"] == 'attachment; filename="bundle.zip"'
     with zipfile.ZipFile(io.BytesIO(response.body), "r") as archive:
         names = archive.namelist()
     assert "bundle/a.txt" in names
+
+
+@pytest.mark.asyncio
+async def test_server_files_download_multiple_paths_uses_selection_zip_name(monkeypatch, tmp_path):
+    workspace_root = _patch_workspace_home(monkeypatch, tmp_path)
+    file_a = workspace_root / "a.txt"
+    file_b = workspace_root / "b.md"
+    file_a.write_text("A", encoding="utf-8")
+    file_b.write_text("B", encoding="utf-8")
+
+    response = await webchat.api_server_files_download(_Request([("paths", str(file_a)), ("paths", str(file_b))]))
+
+    assert response.status == 200
+    assert response.content_type == "application/zip"
+    assert response.headers["Content-Disposition"] == 'attachment; filename="server-files-selection.zip"'
+    with zipfile.ZipFile(io.BytesIO(response.body), "r") as archive:
+        names = archive.namelist()
+    assert "a.txt" in names
+    assert "b.md" in names
+
+
+def test_safe_download_filename_sanitizes_control_characters():
+    sanitized = webchat._safe_download_filename('bad"\\r\\nname.txt')
+
+    assert '\"' not in sanitized
+    assert "\r" not in sanitized
+    assert "\n" not in sanitized
+    assert webchat._safe_download_filename("notes.md") == "notes.md"


### PR DESCRIPTION
### Motivation
- Fix unreliable/unsafe download filenames and provide stable, user-friendly names for single-file, single-directory, and multi-selection downloads.
- Ensure `/api/server-files/download` always triggers a browser download (attachment) while preserving MIME `content_type` for portal passthrough and preview endpoints remain unchanged.
- Add a Download action to the standalone Server Files UI so users can download selections without opening a new tab.

### Description
- Added three small helpers in `src/gateway/webchat.py`: `_safe_download_filename(name, fallback)`, `_attachment_disposition(filename)`, and `_server_files_archive_name(paths)` to sanitize header filenames and compute intuitive archive names (`<dir>.zip` or `server-files-selection.zip`).
- Updated `api_server_files_download` to use the helpers: single-file responses remain `web.FileResponse` with preserved `content_type` and `Content-Disposition` from `_attachment_disposition`, zip responses use `_server_files_archive_name` and set `Content-Disposition` via the helper while keeping `application/zip`.
- Implemented a client-side `downloadServerFiles(paths)` in `src/gateway/static/js/webchat.js` which builds repeated `paths` query params and triggers a hidden `<a>` download (no `window.open`), added a `Download` toolbar button, updated `updateServerFilesToolbarState` to enable/disable and show counts for both Download and Delete, and changed checkbox `title` to "Select for download/delete".
- Tests expanded in `tests/test_webchat_server_files.py` to assert attachment behavior for inline-capable MIME types, directory zip naming, multi-selection zip naming, and to cover `_safe_download_filename` sanitization.

### Testing
- Ran `pytest tests/test_webchat_server_files.py` and all tests passed (`20 passed, 1 warning`).
- New/updated tests include `test_server_files_download_single_file`, `test_server_files_download_inline_type_still_forces_attachment`, `test_server_files_download_directory_uses_directory_zip_name`, `test_server_files_download_multiple_paths_uses_selection_zip_name`, and `test_safe_download_filename_sanitizes_control_characters`, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8bec7b6b8832a9e69c399bb02950e)