### PR TITLE
Improve webchat session ID safety and persist runtime chat failures

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -1732,6 +1732,11 @@ You have access to the following tools. When a user asks you to do something tha
         # This handles tool messages that were saved with tool_call_id
         transformed_messages = []
         for msg in messages:
+            metadata = msg.get("metadata") if isinstance(msg, dict) else None
+            if isinstance(metadata, dict) and metadata.get("exclude_from_model_context"):
+                continue
+            if isinstance(msg, dict) and msg.get("exclude_from_model_context"):
+                continue
             transformed = {"role": msg.get("role", "user"), "content": msg.get("content", "")}
             # Preserve tool_calls for assistant messages
             if msg.get("tool_calls"):

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -1032,6 +1032,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
     Returns: text/event-stream with chunks of the response
     """
     response: Optional[web.StreamResponse] = None
+    response_prepared = False
     run_task: Optional[asyncio.Task] = None
     session_id: Optional[str] = None
     request_id: Optional[str] = None
@@ -1072,6 +1073,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         )
 
         await response.prepare(request)
+        response_prepared = True
 
         # Send start event
         await response.write(
@@ -1203,7 +1205,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             error_type=type(e).__name__,
             metadata=execution_metadata,
         )
-        if response is not None and run_task is not None:
+        if response is not None and response_prepared:
             error_data = json.dumps({'error': str(e)})
             try:
                 await response.write(f"event: error\ndata: {error_data}\n\n".encode())

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -235,6 +235,8 @@ async def _persist_chat_failure_state(
                     "request_id": request_id,
                     "error_type": error_type,
                     "exclude_from_model_context": True,
+                    "ui_hint": "system_error",
+                    **({"display_message": summary} if summary else {}),
                 },
             },
         )

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -197,6 +197,8 @@ def _extract_trusted_model_override(request: web.Request, data: Dict[str, Any]) 
 
 
 def _resolve_webchat_session_id(data: Dict[str, Any]) -> str:
+    # Keep explicit client IDs (trimmed), but generate collision-safe defaults.
+    # The UUID suffix avoids same-second timestamp collisions across rapid new sessions.
     candidate = data.get("session_id")
     if isinstance(candidate, str) and candidate.strip():
         return candidate.strip()
@@ -212,6 +214,8 @@ async def _persist_chat_failure_state(
     error_type: str,
     metadata: Optional[Dict[str, Any]],
 ) -> None:
+    # Best-effort only: persistence/metadata failures must never mask the original request failure.
+    # Persisted system errors are excluded from model context so retry turns are not polluted.
     if not session_id:
         return
 

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -196,6 +196,77 @@ def _extract_trusted_model_override(request: web.Request, data: Dict[str, Any]) 
     return value or None
 
 
+def _resolve_webchat_session_id(data: Dict[str, Any]) -> str:
+    candidate = data.get("session_id")
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate.strip()
+    return f"webchat_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+
+
+async def _persist_chat_failure_state(
+    *,
+    agent_id: Optional[str],
+    session_id: Optional[str],
+    request_id: Optional[str],
+    user_message: str,
+    error_type: str,
+    metadata: Optional[Dict[str, Any]],
+) -> None:
+    if not session_id:
+        return
+
+    try:
+        if not session_manager._initialized:
+            await session_manager.initialize()
+
+        summary = user_message.strip() if isinstance(user_message, str) else ""
+        content = f"System error: {summary}" if summary else "System error: request failed."
+        await session_manager.add_message(
+            session_id,
+            "assistant",
+            content,
+            wait_for_save=True,
+            extra={
+                "author_name": "System",
+                "author_source": "system",
+                "exclude_from_model_context": True,
+                "metadata": {
+                    "kind": "system_error",
+                    "request_id": request_id,
+                    "error_type": error_type,
+                    "exclude_from_model_context": True,
+                },
+            },
+        )
+
+        if agent_id and session_id:
+            await publish_session_metadata(
+                agent_id=agent_id,
+                session_id=session_id,
+                last_execution_id=request_id,
+                latest_event_type="chat.failed",
+                latest_event_state="error",
+                snapshot_version=None,
+                runtime_events=[
+                    {
+                        "event_type": "execution.failed",
+                        "state": "error",
+                        "request_id": request_id,
+                        "session_id": session_id,
+                        "summary": summary,
+                        "detail_payload": {
+                            "message": summary,
+                            "error_type": error_type,
+                        },
+                        "created_at": datetime.utcnow().isoformat() + "Z",
+                    }
+                ],
+                metadata=metadata or {},
+            )
+    except Exception:
+        logger.warning("Best-effort chat failure persistence failed", exc_info=True)
+
+
 def _require_non_empty_string(data: Dict[str, Any], key: str) -> str:
     value = data.get(key)
     if not isinstance(value, str) or not value.strip():
@@ -655,12 +726,16 @@ async def api_chat(request: web.Request) -> web.Response:
     POST /api/chat
     Body: {"message": "...", "session_id": "optional", "attachments": ["file_id1", "file_id2"], "reasoning_replay": false}
     """
+    session_id: Optional[str] = None
+    request_id: Optional[str] = None
+    runtime_agent_id: Optional[str] = None
+    execution_metadata: Dict[str, Any] = {}
     try:
         data = await request.json()
         message = (data.get('message') or '').strip()
         
-        # Dynamic session_id with timestamp-based default for multi-session support
-        session_id = data.get('session_id', f'webchat_{datetime.utcnow().strftime("%Y%m%d_%H%M%S")}')
+        # Dynamic session_id with collision-safe default for multi-session support
+        session_id = _resolve_webchat_session_id(data)
         
         # Get reasoning_replay setting
         reasoning_replay = data.get('reasoning_replay', None)
@@ -925,13 +1000,27 @@ async def api_chat(request: web.Request) -> web.Response:
             # Use the error's message
             user_message = e.message
             status_code = e.status_code or status_code
-        
-        return web.json_response({
+
+        await _persist_chat_failure_state(
+            agent_id=runtime_agent_id,
+            session_id=session_id,
+            request_id=request_id,
+            user_message=user_message,
+            error_type=error_type,
+            metadata=execution_metadata,
+        )
+
+        error_response = {
             'error': user_message,
             'error_type': error_type,
             'details': error_details.get("details", {}),
             'timestamp': error_details.get("timestamp"),
-        }, status=status_code)
+        }
+        if session_id:
+            error_response['session_id'] = session_id
+        if request_id:
+            error_response['request_id'] = request_id
+        return web.json_response(error_response, status=status_code)
 
 
 async def api_chat_stream(request: web.Request) -> web.StreamResponse:
@@ -944,10 +1033,14 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
     """
     response: Optional[web.StreamResponse] = None
     run_task: Optional[asyncio.Task] = None
+    session_id: Optional[str] = None
+    request_id: Optional[str] = None
+    runtime_agent_id: Optional[str] = None
+    execution_metadata: Dict[str, Any] = {}
     try:
         data = await request.json()
         message = (data.get('message') or '').strip()
-        session_id = data.get('session_id', f'webchat_{datetime.utcnow().strftime("%Y%m%d_%H%M%S")}')
+        session_id = _resolve_webchat_session_id(data)
         attachments = data.get('attachments')
         portal_user_id, portal_user_name = _extract_portal_identity(request, data)
         execution_metadata = _extract_trusted_control_plane_metadata(request, data)
@@ -1102,6 +1195,14 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         raise
     except Exception as e:
         logger.error(f"Stream error: {e}")
+        await _persist_chat_failure_state(
+            agent_id=runtime_agent_id,
+            session_id=session_id,
+            request_id=request_id,
+            user_message=str(e),
+            error_type=type(e).__name__,
+            metadata=execution_metadata,
+        )
         if response is not None and run_task is not None:
             error_data = json.dumps({'error': str(e)})
             try:

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -274,6 +274,15 @@ def test_agent_process_source_uses_per_tool_feedback_policy_for_all_tool_feedbac
     assert module_source.count("_tool_feedback_text_for_tool(") >= 4
 
 
+def test_agent_process_source_filters_messages_excluded_from_model_context():
+    from src.agents import core
+
+    process_source = inspect.getsource(core.Agent.process)
+    assert 'metadata = msg.get("metadata") if isinstance(msg, dict) else None' in process_source
+    assert 'metadata.get("exclude_from_model_context")' in process_source
+    assert 'msg.get("exclude_from_model_context")' in process_source
+
+
 def test_to_input_items_source_uses_per_tool_feedback_policy():
     from src.agents import core
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -694,6 +694,8 @@ async def test_api_chat_failure_persists_system_error_and_failed_metadata(monkey
     assert add_message_calls[0]["extra"]["author_name"] == "System"
     assert add_message_calls[0]["extra"]["metadata"]["kind"] == "system_error"
     assert add_message_calls[0]["extra"]["metadata"]["exclude_from_model_context"] is True
+    assert add_message_calls[0]["extra"]["metadata"]["ui_hint"] == "system_error"
+    assert "boom" in add_message_calls[0]["extra"]["metadata"]["display_message"]
     assert metadata_calls
     assert metadata_calls[-1]["latest_event_type"] == "chat.failed"
     assert metadata_calls[-1]["latest_event_state"] == "error"
@@ -767,6 +769,13 @@ async def test_api_chat_stream_failure_persists_system_error_state(monkeypatch):
     assert "stream boom" in call["user_message"]
     assert call["error_type"] == "RuntimeError"
     assert isinstance(call["metadata"], dict)
+
+
+def test_webchat_source_keeps_chat_started_completed_failed_metadata_event_names():
+    source = (Path(__file__).parent.parent / "src" / "gateway" / "webchat.py").read_text(encoding="utf-8")
+    assert 'latest_event_type="chat.started"' in source
+    assert 'default_event_type="chat.completed"' in source
+    assert 'latest_event_type="chat.failed"' in source
 
 
 @pytest.mark.asyncio

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -714,6 +714,62 @@ async def test_api_chat_stream_generic_exception_still_returns_error_response():
 
 
 @pytest.mark.asyncio
+async def test_api_chat_stream_failure_persists_system_error_state(monkeypatch):
+    from src.gateway import webchat
+
+    persist_calls = []
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data.decode())
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        raise RuntimeError("stream boom")
+
+    async def _fake_persist_chat_failure_state(**kwargs):
+        persist_calls.append(kwargs)
+
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat, "_resolve_runtime_agent_identity", lambda _request: ("agent-1", "Agent One"))
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "_persist_chat_failure_state", _fake_persist_chat_failure_state)
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+    monkeypatch.setattr(
+        webchat.global_config,
+        "_config",
+        {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}},
+        raising=False,
+    )
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal"}
+
+        async def json(self):
+            return {"message": "hello stream", "session_id": "s-stream-failure"}
+
+    response = await webchat.api_chat_stream(_Request())
+
+    assert isinstance(response, _FakeStreamResponse)
+    assert len(persist_calls) == 1
+    call = persist_calls[0]
+    assert call["agent_id"] == "agent-1"
+    assert call["session_id"] == "s-stream-failure"
+    assert call["request_id"]
+    assert "stream boom" in call["user_message"]
+    assert call["error_type"] == "RuntimeError"
+    assert isinstance(call["metadata"], dict)
+
+
+@pytest.mark.asyncio
 async def test_api_chat_resolves_portal_identity_from_headers(monkeypatch):
     from src.gateway import webchat
 

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -273,6 +273,18 @@ def test_extract_trusted_model_override_ignores_untrusted_request():
     assert webchat._extract_trusted_model_override(request, {"model_override": "gpt-5"}) is None
 
 
+def test_resolve_webchat_session_id_generates_unique_ids_without_client_session():
+    from src.gateway import webchat
+
+    first = webchat._resolve_webchat_session_id({})
+    second = webchat._resolve_webchat_session_id({})
+    assert first != second
+    assert first.startswith("webchat_")
+    assert second.startswith("webchat_")
+    assert webchat._resolve_webchat_session_id({"session_id": "  s-1  "}) == "s-1"
+    assert webchat._resolve_webchat_session_id({"session_id": ""}).startswith("webchat_")
+
+
 @pytest.mark.asyncio
 async def test_chat_execution_bus_adapter_non_stream(monkeypatch):
     from src.gateway import webchat
@@ -618,6 +630,73 @@ async def test_api_chat_generic_exception_still_returns_error_response():
 
     response = await webchat.api_chat(_Request())
     assert response.status == 500
+
+
+@pytest.mark.asyncio
+async def test_api_chat_failure_persists_system_error_and_failed_metadata(monkeypatch):
+    from src.gateway import webchat
+
+    add_message_calls = []
+    metadata_calls = []
+
+    monkeypatch.setattr(
+        webchat.global_config,
+        "_config",
+        {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}},
+        raising=False,
+    )
+    monkeypatch.setattr(webchat, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(webchat, "_resolve_runtime_agent_identity", lambda _request: ("agent-1", "Agent One"))
+    async def _failing_run_chat_via_execution_bus(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _failing_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+
+    async def _fake_add_message(session_id, role, content, wait_for_save=False, extra=None):
+        add_message_calls.append(
+            {
+                "session_id": session_id,
+                "role": role,
+                "content": content,
+                "wait_for_save": wait_for_save,
+                "extra": extra or {},
+            }
+        )
+        return "msg-system-error"
+
+    async def _fake_publish_session_metadata(**kwargs):
+        metadata_calls.append(kwargs)
+
+    monkeypatch.setattr(webchat.session_manager, "add_message", _fake_add_message)
+    monkeypatch.setattr(webchat, "publish_session_metadata", _fake_publish_session_metadata)
+
+    class _Request:
+        app = {}
+        headers = {"X-Portal-Author-Source": "portal"}
+
+        async def json(self):
+            return {"message": "hello", "session_id": "s-failure"}
+
+    response = await webchat.api_chat(_Request())
+    payload = json.loads(response.text)
+
+    assert response.status == 500
+    assert "boom" in payload["error"] or payload["error"]
+    assert payload["request_id"]
+    assert payload["session_id"] == "s-failure"
+    assert len(add_message_calls) == 1
+    assert add_message_calls[0]["session_id"] == "s-failure"
+    assert add_message_calls[0]["role"] == "assistant"
+    assert add_message_calls[0]["wait_for_save"] is True
+    assert "System error" in add_message_calls[0]["content"]
+    assert "boom" in add_message_calls[0]["content"]
+    assert add_message_calls[0]["extra"]["author_name"] == "System"
+    assert add_message_calls[0]["extra"]["metadata"]["kind"] == "system_error"
+    assert add_message_calls[0]["extra"]["metadata"]["exclude_from_model_context"] is True
+    assert metadata_calls
+    assert metadata_calls[-1]["latest_event_type"] == "chat.failed"
+    assert metadata_calls[-1]["latest_event_state"] == "error"
 
 
 @pytest.mark.asyncio

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -273,7 +273,7 @@ def test_extract_trusted_model_override_ignores_untrusted_request():
     assert webchat._extract_trusted_model_override(request, {"model_override": "gpt-5"}) is None
 
 
-def test_resolve_webchat_session_id_generates_unique_ids_without_client_session():
+def test_resolve_webchat_session_id_avoids_same_second_collisions_without_client_session():
     from src.gateway import webchat
 
     first = webchat._resolve_webchat_session_id({})
@@ -771,7 +771,7 @@ async def test_api_chat_stream_failure_persists_system_error_state(monkeypatch):
     assert isinstance(call["metadata"], dict)
 
 
-def test_webchat_source_keeps_chat_started_completed_failed_metadata_event_names():
+def test_webchat_source_guards_against_chat_metadata_event_name_drift():
     source = (Path(__file__).parent.parent / "src" / "gateway" / "webchat.py").read_text(encoding="utf-8")
     assert 'latest_event_type="chat.started"' in source
     assert 'default_event_type="chat.completed"' in source


### PR DESCRIPTION
### Motivation

- Avoid session-id collisions when multiple new webchat sessions are created in the same second by making default IDs collision-resistant.
- Ensure runtime /api/chat and /api/chat/stream failures are visible to Portal users by persisting a UI-visible system error into session history and publishing failed session metadata.
- Prevent persisted system-error records from polluting the next LLM turn by excluding them from model context construction.

### Description

- Added `_resolve_webchat_session_id(data)` in `src/gateway/webchat.py` and used it in both `api_chat` and `api_chat_stream` so default session IDs include an 8-char UUID suffix and explicit string IDs are trimmed but otherwise unchanged.
- Added `_persist_chat_failure_state(...)` helper in `src/gateway/webchat.py` that best-effort writes an assistant message (author_name="System") to session history with `exclude_from_model_context` and publishes `latest_event_type="chat.failed"` / `latest_event_state="error"` via `publish_session_metadata` inside a safe try/except.
- Wired failure persistence into `api_chat` and `api_chat_stream` exception paths without changing existing HTTP/SSE error semantics and included `session_id` and `request_id` in `api_chat` JSON error responses when available.
- Updated `src/agents/core.py` Agent history->LLM transformation to skip messages that have `metadata.exclude_from_model_context` or top-level `exclude_from_model_context`, ensuring system error messages do not enter the next LLM prompt.
- Tests added/updated: `tests/test_webchat.py` (added `_resolve_webchat_session_id` unit test and `test_api_chat_failure_persists_system_error_and_failed_metadata`), and `tests/test_core_runtime_boundary.py` (source-level assertion that the new filtering code exists).
- Intentionally left out durable execution/event replay, no changes to `/api/tasks/execute`, no execution bus refactor, and no database schema changes.

### Testing

- Ran `python -m pytest tests/test_webchat.py tests/test_webchat_request_id_contract.py tests/test_core_runtime_boundary.py` and all tests passed: `230 passed, 1 warning`.
- Unit tests verify generated session IDs are unique and trimmed, runtime `/api/chat` exceptions cause a persisted System assistant message with `exclude_from_model_context`, and `publish_session_metadata` is invoked with `chat.failed`/`error`.
- Added a source-level test ensuring the `Agent.process` code contains the `exclude_from_model_context` filter to protect LLM inputs from system-error messages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8dce3108c832a942099fcd765e1c5)