### PR TITLE
Refactor Jira Markdown exporter; expose model-facing export_issues_to_markdown

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,6 +5,7 @@ Bash tools with security controls.
 """
 
 from typing import Any, Dict, List, Optional
+import json
 
 
 class ToolResult:
@@ -338,36 +339,39 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
         return ToolResult(success="Error" not in result, content=result)
 
     elif name == "export_issues_to_markdown":
-        # Support both direct input and jql parameter. If jql is provided and input is empty, convert to dict.
-        inp = kwargs.get("input")
-        jql = kwargs.get("jql")
-        page_size = kwargs.get("page_size", 50)
-        if (inp is None or (isinstance(inp, str) and inp.strip() == "")) and jql:
-            inp = {"jql": jql, "page_size": page_size}
-
         result = await jira_module.export_issues_to_markdown(
-            input=inp,
-            output_mode=kwargs.get("output_mode", "single_combined"),
+            input=kwargs.get("input"),
+            issue_keys=kwargs.get("issue_keys"),
+            jql=kwargs.get("jql"),
+            page_size=kwargs.get("page_size", 50),
+            max_issues=kwargs.get("max_issues", 100),
+            output_mode=kwargs.get("output_mode", "auto"),
             output_directory=kwargs.get("output_directory"),
             download_attachments=kwargs.get("download_attachments"),
             attachments_dir=kwargs.get("attachments_dir", "attachments"),
             include_raw_snapshot=kwargs.get("include_raw_snapshot", False),
+            include_coverage_ledger=kwargs.get("include_coverage_ledger", True),
             max_comments=kwargs.get("max_comments", 10),
             comments_order=kwargs.get("comments_order", "latest_first"),
-            field_match_threshold=kwargs.get("field_match_threshold", 0.9),
-            field_similarity_threshold=kwargs.get("field_similarity_threshold", 0.9),
-            array_inline_max_items=kwargs.get("array_inline_max_items", 3),
-            array_inline_max_element_length=kwargs.get("array_inline_max_element_length", 40),
             attachments_concurrency=kwargs.get("attachments_concurrency", 4),
             attachments_max_size=kwargs.get("attachments_max_size", 52428800),
             attachments_inline_text_threshold=kwargs.get("attachments_inline_text_threshold", 2000),
             attachments_retries=kwargs.get("attachments_retries", 3),
             attachments_backoff=kwargs.get("attachments_backoff", [1, 2, 4]),
             attachments_preserve_binary=kwargs.get("attachments_preserve_binary", True),
+            _session_id=kwargs.get("_session_id"),
         )
-        # exporter returns a dict: consider success True if no errors present
-        ok = isinstance(result, dict) and not result.get("errors")
-        return ToolResult(success=bool(ok), content=str(result))
+        ok = isinstance(result, dict) and result.get("status") in {"success", "partial"}
+        first_error = None
+        if isinstance(result, dict):
+            errs = result.get("errors") or []
+            if errs:
+                first_error = errs[0] if isinstance(errs[0], str) else str(errs[0])
+        return ToolResult(
+            success=bool(ok),
+            content=json.dumps(result, ensure_ascii=False, indent=2),
+            error=None if ok else first_error,
+        )
 
     # GitHub tools
     elif name == "github_get_issue":

--- a/src/agents/compaction.py
+++ b/src/agents/compaction.py
@@ -29,7 +29,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from src.utils.truncate import truncate
 from src.runtime.context_summary import build_context_state_from_messages, build_structured_summary
-from src.config import resolve_model_limits
+from src.config import config, resolve_model_limits
 
 logger = logging.getLogger(__name__)
 
@@ -801,64 +801,69 @@ async def compact_messages(
 # Convenience functions
 def resolve_context_window_tokens(model: Optional[str] = None) -> int:
     """Resolve context window tokens for a model.
-    
-    Args:
-        model: Model name (e.g., "gpt-4", "gpt-3.5-turbo")
-        
-    Returns:
-        Context window size
-    """
-    limits = resolve_model_limits(model)
-    if limits.get("max_context_window_tokens"):
-        return int(limits["max_context_window_tokens"])
 
-    # Default context windows
+    Explicit model names use deterministic known-model mapping first so legacy
+    models and unknown strings do not inherit the configured default model's
+    large fallback window. ``model=None`` keeps configured-runtime behavior.
+    """
     context_windows = {
-        # GPT-4 series
         "gpt-4": 8192,
         "gpt-4-turbo": 128000,
         "gpt-4o": 128000,
         "gpt-4o-mini": 128000,
-        # GPT-5 series
         "gpt-5.4-mini": 400000,
         "gpt-5.3-codex": 400000,
         "gpt-5": 200000,
         "gpt-5-mini": 264000,
         "gpt-5-pro": 200000,
-        # GPT-3.5
         "gpt-3.5-turbo": 16385,
-        # Gemini series (64K context)
         "gemini-2.5-pro": 128000,
         "gemini-2.5": 128000,
         "minimax/MiniMax-M3": 200000,
         "gemini-2.0": 32000,
         "gemini-1.5": 32000,
-        # Claude series
-        # 4.x models (including versioned like claude-haiku-4-20250514)
         "claude-opus-4": 200000,
         "claude-sonnet-4": 200000,
         "claude-haiku-4": 200000,
-        # 3.5 models (multiple naming conventions)
         "claude-haiku-3-5": 200000,
         "claude-opus-3-5": 200000,
         "claude-sonnet-3-5": 200000,
         "claude-3-5-sonnet": 200000,
-        # 3.x models
         "claude-3-opus": 200000,
         "claude-3-haiku": 200000,
-        # MiniMax series (64K context)
         "minimax": 64000,
         "minimaxi": 64000,
     }
-    
-    if model:
-        model_lower = model.lower()
-        # Prefer longer matches first to avoid "gpt-4" matching "gpt-4o"
-        for key in sorted(context_windows.keys(), key=len, reverse=True):
-            if key in model_lower:
-                return context_windows[key]
-    
-    return 4096  # Conservative default for unknown models
+
+    if model is None:
+        limits = resolve_model_limits(None)
+        if limits.get("max_context_window_tokens"):
+            return int(limits["max_context_window_tokens"])
+        return 4096
+
+    model_lower = str(model).lower()
+
+    for key in sorted(context_windows.keys(), key=len, reverse=True):
+        if key.lower() in model_lower:
+            return context_windows[key]
+
+    llm_cfg = config.llm if isinstance(config.llm, dict) else {}
+    configured_limits = (
+        llm_cfg.get("model_limits")
+        if isinstance(llm_cfg.get("model_limits"), dict)
+        else {}
+    )
+    for key in sorted(configured_limits.keys(), key=lambda k: len(str(k)), reverse=True):
+        if str(key).lower() in model_lower:
+            raw = configured_limits.get(key) or {}
+            try:
+                value = int(raw.get("max_context_window_tokens") or 0)
+            except Exception:
+                value = 0
+            if value > 0:
+                return value
+
+    return 4096
 
 
 def normalize_compaction_threshold(raw_value, default_value=0.8):

--- a/src/jira/__init__.py
+++ b/src/jira/__init__.py
@@ -26,6 +26,7 @@ from src.utils.attachment import download_and_process_attachment
 from .exporter import export_issues_to_markdown
 from src.source_context import persist_jira_source_bundle_and_digest
 from src.context_blob_store import put_text
+from .source_service import prepare_jira_issue_source, format_jira_source_manifest
 
 __all__ = [
     "JiraChannel", 
@@ -277,224 +278,17 @@ async def jira_prepare_issue_context(
     _session_id: Optional[str] = None,
 ) -> Union[str, dict]:
     """Prepare a source-complete Jira context bundle and bounded digest manifest."""
-    import re
-
-    if not jira_channel.is_configured():
-        return "Error: Jira is not configured."
-
-    issue_key = str(issue_key_or_url or "").strip()
-    instance_channel = jira_channel
-    if "/browse/" in issue_key:
-        match = re.search(r"/browse/([A-Z][A-Z0-9_]*-\d+)", issue_key, re.IGNORECASE)
-        if not match:
-            return f"Could not extract issue key from URL: {issue_key_or_url}"
-        issue_key = match.group(1).upper()
-        instance_channel = jira_channel.get_instance_client(url=issue_key_or_url)
-    session_id = _session_id or "unknown_session"
-
-    adapter = JiraFormatAdapter(instance_channel)
-    issue = await adapter.get_issue(
-        issue_key=issue_key,
-        format="raw",
-        max_comments=None if include_all_comments else 5,
-        include_comments=True,
-        include_fields=None,
-    )
-    fields = issue.get("fields", {}) if isinstance(issue, dict) else {}
-    comments = adapter._get_comments_list(issue if isinstance(issue, dict) else {}, None if include_all_comments else 5)
-    comment_field = fields.get("comment", {})
-    comments_total = int((comment_field or {}).get("total") or len(comments)) if isinstance(comment_field, dict) else len(comments)
-
-    attachments = []
-    text_attachments_total = 0
-    text_attachments_loaded = 0
-    text_attachments_full_loaded = 0
-    text_attachments_preview_only = 0
-    text_attachments_with_full_ref = 0
-    partial_reasons: List[str] = []
-    attachment_body_partial_reasons: List[str] = []
-    attachment_list = fields.get("attachment", []) if isinstance(fields, dict) else []
-    binary_attachments_count = 0
-    binary_attachment_bodies_skipped_count = 0
-    for att in attachment_list:
-        mime = str(att.get("mimeType") or "")
-        filename = str(att.get("filename") or "unknown")
-        is_text = mime.startswith("text/") or filename.lower().endswith((".txt", ".md", ".csv", ".json", ".yaml", ".yml", ".xml", ".log"))
-        if is_text:
-            text_attachments_total += 1
-        else:
-            binary_attachments_count += 1
-            binary_attachment_bodies_skipped_count += 1
-            partial_reasons.append(f"binary_attachment_body_skipped:{filename}")
-        item = {
-            "id": att.get("id"),
-            "filename": filename,
-            "mime_type": mime,
-            "size": att.get("size", 0),
-            "created": att.get("created"),
-            "author": att.get("author"),
-            "text_preview": None,
-            "text_ref": None,
-            "attachment_text_preview_only": False,
-        }
-        if include_attachments and is_text and att.get("content"):
-            try:
-                auth_header = instance_channel._auth_header if instance_channel.is_configured() else None
-                result = await download_and_process_attachment(
-                    url=att.get("content"),
-                    session_id=f"jira-source-{issue_key}",
-                    options={"include_image_data": False},
-                    auth_header=auth_header,
-                )
-                if getattr(result, "content_format", "") == "text":
-                    text_content = str(getattr(result, "content", "") or "")
-                    if len(text_content) <= 4000:
-                        item["text_preview"] = text_content
-                        text_attachments_full_loaded += 1
-                    else:
-                        item["text_preview"] = text_content[:1000]
-                        item["attachment_text_preview_only"] = True
-                        text_attachments_preview_only += 1
-                        item["text_ref"] = put_text(
-                            session_id=session_id,
-                            kind="jira_attachment_text",
-                            source_id=f"{issue_key}_{filename}",
-                            title=f"Jira attachment text {filename}",
-                            content=text_content,
-                            metadata={"issue_key": issue_key, "filename": filename},
-                        )
-                        text_attachments_with_full_ref += 1
-                        attachment_body_partial_reasons.append(f"text_attachment_preview_only:{filename}")
-                    text_attachments_loaded += 1
-            except Exception as exc:
-                partial_reasons.append(f"attachment_text_processing_failed:{filename}:{type(exc).__name__}")
-                attachment_body_partial_reasons.append(f"attachment_text_processing_failed:{filename}:{type(exc).__name__}")
-        attachments.append(item)
-
-    rendered_fields = issue.get("renderedFields") if isinstance(issue, dict) else None
-    bundle = {
-        "issue_key": issue_key,
-        "metadata": {
-            "key": issue.get("key") if isinstance(issue, dict) else issue_key,
-            "title": fields.get("summary"),
-            "status": (fields.get("status") or {}).get("name") if isinstance(fields.get("status"), dict) else "",
-            "type": (fields.get("issuetype") or {}).get("name") if isinstance(fields.get("issuetype"), dict) else "",
-            "priority": (fields.get("priority") or {}).get("name") if isinstance(fields.get("priority"), dict) else "",
-            "assignee": (fields.get("assignee") or {}).get("displayName") if isinstance(fields.get("assignee"), dict) else "",
-        },
-        "description": adapter._convert_description_to_markdown(fields.get("description")),
-        "acceptance_criteria": adapter._extract_acceptance_criteria(issue if isinstance(issue, dict) else {}),
-        "business_rules": "",
-        "validation_rules": "",
-        "comments": [
-            {
-                "id": c.get("id"),
-                "author": c.get("author"),
-                "created": c.get("created"),
-                "body": c.get("body"),
-                "body_markdown": adapter._convert_description_to_markdown(c.get("body")),
-            }
-            for c in comments
-        ],
-        "attachments": attachments,
-        "raw_snapshot": issue if include_raw_snapshot else {},
-        "names": issue.get("names") if isinstance(issue, dict) else {},
-        "renderedFields": issue.get("renderedFields") if isinstance(issue, dict) else {},
-        "completeness_ledger": {
-            "issue_loaded": bool(issue),
-            "raw_issue_loaded": bool(issue),
-            "names_loaded": bool(issue.get("names")) if isinstance(issue, dict) else False,
-            "issue_fields_complete": bool(fields),
-            "comments_loaded": len(comments),
-            "comments_total": comments_total,
-            "comments_complete": len(comments) >= comments_total,
-            "attachments_metadata_loaded": len(attachments),
-            "attachments_total": len(attachment_list),
-            "attachments_metadata_complete": len(attachments) >= len(attachment_list),
-            "attachment_metadata_complete": len(attachments) >= len(attachment_list),
-            "text_attachments_loaded": text_attachments_loaded,
-            "text_attachments_total": text_attachments_total,
-            "text_attachments_complete": text_attachments_loaded >= text_attachments_total,
-            "text_attachment_bodies_complete": text_attachments_loaded >= text_attachments_total and text_attachments_with_full_ref >= text_attachments_preview_only,
-            "text_attachments_full_loaded": text_attachments_full_loaded,
-            "text_attachments_preview_only": text_attachments_preview_only,
-            "text_attachments_with_full_ref": text_attachments_with_full_ref,
-            "binary_attachments_count": binary_attachments_count,
-            "binary_attachment_bodies_available": False,
-            "binary_attachment_bodies_skipped_count": binary_attachment_bodies_skipped_count,
-            "binary_attachment_body_policy": "metadata_only" if binary_attachments_count > 0 else "loaded",
-            "attachment_body_complete": text_attachments_preview_only == 0 and binary_attachment_bodies_skipped_count == 0,
-            "attachment_body_partial_reasons": attachment_body_partial_reasons + [f"binary_attachment_body_skipped:{att.get('filename','unknown')}" for att in attachment_list if not (str(att.get('mimeType') or '').startswith('text/') or str(att.get('filename') or '').lower().endswith((".txt", ".md", ".csv", ".json", ".yaml", ".yml", ".xml", ".log")))],
-            "raw_fields_loaded": bool(fields),
-            "rendered_fields_loaded": bool(rendered_fields),
-            "custom_fields_loaded": bool(issue.get("names")) if isinstance(issue, dict) else False,
-            "source_complete_definition": (
-                "source_complete requires issue fields, all comments, attachment metadata, and text attachment bodies. "
-                "Binary attachment bodies are metadata-only by design and do not block source_complete."
-            ),
-            "partial_reasons": partial_reasons,
-        },
-    }
-    ledger = bundle["completeness_ledger"]
-    ledger["source_metadata_complete"] = bool(
-        ledger.get("issue_fields_complete")
-        and ledger.get("names_loaded")
-        and ledger.get("rendered_fields_loaded")
-        and ledger.get("attachment_metadata_complete")
-    )
-    ledger["source_text_complete"] = bool(
-        ledger.get("comments_complete")
-        and ledger.get("text_attachment_bodies_complete")
-    )
-    ledger["source_tree_complete"] = True
-    ledger["source_complete_for_generation"] = bool(
-        ledger["source_metadata_complete"] and ledger["source_text_complete"]
-    )
-    ledger["source_complete_including_binary_bodies"] = bool(
-        ledger["source_complete_for_generation"]
-        and ledger.get("binary_attachment_bodies_available")
-        and int(ledger.get("binary_attachment_bodies_skipped_count", 0)) == 0
-    )
-    blocking_partial_reasons = [r for r in ledger.get("partial_reasons", []) if not str(r).startswith("binary_attachment_body_skipped:")]
-    ledger["source_complete"] = (
-        ledger["source_complete_for_generation"]
-        and not blocking_partial_reasons
-    )
-    ledger["source_complete_definition"] = (
-        "source_complete_for_generation requires issue metadata, all comments, full text fields, and full text attachment bodies. "
-        "Binary attachments are metadata-only by policy; source_complete_including_binary_bodies is false when binary bodies are unavailable."
-    )
-    persisted = persist_jira_source_bundle_and_digest(session_id=session_id, issue_key=issue_key, bundle=bundle)
-
-    manifest = {
-        "issue_key": issue_key,
-        "context_ref": persisted["context_ref"],
-        "digest_ref": persisted["digest_ref"],
-        "source_complete": ledger["source_complete"],
-        "source_complete_for_generation": ledger["source_complete_for_generation"],
-        "source_complete_including_binary_bodies": ledger["source_complete_including_binary_bodies"],
-        "source_metadata_complete": ledger["source_metadata_complete"],
-        "source_text_complete": ledger["source_text_complete"],
-        "attachment_metadata_complete": ledger["attachment_metadata_complete"],
-        "text_attachment_bodies_complete": ledger["text_attachment_bodies_complete"],
-        "source_tree_complete": ledger["source_tree_complete"],
-        "binary_attachment_body_policy": ledger.get("binary_attachment_body_policy"),
-        "binary_attachment_bodies_available": ledger.get("binary_attachment_bodies_available"),
-        "binary_attachment_bodies_skipped_count": ledger.get("binary_attachment_bodies_skipped_count"),
-        "source_complete_definition": ledger.get("source_complete_definition"),
-        "comments_loaded": f"{ledger['comments_loaded']}/{ledger['comments_total']}",
-        "attachments_metadata_loaded": f"{ledger['attachments_metadata_loaded']}/{ledger['attachments_total']}",
-        "text_attachments_loaded": f"{ledger['text_attachments_loaded']}/{ledger['text_attachments_total']}",
-        "binary_attachments_preserved": max(0, ledger["attachments_total"] - ledger["text_attachments_loaded"]),
-        "partial_reasons": ledger["partial_reasons"],
-        "source_digest_chunk_count": persisted.get("source_digest_chunk_count", 0),
-        "sections": ["metadata", "description", "acceptance_criteria", "comments", "attachments", "raw_snapshot"],
-    }
-    return (
-        "[jira source bundle prepared]\\n"
-        + "\\n".join(f"{k}: {json.dumps(v, ensure_ascii=False) if isinstance(v, (list, dict)) else v}" for k, v in manifest.items())
-        + f"\\n\\nUse context_read_ref(ref=\\\"{persisted['context_ref']}\\\", section=\\\"...\\\") to inspect source sections."
-    )
+    try:
+        result = await prepare_jira_issue_source(
+            issue_key_or_url=issue_key_or_url,
+            include_all_comments=include_all_comments,
+            include_attachments=include_attachments,
+            include_raw_snapshot=include_raw_snapshot,
+            session_id=_session_id or "unknown_session",
+        )
+        return format_jira_source_manifest(result)
+    except Exception as e:
+        return f"Error preparing Jira issue context {issue_key_or_url}: {str(e)}"
 
 
 async def jira_get_comments(issue_key: str, _session_id: Optional[str] = None) -> str:
@@ -681,7 +475,10 @@ def get_tools_schemas() -> list:
 
     # Export tool is intentionally internal/export-oriented; keep it out of
     # model-facing default schemas to avoid partial source acquisition paths.
-    return [schema for schema in result if (schema.get("function", {}).get("name") != "export_issues_to_markdown")]
+    return [
+        schema for schema in result
+        if schema.get("function", {}).get("name") not in {"jira_get_issue_preview", "jira_get_issue_by_url_preview"}
+    ]
 
 
 def _get_all_schemas() -> list:

--- a/src/jira/__init__.py
+++ b/src/jira/__init__.py
@@ -285,6 +285,7 @@ async def jira_prepare_issue_context(
             include_attachments=include_attachments,
             include_raw_snapshot=include_raw_snapshot,
             session_id=_session_id or "unknown_session",
+            attachment_body_policy="source_complete",
         )
         return format_jira_source_manifest(result)
     except Exception as e:
@@ -473,8 +474,8 @@ def get_tools_schemas() -> list:
         if name not in seen_names:
             result.append(schema)
 
-    # Export tool is intentionally internal/export-oriented; keep it out of
-    # model-facing default schemas to avoid partial source acquisition paths.
+    # Preview tools remain internal. The export tool is model-facing because users
+    # explicitly ask for "Jira tickets to markdown / save to folder / download attachments".
     return [
         schema for schema in result
         if schema.get("function", {}).get("name") not in {"jira_get_issue_preview", "jira_get_issue_by_url_preview"}

--- a/src/jira/api.py
+++ b/src/jira/api.py
@@ -1351,7 +1351,7 @@ def get_tools_schemas() -> list:
                         "page_size": {"type": "integer", "default": 50},
                         "max_issues": {"type": "integer", "default": 100},
                         "output_mode": {"type": "string", "enum": ["auto", "single_combined", "one_file_per_issue", "zip"], "default": "auto"},
-                        "output_directory": {"type": "string", "description": "Must be under ~/.efp/workspace. Example: /root/.efp/workspace/FXOW/FXLanding"},
+                        "output_directory": {"type": "string", "description": "Must be under ~/.efp/workspace. Example: /root/.efp/workspace/FXOW/FXLanding. Allowed roots are ~/.efp/workspace, /root/.efp/workspace, or EFP_WORKSPACE_ROOT when configured."},
                         "download_attachments": {"type": "boolean", "description": "If omitted, defaults to true when output_directory is provided."},
                         "attachments_dir": {"type": "string", "default": "attachments"},
                         "include_raw_snapshot": {"type": "boolean", "default": False},

--- a/src/jira/api.py
+++ b/src/jira/api.py
@@ -1334,35 +1334,37 @@ def get_tools_schemas() -> list:
             "type": "function",
             "function": {
                 "name": "export_issues_to_markdown",
-                "description": "Export one or more Jira issues to Markdown. Supports single issue key, comma-separated keys, a list of keys, or a JQL input (pass a dict with 'jql'). Can write per-issue files, a combined file, or produce a zip.",
+                "description": "Export Jira tickets/issues to Markdown files. Use this when the user asks to convert Jira tickets to markdown, save to a folder, or download Jira attachments. Supports newline-separated issue keys and natural language text containing issue keys.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "input": {
-                            "type": "string",
-                            "description": "Issue input: single key (e.g., PROJ-123), comma-separated keys (e.g., PROJ-1,PROJ-2), a JSON list like [\"PROJ-1\",\"PROJ-2\"], or a JSON object like {\"jql\": \"project = PROJ\"}. For complex inputs, pass a JSON-encoded string."
+                            "anyOf": [
+                                {"type": "string"},
+                                {"type": "array", "items": {"type": "string"}},
+                                {"type": "object"}
+                            ],
+                            "description": "Can be a single issue key, newline-separated keys, comma-separated keys, a JSON list, a dict with jql, or the original user text containing issue keys."
                         },
-                        "jql": {"type": "string", "description": "Optional JQL query string (alternative to using 'input' with a dict)"},
-                        "page_size": {"type": "integer", "description": "Optional page size when using JQL", "default": 50},
-                        "output_mode": {"type": "string", "enum": ["single_combined", "one_file_per_issue", "zip_per_issue"], "default": "single_combined"},
-                        "output_directory": {"type": "string", "description": "Directory to write files (required for file modes)"},
-                        "download_attachments": {"type": "boolean", "description": "Whether to download attachments"},
-                        "attachments_dir": {"type": "string", "description": "Relative attachments directory under output_directory"},
-                        "attachments_concurrency": {"type": "integer", "description": "Concurrent downloads for attachments", "default": 4},
-                        "attachments_max_size": {"type": "integer", "description": "Maximum attachment download size in bytes", "default": 52428800},
-                        "attachments_inline_text_threshold": {"type": "integer", "description": "Max chars for inline text embedding", "default": 2000},
-                        "attachments_retries": {"type": "integer", "description": "Retry attempts for attachment downloads", "default": 3},
-                        "attachments_backoff": {"type": "array", "items": {"type": "integer"}, "description": "Backoff seconds for retries", "default": [1, 2, 4]},
-                        "attachments_preserve_binary": {"type": "boolean", "description": "Whether to preserve and copy the original binary files", "default": True},
-                        "include_raw_snapshot": {"type": "boolean", "description": "Include a raw fields snapshot in the Markdown"},
-                        "max_comments": {"type": "integer", "description": "Maximum number of comments to include", "default": 10},
+                        "issue_keys": {"type": "array", "items": {"type": "string"}},
+                        "jql": {"type": "string"},
+                        "page_size": {"type": "integer", "default": 50},
+                        "max_issues": {"type": "integer", "default": 100},
+                        "output_mode": {"type": "string", "enum": ["auto", "single_combined", "one_file_per_issue", "zip"], "default": "auto"},
+                        "output_directory": {"type": "string", "description": "Must be under ~/.efp/workspace. Example: /root/.efp/workspace/FXOW/FXLanding"},
+                        "download_attachments": {"type": "boolean", "description": "If omitted, defaults to true when output_directory is provided."},
+                        "attachments_dir": {"type": "string", "default": "attachments"},
+                        "include_raw_snapshot": {"type": "boolean", "default": False},
+                        "include_coverage_ledger": {"type": "boolean", "default": True},
+                        "max_comments": {"type": "integer", "default": 10},
                         "comments_order": {"type": "string", "enum": ["latest_first", "oldest_first"], "default": "latest_first"},
-                        "field_match_threshold": {"type": "number", "description": "Similarity threshold for custom field matching", "default": 0.9},
-                        "field_similarity_threshold": {"type": "number", "description": "Similarity threshold for content de-duplication", "default": 0.9},
-                        "array_inline_max_items": {"type": "integer", "default": 3},
-                        "array_inline_max_element_length": {"type": "integer", "default": 40}
-                    },
-                    "required": ["input"]
+                        "attachments_concurrency": {"type": "integer", "default": 4},
+                        "attachments_max_size": {"type": "integer", "default": 52428800},
+                        "attachments_inline_text_threshold": {"type": "integer", "default": 2000},
+                        "attachments_retries": {"type": "integer", "default": 3},
+                        "attachments_backoff": {"type": "array", "items": {"type": "integer"}, "default": [1, 2, 4]},
+                        "attachments_preserve_binary": {"type": "boolean", "default": True}
+                    }
                 }
             }
         },

--- a/src/jira/exporter.py
+++ b/src/jira/exporter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 import shutil
 import time
@@ -42,15 +43,34 @@ def _summary_to_slug(summary: str, max_len: int = 80) -> str:
     return s or "untitled"
 
 
-def _workspace_root() -> Path:
-    return Path.home() / ".efp" / "workspace"
+def _allowed_workspace_roots() -> list[Path]:
+    roots: list[Path] = []
+    env_root = os.getenv("EFP_WORKSPACE_ROOT")
+    if env_root:
+        roots.append(Path(env_root).expanduser())
+    roots.append(Path.home() / ".efp" / "workspace")
+    roots.append(Path("/root/.efp/workspace"))
+
+    resolved: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        try:
+            r = root.resolve()
+        except Exception:
+            r = root.expanduser().absolute()
+        key = str(r)
+        if key not in seen:
+            seen.add(key)
+            resolved.append(r)
+    return resolved
 
 
 def _resolve_output_directory(output_directory: str) -> Path:
     output = Path(output_directory).expanduser().resolve()
-    workspace = _workspace_root().expanduser().resolve()
-    if output != workspace and workspace not in output.parents:
-        raise ValueError("output_directory must be under ~/.efp/workspace")
+    allowed_roots = _allowed_workspace_roots()
+    if not any(output == root or root in output.parents for root in allowed_roots):
+        allowed = ", ".join(str(root) for root in allowed_roots)
+        raise ValueError(f"output_directory must be under an EFP workspace root: {allowed}")
     output.mkdir(parents=True, exist_ok=True)
     return output
 
@@ -102,8 +122,10 @@ async def _download_issue_attachments(
     attachments_retries: int,
     attachments_backoff: Optional[List[int]],
     attachments_preserve_binary: bool,
+    source_channel: Any = None,
 ) -> list[dict]:
-    auth_header = jira_channel._auth_header if jira_channel.is_configured() else None
+    channel = source_channel or jira_channel
+    auth_header = channel._auth_header if channel and channel.is_configured() else None
     issue_dir = output_dir / attachments_dir / issue_key
     issue_dir.mkdir(parents=True, exist_ok=True)
     sem = asyncio.Semaphore(max(1, int(concurrency or 1)))
@@ -243,6 +265,20 @@ async def export_issues_to_markdown(
                 break
         selected_keys = all_keys
 
+    if not selected_keys:
+        errors.append("No Jira issues matched the selector.")
+        return {
+            "success": False,
+            "status": "failed",
+            "run_id": run_id,
+            "selector": selector,
+            "output_mode": output_mode,
+            "output_directory": output_directory,
+            "issues": [],
+            "artifacts": {},
+            "errors": errors,
+        }
+
     resolved_output_mode = output_mode
     zip_after_export = False
     if output_mode == "auto":
@@ -283,6 +319,7 @@ async def export_issues_to_markdown(
                 include_attachments=True,
                 include_raw_snapshot=include_raw_snapshot,
                 session_id=_session_id or "unknown_session",
+                attachment_body_policy="metadata_only" if download_attachments else "source_complete",
             )
             issue_result["context_ref"] = source.manifest.get("context_ref")
             issue_result["digest_ref"] = source.manifest.get("digest_ref")
@@ -303,6 +340,7 @@ async def export_issues_to_markdown(
                     attachments_retries=attachments_retries,
                     attachments_backoff=attachments_backoff,
                     attachments_preserve_binary=attachments_preserve_binary,
+                    source_channel=source.channel,
                 )
 
             markdown = render_jira_issue_export_markdown(
@@ -342,23 +380,48 @@ async def export_issues_to_markdown(
             artifacts["combined_content"] = combined
 
     if output_dir_path:
-        manifest = {
-            "run_id": run_id,
-            "selector": selector,
-            "output_mode": output_mode,
-            "resolved_output_mode": resolved_output_mode,
-            "issues": issues_out,
-            "artifacts": artifacts,
-            "errors": errors,
-        }
         manifest_path = output_dir_path / "manifest.json"
-        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
         artifacts["manifest_path"] = str(manifest_path)
 
         if zip_after_export:
+            pre_zip_manifest = {
+                "run_id": run_id,
+                "selector": selector,
+                "output_mode": output_mode,
+                "resolved_output_mode": resolved_output_mode,
+                "output_directory": str(output_dir_path),
+                "issues": issues_out,
+                "artifacts": artifacts,
+                "errors": errors,
+            }
+            manifest_path.write_text(json.dumps(pre_zip_manifest, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
+
             zip_path = _unique_path(output_dir_path / "jira-export.zip")
-            _zip_export_tree(output_dir_path, zip_path)
             artifacts["zip_path"] = str(zip_path)
+            final_manifest = {
+                "run_id": run_id,
+                "selector": selector,
+                "output_mode": output_mode,
+                "resolved_output_mode": resolved_output_mode,
+                "output_directory": str(output_dir_path),
+                "issues": issues_out,
+                "artifacts": artifacts,
+                "errors": errors,
+            }
+            manifest_path.write_text(json.dumps(final_manifest, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
+            _zip_export_tree(output_dir_path, zip_path)
+        else:
+            final_manifest = {
+                "run_id": run_id,
+                "selector": selector,
+                "output_mode": output_mode,
+                "resolved_output_mode": resolved_output_mode,
+                "output_directory": str(output_dir_path),
+                "issues": issues_out,
+                "artifacts": artifacts,
+                "errors": errors,
+            }
+            manifest_path.write_text(json.dumps(final_manifest, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
 
     exported_count = sum(1 for x in issues_out if x["status"] == "exported")
     if exported_count == len(issues_out) and issues_out:

--- a/src/jira/exporter.py
+++ b/src/jira/exporter.py
@@ -94,14 +94,57 @@ def _unique_path(path: Path) -> Path:
         idx += 1
 
 
-def _zip_export_tree(export_dir: Path, zip_path: Path) -> None:
+def _sanitize_attachments_dir(attachments_dir: str) -> str:
+    raw = str(attachments_dir or "attachments").strip()
+    if not raw:
+        return "attachments"
+    p = Path(raw)
+    if p.is_absolute():
+        raise ValueError("attachments_dir must be a relative directory name")
+    if any(part in {"..", ""} for part in p.parts):
+        raise ValueError("attachments_dir must not contain path traversal")
+    if len(p.parts) != 1:
+        raise ValueError("attachments_dir must be a simple directory name")
+    safe = sanitize_filename(raw)
+    if not safe or safe in {".", ".."}:
+        raise ValueError("attachments_dir is invalid")
+    return safe
+
+
+def _resolve_attachment_issue_dir(output_dir: Path, attachments_dir: str, issue_key: str) -> tuple[Path, str]:
+    safe_attachments_dir = _sanitize_attachments_dir(attachments_dir)
+    safe_issue_key = sanitize_filename(issue_key.upper())
+    issue_dir = (output_dir / safe_attachments_dir / safe_issue_key).resolve()
+    output_root = output_dir.resolve()
+    if issue_dir != output_root and output_root not in issue_dir.parents:
+        raise ValueError("attachment directory must stay under output_directory")
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    return issue_dir, safe_attachments_dir
+
+
+def _zip_export_paths(export_dir: Path, zip_path: Path, paths: list[Path]) -> None:
+    export_root = export_dir.resolve()
+    normalized: list[Path] = []
+    seen: set[str] = set()
+    for p in paths:
+        if not p:
+            continue
+        rp = Path(p).resolve()
+        if not rp.exists() or not rp.is_file():
+            continue
+        if rp == zip_path.resolve():
+            continue
+        if export_root not in rp.parents and rp != export_root:
+            continue
+        key = str(rp)
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(rp)
+
     with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        for file_path in export_dir.rglob("*"):
-            if not file_path.is_file():
-                continue
-            if file_path.resolve() == zip_path.resolve():
-                continue
-            zf.write(file_path, arcname=str(file_path.relative_to(export_dir)))
+        for file_path in normalized:
+            zf.write(file_path, arcname=file_path.relative_to(export_root).as_posix())
 
 
 def _is_probably_text_attachment(att: dict, result: Any) -> bool:
@@ -126,8 +169,7 @@ async def _download_issue_attachments(
 ) -> list[dict]:
     channel = source_channel or jira_channel
     auth_header = channel._auth_header if channel and channel.is_configured() else None
-    issue_dir = output_dir / attachments_dir / issue_key
-    issue_dir.mkdir(parents=True, exist_ok=True)
+    issue_dir, safe_attachments_dir = _resolve_attachment_issue_dir(output_dir, attachments_dir, issue_key)
     sem = asyncio.Semaphore(max(1, int(concurrency or 1)))
     backoff = attachments_backoff or DEFAULT_BACKOFF
 
@@ -174,16 +216,23 @@ async def _download_issue_attachments(
 
                 src = get_file_path(result.file_id)
                 target_name = sanitize_filename(getattr(result, "filename", "") or filename)
-                target_path = _unique_path(issue_dir / target_name)
-                shutil.copyfile(src, target_path)
+                if not target_name:
+                    target_name = "attachment"
+                candidate_path = _unique_path(issue_dir / target_name).resolve()
+                output_root = output_dir.resolve()
+                if output_root not in candidate_path.parents:
+                    raise ValueError("attachment target path escaped output_directory")
+                if issue_dir not in candidate_path.parents and candidate_path.parent != issue_dir:
+                    raise ValueError("attachment target path escaped issue attachment directory")
+                shutil.copyfile(src, candidate_path)
 
-                rel_path = target_path.relative_to(output_dir)
+                rel_path = candidate_path.relative_to(output_root).as_posix()
                 item.update(
                     {
                         "status": "saved",
-                        "path": str(rel_path),
-                        "absolute_path": str(target_path),
-                        "size": int(getattr(result, "metadata", {}).get("size") or size or target_path.stat().st_size),
+                        "path": rel_path,
+                        "absolute_path": str(candidate_path),
+                        "size": int(getattr(result, "metadata", {}).get("size") or size or candidate_path.stat().st_size),
                         "mime_type": getattr(result, "content_type", mime_type),
                     }
                 )
@@ -299,6 +348,7 @@ async def export_issues_to_markdown(
     issues_out = []
     combined_chunks: list[str] = []
     artifacts: dict[str, Any] = {}
+    created_paths: list[Path] = []
 
     for key in selected_keys:
         issue_result = {
@@ -310,7 +360,10 @@ async def export_issues_to_markdown(
             "digest_ref": None,
             "source_complete": False,
             "source_complete_for_generation": False,
+            "source_partial_reasons": [],
+            "export_partial_reasons": [],
             "partial_reasons": [],
+            "attachment_download_complete": True,
         }
         try:
             source = await prepare_jira_issue_source(
@@ -325,7 +378,7 @@ async def export_issues_to_markdown(
             issue_result["digest_ref"] = source.manifest.get("digest_ref")
             issue_result["source_complete"] = bool(source.manifest.get("source_complete"))
             issue_result["source_complete_for_generation"] = bool(source.manifest.get("source_complete_for_generation"))
-            issue_result["partial_reasons"] = list(source.manifest.get("partial_reasons") or [])
+            issue_result["source_partial_reasons"] = list(source.manifest.get("partial_reasons") or [])
 
             downloaded = []
             if download_attachments and output_dir_path:
@@ -343,6 +396,19 @@ async def export_issues_to_markdown(
                     source_channel=source.channel,
                 )
 
+            export_partial_reasons = []
+            for att in downloaded:
+                if att.get("status") in {"failed", "skipped"}:
+                    filename = att.get("filename") or "unknown"
+                    reason = att.get("reason") or "unknown"
+                    export_partial_reasons.append(f"attachment_{att.get('status')}:{filename}:{reason}")
+                if att.get("status") == "saved" and att.get("absolute_path"):
+                    created_paths.append(Path(att["absolute_path"]))
+
+            issue_result["export_partial_reasons"] = export_partial_reasons
+            issue_result["partial_reasons"] = export_partial_reasons
+            issue_result["attachment_download_complete"] = not export_partial_reasons
+
             markdown = render_jira_issue_export_markdown(
                 source,
                 downloaded_attachments=downloaded if downloaded else None,
@@ -359,6 +425,7 @@ async def export_issues_to_markdown(
                     raise ValueError("output_directory is required for one_file_per_issue export")
                 md_path = _unique_path(output_dir_path / _safe_issue_markdown_filename(key, summary))
                 md_path.write_text(markdown, encoding="utf-8")
+                created_paths.append(md_path)
                 issue_result["markdown_path"] = str(md_path)
             else:
                 combined_chunks.append(markdown)
@@ -366,7 +433,9 @@ async def export_issues_to_markdown(
         except Exception as exc:
             issue_result["status"] = "failed"
             msg = f"{key}: {type(exc).__name__}: {exc}"
+            issue_result["export_partial_reasons"].append(msg)
             issue_result["partial_reasons"].append(msg)
+            issue_result["attachment_download_complete"] = False
             errors.append(msg)
         issues_out.append(issue_result)
 
@@ -375,29 +444,26 @@ async def export_issues_to_markdown(
         if output_dir_path:
             combined_path = _unique_path(output_dir_path / "jira-export.md")
             combined_path.write_text(combined, encoding="utf-8")
+            created_paths.append(combined_path)
             artifacts["combined_markdown_path"] = str(combined_path)
         else:
             artifacts["combined_content"] = combined
+
+    warnings: list[str] = []
+    if selector.get("truncated"):
+        warnings.extend(selector.get("partial_reasons") or [])
+    for issue in issues_out:
+        for reason in issue.get("export_partial_reasons") or []:
+            warnings.append(f"{issue.get('issue_key')}: {reason}")
 
     if output_dir_path:
         manifest_path = output_dir_path / "manifest.json"
         artifacts["manifest_path"] = str(manifest_path)
 
         if zip_after_export:
-            pre_zip_manifest = {
-                "run_id": run_id,
-                "selector": selector,
-                "output_mode": output_mode,
-                "resolved_output_mode": resolved_output_mode,
-                "output_directory": str(output_dir_path),
-                "issues": issues_out,
-                "artifacts": artifacts,
-                "errors": errors,
-            }
-            manifest_path.write_text(json.dumps(pre_zip_manifest, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
-
             zip_path = _unique_path(output_dir_path / "jira-export.zip")
             artifacts["zip_path"] = str(zip_path)
+
             final_manifest = {
                 "run_id": run_id,
                 "selector": selector,
@@ -406,10 +472,12 @@ async def export_issues_to_markdown(
                 "output_directory": str(output_dir_path),
                 "issues": issues_out,
                 "artifacts": artifacts,
+                "warnings": warnings,
                 "errors": errors,
             }
             manifest_path.write_text(json.dumps(final_manifest, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
-            _zip_export_tree(output_dir_path, zip_path)
+            created_paths.append(manifest_path)
+            _zip_export_paths(output_dir_path, zip_path, created_paths)
         else:
             final_manifest = {
                 "run_id": run_id,
@@ -419,17 +487,24 @@ async def export_issues_to_markdown(
                 "output_directory": str(output_dir_path),
                 "issues": issues_out,
                 "artifacts": artifacts,
+                "warnings": warnings,
                 "errors": errors,
             }
             manifest_path.write_text(json.dumps(final_manifest, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
+            created_paths.append(manifest_path)
 
     exported_count = sum(1 for x in issues_out if x["status"] == "exported")
-    if exported_count == len(issues_out) and issues_out:
-        status = "success"
-    elif exported_count > 0:
+    failed_count = len(issues_out) - exported_count
+    has_export_warnings = bool(selector.get("truncated")) or any(
+        x.get("export_partial_reasons") for x in issues_out
+    )
+
+    if exported_count == 0:
+        status = "failed"
+    elif failed_count > 0 or has_export_warnings:
         status = "partial"
     else:
-        status = "failed"
+        status = "success"
 
     return {
         "success": status in {"success", "partial"},
@@ -440,6 +515,7 @@ async def export_issues_to_markdown(
         "output_directory": str(output_dir_path) if output_dir_path else None,
         "issues": issues_out,
         "artifacts": artifacts,
+        "warnings": warnings,
         "errors": errors,
     }
 

--- a/src/jira/exporter.py
+++ b/src/jira/exporter.py
@@ -1,405 +1,384 @@
-"""Jira exporter utilities - export issues to Markdown files or combined document.
+"""Canonical Jira markdown exporter."""
 
-This module implements a Python tool `export_issues_to_markdown` that follows
-the jira-fields-to-markdown specification. It reuses the existing
-`JiraFormatAdapter` and `jira_channel` to fetch issue data and converts
-rich text to Markdown while preserving Acceptance Criteria and tables.
-"""
+from __future__ import annotations
 
-import logging
-import os
-import re
-import zipfile
-import shutil
 import asyncio
+import json
+import logging
+import re
+import shutil
 import time
+import uuid
+import zipfile
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
+from src.utils.attachment import download_and_process_attachment
 from src.utils.file_parser import get_file_path
 from src.utils.file_parser.validators import sanitize_filename
 
-# Attachment handling defaults
-DEFAULT_CONCURRENCY = 4
-DEFAULT_MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
-DEFAULT_INLINE_TEXT_THRESHOLD = 2000  # chars
-DEFAULT_RETRIES = 3
-DEFAULT_BACKOFF = [1, 2, 4]
-from typing import Any, Dict, List, Optional
-
 from .api import jira_channel
-from .adapter import JiraFormatAdapter
-from src.utils.attachment import download_and_process_attachment
+from .markdown_renderer import render_jira_issue_export_markdown
+from .selector import extract_output_directory_from_text, normalize_jira_issue_selector
+from .source_service import prepare_jira_issue_source
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_CONCURRENCY = 4
+DEFAULT_MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024
+DEFAULT_INLINE_TEXT_THRESHOLD = 2000
+DEFAULT_RETRIES = 3
+DEFAULT_BACKOFF = [1, 2, 4]
 
 
 def _summary_to_slug(summary: str, max_len: int = 80) -> str:
     if not summary:
         return "untitled"
     s = summary.lower()
-    # Replace non-alphanumeric with '-'
-    s = re.sub(r'[^a-z0-9]+', '-', s)
-    s = re.sub(r'-{2,}', '-', s).strip('-')
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = re.sub(r"-{2,}", "-", s).strip("-")
     if len(s) > max_len:
-        s = s[:max_len].rstrip('-')
+        s = s[:max_len].rstrip("-")
     return s or "untitled"
 
 
-def _safe_mkdir(path: str) -> None:
-    os.makedirs(path, exist_ok=True)
+def _workspace_root() -> Path:
+    return Path.home() / ".efp" / "workspace"
 
 
-def _write_file(path: str, content: str) -> None:
-    with open(path, 'w', encoding='utf-8') as f:
-        f.write(content)
+def _resolve_output_directory(output_directory: str) -> Path:
+    output = Path(output_directory).expanduser().resolve()
+    workspace = _workspace_root().expanduser().resolve()
+    if output != workspace and workspace not in output.parents:
+        raise ValueError("output_directory must be under ~/.efp/workspace")
+    output.mkdir(parents=True, exist_ok=True)
+    return output
 
 
-async def _download_attachments(
+def _safe_issue_markdown_filename(issue_key: str, summary: str) -> str:
+    issue_part = sanitize_filename(issue_key.upper())
+    slug = sanitize_filename(_summary_to_slug(summary or "untitled"))
+    return f"{issue_part} - {slug}.md"
+
+
+def _unique_path(path: Path) -> Path:
+    if not path.exists():
+        return path
+    base = path.with_suffix("")
+    suffix = path.suffix
+    idx = 1
+    while True:
+        candidate = Path(f"{base}-{idx}{suffix}")
+        if not candidate.exists():
+            return candidate
+        idx += 1
+
+
+def _zip_export_tree(export_dir: Path, zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for file_path in export_dir.rglob("*"):
+            if not file_path.is_file():
+                continue
+            if file_path.resolve() == zip_path.resolve():
+                continue
+            zf.write(file_path, arcname=str(file_path.relative_to(export_dir)))
+
+
+def _is_probably_text_attachment(att: dict, result: Any) -> bool:
+    mime = str((att or {}).get("mimeType") or getattr(result, "content_type", "") or "").lower()
+    filename = str((att or {}).get("filename") or getattr(result, "filename", "") or "").lower()
+    return mime.startswith("text/") or filename.endswith((".txt", ".md", ".csv", ".json", ".yaml", ".yml", ".xml", ".log"))
+
+
+async def _download_issue_attachments(
     issue_key: str,
-    attachments: List[dict],
-    out_dir: str,
-    auth_header: dict,
-    concurrency: int = DEFAULT_CONCURRENCY,
-    max_download_size: int = DEFAULT_MAX_DOWNLOAD_SIZE,
-    inline_text_threshold: int = DEFAULT_INLINE_TEXT_THRESHOLD,
-    retries: int = DEFAULT_RETRIES,
-    backoff: List[int] = None,
-    preserve_binary: bool = True,
-) -> List[str]:
-    """Download attachments concurrently with retries, size checks, and inline text handling.
+    attachment_list: list[dict],
+    *,
+    output_dir: Path,
+    attachments_dir: str,
+    concurrency: int,
+    attachments_max_size: int,
+    attachments_inline_text_threshold: int,
+    attachments_retries: int,
+    attachments_backoff: Optional[List[int]],
+    attachments_preserve_binary: bool,
+) -> list[dict]:
+    auth_header = jira_channel._auth_header if jira_channel.is_configured() else None
+    issue_dir = output_dir / attachments_dir / issue_key
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    sem = asyncio.Semaphore(max(1, int(concurrency or 1)))
+    backoff = attachments_backoff or DEFAULT_BACKOFF
 
-    Returns a list of strings which are either relative paths under out_dir or
-    small preformatted markdown snippets for inline display.
-    """
-    results: List[str] = []
-    _safe_mkdir(out_dir)
+    async def _handle(att: dict) -> dict:
+        filename = str(att.get("filename") or "unknown")
+        size = int(att.get("size") or 0)
+        mime_type = str(att.get("mimeType") or "")
+        url = att.get("content")
+        item = {
+            "filename": filename,
+            "status": "failed",
+            "path": None,
+            "absolute_path": None,
+            "size": size,
+            "mime_type": mime_type,
+        }
 
-    semaphore = asyncio.Semaphore(concurrency)
-    backoff_list = backoff if backoff is not None else DEFAULT_BACKOFF
-
-    async def download_one(att: dict) -> str:
-        filename = att.get('filename', 'unknown')
-        url = att.get('content') or att.get('content', '')
-        size = att.get('size') or 0
         if not url:
-            return f"{filename} - no URL"
+            item["status"] = "skipped"
+            item["reason"] = "missing_content_url"
+            return item
 
-        # Size check
-        if size and size > max_download_size:
-            return f"{filename} - skipped (size {size} > {max_download_size})"
+        if size and size > attachments_max_size:
+            item["status"] = "skipped"
+            item["reason"] = f"size_exceeds_limit:{size}>{attachments_max_size}"
+            return item
 
-        attempt = 0
-        last_exc = None
-        while attempt < retries:
+        last_error = None
+        for attempt in range(max(1, int(attachments_retries or 1))):
             try:
-                async with semaphore:
-                    res = await download_and_process_attachment(
+                async with sem:
+                    result = await download_and_process_attachment(
                         url=url,
-                        session_id=f"jira-{issue_key}",
+                        session_id=f"jira-export-{issue_key}",
                         options={"include_image_data": True},
                         auth_header=auth_header,
                     )
 
-                # If helper saved the file and returned file_id, copy stored file
-                if hasattr(res, 'file_id') and getattr(res, 'file_id', None):
-                    try:
-                        src_path = str(get_file_path(res.file_id))
-                        out_filename = sanitize_filename(res.filename or filename)
-                        target_path = os.path.join(out_dir, out_filename)
-                        base, ext = os.path.splitext(target_path)
-                        idx = 1
-                        while os.path.exists(target_path):
-                            target_path = f"{base}-{idx}{ext}"
-                            idx += 1
-                        shutil.copyfile(src_path, target_path)
-                        return os.path.relpath(target_path, start=out_dir)
-                    except Exception as e:
-                        logger.warning(f"Failed to copy stored file for attachment {filename}: {e}")
-                        return f"{filename} - stored copy failed: {e}"
+                is_text = _is_probably_text_attachment(att, result)
+                if not is_text and not attachments_preserve_binary:
+                    item["status"] = "skipped"
+                    item["reason"] = "binary_preserve_disabled"
+                    return item
 
-                # Inline content handling
-                content_format = getattr(res, 'content_format', None)
-                content = getattr(res, 'content', None)
+                src = get_file_path(result.file_id)
+                target_name = sanitize_filename(getattr(result, "filename", "") or filename)
+                target_path = _unique_path(issue_dir / target_name)
+                shutil.copyfile(src, target_path)
 
-                out_filename = sanitize_filename(filename)
-                target_path = os.path.join(out_dir, out_filename)
-                base, ext = os.path.splitext(target_path)
-                idx = 1
-                while os.path.exists(target_path):
-                    target_path = f"{base}-{idx}{ext}"
-                    idx += 1
+                rel_path = target_path.relative_to(output_dir)
+                item.update(
+                    {
+                        "status": "saved",
+                        "path": str(rel_path),
+                        "absolute_path": str(target_path),
+                        "size": int(getattr(result, "metadata", {}).get("size") or size or target_path.stat().st_size),
+                        "mime_type": getattr(result, "content_type", mime_type),
+                    }
+                )
 
-                if content_format == 'text' and content:
-                    text = content.decode('utf-8') if isinstance(content, bytes) else content
-                    # if small, return preformatted markdown snippet with inline content
-                    if len(text) <= DEFAULT_INLINE_TEXT_THRESHOLD:
-                        # Save file and also return inline snippet
-                        with open(target_path, 'w', encoding='utf-8') as f:
-                            f.write(text)
-                        snippet = f"{out_filename}\n\n```text\n{text}\n```"
-                        return snippet
-                    else:
-                        with open(target_path, 'w', encoding='utf-8') as f:
-                            f.write(text)
-                        return os.path.relpath(target_path, start=out_dir)
+                if getattr(result, "content_format", None) == "text":
+                    content = getattr(result, "content", "") or ""
+                    text = content.decode("utf-8", errors="replace") if isinstance(content, bytes) else str(content)
+                    if len(text) <= attachments_inline_text_threshold:
+                        item["inline_text"] = text
 
-                if content_format == 'base64' and content:
-                    # Save base64 blob to .b64 file
-                    with open(target_path + '.b64', 'wb') as f:
-                        blob = content if isinstance(content, bytes) else content.encode('utf-8')
-                        f.write(blob)
-                    return os.path.relpath(target_path + '.b64', start=out_dir)
+                return item
+            except Exception as exc:
+                last_error = exc
+                sleep_sec = backoff[min(attempt, len(backoff) - 1)] if backoff else 1
+                await asyncio.sleep(max(0, sleep_sec))
 
-                # Unknown content: create metadata note
-                note_path = target_path + '.txt'
-                with open(note_path, 'w', encoding='utf-8') as f:
-                    f.write(f"Attachment: {filename}\nSource: {url}\nContent format: {content_format}\n")
-                return os.path.relpath(note_path, start=out_dir)
+        item["status"] = "failed"
+        item["reason"] = f"download_failed:{type(last_error).__name__}:{last_error}"
+        return item
 
-            except Exception as e:
-                last_exc = e
-                logger.debug(f"Attachment download attempt {attempt+1} failed for {filename}: {e}")
-                # Backoff
-                if attempt < len(backoff_list):
-                    await asyncio.sleep(backoff_list[attempt])
-                else:
-                    await asyncio.sleep(backoff_list[-1])
-                attempt += 1
-
-        # If all attempts failed
-        return f"{filename} - download failed: {last_exc}"
-
-    # Launch downloads concurrently
-    tasks = [asyncio.create_task(download_one(att)) for att in attachments]
-    completed = await asyncio.gather(*tasks)
-    results.extend(completed)
-    return results
+    return await asyncio.gather(*[_handle(att) for att in attachment_list])
 
 
 async def export_issues_to_markdown(
-    input: Any,
-    output_mode: str = "single_combined",
+    input: Any = None,
+    *,
+    issue_keys: Optional[List[str]] = None,
+    jql: Optional[str] = None,
+    page_size: int = 50,
+    max_issues: int = 100,
+    output_mode: str = "auto",
     output_directory: Optional[str] = None,
     download_attachments: Optional[bool] = None,
     attachments_dir: str = "attachments",
     include_raw_snapshot: bool = False,
-    max_comments: int = 10,
+    include_coverage_ledger: bool = True,
+    max_comments: Optional[int] = 10,
     comments_order: str = "latest_first",
-    field_match_threshold: float = 0.9,
-    field_similarity_threshold: float = 0.9,
-    array_inline_max_items: int = 3,
-    array_inline_max_element_length: int = 40,
-    # Attachment handling tunables
     attachments_concurrency: int = DEFAULT_CONCURRENCY,
     attachments_max_size: int = DEFAULT_MAX_DOWNLOAD_SIZE,
     attachments_inline_text_threshold: int = DEFAULT_INLINE_TEXT_THRESHOLD,
     attachments_retries: int = DEFAULT_RETRIES,
     attachments_backoff: Optional[List[int]] = None,
     attachments_preserve_binary: bool = True,
+    _session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Export Jira issues (single, list, or JQL) to Markdown.
+    run_id = f"jira-export-{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    errors: list[str] = []
 
-    Returns a dict {"success": [filepaths or issue_keys], "errors": [{issue_key, error}]}
-    """
-    # Validate output_mode
-    if output_mode not in ("single_combined", "one_file_per_issue", "zip_per_issue"):
-        return {"success": [], "errors": [{"issue_key": None, "error": f"Invalid output_mode: {output_mode}"}]}
+    if not output_directory and isinstance(input, str):
+        output_directory = extract_output_directory_from_text(input)
 
-    if output_mode in ("one_file_per_issue", "zip_per_issue") and not output_directory:
-        return {"success": [], "errors": [{"issue_key": None, "error": "output_directory is required for file output modes"}]}
+    selector = normalize_jira_issue_selector(
+        input=input,
+        issue_keys=issue_keys,
+        jql=jql,
+        page_size=page_size,
+        max_issues=max_issues,
+    )
 
-    # Determine default for download_attachments
-    if download_attachments is None:
-        download_attachments = bool(output_directory)
+    selected_keys = list(selector.get("issue_keys") or [])
+    if selector.get("selector_type") == "jql":
+        jql_query = selector.get("jql")
+        start_at = 0
+        all_keys: list[str] = []
+        while True:
+            page = await jira_channel.search_issues(jql_query, max_results=selector["page_size"], start_at=start_at)
+            issues = page.get("issues") or []
+            if not issues:
+                break
+            all_keys.extend([i.get("key") for i in issues if i.get("key")])
+            start_at += len(issues)
+            if len(all_keys) >= selector["max_issues"]:
+                selector["truncated"] = True
+                selector["partial_reasons"].append(f"max_issues_truncated:{selector['max_issues']}")
+                all_keys = all_keys[: selector["max_issues"]]
+                break
+            if start_at >= int(page.get("total") or 0):
+                break
+        selected_keys = all_keys
 
-    adapter = JiraFormatAdapter(jira_channel)
+    resolved_output_mode = output_mode
+    zip_after_export = False
+    if output_mode == "auto":
+        resolved_output_mode = "one_file_per_issue" if output_directory else "single_combined"
+    elif output_mode == "zip":
+        resolved_output_mode = "one_file_per_issue"
+        zip_after_export = True
+    elif output_mode not in {"single_combined", "one_file_per_issue"}:
+        raise ValueError(f"Invalid output_mode: {output_mode}")
 
-    # Determine issue keys list
-    issue_keys: List[str] = []
-    errors: List[Dict[str, str]] = []
-    successes: List[str] = []
-
-    # Helper to add error
-    def _add_error(key, msg):
-        errors.append({"issue_key": key, "error": msg})
-
-    # Standardize input, support string 'jql:...' auto convert to dict
-    if isinstance(input, str) and input.strip().lower().startswith('jql:'):
-        input = {"jql": input.strip()[4:].strip()}
-
-    try:
-        # Input can be: string key, comma separated, or dict with jql
-        if isinstance(input, dict) and input.get("jql"):
-            jql = input.get("jql")
-            # Use channel search to paginate (default page size 50)
-            start_at = 0
-            page_size = input.get("page_size", 50)
-            while True:
-                result = await jira_channel.search_issues(jql, max_results=page_size, start_at=start_at)
-                issues = result.get("issues", [])
-                if not issues:
-                    break
-                for issue in issues:
-                    key = issue.get("key")
-                    if key:
-                        issue_keys.append(key)
-                start_at += len(issues)
-                total = result.get("total", 0)
-                if start_at >= total:
-                    break
-        elif isinstance(input, str):
-            # comma separated or single
-            parts = [p.strip() for p in input.split(",") if p.strip()]
-            issue_keys.extend(parts)
-        elif isinstance(input, list):
-            for p in input:
-                if isinstance(p, str):
-                    issue_keys.append(p.strip())
-        else:
-            return {"success": [], "errors": [{"issue_key": None, "error": "Unsupported input type"}]}
-    except Exception as e:
-        return {"success": [], "errors": [{"issue_key": None, "error": f"Failed to resolve input: {e}"}]}
-
-    if not issue_keys:
-        return {"success": [], "errors": [{"issue_key": None, "error": "No issue keys resolved from input"}]}
-
-    combined_lines: List[str] = []
-
-    # Ensure output dir exists
+    output_dir_path: Optional[Path] = None
     if output_directory:
-        _safe_mkdir(output_directory)
+        output_dir_path = _resolve_output_directory(output_directory)
 
-    for key in issue_keys:
+    if download_attachments is None:
+        download_attachments = bool(output_dir_path)
+
+    issues_out = []
+    combined_chunks: list[str] = []
+    artifacts: dict[str, Any] = {}
+
+    for key in selected_keys:
+        issue_result = {
+            "issue_key": key,
+            "status": "failed",
+            "markdown_path": None,
+            "attachments": [],
+            "context_ref": None,
+            "digest_ref": None,
+            "source_complete": False,
+            "source_complete_for_generation": False,
+            "partial_reasons": [],
+        }
         try:
-            # Fetch raw issue with expanded names and renderedFields for better extraction
-            issue = await jira_channel.get_issue(key, expand=["names", "renderedFields"])
+            source = await prepare_jira_issue_source(
+                issue_key_or_url=key,
+                include_all_comments=True,
+                include_attachments=True,
+                include_raw_snapshot=include_raw_snapshot,
+                session_id=_session_id or "unknown_session",
+            )
+            issue_result["context_ref"] = source.manifest.get("context_ref")
+            issue_result["digest_ref"] = source.manifest.get("digest_ref")
+            issue_result["source_complete"] = bool(source.manifest.get("source_complete"))
+            issue_result["source_complete_for_generation"] = bool(source.manifest.get("source_complete_for_generation"))
+            issue_result["partial_reasons"] = list(source.manifest.get("partial_reasons") or [])
 
-            # Ensure comments loaded (must use return value!)
-            try:
-                issue = await adapter._ensure_comments_loaded(key, issue, max_comments)
-            except Exception:
-                logger.debug(f"Failed to ensure comments loaded for {key}")
+            downloaded = []
+            if download_attachments and output_dir_path:
+                downloaded = await _download_issue_attachments(
+                    key,
+                    source.attachment_list,
+                    output_dir=output_dir_path,
+                    attachments_dir=attachments_dir,
+                    concurrency=attachments_concurrency,
+                    attachments_max_size=attachments_max_size,
+                    attachments_inline_text_threshold=attachments_inline_text_threshold,
+                    attachments_retries=attachments_retries,
+                    attachments_backoff=attachments_backoff,
+                    attachments_preserve_binary=attachments_preserve_binary,
+                )
 
-            fields = issue.get("fields", {})
+            markdown = render_jira_issue_export_markdown(
+                source,
+                downloaded_attachments=downloaded if downloaded else None,
+                include_raw_snapshot=include_raw_snapshot,
+                include_coverage_ledger=include_coverage_ledger,
+                max_comments=max_comments,
+                comments_order=comments_order,
+            )
 
-            summary = fields.get("summary", "")
-            description_md = adapter._convert_description_to_markdown(fields.get("description"))
-            acceptance = adapter._extract_acceptance_criteria(issue) or "N/A"
-
-            # Comments
-            comments = adapter._get_comments_list(issue, max_comments)
-            if comments_order == "latest_first":
-                comments = comments[:max_comments]
+            issue_result["attachments"] = downloaded
+            summary = source.fields.get("summary") or source.bundle.get("metadata", {}).get("title") or ""
+            if resolved_output_mode == "one_file_per_issue":
+                if not output_dir_path:
+                    raise ValueError("output_directory is required for one_file_per_issue export")
+                md_path = _unique_path(output_dir_path / _safe_issue_markdown_filename(key, summary))
+                md_path.write_text(markdown, encoding="utf-8")
+                issue_result["markdown_path"] = str(md_path)
             else:
-                comments = list(reversed(comments))[:max_comments]
+                combined_chunks.append(markdown)
+            issue_result["status"] = "exported"
+        except Exception as exc:
+            issue_result["status"] = "failed"
+            msg = f"{key}: {type(exc).__name__}: {exc}"
+            issue_result["partial_reasons"].append(msg)
+            errors.append(msg)
+        issues_out.append(issue_result)
 
-            # Attachments
-            attachments = fields.get("attachment", []) or []
-
-            # Build markdown using strict template
-            md_lines = []
-            md_lines.append(f"# {key}: {summary}\n")
-            md_lines.append("## Description")
-            md_lines.append(description_md or "N/A")
-            md_lines.append("\n## Acceptance Criteria")
-            md_lines.append(acceptance)
-            md_lines.append("\n## Comments")
-            if comments:
-                for i, c in enumerate(comments, 1):
-                    author = c.get('author') if isinstance(c.get('author'), str) else c.get('author', {}).get('displayName', 'Unknown')
-                    created = c.get('created', '')[:10] if c.get('created') else 'N/A'
-                    body_md = adapter._convert_description_to_markdown(c.get('body'))
-                    md_lines.append(f"### {i}) {author} - {created}\n{body_md}\n")
-            else:
-                md_lines.append("N/A")
-
-            # Attachments handling and optional downloads
-            md_lines.append("\n## Attachments")
-            attachment_entries: List[str] = []
-            downloaded_files: List[str] = []
-            if attachments:
-                if download_attachments and output_directory:
-                    # Download into output_directory/attachments/<issue_key>/
-                    att_out_dir = os.path.join(output_directory, attachments_dir, key)
-                    auth_header = jira_channel._auth_header if jira_channel.is_configured() else None
-                    downloaded = await _download_attachments(
-                        key,
-                        attachments,
-                        att_out_dir,
-                        auth_header,
-                        concurrency=attachments_concurrency,
-                        max_download_size=attachments_max_size,
-                        inline_text_threshold=attachments_inline_text_threshold,
-                        retries=attachments_retries,
-                        backoff=attachments_backoff,
-                        preserve_binary=attachments_preserve_binary,
-                    )
-                    for d in downloaded:
-                        attachment_entries.append(f"- {d}")
-                        downloaded_files.append(os.path.join(att_out_dir, d) if not d.endswith(' - no URL') and 'download failed' not in d else d)
-                else:
-                    for att in attachments:
-                        filename = att.get('filename', 'unknown')
-                        url = att.get('content') or att.get('content', '')
-                        attachment_entries.append(f"- {filename} ({url})")
-            else:
-                attachment_entries.append("N/A")
-
-            md_lines.extend(attachment_entries)
-
-            # Raw snapshot
-            if include_raw_snapshot:
-                md_lines.append("\n## Raw Fields Snapshot")
-                md_lines.append(str({"key": key, "fields": {k: v for k, v in fields.items() if k in ['summary','status','description','attachment']}}))
-
-            markdown = "\n".join(md_lines)
-
-            # Output modes
-            if output_mode == "single_combined":
-                combined_lines.append(markdown)
-                successes.append(key)
-            else:
-                # file per issue
-                slug = _summary_to_slug(summary)
-                filename = f"{key} - {slug}.md"
-                dest = os.path.join(output_directory, filename)
-                # handle collisions
-                base, ext = os.path.splitext(dest)
-                idx = 1
-                while os.path.exists(dest):
-                    dest = f"{base}-{idx}{ext}"
-                    idx += 1
-                _write_file(dest, markdown)
-                successes.append(dest)
-
-        except Exception as e:
-            logger.exception(f"Failed to export {key}")
-            _add_error(key, str(e))
-
-    # finalize results
-    result: Dict[str, Any] = {"success": successes, "errors": errors}
-
-    if output_mode == "single_combined":
-        combined = "\n\n---\n\n".join(combined_lines)
-        if output_directory:
-            dest = os.path.join(output_directory, "jira-export.md")
-            _write_file(dest, combined)
-            result["export_path"] = dest
-            result["success"] = [dest]
+    if resolved_output_mode == "single_combined":
+        combined = "\n\n---\n\n".join(combined_chunks)
+        if output_dir_path:
+            combined_path = _unique_path(output_dir_path / "jira-export.md")
+            combined_path.write_text(combined, encoding="utf-8")
+            artifacts["combined_markdown_path"] = str(combined_path)
         else:
-            result["content"] = combined
+            artifacts["combined_content"] = combined
 
-    if output_mode == "zip_per_issue" and output_directory and successes:
-        zip_path = os.path.join(output_directory, "jira-export.zip")
-        with zipfile.ZipFile(zip_path, 'w', compression=zipfile.ZIP_DEFLATED) as zf:
-            for path in successes:
-                if os.path.exists(path):
-                    arcname = os.path.relpath(path, start=output_directory)
-                    zf.write(path, arcname=arcname)
-        result["zip"] = zip_path
+    if output_dir_path:
+        manifest = {
+            "run_id": run_id,
+            "selector": selector,
+            "output_mode": output_mode,
+            "resolved_output_mode": resolved_output_mode,
+            "issues": issues_out,
+            "artifacts": artifacts,
+            "errors": errors,
+        }
+        manifest_path = output_dir_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+        artifacts["manifest_path"] = str(manifest_path)
 
-    return result
+        if zip_after_export:
+            zip_path = _unique_path(output_dir_path / "jira-export.zip")
+            _zip_export_tree(output_dir_path, zip_path)
+            artifacts["zip_path"] = str(zip_path)
+
+    exported_count = sum(1 for x in issues_out if x["status"] == "exported")
+    if exported_count == len(issues_out) and issues_out:
+        status = "success"
+    elif exported_count > 0:
+        status = "partial"
+    else:
+        status = "failed"
+
+    return {
+        "success": status in {"success", "partial"},
+        "status": status,
+        "run_id": run_id,
+        "selector": selector,
+        "output_mode": output_mode,
+        "output_directory": str(output_dir_path) if output_dir_path else None,
+        "issues": issues_out,
+        "artifacts": artifacts,
+        "errors": errors,
+    }
 
 
 __all__ = ["export_issues_to_markdown"]
-

--- a/src/jira/markdown_renderer.py
+++ b/src/jira/markdown_renderer.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+from .source_service import JiraIssueSourceResult
+
+
+def _comment_author_name(author) -> str:
+    if isinstance(author, dict):
+        return author.get("displayName") or author.get("name") or "Unknown"
+    if isinstance(author, str) and author.strip():
+        return author.strip()
+    return "Unknown"
+
+
+def render_jira_issue_export_markdown(
+    source: JiraIssueSourceResult,
+    *,
+    downloaded_attachments: Optional[list[dict]] = None,
+    include_raw_snapshot: bool = False,
+    include_coverage_ledger: bool = True,
+    max_comments: Optional[int] = 10,
+    comments_order: str = "latest_first",
+) -> str:
+    bundle = source.bundle or {}
+    metadata = bundle.get("metadata", {}) or {}
+    issue_key = source.issue_key
+    title = metadata.get("title") or source.fields.get("summary") or ""
+
+    description = bundle.get("description") or ""
+    description = source.adapter._strip_acceptance_criteria_from_markdown_description(description) if description else ""
+    acceptance = bundle.get("acceptance_criteria") or "N/A"
+
+    comments = list(bundle.get("comments") or [])
+    comments.sort(key=lambda c: str(c.get("created") or ""))
+    if comments_order == "latest_first":
+        comments.reverse()
+    if max_comments is not None and int(max_comments) > 0:
+        comments = comments[: int(max_comments)]
+
+    lines: list[str] = []
+    lines.append(f"# {issue_key}: {title}")
+    lines.append("")
+    lines.append("## Metadata")
+    lines.append(f"- Key: {metadata.get('key') or issue_key}")
+    lines.append(f"- Status: {metadata.get('status') or 'N/A'}")
+    lines.append(f"- Type: {metadata.get('type') or 'N/A'}")
+    lines.append(f"- Priority: {metadata.get('priority') or 'N/A'}")
+    lines.append(f"- Assignee: {metadata.get('assignee') or 'N/A'}")
+
+    lines.append("")
+    lines.append("## Description")
+    lines.append(description or "N/A")
+
+    lines.append("")
+    lines.append("## Acceptance Criteria")
+    lines.append(acceptance)
+
+    lines.append("")
+    lines.append("## Comments")
+    if comments:
+        for idx, c in enumerate(comments, 1):
+            author = _comment_author_name(c.get("author"))
+            created = c.get("created") or "N/A"
+            body = c.get("body_markdown") or source.adapter._convert_description_to_markdown(c.get("body")) or "N/A"
+            lines.append(f"### {idx}) {author} - {created}")
+            lines.append(body)
+            lines.append("")
+    else:
+        lines.append("N/A")
+
+    lines.append("## Attachments")
+    attachments_to_render = downloaded_attachments if downloaded_attachments is not None else (bundle.get("attachments") or [])
+    if attachments_to_render:
+        for item in attachments_to_render:
+            filename = item.get("filename", "unknown")
+            status = item.get("status")
+            if status == "saved":
+                rel_path = item.get("path") or filename
+                size = item.get("size")
+                lines.append(f"- [{filename}]({rel_path}) — saved, {size} bytes")
+            elif status in {"skipped", "failed"}:
+                lines.append(f"- {filename} — {status}: {item.get('reason', 'N/A')}")
+            else:
+                lines.append(f"- {filename}")
+    else:
+        lines.append("N/A")
+
+    if include_coverage_ledger:
+        lines.append("")
+        lines.append("## Source Coverage")
+        lines.append("```json")
+        lines.append(json.dumps(bundle.get("completeness_ledger") or {}, ensure_ascii=False, indent=2, default=str))
+        lines.append("```")
+
+    if include_raw_snapshot:
+        lines.append("")
+        lines.append("## Raw Fields Snapshot")
+        lines.append("```json")
+        lines.append(json.dumps(bundle.get("raw_snapshot") or {}, ensure_ascii=False, indent=2, default=str))
+        lines.append("```")
+
+    return "\n".join(lines).strip() + "\n"

--- a/src/jira/selector.py
+++ b/src/jira/selector.py
@@ -1,0 +1,166 @@
+import json
+import re
+from typing import Any, Optional
+
+ISSUE_KEY_RE = re.compile(r"\b[A-Z][A-Z0-9_]*-\d+\b", re.IGNORECASE)
+
+
+def validate_issue_key(key: str) -> str:
+    normalized = str(key or "").strip().upper()
+    if not normalized or not ISSUE_KEY_RE.fullmatch(normalized):
+        raise ValueError(f"Invalid issue key: {key}")
+    return normalized
+
+
+def dedupe_issue_keys(keys: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for key in keys or []:
+        normalized = validate_issue_key(key)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        out.append(normalized)
+    return out
+
+
+def extract_issue_keys_from_text(text: str) -> list[str]:
+    raw = str(text or "")
+    matches = []
+    for m in ISSUE_KEY_RE.finditer(raw):
+        start, end = m.span()
+        prev_c = raw[start - 1] if start > 0 else ""
+        next_c = raw[end] if end < len(raw) else ""
+        if prev_c == "/" or next_c == "/":
+            continue
+        matches.append(m.group(0))
+    return dedupe_issue_keys(matches)
+
+
+def extract_output_directory_from_text(text: str) -> Optional[str]:
+    raw = str(text or "")
+    patterns = [
+        r"(?:save\s*to\s*folder|save到folder|folder|目录)\s*[：:]\s*([^\s，,。]+)",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, raw, re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def _normalize_limits(page_size: int, max_issues: int) -> tuple[int, int]:
+    try:
+        page_size_v = int(page_size)
+    except Exception:
+        page_size_v = 50
+    try:
+        max_issues_v = int(max_issues)
+    except Exception:
+        max_issues_v = 100
+    page_size_v = max(1, min(100, page_size_v))
+    max_issues_v = max(1, max_issues_v)
+    return page_size_v, max_issues_v
+
+
+def normalize_jira_issue_selector(
+    input: Any = None,
+    issue_keys: Optional[list[str]] = None,
+    jql: Optional[str] = None,
+    page_size: int = 50,
+    max_issues: int = 100,
+) -> dict:
+    page_size_v, max_issues_v = _normalize_limits(page_size, max_issues)
+    selector = {
+        "selector_type": "issue_keys",
+        "issue_keys": [],
+        "jql": "",
+        "page_size": page_size_v,
+        "max_issues": max_issues_v,
+        "truncated": False,
+        "partial_reasons": [],
+    }
+
+    if issue_keys:
+        keys = dedupe_issue_keys(issue_keys)
+        if len(keys) > max_issues_v:
+            selector["truncated"] = True
+            selector["partial_reasons"].append(f"max_issues_truncated:{max_issues_v}")
+            keys = keys[:max_issues_v]
+        selector["selector_type"] = "issue_keys"
+        selector["issue_keys"] = keys
+        return selector
+
+    if jql and input in (None, "", []):
+        selector["selector_type"] = "jql"
+        selector["jql"] = str(jql).strip()
+        return selector
+
+    if isinstance(input, dict):
+        merged_page_size = input.get("page_size", page_size_v)
+        merged_max_issues = input.get("max_issues", max_issues_v)
+        if input.get("jql"):
+            normalized = normalize_jira_issue_selector(
+                input=None,
+                jql=input.get("jql"),
+                page_size=merged_page_size,
+                max_issues=merged_max_issues,
+            )
+            return normalized
+        if input.get("issue_keys"):
+            normalized = normalize_jira_issue_selector(
+                input=None,
+                issue_keys=input.get("issue_keys"),
+                page_size=merged_page_size,
+                max_issues=merged_max_issues,
+            )
+            return normalized
+
+    if isinstance(input, list):
+        return normalize_jira_issue_selector(
+            input=None,
+            issue_keys=[str(x) for x in input],
+            page_size=page_size_v,
+            max_issues=max_issues_v,
+        )
+
+    if isinstance(input, str):
+        s = input.strip()
+        if s.lower().startswith("jql:"):
+            selector["selector_type"] = "jql"
+            selector["jql"] = s[4:].strip()
+            return selector
+
+        if (s.startswith("[") and s.endswith("]")) or (s.startswith("{") and s.endswith("}")):
+            try:
+                decoded = json.loads(s)
+                return normalize_jira_issue_selector(
+                    input=decoded,
+                    page_size=page_size_v,
+                    max_issues=max_issues_v,
+                )
+            except Exception:
+                pass
+
+        keys = extract_issue_keys_from_text(s)
+        if not keys:
+            for token in re.split(r"[\s,\n\r\t]+", s):
+                token = token.strip()
+                if not token:
+                    continue
+                try:
+                    keys.append(validate_issue_key(token))
+                except Exception:
+                    continue
+            keys = dedupe_issue_keys(keys)
+
+        if keys:
+            if len(keys) > max_issues_v:
+                selector["truncated"] = True
+                selector["partial_reasons"].append(f"max_issues_truncated:{max_issues_v}")
+                keys = keys[:max_issues_v]
+            selector["selector_type"] = "issue_keys"
+            selector["issue_keys"] = keys
+            return selector
+
+    raise ValueError("Unable to resolve Jira issue selector from input/issue_keys/jql")

--- a/src/jira/source_service.py
+++ b/src/jira/source_service.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from src.context_blob_store import put_text
+from src.source_context import persist_jira_source_bundle_and_digest
+from src.utils.attachment import download_and_process_attachment as _default_download_and_process_attachment
+
+from .adapter import JiraFormatAdapter
+
+
+@dataclass
+class JiraIssueSourceResult:
+    issue_key: str
+    issue: dict
+    fields: dict
+    bundle: dict
+    manifest: dict
+    persisted: dict
+    channel: Any
+    adapter: JiraFormatAdapter
+    attachment_list: list[dict]
+
+
+async def prepare_jira_issue_source(
+    issue_key_or_url: str,
+    *,
+    include_all_comments: bool = True,
+    include_attachments: bool = True,
+    include_raw_snapshot: bool = True,
+    session_id: str = "unknown_session",
+) -> JiraIssueSourceResult:
+    from src import jira as jira_module
+
+    channel = getattr(jira_module, "jira_channel", None)
+    downloader = getattr(jira_module, "download_and_process_attachment", _default_download_and_process_attachment)
+    put_text_fn = getattr(jira_module, "put_text", put_text)
+
+    if not channel or not channel.is_configured():
+        raise RuntimeError("Jira is not configured.")
+
+    issue_key = str(issue_key_or_url or "").strip()
+    instance_channel = channel
+    if "/browse/" in issue_key:
+        match = re.search(r"/browse/([A-Z][A-Z0-9_]*-\d+)", issue_key, re.IGNORECASE)
+        if not match:
+            raise ValueError(f"Could not extract issue key from URL: {issue_key_or_url}")
+        issue_key = match.group(1).upper()
+        instance_channel = channel.get_instance_client(url=issue_key_or_url)
+
+    adapter = JiraFormatAdapter(instance_channel)
+    issue = await adapter.get_issue(
+        issue_key=issue_key,
+        format="raw",
+        max_comments=None if include_all_comments else 5,
+        include_comments=True,
+        include_fields=None,
+    )
+    fields = issue.get("fields", {}) if isinstance(issue, dict) else {}
+    comments = adapter._get_comments_list(issue if isinstance(issue, dict) else {}, None if include_all_comments else 5)
+    comment_field = fields.get("comment", {})
+    comments_total = int((comment_field or {}).get("total") or len(comments)) if isinstance(comment_field, dict) else len(comments)
+
+    attachments = []
+    text_attachments_total = 0
+    text_attachments_loaded = 0
+    text_attachments_full_loaded = 0
+    text_attachments_preview_only = 0
+    text_attachments_with_full_ref = 0
+    partial_reasons: list[str] = []
+    attachment_body_partial_reasons: list[str] = []
+    attachment_list = fields.get("attachment", []) if isinstance(fields, dict) else []
+    binary_attachments_count = 0
+    binary_attachment_bodies_skipped_count = 0
+
+    for att in attachment_list:
+        mime = str(att.get("mimeType") or "")
+        filename = str(att.get("filename") or "unknown")
+        is_text = mime.startswith("text/") or filename.lower().endswith((".txt", ".md", ".csv", ".json", ".yaml", ".yml", ".xml", ".log"))
+        if is_text:
+            text_attachments_total += 1
+        else:
+            binary_attachments_count += 1
+            binary_attachment_bodies_skipped_count += 1
+            partial_reasons.append(f"binary_attachment_body_skipped:{filename}")
+
+        item = {
+            "id": att.get("id"),
+            "filename": filename,
+            "mime_type": mime,
+            "size": att.get("size", 0),
+            "created": att.get("created"),
+            "author": att.get("author"),
+            "text_preview": None,
+            "text_ref": None,
+            "attachment_text_preview_only": False,
+        }
+
+        if include_attachments and is_text and att.get("content"):
+            try:
+                auth_header = instance_channel._auth_header if instance_channel.is_configured() else None
+                result = await downloader(
+                    url=att.get("content"),
+                    session_id=f"jira-source-{issue_key}",
+                    options={"include_image_data": False},
+                    auth_header=auth_header,
+                )
+                if getattr(result, "content_format", "") == "text":
+                    text_content = str(getattr(result, "content", "") or "")
+                    if len(text_content) <= 4000:
+                        item["text_preview"] = text_content
+                        text_attachments_full_loaded += 1
+                    else:
+                        item["text_preview"] = text_content[:1000]
+                        item["attachment_text_preview_only"] = True
+                        text_attachments_preview_only += 1
+                        item["text_ref"] = put_text_fn(
+                            session_id=session_id,
+                            kind="jira_attachment_text",
+                            source_id=f"{issue_key}_{filename}",
+                            title=f"Jira attachment text {filename}",
+                            content=text_content,
+                            metadata={"issue_key": issue_key, "filename": filename},
+                        )
+                        text_attachments_with_full_ref += 1
+                        attachment_body_partial_reasons.append(f"text_attachment_preview_only:{filename}")
+                    text_attachments_loaded += 1
+            except Exception as exc:
+                partial_reasons.append(f"attachment_text_processing_failed:{filename}:{type(exc).__name__}")
+                attachment_body_partial_reasons.append(f"attachment_text_processing_failed:{filename}:{type(exc).__name__}")
+        attachments.append(item)
+
+    rendered_fields = issue.get("renderedFields") if isinstance(issue, dict) else None
+    bundle = {
+        "issue_key": issue_key,
+        "metadata": {
+            "key": issue.get("key") if isinstance(issue, dict) else issue_key,
+            "title": fields.get("summary"),
+            "status": (fields.get("status") or {}).get("name") if isinstance(fields.get("status"), dict) else "",
+            "type": (fields.get("issuetype") or {}).get("name") if isinstance(fields.get("issuetype"), dict) else "",
+            "priority": (fields.get("priority") or {}).get("name") if isinstance(fields.get("priority"), dict) else "",
+            "assignee": (fields.get("assignee") or {}).get("displayName") if isinstance(fields.get("assignee"), dict) else "",
+        },
+        "description": adapter._convert_description_to_markdown(fields.get("description")),
+        "acceptance_criteria": adapter._extract_acceptance_criteria(issue if isinstance(issue, dict) else {}),
+        "business_rules": "",
+        "validation_rules": "",
+        "comments": [
+            {
+                "id": c.get("id"),
+                "author": c.get("author"),
+                "created": c.get("created"),
+                "body": c.get("body"),
+                "body_markdown": adapter._convert_description_to_markdown(c.get("body")),
+            }
+            for c in comments
+        ],
+        "attachments": attachments,
+        "raw_snapshot": issue if include_raw_snapshot else {},
+        "names": issue.get("names") if isinstance(issue, dict) else {},
+        "renderedFields": issue.get("renderedFields") if isinstance(issue, dict) else {},
+        "completeness_ledger": {
+            "issue_loaded": bool(issue),
+            "raw_issue_loaded": bool(issue),
+            "names_loaded": bool(issue.get("names")) if isinstance(issue, dict) else False,
+            "issue_fields_complete": bool(fields),
+            "comments_loaded": len(comments),
+            "comments_total": comments_total,
+            "comments_complete": len(comments) >= comments_total,
+            "attachments_metadata_loaded": len(attachments),
+            "attachments_total": len(attachment_list),
+            "attachments_metadata_complete": len(attachments) >= len(attachment_list),
+            "attachment_metadata_complete": len(attachments) >= len(attachment_list),
+            "text_attachments_loaded": text_attachments_loaded,
+            "text_attachments_total": text_attachments_total,
+            "text_attachments_complete": text_attachments_loaded >= text_attachments_total,
+            "text_attachment_bodies_complete": text_attachments_loaded >= text_attachments_total and text_attachments_with_full_ref >= text_attachments_preview_only,
+            "text_attachments_full_loaded": text_attachments_full_loaded,
+            "text_attachments_preview_only": text_attachments_preview_only,
+            "text_attachments_with_full_ref": text_attachments_with_full_ref,
+            "binary_attachments_count": binary_attachments_count,
+            "binary_attachment_bodies_available": False,
+            "binary_attachment_bodies_skipped_count": binary_attachment_bodies_skipped_count,
+            "binary_attachment_body_policy": "metadata_only" if binary_attachments_count > 0 else "loaded",
+            "attachment_body_complete": text_attachments_preview_only == 0 and binary_attachment_bodies_skipped_count == 0,
+            "attachment_body_partial_reasons": attachment_body_partial_reasons + [
+                f"binary_attachment_body_skipped:{att.get('filename', 'unknown')}"
+                for att in attachment_list
+                if not (str(att.get("mimeType") or "").startswith("text/") or str(att.get("filename") or "").lower().endswith((".txt", ".md", ".csv", ".json", ".yaml", ".yml", ".xml", ".log")))
+            ],
+            "raw_fields_loaded": bool(fields),
+            "rendered_fields_loaded": bool(rendered_fields),
+            "custom_fields_loaded": bool(issue.get("names")) if isinstance(issue, dict) else False,
+            "source_complete_definition": (
+                "source_complete requires issue fields, all comments, attachment metadata, and text attachment bodies. "
+                "Binary attachment bodies are metadata-only by design and do not block source_complete."
+            ),
+            "partial_reasons": partial_reasons,
+        },
+    }
+
+    ledger = bundle["completeness_ledger"]
+    ledger["source_metadata_complete"] = bool(
+        ledger.get("issue_fields_complete")
+        and ledger.get("names_loaded")
+        and ledger.get("rendered_fields_loaded")
+        and ledger.get("attachment_metadata_complete")
+    )
+    ledger["source_text_complete"] = bool(
+        ledger.get("comments_complete")
+        and ledger.get("text_attachment_bodies_complete")
+    )
+    ledger["source_tree_complete"] = True
+    ledger["source_complete_for_generation"] = bool(
+        ledger["source_metadata_complete"] and ledger["source_text_complete"]
+    )
+    ledger["source_complete_including_binary_bodies"] = bool(
+        ledger["source_complete_for_generation"]
+        and ledger.get("binary_attachment_bodies_available")
+        and int(ledger.get("binary_attachment_bodies_skipped_count", 0)) == 0
+    )
+    blocking_partial_reasons = [r for r in ledger.get("partial_reasons", []) if not str(r).startswith("binary_attachment_body_skipped:")]
+    ledger["source_complete"] = ledger["source_complete_for_generation"] and not blocking_partial_reasons
+    ledger["source_complete_definition"] = (
+        "source_complete_for_generation requires issue metadata, all comments, full text fields, and full text attachment bodies. "
+        "Binary attachments are metadata-only by policy; source_complete_including_binary_bodies is false when binary bodies are unavailable."
+    )
+
+    persisted = persist_jira_source_bundle_and_digest(session_id=session_id, issue_key=issue_key, bundle=bundle)
+    manifest = {
+        "issue_key": issue_key,
+        "title": (fields.get("summary") if isinstance(fields, dict) else "") or "",
+        "context_ref": persisted["context_ref"],
+        "digest_ref": persisted["digest_ref"],
+        "source_complete": ledger["source_complete"],
+        "source_complete_for_generation": ledger["source_complete_for_generation"],
+        "source_complete_including_binary_bodies": ledger["source_complete_including_binary_bodies"],
+        "source_metadata_complete": ledger["source_metadata_complete"],
+        "source_text_complete": ledger["source_text_complete"],
+        "attachment_metadata_complete": ledger["attachment_metadata_complete"],
+        "text_attachment_bodies_complete": ledger["text_attachment_bodies_complete"],
+        "source_tree_complete": ledger["source_tree_complete"],
+        "binary_attachment_body_policy": ledger.get("binary_attachment_body_policy"),
+        "binary_attachment_bodies_available": ledger.get("binary_attachment_bodies_available"),
+        "binary_attachment_bodies_skipped_count": ledger.get("binary_attachment_bodies_skipped_count"),
+        "source_complete_definition": ledger.get("source_complete_definition"),
+        "comments_loaded": f"{ledger['comments_loaded']}/{ledger['comments_total']}",
+        "attachments_metadata_loaded": f"{ledger['attachments_metadata_loaded']}/{ledger['attachments_total']}",
+        "text_attachments_loaded": f"{ledger['text_attachments_loaded']}/{ledger['text_attachments_total']}",
+        "binary_attachments_preserved": max(0, ledger["attachments_total"] - ledger["text_attachments_loaded"]),
+        "partial_reasons": ledger["partial_reasons"],
+        "source_digest_chunk_count": persisted.get("source_digest_chunk_count", 0),
+        "sections": ["metadata", "description", "acceptance_criteria", "comments", "attachments", "raw_snapshot"],
+    }
+
+    return JiraIssueSourceResult(
+        issue_key=issue_key,
+        issue=issue if isinstance(issue, dict) else {},
+        fields=fields if isinstance(fields, dict) else {},
+        bundle=bundle,
+        manifest=manifest,
+        persisted=persisted,
+        channel=instance_channel,
+        adapter=adapter,
+        attachment_list=list(attachment_list),
+    )
+
+
+def format_jira_source_manifest(result: JiraIssueSourceResult) -> str:
+    return (
+        "[jira source bundle prepared]\\n"
+        + "\\n".join(
+            f"{k}: {json.dumps(v, ensure_ascii=False) if isinstance(v, (list, dict)) else v}"
+            for k, v in result.manifest.items()
+        )
+        + f"\\n\\nUse context_read_ref(ref=\\\"{result.persisted['context_ref']}\\\", section=\\\"...\\\") to inspect source sections."
+    )

--- a/src/jira/source_service.py
+++ b/src/jira/source_service.py
@@ -32,6 +32,7 @@ async def prepare_jira_issue_source(
     include_attachments: bool = True,
     include_raw_snapshot: bool = True,
     session_id: str = "unknown_session",
+    attachment_body_policy: str = "source_complete",
 ) -> JiraIssueSourceResult:
     from src import jira as jira_module
 
@@ -99,7 +100,14 @@ async def prepare_jira_issue_source(
             "attachment_text_preview_only": False,
         }
 
-        if include_attachments and is_text and att.get("content"):
+        should_load_text_body = (
+            include_attachments
+            and attachment_body_policy == "source_complete"
+            and is_text
+            and att.get("content")
+        )
+
+        if should_load_text_body:
             try:
                 auth_header = instance_channel._auth_header if instance_channel.is_configured() else None
                 result = await downloader(
@@ -131,6 +139,9 @@ async def prepare_jira_issue_source(
             except Exception as exc:
                 partial_reasons.append(f"attachment_text_processing_failed:{filename}:{type(exc).__name__}")
                 attachment_body_partial_reasons.append(f"attachment_text_processing_failed:{filename}:{type(exc).__name__}")
+        elif include_attachments and attachment_body_policy == "metadata_only" and is_text:
+            partial_reasons.append(f"text_attachment_body_metadata_only:{filename}")
+            attachment_body_partial_reasons.append(f"text_attachment_body_metadata_only:{filename}")
         attachments.append(item)
 
     rendered_fields = issue.get("renderedFields") if isinstance(issue, dict) else None
@@ -270,11 +281,12 @@ async def prepare_jira_issue_source(
 
 
 def format_jira_source_manifest(result: JiraIssueSourceResult) -> str:
-    return (
-        "[jira source bundle prepared]\\n"
-        + "\\n".join(
-            f"{k}: {json.dumps(v, ensure_ascii=False) if isinstance(v, (list, dict)) else v}"
-            for k, v in result.manifest.items()
-        )
-        + f"\\n\\nUse context_read_ref(ref=\\\"{result.persisted['context_ref']}\\\", section=\\\"...\\\") to inspect source sections."
+    lines = ["[jira source bundle prepared]"]
+    for k, v in result.manifest.items():
+        rendered = json.dumps(v, ensure_ascii=False) if isinstance(v, (list, dict)) else v
+        lines.append(f"{k}: {rendered}")
+    lines.append("")
+    lines.append(
+        f'Use context_read_ref(ref="{result.persisted["context_ref"]}", section="...") to inspect source sections.'
     )
+    return "\n".join(lines)

--- a/src/runtime/adapter_executor.py
+++ b/src/runtime/adapter_executor.py
@@ -110,6 +110,8 @@ async def execute_jira_workflow_action(action_name: str, kwargs: Dict[str, Any])
                 "action_name": action,
             }
         raw = await jira_module.jira_add_comment(issue_key=issue_key, comment=comment)
+    elif action == "export_issues_to_markdown":
+        raw = await jira_module.export_issues_to_markdown(**payload)
     else:
         return {"success": False, "error": f"Unsupported jira action: {action}", "system": "jira", "action_name": action}
 
@@ -262,6 +264,7 @@ ACTION_ID_TO_EXECUTOR = {
     "adapter:jira:assign_issue": lambda payload: _exec_jira("assign_issue", payload),
     "adapter:jira:transition_issue": lambda payload: _exec_jira("transition_issue", payload),
     "adapter:jira:add_comment": lambda payload: _exec_jira("add_comment", payload),
+    "adapter:jira:export_issues_to_markdown": lambda payload: _exec_jira("export_issues_to_markdown", payload),
     "adapter:github:review_pull_request": lambda payload: _exec_github("review_pull_request", payload),
     "adapter:github:add_comment": lambda payload: _exec_github("add_comment", payload),
     "adapter:portal:create_delegation": lambda payload: _exec_portal("create_delegation", payload),

--- a/src/runtime/capability_adapters.py
+++ b/src/runtime/capability_adapters.py
@@ -134,6 +134,7 @@ def build_jira_adapter_capabilities() -> List[AdapterActionDescriptor]:
                     "issues": {"type": "array"},
                     "artifacts": {"type": "object"},
                     "errors": {"type": "array"},
+                    "warnings": {"type": "array"},
                 },
             },
             policy_tags=["jira", "read", "export", "artifact_write", "filesystem_write", "attachment_download"],

--- a/src/runtime/capability_adapters.py
+++ b/src/runtime/capability_adapters.py
@@ -112,6 +112,34 @@ def build_jira_adapter_capabilities() -> List[AdapterActionDescriptor]:
             requires_identity_binding=True,
             source_ref="src.jira",
         ),
+        AdapterActionDescriptor(
+            action_id="adapter:jira:export_issues_to_markdown",
+            adapter="jira",
+            name="export_issues_to_markdown",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "input": {},
+                    "issue_keys": {"type": "array", "items": {"type": "string"}},
+                    "jql": {"type": "string"},
+                    "output_mode": {"type": "string", "enum": ["auto", "single_combined", "one_file_per_issue", "zip"]},
+                    "output_directory": {"type": "string"},
+                    "download_attachments": {"type": "boolean"},
+                },
+            },
+            output_schema={
+                "type": "object",
+                "properties": {
+                    "status": {"type": "string"},
+                    "issues": {"type": "array"},
+                    "artifacts": {"type": "object"},
+                    "errors": {"type": "array"},
+                },
+            },
+            policy_tags=["jira", "read", "export", "artifact_write", "filesystem_write", "attachment_download"],
+            requires_identity_binding=True,
+            source_ref="src.jira.exporter",
+        ),
     ])
 
 

--- a/tests/_import_helpers.py
+++ b/tests/_import_helpers.py
@@ -8,26 +8,72 @@ import types
 from pathlib import Path
 
 
-def _ensure_package(package_name: str) -> None:
-    if package_name in sys.modules:
+def _attach_lazy_package_init(module: types.ModuleType, package_name: str, package_dir: Path) -> None:
+    init_file = package_dir / "__init__.py"
+    if not init_file.is_file():
         return
-    module = types.ModuleType(package_name)
-    module.__path__ = []  # type: ignore[attr-defined]
-    sys.modules[package_name] = module
+    if module.__dict__.get("__lazy_init_attached__", False):
+        return
+
+    def _load_init_once() -> None:
+        if module.__dict__.get("__lazy_init_loaded__", False):
+            return
+        spec = importlib.util.spec_from_file_location(package_name, init_file)
+        if spec is None or spec.loader is None:
+            return
+        module.__lazy_init_loaded__ = True
+        module.__file__ = str(init_file)
+        module.__package__ = package_name
+        module.__spec__ = spec
+        spec.loader.exec_module(module)
+
+    def __getattr__(name: str):
+        _load_init_once()
+        if name in module.__dict__:
+            return module.__dict__[name]
+        raise AttributeError(name)
+
+    module.__getattr__ = __getattr__  # type: ignore[attr-defined]
+    module.__lazy_init_attached__ = True
+
+
+def _ensure_package(package_name: str, repo_root: Path) -> None:
+    module = sys.modules.get(package_name)
+
+    package_parts = package_name.split(".")
+    package_dir = repo_root.joinpath(*package_parts)
+    package_path = str(package_dir) if package_dir.is_dir() else None
+
+    if module is None:
+        module = types.ModuleType(package_name)
+        module.__path__ = [package_path] if package_path else []  # type: ignore[attr-defined]
+        if package_path:
+            _attach_lazy_package_init(module, package_name, Path(package_path))
+        sys.modules[package_name] = module
+        return
+
+    current_path = getattr(module, "__path__", None)
+    if package_path is not None and current_path is not None:
+        if package_path not in list(current_path):
+            current_path.append(package_path)
+        _attach_lazy_package_init(module, package_name, Path(package_path))
 
 
 def load_module_from_repo_path(module_name: str, relative_path: str):
     """Load and execute a module from ``relative_path`` under repo root.
 
-    Supports package-qualified names (for example ``src.gateway.events``) so
-    relative imports inside the loaded module continue to resolve.
+    Supports package-qualified names such as ``src.gateway.events`` so relative
+    imports inside the loaded module continue to resolve. The helper creates
+    lightweight package modules with real ``__path__`` values so later standard
+    imports such as ``src.gateway.server`` keep working during full test
+    collection.
     """
     repo_root = Path(__file__).resolve().parent.parent
     module_path = repo_root / relative_path
 
     package_parts = module_name.split(".")[:-1]
     for idx in range(1, len(package_parts) + 1):
-        _ensure_package(".".join(package_parts[:idx]))
+        _ensure_package(".".join(package_parts[:idx]), repo_root)
 
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     if spec is None or spec.loader is None:

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -67,6 +67,19 @@ async def test_execute_adapter_action_add_comment(monkeypatch):
     assert result["action_id"] == "adapter:jira:add_comment"
 
 
+
+
+@pytest.mark.asyncio
+async def test_execute_adapter_action_jira_export(monkeypatch):
+    async def _fake_export_issues_to_markdown(**kwargs):
+        return {"success": True, "status": "success", "issues": [], "artifacts": {}, "errors": []}
+
+    monkeypatch.setattr("src.jira.export_issues_to_markdown", _fake_export_issues_to_markdown)
+    result = await execute_adapter_action("adapter:jira:export_issues_to_markdown", {"input": ["PROJ-1"]})
+
+    assert result["success"] is True
+    assert result["action_id"] == "adapter:jira:export_issues_to_markdown"
+
 @pytest.mark.asyncio
 async def test_execute_adapter_action_github_review_pull_request(monkeypatch):
     captured = {}

--- a/tests/test_author_metadata_persistence.py
+++ b/tests/test_author_metadata_persistence.py
@@ -48,6 +48,9 @@ def _isolated_home(tmp_path, monkeypatch):
 
 def _mk_session_manager(calls):
     class FakeSessionManager:
+        def __init__(self):
+            self._active_skill_sessions = {}
+
         async def add_message(self, session_id, role, content, extra=None):
             message = {
                 "session_id": session_id,
@@ -62,7 +65,14 @@ def _mk_session_manager(calls):
         async def get_history(self, session_id):
             return []
 
+        async def get_active_skill_session(self, session_id):
+            return self._active_skill_sessions.get(session_id)
+
         async def set_active_skill_session(self, session_id, state):
+            if state is None:
+                self._active_skill_sessions.pop(session_id, None)
+            else:
+                self._active_skill_sessions[session_id] = state
             return None
 
     return FakeSessionManager()

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -68,6 +68,9 @@ def test_default_registry_includes_skill_and_adapter_capabilities():
     assert portal_actions
     assert all(item.metadata.get("internal_portal_api") is True for item in portal_actions)
     assert any(item.capability_id == "adapter:jira:add_comment" for item in adapters)
+    export_descriptor = next(item for item in adapters if item.capability_id == "adapter:jira:export_issues_to_markdown")
+    assert "filesystem_write" in export_descriptor.policy_tags
+    assert "attachment_download" in export_descriptor.policy_tags
 
 
 def test_descriptor_fields_preserved():

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -71,6 +71,7 @@ def test_default_registry_includes_skill_and_adapter_capabilities():
     export_descriptor = next(item for item in adapters if item.capability_id == "adapter:jira:export_issues_to_markdown")
     assert "filesystem_write" in export_descriptor.policy_tags
     assert "attachment_download" in export_descriptor.policy_tags
+    assert "warnings" in export_descriptor.output_schema.get("properties", {})
 
 
 def test_descriptor_fields_preserved():

--- a/tests/test_confluence_image_handling.py
+++ b/tests/test_confluence_image_handling.py
@@ -37,7 +37,8 @@ async def test_confluence_get_page_by_url_processes_attachments_with_instance_ch
         from src.confluence import confluence_get_page_by_url
 
         result = await confluence_get_page_by_url(
-            "https://right.example/wiki/spaces/SPACE/pages/123456/Page-Title"
+            "https://right.example/wiki/spaces/SPACE/pages/123456/Page-Title",
+            preview=True,
         )
 
         assert "# Test Page" in result
@@ -80,7 +81,7 @@ async def test_confluence_get_page_does_not_emit_raw_base64_for_image_attachment
 
         from src.confluence import confluence_get_page
 
-        result = await confluence_get_page("1")
+        result = await confluence_get_page("1", preview=True)
 
         assert "**Attachments:**" in result
         assert "image.png" in result
@@ -108,7 +109,7 @@ async def test_confluence_get_page_by_url_works_even_if_default_channel_not_conf
         from src.confluence import confluence_get_page_by_url
 
         url = "https://right.example/wiki/spaces/SPACE/pages/123456/Page-Title"
-        result = await confluence_get_page_by_url(url)
+        result = await confluence_get_page_by_url(url, preview=True)
 
         assert "# Test Page" in result
         mock_channel.get_instance_client.assert_called_once_with(url=url, strict=True)
@@ -126,7 +127,8 @@ async def test_confluence_get_page_by_url_returns_instance_error_when_url_does_n
         from src.confluence import confluence_get_page_by_url
 
         result = await confluence_get_page_by_url(
-            "https://unknown.example/wiki/spaces/SPACE/pages/123456/Page-Title"
+            "https://unknown.example/wiki/spaces/SPACE/pages/123456/Page-Title",
+            preview=True,
         )
 
         assert "Confluence instance for URL is not configured" in result

--- a/tests/test_import_helpers.py
+++ b/tests/test_import_helpers.py
@@ -1,0 +1,22 @@
+def test_load_module_from_repo_path_keeps_gateway_importable():
+    from tests._import_helpers import load_module_from_repo_path
+
+    load_module_from_repo_path("src.gateway.event_bus", "src/gateway/event_bus.py")
+
+    import src.gateway.server as gateway_server
+    from src.gateway import webchat
+
+    assert gateway_server is not None
+    assert webchat is not None
+
+
+def test_load_module_from_repo_path_sets_real_package_paths():
+    import sys
+    from tests._import_helpers import load_module_from_repo_path
+
+    load_module_from_repo_path("src.gateway.event_bus", "src/gateway/event_bus.py")
+
+    assert "src" in sys.modules
+    assert "src.gateway" in sys.modules
+    assert getattr(sys.modules["src"], "__path__", None)
+    assert getattr(sys.modules["src.gateway"], "__path__", None)

--- a/tests/test_jira_markdown_export.py
+++ b/tests/test_jira_markdown_export.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.jira.exporter import _resolve_output_directory, export_issues_to_markdown
+from src.jira.exporter import _download_issue_attachments, _resolve_output_directory, export_issues_to_markdown
 from src.jira.selector import (
     extract_issue_keys_from_text,
     extract_output_directory_from_text,
@@ -306,3 +306,182 @@ async def test_download_attachments_uses_source_channel_auth_header(tmp_path, mo
         source_channel=source_channel,
     )
     assert seen["auth_header"] == {"Authorization": "Basic source"}
+
+
+def _fake_source_result(issue_key: str, attachment=True):
+    class FakeAdapter:
+        def _strip_acceptance_criteria_from_markdown_description(self, text): return text
+        def _convert_description_to_markdown(self, body): return str(body or "")
+
+    fields = {"summary": "S", "attachment": []}
+    if attachment:
+        fields["attachment"] = [{"filename": "a.txt", "mimeType": "text/plain", "size": 1, "content": "http://x"}]
+    bundle = {"metadata": {"title": "S"}, "description": "D", "acceptance_criteria": "AC", "comments": [], "attachments": [], "completeness_ledger": {}}
+    return JiraIssueSourceResult(
+        issue_key=issue_key,
+        issue={},
+        fields=fields,
+        bundle=bundle,
+        manifest={"context_ref": "c", "digest_ref": "d", "source_complete": True, "source_complete_for_generation": True, "partial_reasons": []},
+        persisted={},
+        channel=SimpleNamespace(is_configured=lambda: True, _auth_header={"Authorization": "Basic source"}),
+        adapter=FakeAdapter(),
+        attachment_list=fields["attachment"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_attachments_dir_rejects_path_traversal(tmp_path, monkeypatch):
+    source_file = tmp_path / "source.txt"
+    source_file.write_text("x", encoding="utf-8")
+
+    async def fake_download(url, session_id=None, options=None, auth_header=None):
+        return SimpleNamespace(file_id="fid", filename="a.txt", metadata={"size": 1}, content_type="text/plain", content_format="text", content="x")
+
+    monkeypatch.setattr("src.jira.exporter.download_and_process_attachment", fake_download)
+    monkeypatch.setattr("src.jira.exporter.get_file_path", lambda file_id: source_file)
+
+    output_dir = tmp_path / "home" / ".efp" / "workspace" / "out"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        await _download_issue_attachments(
+            "MMGFX-1",
+            [{"filename": "a.txt", "mimeType": "text/plain", "size": 1, "content": "http://x"}],
+            output_dir=output_dir,
+            attachments_dir="../../escape",
+            concurrency=1,
+            attachments_max_size=1024,
+            attachments_inline_text_threshold=10,
+            attachments_retries=1,
+            attachments_backoff=[0],
+            attachments_preserve_binary=True,
+            source_channel=SimpleNamespace(is_configured=lambda: True, _auth_header={}),
+        )
+    with pytest.raises(ValueError):
+        await _download_issue_attachments(
+            "MMGFX-1",
+            [{"filename": "a.txt", "mimeType": "text/plain", "size": 1, "content": "http://x"}],
+            output_dir=output_dir,
+            attachments_dir="/tmp/escape",
+            concurrency=1,
+            attachments_max_size=1024,
+            attachments_inline_text_threshold=10,
+            attachments_retries=1,
+            attachments_backoff=[0],
+            attachments_preserve_binary=True,
+            source_channel=SimpleNamespace(is_configured=lambda: True, _auth_header={}),
+        )
+    assert not (output_dir.parent.parent / "escape").exists()
+
+
+@pytest.mark.asyncio
+async def test_zip_does_not_include_preexisting_files(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    output_dir = home / ".efp" / "workspace" / "FXOW" / "FXLanding"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "stale.txt").write_text("stale", encoding="utf-8")
+
+    async def fake_prepare(issue_key_or_url, **kwargs):
+        return _fake_source_result(issue_key_or_url, attachment=True)
+
+    async def fake_download(*args, **kwargs):
+        out = kwargs["output_dir"]
+        issue_key = args[0]
+        p = out / "attachments" / issue_key / "a.txt"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+        return [{"filename": "a.txt", "status": "saved", "path": f"attachments/{issue_key}/a.txt", "absolute_path": str(p), "size": 1, "mime_type": "text/plain"}]
+
+    monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
+    monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
+
+    result = await export_issues_to_markdown(input=["MMGFX-1"], output_mode="zip", output_directory=str(output_dir))
+    with zipfile.ZipFile(result["artifacts"]["zip_path"]) as zf:
+        names = set(zf.namelist())
+        assert "manifest.json" in names
+        assert any(name.endswith(".md") for name in names)
+        assert "attachments/MMGFX-1/a.txt" in names
+        assert "stale.txt" not in names
+
+
+@pytest.mark.asyncio
+async def test_attachment_failure_marks_export_partial(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    output_dir = home / ".efp" / "workspace" / "FXOW" / "FXLanding"
+
+    async def fake_prepare(issue_key_or_url, **kwargs):
+        return _fake_source_result(issue_key_or_url, attachment=True)
+
+    async def fake_download(*args, **kwargs):
+        return [{"filename": "a.txt", "status": "failed", "reason": "download_failed:TimeoutError"}]
+
+    monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
+    monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
+
+    result = await export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(output_dir))
+    assert result["status"] == "partial"
+    assert result["success"] is True
+    assert result["warnings"]
+    issue = result["issues"][0]
+    assert issue["status"] == "exported"
+    assert issue["attachment_download_complete"] is False
+    assert any("attachment_failed:a.txt" in r for r in issue["export_partial_reasons"])
+
+
+@pytest.mark.asyncio
+async def test_metadata_only_source_partial_does_not_force_export_partial(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    output_dir = home / ".efp" / "workspace" / "FXOW" / "FXLanding"
+
+    async def fake_prepare(issue_key_or_url, **kwargs):
+        result = _fake_source_result(issue_key_or_url, attachment=True)
+        result.manifest["partial_reasons"] = ["text_attachment_body_metadata_only:a.txt"]
+        return result
+
+    async def fake_download(*args, **kwargs):
+        out = kwargs["output_dir"]
+        issue_key = args[0]
+        p = out / "attachments" / issue_key / "a.txt"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+        return [{"filename": "a.txt", "status": "saved", "path": f"attachments/{issue_key}/a.txt", "absolute_path": str(p), "size": 1, "mime_type": "text/plain"}]
+
+    monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
+    monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
+
+    result = await export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(output_dir), download_attachments=True)
+    assert result["status"] == "success"
+    issue = result["issues"][0]
+    assert "text_attachment_body_metadata_only:a.txt" in issue["source_partial_reasons"]
+    assert issue["export_partial_reasons"] == []
+    assert issue["partial_reasons"] == []
+
+
+@pytest.mark.asyncio
+async def test_attachment_markdown_paths_are_posix_relative(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    output_dir = home / ".efp" / "workspace" / "FXOW" / "FXLanding"
+
+    async def fake_prepare(issue_key_or_url, **kwargs):
+        return _fake_source_result(issue_key_or_url, attachment=True)
+
+    async def fake_download(*args, **kwargs):
+        out = kwargs["output_dir"]
+        issue_key = args[0]
+        p = out / "attachments" / issue_key / "a.txt"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+        return [{"filename": "a.txt", "status": "saved", "path": f"attachments/{issue_key}/a.txt", "absolute_path": str(p), "size": 1, "mime_type": "text/plain"}]
+
+    monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
+    monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
+
+    result = await export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(output_dir))
+    md = Path(result["issues"][0]["markdown_path"]).read_text(encoding="utf-8")
+    assert "attachments/MMGFX-1/a.txt" in md
+    assert "\\" not in md
+    assert str(output_dir) not in md

--- a/tests/test_jira_markdown_export.py
+++ b/tests/test_jira_markdown_export.py
@@ -1,0 +1,203 @@
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.jira.exporter import _resolve_output_directory, export_issues_to_markdown
+from src.jira.selector import (
+    extract_issue_keys_from_text,
+    extract_output_directory_from_text,
+    normalize_jira_issue_selector,
+)
+from src.jira.source_service import JiraIssueSourceResult
+from src.jira.markdown_renderer import render_jira_issue_export_markdown
+
+
+EXACT_PROMPT = """帮我把下面jira ticket 转成markdown, 并save到folder：/root/.efp/workspace/FXOW/FXLanding，如果ticket有attachment，请一并下载
+MMGFX-14839
+MMGFX-14838
+MMGFX-14833
+MMGFX-14832"""
+
+
+def test_selector_extracts_exact_user_prompt():
+    keys = extract_issue_keys_from_text(EXACT_PROMPT)
+    assert keys == ["MMGFX-14839", "MMGFX-14838", "MMGFX-14833", "MMGFX-14832"]
+    assert extract_output_directory_from_text(EXACT_PROMPT) == "/root/.efp/workspace/FXOW/FXLanding"
+    selector = normalize_jira_issue_selector(input=EXACT_PROMPT)
+    assert selector["selector_type"] == "issue_keys"
+    assert selector["issue_keys"] == keys
+
+
+def test_json_string_input_list():
+    selector = normalize_jira_issue_selector(input='["MMGFX-14839","MMGFX-14838"]')
+    assert selector["issue_keys"] == ["MMGFX-14839", "MMGFX-14838"]
+
+
+def test_json_string_input_jql():
+    selector = normalize_jira_issue_selector(input='{"jql":"project = MMGFX","page_size":25}')
+    assert selector["selector_type"] == "jql"
+    assert selector["jql"] == "project = MMGFX"
+    assert selector["page_size"] == 25
+
+
+def test_output_directory_workspace_guard(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: Path("/root"))
+    ok = _resolve_output_directory("/root/.efp/workspace/FXOW/FXLanding")
+    assert str(ok).endswith("/root/.efp/workspace/FXOW/FXLanding")
+    with pytest.raises(ValueError):
+        _resolve_output_directory("/etc")
+    with pytest.raises(ValueError):
+        _resolve_output_directory("/root/.ssh")
+    with pytest.raises(ValueError):
+        _resolve_output_directory("/root/.efp/workspace/../.ssh")
+
+
+@pytest.mark.asyncio
+async def test_export_exact_prompt_writes_markdown_and_attachments(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    prompt = EXACT_PROMPT.replace("/root", str(home))
+
+    class FakeAdapter:
+        def _strip_acceptance_criteria_from_markdown_description(self, text):
+            return text.replace("## Acceptance Criteria\n- AC", "").strip()
+
+        def _convert_description_to_markdown(self, body):
+            return str(body or "")
+
+    async def fake_prepare(issue_key_or_url, **kwargs):
+        key = issue_key_or_url
+        fields = {"summary": f"Summary {key}", "attachment": [{"filename": "note.txt", "mimeType": "text/plain", "size": 10, "content": "http://x"}]}
+        bundle = {
+            "metadata": {"key": key, "title": f"Summary {key}", "status": "Open", "type": "Task", "priority": "P1", "assignee": "A"},
+            "description": "Desc\n## Acceptance Criteria\n- AC",
+            "acceptance_criteria": "- AC",
+            "comments": [
+                {"author": {"displayName": "U1"}, "created": "2026-01-01", "body": "c1", "body_markdown": "c1"},
+            ],
+            "attachments": [{"filename": "note.txt", "size": 10, "mime_type": "text/plain"}],
+            "completeness_ledger": {"comments_loaded": 1},
+            "raw_snapshot": {"k": "v"},
+        }
+        manifest = {"context_ref": f"ctx-{key}", "digest_ref": f"dig-{key}", "source_complete": True, "source_complete_for_generation": True, "partial_reasons": []}
+        return JiraIssueSourceResult(
+            issue_key=key,
+            issue={"key": key, "fields": fields},
+            fields=fields,
+            bundle=bundle,
+            manifest=manifest,
+            persisted={},
+            channel=SimpleNamespace(),
+            adapter=FakeAdapter(),
+            attachment_list=fields["attachment"],
+        )
+
+    async def fake_download(*args, **kwargs):
+        output_dir = kwargs["output_dir"]
+        issue_key = args[0]
+        p = output_dir / "attachments" / issue_key / "note.txt"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("hello", encoding="utf-8")
+        return [{"filename": "note.txt", "status": "saved", "path": f"attachments/{issue_key}/note.txt", "absolute_path": str(p), "size": 5, "mime_type": "text/plain"}]
+
+    monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
+    monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
+
+    result = await export_issues_to_markdown(input=prompt, _session_id="test-session")
+    assert result["status"] == "success"
+    assert len(result["issues"]) == 4
+    manifest_path = Path(result["artifacts"]["manifest_path"])
+    assert manifest_path.exists()
+    first_issue = result["issues"][0]
+    md_path = Path(first_issue["markdown_path"])
+    assert md_path.exists()
+    text = md_path.read_text(encoding="utf-8")
+    assert "## Description" in text
+    assert "## Acceptance Criteria" in text
+    assert "## Comments" in text
+    assert "## Attachments" in text
+    assert f"attachments/{first_issue['issue_key']}/note.txt" in text
+    assert (manifest_path.parent / "attachments" / first_issue["issue_key"] / "note.txt").exists()
+
+
+def test_comments_latest_first_sorts_before_truncating():
+    source = JiraIssueSourceResult(
+        issue_key="MMGFX-1",
+        issue={},
+        fields={"summary": "S"},
+        bundle={
+            "metadata": {"title": "S"},
+            "description": "D",
+            "acceptance_criteria": "AC",
+            "comments": [
+                {"author": "A", "created": "2026-01-01", "body_markdown": "old"},
+                {"author": "A", "created": "2026-01-03", "body_markdown": "newest"},
+                {"author": "A", "created": "2026-01-02", "body_markdown": "mid"},
+            ],
+            "attachments": [],
+            "completeness_ledger": {},
+        },
+        manifest={},
+        persisted={},
+        channel=SimpleNamespace(),
+        adapter=SimpleNamespace(_strip_acceptance_criteria_from_markdown_description=lambda x: x, _convert_description_to_markdown=lambda x: x),
+        attachment_list=[],
+    )
+    md = render_jira_issue_export_markdown(source, max_comments=2, comments_order="latest_first")
+    assert md.index("newest") < md.index("mid")
+    assert "old" not in md
+
+
+def test_raw_snapshot_is_json_fenced_block():
+    source = JiraIssueSourceResult(
+        issue_key="MMGFX-1",
+        issue={},
+        fields={"summary": "S"},
+        bundle={"metadata": {"title": "S"}, "description": "D", "acceptance_criteria": "AC", "comments": [], "attachments": [], "completeness_ledger": {}, "raw_snapshot": {"a": 1}},
+        manifest={}, persisted={}, channel=SimpleNamespace(),
+        adapter=SimpleNamespace(_strip_acceptance_criteria_from_markdown_description=lambda x: x, _convert_description_to_markdown=lambda x: x),
+        attachment_list=[],
+    )
+    md = render_jira_issue_export_markdown(source, include_raw_snapshot=True)
+    assert "```json" in md
+    assert "{'a': 1}" not in md
+
+
+@pytest.mark.asyncio
+async def test_zip_includes_attachments_and_manifest(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = home / ".efp" / "workspace" / "FXOW" / "FXLanding"
+
+    class FakeAdapter:
+        def _strip_acceptance_criteria_from_markdown_description(self, text): return text
+        def _convert_description_to_markdown(self, body): return str(body or "")
+
+    async def fake_prepare(issue_key_or_url, **kwargs):
+        key = issue_key_or_url
+        fields = {"summary": "S", "attachment": [{"filename": "a.txt", "mimeType": "text/plain", "size": 10, "content": "http://x"}]}
+        bundle = {"metadata": {"title": "S"}, "description": "D", "acceptance_criteria": "AC", "comments": [], "attachments": [], "completeness_ledger": {}}
+        return JiraIssueSourceResult(issue_key=key, issue={}, fields=fields, bundle=bundle, manifest={"context_ref": "c", "digest_ref": "d", "source_complete": True, "source_complete_for_generation": True, "partial_reasons": []}, persisted={}, channel=SimpleNamespace(), adapter=FakeAdapter(), attachment_list=fields["attachment"])
+
+    async def fake_download(*args, **kwargs):
+        output_dir = kwargs["output_dir"]
+        issue_key = args[0]
+        p = output_dir / "attachments" / issue_key / "a.txt"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+        return [{"filename": "a.txt", "status": "saved", "path": f"attachments/{issue_key}/a.txt", "absolute_path": str(p), "size": 1, "mime_type": "text/plain"}]
+
+    monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
+    monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
+
+    result = await export_issues_to_markdown(input=["MMGFX-1"], output_mode="zip", output_directory=str(out))
+    zp = Path(result["artifacts"]["zip_path"])
+    assert zp.exists()
+    with zipfile.ZipFile(zp) as zf:
+        names = set(zf.namelist())
+        assert "manifest.json" in names
+        assert any(name.endswith(".md") for name in names)
+        assert "attachments/MMGFX-1/a.txt" in names

--- a/tests/test_jira_markdown_export.py
+++ b/tests/test_jira_markdown_export.py
@@ -44,15 +44,27 @@ def test_json_string_input_jql():
 
 
 def test_output_directory_workspace_guard(tmp_path, monkeypatch):
-    monkeypatch.setattr("pathlib.Path.home", lambda: Path("/root"))
-    ok = _resolve_output_directory("/root/.efp/workspace/FXOW/FXLanding")
-    assert str(ok).endswith("/root/.efp/workspace/FXOW/FXLanding")
+    home = tmp_path / "home"
+    root_workspace = tmp_path / "root" / ".efp" / "workspace"
+    env_workspace = tmp_path / "env-workspace"
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setenv("EFP_WORKSPACE_ROOT", str(env_workspace))
+
+    ok1 = _resolve_output_directory(str(home / ".efp" / "workspace" / "FXOW"))
+    assert ok1.exists()
+
+    ok2 = _resolve_output_directory(str(env_workspace / "FXOW"))
+    assert ok2.exists()
+
+    monkeypatch.setattr("src.jira.exporter._allowed_workspace_roots", lambda: [root_workspace.resolve()])
+    ok3 = _resolve_output_directory(str(root_workspace / "FXOW" / "FXLanding"))
+    assert ok3.exists()
+
     with pytest.raises(ValueError):
-        _resolve_output_directory("/etc")
+        _resolve_output_directory(str(tmp_path / "etc"))
     with pytest.raises(ValueError):
-        _resolve_output_directory("/root/.ssh")
-    with pytest.raises(ValueError):
-        _resolve_output_directory("/root/.efp/workspace/../.ssh")
+        _resolve_output_directory(str(root_workspace / ".." / ".ssh"))
 
 
 @pytest.mark.asyncio
@@ -201,3 +213,96 @@ async def test_zip_includes_attachments_and_manifest(tmp_path, monkeypatch):
         assert "manifest.json" in names
         assert any(name.endswith(".md") for name in names)
         assert "attachments/MMGFX-1/a.txt" in names
+
+
+@pytest.mark.asyncio
+async def test_manifest_contains_final_artifacts(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = home / ".efp" / "workspace" / "FXOW" / "FXLanding"
+
+    class FakeAdapter:
+        def _strip_acceptance_criteria_from_markdown_description(self, text): return text
+        def _convert_description_to_markdown(self, body): return str(body or "")
+
+    async def fake_prepare(issue_key_or_url, **kwargs):
+        key = issue_key_or_url
+        fields = {"summary": "S", "attachment": [{"filename": "a.txt", "mimeType": "text/plain", "size": 10, "content": "http://x"}]}
+        bundle = {"metadata": {"title": "S"}, "description": "D", "acceptance_criteria": "AC", "comments": [], "attachments": [], "completeness_ledger": {}}
+        return JiraIssueSourceResult(issue_key=key, issue={}, fields=fields, bundle=bundle, manifest={"context_ref": "c", "digest_ref": "d", "source_complete": True, "source_complete_for_generation": True, "partial_reasons": []}, persisted={}, channel=SimpleNamespace(), adapter=FakeAdapter(), attachment_list=fields["attachment"])
+
+    async def fake_download(*args, **kwargs):
+        output_dir = kwargs["output_dir"]
+        issue_key = args[0]
+        p = output_dir / "attachments" / issue_key / "a.txt"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+        return [{"filename": "a.txt", "status": "saved", "path": f"attachments/{issue_key}/a.txt", "absolute_path": str(p), "size": 1, "mime_type": "text/plain"}]
+
+    monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
+    monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
+
+    result = await export_issues_to_markdown(input=["MMGFX-1"], output_mode="zip", output_directory=str(out))
+    manifest = json.loads(Path(result["artifacts"]["manifest_path"]).read_text(encoding="utf-8"))
+    assert manifest["artifacts"]["manifest_path"] == result["artifacts"]["manifest_path"]
+    assert manifest["artifacts"]["zip_path"] == result["artifacts"]["zip_path"]
+    assert manifest["output_directory"] == result["output_directory"]
+
+
+@pytest.mark.asyncio
+async def test_export_uses_metadata_only_source_policy_when_downloading_attachments(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = home / ".efp" / "workspace" / "FXOW" / "FXLanding"
+    captured = {}
+
+    class FakeAdapter:
+        def _strip_acceptance_criteria_from_markdown_description(self, text): return text
+        def _convert_description_to_markdown(self, body): return str(body or "")
+
+    async def fake_prepare(issue_key_or_url, **kwargs):
+        captured[issue_key_or_url] = kwargs
+        fields = {"summary": "S", "attachment": []}
+        bundle = {"metadata": {"title": "S"}, "description": "D", "acceptance_criteria": "AC", "comments": [], "attachments": [], "completeness_ledger": {}}
+        return JiraIssueSourceResult(issue_key=issue_key_or_url, issue={}, fields=fields, bundle=bundle, manifest={"context_ref": "c", "digest_ref": "d", "source_complete": True, "source_complete_for_generation": True, "partial_reasons": []}, persisted={}, channel=SimpleNamespace(is_configured=lambda: True, _auth_header={}), adapter=FakeAdapter(), attachment_list=[])
+
+    monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
+
+    await export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(out), download_attachments=True)
+    assert captured["MMGFX-1"]["attachment_body_policy"] == "metadata_only"
+
+    await export_issues_to_markdown(input=["MMGFX-1"], download_attachments=False)
+    assert captured["MMGFX-1"]["attachment_body_policy"] == "source_complete"
+
+
+@pytest.mark.asyncio
+async def test_download_attachments_uses_source_channel_auth_header(tmp_path, monkeypatch):
+    from src.jira.exporter import _download_issue_attachments
+
+    source_file = tmp_path / "stored.txt"
+    source_file.write_text("x", encoding="utf-8")
+    seen = {}
+
+    async def fake_download_and_process_attachment(url, session_id=None, options=None, auth_header=None):
+        seen["auth_header"] = auth_header
+        return SimpleNamespace(file_id="fid", filename="a.txt", metadata={"size": 1}, content_type="text/plain", content_format="text", content="x")
+
+    monkeypatch.setattr("src.jira.exporter.download_and_process_attachment", fake_download_and_process_attachment)
+    monkeypatch.setattr("src.jira.exporter.get_file_path", lambda file_id: source_file)
+
+    output_dir = tmp_path / "out"
+    source_channel = SimpleNamespace(is_configured=lambda: True, _auth_header={"Authorization": "Basic source"})
+    await _download_issue_attachments(
+        "MMGFX-1",
+        [{"filename": "a.txt", "mimeType": "text/plain", "size": 1, "content": "http://x"}],
+        output_dir=output_dir,
+        attachments_dir="attachments",
+        concurrency=1,
+        attachments_max_size=1024,
+        attachments_inline_text_threshold=100,
+        attachments_retries=1,
+        attachments_backoff=[0],
+        attachments_preserve_binary=True,
+        source_channel=source_channel,
+    )
+    assert seen["auth_header"] == {"Authorization": "Basic source"}

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -194,12 +194,14 @@ async def test_jira_prepare_issue_context_persists_all_comments_and_bounded_mani
 
     monkeypatch.setattr("src.jira.jira_channel", _Channel())
     out = await jira_prepare_issue_context("PROJ-1", _session_id="s-jira-prepare")
+    assert "\\nissue_key:" not in out
+    assert "\nissue_key:" in out
     assert "[jira source bundle prepared]" in out
     assert "comments_loaded: 20/20" in out
     assert "source_complete_for_generation: True" in out
     assert "source_digest_chunk_count:" in out
     assert len(out) < 8000
-    ref = out.split("context_ref: ", 1)[1].split("\\n", 1)[0].strip().strip('"')
+    ref = out.split("context_ref: ", 1)[1].split("\n", 1)[0].strip().strip('"')
     raw = read_ref(ref, session_id="s-jira-prepare", section="raw", max_chars=50000)
     assert '"comments_loaded": 20' in raw
     assert '"comments_complete": true' in raw.lower()
@@ -241,8 +243,10 @@ async def test_jira_prepare_issue_context_attachment_full_and_preview_ledger(mon
     monkeypatch.setattr("src.jira.jira_channel", _Channel())
     monkeypatch.setattr("src.jira.download_and_process_attachment", _fake_download)
     out = await jira_prepare_issue_context("PROJ-2", _session_id="s-jira-attach")
+    assert "\\nissue_key:" not in out
+    assert "\nissue_key:" in out
     assert "text_attachments_loaded: 2/2" in out
-    ref = out.split("context_ref: ", 1)[1].split("\\n", 1)[0].strip().strip('"')
+    ref = out.split("context_ref: ", 1)[1].split("\n", 1)[0].strip().strip('"')
     from src.context_blob_store import read_ref
     raw = read_ref(ref, session_id="s-jira-attach", section="coverage_ledger", max_chars=50000)
     assert "text_attachments_full_loaded" in raw
@@ -280,7 +284,9 @@ async def test_jira_preview_only_text_attachment_marks_text_incomplete(monkeypat
     monkeypatch.setattr("src.jira.download_and_process_attachment", _fake_download)
     monkeypatch.setattr("src.jira.put_text", _raise_put_text)
     out = await jira_prepare_issue_context("PROJ-9", _session_id="s-jira-preview")
-    ref = out.split("context_ref: ", 1)[1].split("\\n", 1)[0].strip().strip('"')
+    assert "\\nissue_key:" not in out
+    assert "\nissue_key:" in out
+    ref = out.split("context_ref: ", 1)[1].split("\n", 1)[0].strip().strip('"')
     raw = read_ref(ref, session_id="s-jira-preview", section="coverage_ledger", max_chars=50000)
     assert '"text_attachment_bodies_complete": false' in raw.lower()
     assert '"source_complete_for_generation": false' in raw.lower()
@@ -305,7 +311,9 @@ async def test_jira_digest_chunks_do_not_silently_truncate_long_comment(monkeypa
 
     monkeypatch.setattr("src.jira.jira_channel", _Channel())
     out = await jira_prepare_issue_context("PROJ-3", _session_id="s-jira-long")
-    ref = out.split("context_ref: ", 1)[1].split("\\n", 1)[0].strip().strip('"')
+    assert "\\nissue_key:" not in out
+    assert "\nissue_key:" in out
+    ref = out.split("context_ref: ", 1)[1].split("\n", 1)[0].strip().strip('"')
     raw = read_ref(ref, session_id="s-jira-long", section="raw", max_chars=60000)
     assert "L" * 1000 in raw
 

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -46,7 +46,7 @@ def test_jira_preview_tools_not_model_facing():
     names = {s.get("function", {}).get("name") for s in get_tools_schemas()}
     assert "jira_get_issue_preview" not in names
     assert "jira_get_issue_by_url_preview" not in names
-    assert "export_issues_to_markdown" not in names
+    assert "export_issues_to_markdown" in names
 
 
 def test_jira_get_comments_schema_is_model_facing():

--- a/tests/test_multi_instance.py
+++ b/tests/test_multi_instance.py
@@ -46,7 +46,7 @@ class TestJiraGetIssueByUrl:
     async def test_jira_get_issue_by_url_invalid_url(self):
         """Test jira_get_issue_by_url returns error for invalid URL"""
         from src.jira import jira_get_issue_by_url
-        result = await jira_get_issue_by_url("https://invalid.com/browse/")
+        result = await jira_get_issue_by_url("https://invalid.com/browse/", preview=True)
         
         # Should return error about extracting issue key
         assert "Could not extract issue key" in result
@@ -66,11 +66,15 @@ class TestConfluenceGetPageByUrl:
                 "title": "Test Page",
                 "body": {"storage": {"value": "Test content"}}
             })
+            mock_instance.get_attachments = AsyncMock(return_value=[])
             
             mock_channel.get_instance_client.return_value = mock_instance
             
             from src.confluence import confluence_get_page_by_url
-            result = await confluence_get_page_by_url("https://company.atlassian.net/wiki/spaces/SPACE/pages/123456/Page-Title")
+            result = await confluence_get_page_by_url(
+                "https://company.atlassian.net/wiki/spaces/SPACE/pages/123456/Page-Title",
+                preview=True,
+            )
             
             # Should have called get_instance_client with the URL
             mock_channel.get_instance_client.assert_called_with(


### PR DESCRIPTION
### Motivation
- Replace a bug-prone monolithic Jira exporter with a layered, testable pipeline so model-facing calls reliably parse NL prompts, fetch sources, render Markdown, download attachments, and write artifacts under a guarded workspace path.
- Ensure the export tool is discoverable by the model (model-facing schema) and that execute paths and runtime adapter capabilities support programmatic execution and attachment download policies.

### Description
- Added a selector layer `src/jira/selector.py` that extracts/deduplicates issue keys, recognizes newline/comma/JSON/JQL inputs, enforces `page_size`/`max_issues` limits, and extracts output directory paths from natural language prompts.
- Introduced `src/jira/source_service.py` which encapsulates source-complete issue acquisition (preserves completeness ledger and calls `persist_jira_source_bundle_and_digest`) and returns a `JiraIssueSourceResult` used by both exporter and `jira_prepare_issue_context`.
- Implemented `src/jira/markdown_renderer.py` to render Markdown from a source bundle (removes acceptance criteria from Description, sorts/truncates comments correctly, includes JSON fenced raw snapshot, and renders attachment entries using download results).
- Rewrote `src/jira/exporter.py` as the canonical `export_issues_to_markdown` implementing selector → source → render → artifact export, with workspace-guarded `output_directory`, safe filenames, per-issue or combined output, attachment download/copy into `attachments/<ISSUE_KEY>/`, manifest.json, and optional zip of the whole export tree.
- Made `jira_prepare_issue_context` a thin wrapper calling the new source service and `format_jira_source_manifest` to preserve existing manifest/string format behavior.
- Updated `src/jira/api.py` tool schema for `export_issues_to_markdown` to be model-facing and accept natural language/text/array/object/JQL and new output parameters (`output_mode`, `output_directory`, `download_attachments`, etc.).
- Updated tool dispatch in `src/__init__.py` to pass the new exporter arguments and return stable JSON using `json.dumps(...)` instead of `str(dict)`, and added adapter capability and executor wiring in `src/runtime/capability_adapters.py` and `src/runtime/adapter_executor.py` for `adapter:jira:export_issues_to_markdown` (policy tags include `filesystem_write` and `attachment_download`).
- Tests added/updated: `tests/test_jira_markdown_export.py` (selector, workspace guard, end-to-end export flow, comments ordering, raw snapshot formatting, zip contents) and small updates to existing Jira/adapters tests to reflect the exporter being model-facing and the new adapter action.

### Testing
- Ran targeted Jira and runtime tests: `pytest -q tests/test_jira_tools.py tests/test_jira_markdown.py tests/test_jira_markdown_export.py tests/test_adapter_executor.py tests/test_capability_registry.py tests/test_runtime_adapter_execution.py`, and they passed (the modified and new Jira export tests passed).
- Verified `py_compile` of modified modules to ensure syntax correctness and ran the combined subset above to validate behavior of selector, source preparation, renderer, exporter, attachment handling, manifest, and adapter execution.
- Full `pytest -q` in this environment fails during collection due to unrelated missing `src.gateway.*` modules (pre-existing environment issue) and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f022447c832aaa836dbab401037a)