### PR TITLE
Fix Jira export tool `input` schema for Responses strict validation

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -338,8 +338,8 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
         result = await jira_module.jira_assign_issue(issue_key, assignee)
         return ToolResult(success="Error" not in result, content=result)
 
-    elif name == "export_issues_to_markdown":
-        result = await jira_module.export_issues_to_markdown(
+    elif name == "jira_export_issues_to_markdown":
+        result = await jira_module.jira_export_issues_to_markdown(
             input=kwargs.get("input"),
             issue_keys=kwargs.get("issue_keys"),
             jql=kwargs.get("jql"),

--- a/src/jira/__init__.py
+++ b/src/jira/__init__.py
@@ -23,7 +23,7 @@ from .api import (
 )
 from .adapter import JiraFormatAdapter
 from src.utils.attachment import download_and_process_attachment
-from .exporter import export_issues_to_markdown
+from .exporter import jira_export_issues_to_markdown
 from src.source_context import persist_jira_source_bundle_and_digest
 from src.context_blob_store import put_text
 from .source_service import prepare_jira_issue_source, format_jira_source_manifest
@@ -51,7 +51,7 @@ __all__ = [
     "jira_get_versions",
     "jira_get_worklog",
     "jira_add_worklog",
-    "export_issues_to_markdown",
+    "jira_export_issues_to_markdown",
 ]
 
 

--- a/src/jira/api.py
+++ b/src/jira/api.py
@@ -1333,8 +1333,11 @@ def get_tools_schemas() -> list:
         {
             "type": "function",
             "function": {
-                "name": "export_issues_to_markdown",
-                "description": "Export Jira tickets/issues to Markdown files. Use this when the user asks to convert Jira tickets to markdown, save to a folder, or download Jira attachments. Supports newline-separated issue keys and natural language text containing issue keys.",
+                "name": "jira_export_issues_to_markdown",
+                "description": (
+                    "Export Jira tickets/issues to Markdown files. Use this when the user asks to convert Jira tickets to markdown, "
+                    "save Jira tickets to a folder, or download Jira ticket attachments. Supports natural language text containing Jira issue keys."
+                ),
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/src/jira/api.py
+++ b/src/jira/api.py
@@ -1339,12 +1339,13 @@ def get_tools_schemas() -> list:
                     "type": "object",
                     "properties": {
                         "input": {
-                            "anyOf": [
-                                {"type": "string"},
-                                {"type": "array", "items": {"type": "string"}},
-                                {"type": "object"}
-                            ],
-                            "description": "Can be a single issue key, newline-separated keys, comma-separated keys, a JSON list, a dict with jql, or the original user text containing issue keys."
+                            "type": "string",
+                            "description": (
+                                "Original user text or Jira issue keys. Use this for natural-language requests "
+                                "such as 'convert these Jira tickets to markdown and save to folder: ...'. "
+                                "It may contain newline-separated, comma-separated, or space-separated issue keys. "
+                                "For structured calls, use issue_keys or jql fields instead."
+                            ),
                         },
                         "issue_keys": {"type": "array", "items": {"type": "string"}},
                         "jql": {"type": "string"},

--- a/src/jira/exporter.py
+++ b/src/jira/exporter.py
@@ -256,7 +256,7 @@ async def _download_issue_attachments(
     return await asyncio.gather(*[_handle(att) for att in attachment_list])
 
 
-async def export_issues_to_markdown(
+async def jira_export_issues_to_markdown(
     input: Any = None,
     *,
     issue_keys: Optional[List[str]] = None,
@@ -520,4 +520,4 @@ async def export_issues_to_markdown(
     }
 
 
-__all__ = ["export_issues_to_markdown"]
+__all__ = ["jira_export_issues_to_markdown"]

--- a/src/jira/exporter.py
+++ b/src/jira/exporter.py
@@ -9,6 +9,7 @@ import os
 import re
 import shutil
 import time
+import unicodedata
 import uuid
 import zipfile
 from pathlib import Path
@@ -30,17 +31,6 @@ DEFAULT_MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024
 DEFAULT_INLINE_TEXT_THRESHOLD = 2000
 DEFAULT_RETRIES = 3
 DEFAULT_BACKOFF = [1, 2, 4]
-
-
-def _summary_to_slug(summary: str, max_len: int = 80) -> str:
-    if not summary:
-        return "untitled"
-    s = summary.lower()
-    s = re.sub(r"[^a-z0-9]+", "-", s)
-    s = re.sub(r"-{2,}", "-", s).strip("-")
-    if len(s) > max_len:
-        s = s[:max_len].rstrip("-")
-    return s or "untitled"
 
 
 def _allowed_workspace_roots() -> list[Path]:
@@ -75,10 +65,57 @@ def _resolve_output_directory(output_directory: str) -> Path:
     return output
 
 
-def _safe_issue_markdown_filename(issue_key: str, summary: str) -> str:
+def _safe_issue_markdown_filename(issue_key: str) -> str:
     issue_part = sanitize_filename(issue_key.upper())
-    slug = sanitize_filename(_summary_to_slug(summary or "untitled"))
-    return f"{issue_part} - {slug}.md"
+    if not issue_part:
+        raise ValueError(f"Invalid issue key for markdown filename: {issue_key}")
+    return f"{issue_part}.md"
+
+
+def _safe_export_attachment_filename(
+    jira_filename: str,
+    fallback_filename: str = "",
+    default_stem: str = "attachment",
+    max_len: int = 200,
+) -> str:
+    raw = str(jira_filename or fallback_filename or "").strip()
+    raw = Path(raw).name
+    raw = unicodedata.normalize("NFKC", raw)
+    raw = "".join(ch for ch in raw if ord(ch) >= 32)
+    raw = raw.replace("/", "_").replace("\\", "_")
+
+    ext = Path(raw).suffix
+    stem = raw[: -len(ext)] if ext else raw
+
+    out_chars: list[str] = []
+    for ch in stem:
+        if ch.isalnum():
+            out_chars.append(ch)
+        elif ch in {" ", ".", "_", "-"}:
+            out_chars.append("_" if ch == " " else ch)
+        else:
+            out_chars.append("_")
+
+    safe_stem = "".join(out_chars)
+    safe_stem = re.sub(r"_+", "_", safe_stem)
+    safe_stem = re.sub(r"-{2,}", "-", safe_stem)
+    safe_stem = safe_stem.strip("._-")
+
+    if not safe_stem:
+        safe_stem = default_stem
+
+    safe_ext = ""
+    if ext:
+        ext_body = re.sub(r"[^A-Za-z0-9]+", "", ext.lstrip("."))
+        if ext_body:
+            safe_ext = f".{ext_body}"
+
+    max_stem_len = max(1, max_len - len(safe_ext))
+    safe_stem = safe_stem[:max_stem_len].rstrip("._-")
+    if not safe_stem:
+        safe_stem = default_stem[:max_stem_len] or "attachment"
+
+    return f"{safe_stem}{safe_ext}"
 
 
 def _unique_path(path: Path) -> Path:
@@ -215,9 +252,10 @@ async def _download_issue_attachments(
                     return item
 
                 src = get_file_path(result.file_id)
-                target_name = sanitize_filename(getattr(result, "filename", "") or filename)
-                if not target_name:
-                    target_name = "attachment"
+                target_name = _safe_export_attachment_filename(
+                    jira_filename=filename,
+                    fallback_filename=getattr(result, "filename", "") or "",
+                )
                 candidate_path = _unique_path(issue_dir / target_name).resolve()
                 output_root = output_dir.resolve()
                 if output_root not in candidate_path.parents:
@@ -419,11 +457,10 @@ async def jira_export_issues_to_markdown(
             )
 
             issue_result["attachments"] = downloaded
-            summary = source.fields.get("summary") or source.bundle.get("metadata", {}).get("title") or ""
             if resolved_output_mode == "one_file_per_issue":
                 if not output_dir_path:
                     raise ValueError("output_directory is required for one_file_per_issue export")
-                md_path = _unique_path(output_dir_path / _safe_issue_markdown_filename(key, summary))
+                md_path = _unique_path(output_dir_path / _safe_issue_markdown_filename(key))
                 md_path.write_text(markdown, encoding="utf-8")
                 created_paths.append(md_path)
                 issue_result["markdown_path"] = str(md_path)

--- a/src/jira/exporter.py
+++ b/src/jira/exporter.py
@@ -84,8 +84,14 @@ def _safe_export_attachment_filename(
     raw = "".join(ch for ch in raw if ord(ch) >= 32)
     raw = raw.replace("/", "_").replace("\\", "_")
 
-    ext = Path(raw).suffix
-    stem = raw[: -len(ext)] if ext else raw
+    # Path('.pdf').suffix treats this as a hidden file with no extension.
+    # For export artifacts we want extension-only names to become attachment.<ext>.
+    if raw.startswith(".") and raw.count(".") == 1 and len(raw) > 1:
+        stem = ""
+        ext = raw
+    else:
+        ext = Path(raw).suffix
+        stem = raw[: -len(ext)] if ext else raw
 
     out_chars: list[str] = []
     for ch in stem:
@@ -101,14 +107,14 @@ def _safe_export_attachment_filename(
     safe_stem = re.sub(r"-{2,}", "-", safe_stem)
     safe_stem = safe_stem.strip("._-")
 
-    if not safe_stem:
-        safe_stem = default_stem
-
     safe_ext = ""
     if ext:
         ext_body = re.sub(r"[^A-Za-z0-9]+", "", ext.lstrip("."))
         if ext_body:
             safe_ext = f".{ext_body}"
+
+    if not safe_stem:
+        safe_stem = default_stem
 
     max_stem_len = max(1, max_len - len(safe_ext))
     safe_stem = safe_stem[:max_stem_len].rstrip("._-")

--- a/src/runtime/adapter_executor.py
+++ b/src/runtime/adapter_executor.py
@@ -111,7 +111,7 @@ async def execute_jira_workflow_action(action_name: str, kwargs: Dict[str, Any])
             }
         raw = await jira_module.jira_add_comment(issue_key=issue_key, comment=comment)
     elif action == "export_issues_to_markdown":
-        raw = await jira_module.export_issues_to_markdown(**payload)
+        raw = await jira_module.jira_export_issues_to_markdown(**payload)
     else:
         return {"success": False, "error": f"Unsupported jira action: {action}", "system": "jira", "action_name": action}
 

--- a/src/runtime/capability_adapters.py
+++ b/src/runtime/capability_adapters.py
@@ -119,7 +119,7 @@ def build_jira_adapter_capabilities() -> List[AdapterActionDescriptor]:
             input_schema={
                 "type": "object",
                 "properties": {
-                    "input": {},
+                    "input": {"type": "string"},
                     "issue_keys": {"type": "array", "items": {"type": "string"}},
                     "jql": {"type": "string"},
                     "output_mode": {"type": "string", "enum": ["auto", "single_combined", "one_file_per_issue", "zip"]},

--- a/tests/test_adapter_executor.py
+++ b/tests/test_adapter_executor.py
@@ -71,10 +71,10 @@ async def test_execute_adapter_action_add_comment(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_execute_adapter_action_jira_export(monkeypatch):
-    async def _fake_export_issues_to_markdown(**kwargs):
+    async def _fake_jira_export_issues_to_markdown(**kwargs):
         return {"success": True, "status": "success", "issues": [], "artifacts": {}, "errors": []}
 
-    monkeypatch.setattr("src.jira.export_issues_to_markdown", _fake_export_issues_to_markdown)
+    monkeypatch.setattr("src.jira.jira_export_issues_to_markdown", _fake_jira_export_issues_to_markdown)
     result = await execute_adapter_action("adapter:jira:export_issues_to_markdown", {"input": ["PROJ-1"]})
 
     assert result["success"] is True

--- a/tests/test_jira_markdown_export.py
+++ b/tests/test_jira_markdown_export.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.jira.exporter import _download_issue_attachments, _resolve_output_directory, export_issues_to_markdown
+from src.jira.exporter import _download_issue_attachments, _resolve_output_directory, jira_export_issues_to_markdown
 from src.jira.selector import (
     extract_issue_keys_from_text,
     extract_output_directory_from_text,
@@ -133,7 +133,7 @@ async def test_export_exact_prompt_writes_markdown_and_attachments(tmp_path, mon
     monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
     monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
 
-    result = await export_issues_to_markdown(input=prompt, _session_id="test-session")
+    result = await jira_export_issues_to_markdown(input=prompt, _session_id="test-session")
     assert result["status"] == "success"
     assert len(result["issues"]) == 4
     manifest_path = Path(result["artifacts"]["manifest_path"])
@@ -220,7 +220,7 @@ async def test_zip_includes_attachments_and_manifest(tmp_path, monkeypatch):
     monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
     monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
 
-    result = await export_issues_to_markdown(input=["MMGFX-1"], output_mode="zip", output_directory=str(out))
+    result = await jira_export_issues_to_markdown(input=["MMGFX-1"], output_mode="zip", output_directory=str(out))
     zp = Path(result["artifacts"]["zip_path"])
     assert zp.exists()
     with zipfile.ZipFile(zp) as zf:
@@ -257,7 +257,7 @@ async def test_manifest_contains_final_artifacts(tmp_path, monkeypatch):
     monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
     monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
 
-    result = await export_issues_to_markdown(input=["MMGFX-1"], output_mode="zip", output_directory=str(out))
+    result = await jira_export_issues_to_markdown(input=["MMGFX-1"], output_mode="zip", output_directory=str(out))
     manifest = json.loads(Path(result["artifacts"]["manifest_path"]).read_text(encoding="utf-8"))
     assert manifest["artifacts"]["manifest_path"] == result["artifacts"]["manifest_path"]
     assert manifest["artifacts"]["zip_path"] == result["artifacts"]["zip_path"]
@@ -283,10 +283,10 @@ async def test_export_uses_metadata_only_source_policy_when_downloading_attachme
 
     monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
 
-    await export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(out), download_attachments=True)
+    await jira_export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(out), download_attachments=True)
     assert captured["MMGFX-1"]["attachment_body_policy"] == "metadata_only"
 
-    await export_issues_to_markdown(input=["MMGFX-1"], download_attachments=False)
+    await jira_export_issues_to_markdown(input=["MMGFX-1"], download_attachments=False)
     assert captured["MMGFX-1"]["attachment_body_policy"] == "source_complete"
 
 
@@ -411,7 +411,7 @@ async def test_zip_does_not_include_preexisting_files(tmp_path, monkeypatch):
     monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
     monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
 
-    result = await export_issues_to_markdown(input=["MMGFX-1"], output_mode="zip", output_directory=str(output_dir))
+    result = await jira_export_issues_to_markdown(input=["MMGFX-1"], output_mode="zip", output_directory=str(output_dir))
     with zipfile.ZipFile(result["artifacts"]["zip_path"]) as zf:
         names = set(zf.namelist())
         assert "manifest.json" in names
@@ -435,7 +435,7 @@ async def test_attachment_failure_marks_export_partial(tmp_path, monkeypatch):
     monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
     monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
 
-    result = await export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(output_dir))
+    result = await jira_export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(output_dir))
     assert result["status"] == "partial"
     assert result["success"] is True
     assert result["warnings"]
@@ -467,7 +467,7 @@ async def test_metadata_only_source_partial_does_not_force_export_partial(tmp_pa
     monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
     monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
 
-    result = await export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(output_dir), download_attachments=True)
+    result = await jira_export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(output_dir), download_attachments=True)
     assert result["status"] == "success"
     issue = result["issues"][0]
     assert "text_attachment_body_metadata_only:a.txt" in issue["source_partial_reasons"]
@@ -495,7 +495,7 @@ async def test_attachment_markdown_paths_are_posix_relative(tmp_path, monkeypatc
     monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
     monkeypatch.setattr("src.jira.exporter._download_issue_attachments", fake_download)
 
-    result = await export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(output_dir))
+    result = await jira_export_issues_to_markdown(input=["MMGFX-1"], output_directory=str(output_dir))
     md = Path(result["issues"][0]["markdown_path"]).read_text(encoding="utf-8")
     assert "attachments/MMGFX-1/a.txt" in md
     assert "\\" not in md

--- a/tests/test_jira_markdown_export.py
+++ b/tests/test_jira_markdown_export.py
@@ -5,7 +5,12 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.jira.exporter import _download_issue_attachments, _resolve_output_directory, jira_export_issues_to_markdown
+from src.jira.exporter import (
+    _download_issue_attachments,
+    _resolve_output_directory,
+    _safe_export_attachment_filename,
+    jira_export_issues_to_markdown,
+)
 from src.jira.selector import (
     extract_issue_keys_from_text,
     extract_output_directory_from_text,
@@ -56,6 +61,16 @@ def test_json_string_input_jql():
     assert selector["selector_type"] == "jql"
     assert selector["jql"] == "project = MMGFX"
     assert selector["page_size"] == 25
+
+
+def test_safe_export_attachment_filename_extension_only_uses_default_stem():
+    assert _safe_export_attachment_filename("   .pdf") == "attachment.pdf"
+    assert _safe_export_attachment_filename(".docx") == "attachment.docx"
+
+
+def test_safe_export_attachment_filename_empty_or_unsafe_stem_preserves_extension():
+    assert _safe_export_attachment_filename("../?.xlsx") == "attachment.xlsx"
+    assert _safe_export_attachment_filename("  !!!.txt  ") == "attachment.txt"
 
 
 def test_output_directory_workspace_guard(tmp_path, monkeypatch):

--- a/tests/test_jira_markdown_export.py
+++ b/tests/test_jira_markdown_export.py
@@ -150,6 +150,32 @@ async def test_export_exact_prompt_writes_markdown_and_attachments(tmp_path, mon
     assert (manifest_path.parent / "attachments" / first_issue["issue_key"] / "note.txt").exists()
 
 
+@pytest.mark.asyncio
+async def test_issue_markdown_filename_defaults_to_issue_key_only(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = home / ".efp" / "workspace" / "FXOW" / "FXLanding"
+
+    class FakeAdapter:
+        def _strip_acceptance_criteria_from_markdown_description(self, text): return text
+        def _convert_description_to_markdown(self, body): return str(body or "")
+
+    async def fake_prepare(issue_key_or_url, **kwargs):
+        key = issue_key_or_url
+        result = _fake_source_result(key, attachment=False)
+        result.fields["summary"] = "Landing page CTA alignment bug"
+        result.bundle["metadata"]["title"] = "Landing page CTA alignment bug"
+        result.adapter = FakeAdapter()
+        return result
+
+    monkeypatch.setattr("src.jira.exporter.prepare_jira_issue_source", fake_prepare)
+
+    result = await jira_export_issues_to_markdown(input=["MMGFX-14839"], output_directory=str(out))
+    md_name = Path(result["issues"][0]["markdown_path"]).name
+    assert md_name == "MMGFX-14839.md"
+    assert " - " not in md_name
+
+
 def test_comments_latest_first_sorts_before_truncating():
     source = JiraIssueSourceResult(
         issue_key="MMGFX-1",
@@ -321,6 +347,83 @@ async def test_download_attachments_uses_source_channel_auth_header(tmp_path, mo
         source_channel=source_channel,
     )
     assert seen["auth_header"] == {"Authorization": "Basic source"}
+
+
+@pytest.mark.asyncio
+async def test_attachment_export_uses_jira_filename_not_download_result_filename(tmp_path, monkeypatch):
+    source_file = tmp_path / "stored.bin"
+    source_file.write_text("x", encoding="utf-8")
+
+    async def fake_download_and_process_attachment(url, session_id=None, options=None, auth_header=None):
+        return SimpleNamespace(
+            file_id="fid",
+            filename="file_deadbeef",
+            metadata={"size": 1},
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            content_format="text",
+            content="x",
+        )
+
+    monkeypatch.setattr("src.jira.exporter.download_and_process_attachment", fake_download_and_process_attachment)
+    monkeypatch.setattr("src.jira.exporter.get_file_path", lambda file_id: source_file)
+
+    output_dir = tmp_path / "out"
+    result = await _download_issue_attachments(
+        "MMGFX-1",
+        [{"filename": "My Report (Final) v2.xlsx", "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "size": 1, "content": "http://x"}],
+        output_dir=output_dir,
+        attachments_dir="attachments",
+        concurrency=1,
+        attachments_max_size=1024,
+        attachments_inline_text_threshold=100,
+        attachments_retries=1,
+        attachments_backoff=[0],
+        attachments_preserve_binary=True,
+        source_channel=SimpleNamespace(is_configured=lambda: True, _auth_header={}),
+    )
+
+    assert result[0]["status"] == "saved"
+    assert result[0]["path"].endswith("attachments/MMGFX-1/My_Report_Final_v2.xlsx")
+    assert Path(result[0]["absolute_path"]).name == "My_Report_Final_v2.xlsx"
+    assert "file_" not in Path(result[0]["absolute_path"]).name
+
+
+@pytest.mark.asyncio
+async def test_attachment_export_preserves_unicode_and_extension(tmp_path, monkeypatch):
+    source_file = tmp_path / "stored.bin"
+    source_file.write_text("x", encoding="utf-8")
+
+    async def fake_download_and_process_attachment(url, session_id=None, options=None, auth_header=None):
+        return SimpleNamespace(
+            file_id="fid",
+            filename="file_deadbeef",
+            metadata={"size": 1},
+            content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            content_format="text",
+            content="x",
+        )
+
+    monkeypatch.setattr("src.jira.exporter.download_and_process_attachment", fake_download_and_process_attachment)
+    monkeypatch.setattr("src.jira.exporter.get_file_path", lambda file_id: source_file)
+
+    output_dir = tmp_path / "out"
+    result = await _download_issue_attachments(
+        "MMGFX-1",
+        [{"filename": "需求说明（最终版）.docx", "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "size": 1, "content": "http://x"}],
+        output_dir=output_dir,
+        attachments_dir="attachments",
+        concurrency=1,
+        attachments_max_size=1024,
+        attachments_inline_text_threshold=100,
+        attachments_retries=1,
+        attachments_backoff=[0],
+        attachments_preserve_binary=True,
+        source_channel=SimpleNamespace(is_configured=lambda: True, _auth_header={}),
+    )
+
+    assert result[0]["status"] == "saved"
+    assert Path(result[0]["absolute_path"]).name == "需求说明_最终版.docx"
+    assert result[0]["path"].endswith("attachments/MMGFX-1/需求说明_最终版.docx")
 
 
 def _fake_source_result(issue_key: str, attachment=True):

--- a/tests/test_jira_markdown_export.py
+++ b/tests/test_jira_markdown_export.py
@@ -31,6 +31,21 @@ def test_selector_extracts_exact_user_prompt():
     assert selector["issue_keys"] == keys
 
 
+def test_selector_extracts_current_required_prompt():
+    prompt = (
+        "帮我把下面jira ticket 转成markdown, 并save到folder："
+        "/root/.efp/workspace/FXOW/FXLanding，如果ticket有attachment，请一并下载 "
+        "MMGFX-14839 MMGFX-14838"
+    )
+
+    assert extract_output_directory_from_text(prompt) == "/root/.efp/workspace/FXOW/FXLanding"
+    assert extract_issue_keys_from_text(prompt) == ["MMGFX-14839", "MMGFX-14838"]
+
+    selector = normalize_jira_issue_selector(input=prompt)
+    assert selector["selector_type"] == "issue_keys"
+    assert selector["issue_keys"] == ["MMGFX-14839", "MMGFX-14838"]
+
+
 def test_json_string_input_list():
     selector = normalize_jira_issue_selector(input='["MMGFX-14839","MMGFX-14838"]')
     assert selector["issue_keys"] == ["MMGFX-14839", "MMGFX-14838"]

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -56,6 +56,35 @@ def test_jira_get_comments_schema_is_model_facing():
     assert "jira_get_comments" in names
 
 
+def test_export_issues_to_markdown_schema_is_strict_responses_compatible():
+    from src.jira import get_tools_schemas
+    from src.agents.llm import _convert_tools_schema
+
+    schema = next(
+        s for s in get_tools_schemas()
+        if s.get("function", {}).get("name") == "export_issues_to_markdown"
+    )
+
+    input_schema = schema["function"]["parameters"]["properties"]["input"]
+
+    # The model-facing schema must not expose anyOf with a bare object branch.
+    assert "anyOf" not in input_schema
+    assert input_schema["type"] == "string"
+
+    converted = _convert_tools_schema([schema])[0]
+    assert converted["strict"] is True
+    assert converted["parameters"]["additionalProperties"] is False
+
+    converted_input = converted["parameters"]["properties"]["input"]
+
+    # Optional top-level string fields become nullable under Responses strict conversion.
+    assert "null" in converted_input["type"]
+    assert "string" in converted_input["type"]
+
+    # No nested object schema should remain under input.
+    assert "anyOf" not in converted_input
+
+
 @pytest.mark.asyncio
 async def test_jira_update_issue_summary_only(mock_jira_channel):
     """Test jira_update_issue with summary only"""
@@ -414,3 +443,74 @@ async def test_execute_tool_jira_get_comments_dispatches_with_session(monkeypatc
     assert captured["session_id"] == "s1"
     assert "[jira comments bundle prepared]" in result.content
     assert "ctx://context/s1/" in result.content
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_export_handles_strict_nullable_optional_args(monkeypatch):
+    from src import execute_tool
+
+    prompt = (
+        "帮我把下面jira ticket 转成markdown, 并save到folder："
+        "/root/.efp/workspace/FXOW/FXLanding，如果ticket有attachment，请一并下载 "
+        "MMGFX-14839 MMGFX-14838"
+    )
+
+    captured = {}
+
+    async def fake_export_issues_to_markdown(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "status": "success",
+            "run_id": "test-run",
+            "selector": {"issue_keys": ["MMGFX-14839", "MMGFX-14838"]},
+            "output_mode": kwargs.get("output_mode"),
+            "output_directory": "/root/.efp/workspace/FXOW/FXLanding",
+            "issues": [],
+            "artifacts": {},
+            "warnings": [],
+            "errors": [],
+        }
+
+    monkeypatch.setattr("src.jira.export_issues_to_markdown", fake_export_issues_to_markdown)
+
+    result = await execute_tool(
+        "export_issues_to_markdown",
+        input=prompt,
+        issue_keys=None,
+        jql=None,
+        page_size=None,
+        max_issues=None,
+        output_mode=None,
+        output_directory=None,
+        download_attachments=None,
+        attachments_dir=None,
+        include_raw_snapshot=None,
+        include_coverage_ledger=None,
+        max_comments=None,
+        comments_order=None,
+        attachments_concurrency=None,
+        attachments_max_size=None,
+        attachments_inline_text_threshold=None,
+        attachments_retries=None,
+        attachments_backoff=None,
+        attachments_preserve_binary=None,
+    )
+
+    assert result.success is True
+    assert captured["input"] == prompt
+
+    # These should fall back to dispatch defaults after _strip_none_values removes None.
+    assert captured["page_size"] == 50
+    assert captured["max_issues"] == 100
+    assert captured["output_mode"] == "auto"
+    assert captured["attachments_dir"] == "attachments"
+    assert captured["include_raw_snapshot"] is False
+    assert captured["include_coverage_ledger"] is True
+    assert captured["comments_order"] == "latest_first"
+    assert captured["attachments_concurrency"] == 4
+    assert captured["attachments_max_size"] == 52428800
+    assert captured["attachments_inline_text_threshold"] == 2000
+    assert captured["attachments_retries"] == 3
+    assert captured["attachments_backoff"] == [1, 2, 4]
+    assert captured["attachments_preserve_binary"] is True

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -46,7 +46,8 @@ def test_jira_preview_tools_not_model_facing():
     names = {s.get("function", {}).get("name") for s in get_tools_schemas()}
     assert "jira_get_issue_preview" not in names
     assert "jira_get_issue_by_url_preview" not in names
-    assert "export_issues_to_markdown" in names
+    assert "jira_export_issues_to_markdown" in names
+    assert "export_issues_to_markdown" not in names
 
 
 def test_jira_get_comments_schema_is_model_facing():
@@ -56,13 +57,13 @@ def test_jira_get_comments_schema_is_model_facing():
     assert "jira_get_comments" in names
 
 
-def test_export_issues_to_markdown_schema_is_strict_responses_compatible():
+def test_jira_export_issues_to_markdown_schema_is_strict_responses_compatible():
     from src.jira import get_tools_schemas
     from src.agents.llm import _convert_tools_schema
 
     schema = next(
         s for s in get_tools_schemas()
-        if s.get("function", {}).get("name") == "export_issues_to_markdown"
+        if s.get("function", {}).get("name") == "jira_export_issues_to_markdown"
     )
 
     input_schema = schema["function"]["parameters"]["properties"]["input"]
@@ -457,7 +458,7 @@ async def test_execute_tool_export_handles_strict_nullable_optional_args(monkeyp
 
     captured = {}
 
-    async def fake_export_issues_to_markdown(**kwargs):
+    async def fake_jira_export_issues_to_markdown(**kwargs):
         captured.update(kwargs)
         return {
             "success": True,
@@ -472,10 +473,10 @@ async def test_execute_tool_export_handles_strict_nullable_optional_args(monkeyp
             "errors": [],
         }
 
-    monkeypatch.setattr("src.jira.export_issues_to_markdown", fake_export_issues_to_markdown)
+    monkeypatch.setattr("src.jira.jira_export_issues_to_markdown", fake_jira_export_issues_to_markdown)
 
     result = await execute_tool(
-        "export_issues_to_markdown",
+        "jira_export_issues_to_markdown",
         input=prompt,
         issue_keys=None,
         jql=None,
@@ -514,3 +515,16 @@ async def test_execute_tool_export_handles_strict_nullable_optional_args(monkeyp
     assert captured["attachments_retries"] == 3
     assert captured["attachments_backoff"] == [1, 2, 4]
     assert captured["attachments_preserve_binary"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_old_export_name_is_not_supported():
+    from src import execute_tool
+
+    result = await execute_tool(
+        "export_issues_to_markdown",
+        input="MMGFX-14839",
+    )
+
+    assert result.success is False
+    assert "not implemented" in (result.error or result.content or "")


### PR DESCRIPTION
### Motivation
- The Responses API rejected the `export_issues_to_markdown` tool because `input` exposed an `anyOf` branch with a bare `object`, triggering nested `additionalProperties` validation errors. 
- The primary user prompt must accept a one-line natural-language `input` (e.g., the Chinese prompt that includes folder and issue keys), so the model-facing schema should present `input` as a simple string while preserving structured fields for internal/structured calls.

### Description
- Changed the `export_issues_to_markdown` tool schema in `src/jira/api.py` so `parameters.properties.input` is `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a7dc17f0832a91066b06c443eaab)