### PR TITLE
Tighten runtime skill activation and remove proactive staged-mode forcing

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -2430,8 +2430,9 @@ You have access to the following tools. When a user asks you to do something tha
             if request_estimated_tokens > prompt_budget_tokens:
                 llm_kwargs["system_prompt"] = (
                     (llm_kwargs.get("system_prompt") or "")
-                    + "\n\nBudget guard: Do not emit all generated files in chat. "
-                    "Write artifacts/files via tools when possible; otherwise output a concise manifest and ask to continue file-by-file."
+                    + "\n\nBudget guard: Keep the chat response concise and within the current output budget. "
+                    "Prefer writing artifacts/files via tools when available. "
+                    "Do not dump extremely large multi-file content in a single reply."
                 )
             
             raw_max_chat = (

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -58,6 +58,7 @@ from src.skills.active_contract import (
     get_contract_skill_name,
     is_active_skill_contract_usable,
     is_clear_active_skill_command,
+    is_explicit_skill_invocation,
     parse_explicit_skill_switch_name,
 )
 from src.runtime.chat_orchestration_adapter import execute_tool_or_task_orchestration
@@ -676,11 +677,11 @@ def _large_generation_output_guard(
     max_chars = int(boundary.get("max_chat_output_chars") or 0)
     max_tokens = int(boundary.get("max_chat_output_tokens") or 0)
     return (
-        "Large generation output guard: Do not emit a complete multi-file implementation or very long generated "
-        "artifact in a single chat response. Generate one bounded phase/file at a time. Prefer writing artifacts/files "
-        "through tools when available. In chat, return a concise manifest, file paths, and next step. "
+        "Large generation output guard: Keep output bounded to the current response budget. "
+        "Do not dump extremely large multi-file content in one reply. Prefer writing artifacts/files "
+        "through tools when available and summarize what was produced. "
         f"Keep response within resolved output boundary (tokens≈{max_tokens}, chars≈{max_chars}).\n"
-        f"generation_mode=staged\nmax_chat_output_chars={max_chars}\ncurrent_phase=manifest"
+        f"max_chat_output_chars={max_chars}"
     )
 
 
@@ -1860,16 +1861,21 @@ You have access to the following tools. When a user asks you to do something tha
                 selected_skill = explicit_skill
                 activation_reason = "matched"
             else:
-                not_found_message = f"Skill not found: {explicit_skill_name}"
-                await self._persist_assistant_message(session_id, not_found_message)
-                return build_early_result(
-                    not_found_message,
-                    state="failed",
-                    event_type="execution.failed",
-                    event_data={"reason": "skill_not_found", "skill": explicit_skill_name},
-                )
+                matched_skills = skill_registry.match_skill(message) if is_explicit_skill_invocation(message) else []
+                if matched_skills:
+                    selected_skill = matched_skills[0]
+                    activation_reason = "matched"
+                else:
+                    not_found_message = f"Skill not found: {explicit_skill_name}"
+                    await self._persist_assistant_message(session_id, not_found_message)
+                    return build_early_result(
+                        not_found_message,
+                        state="failed",
+                        event_type="execution.failed",
+                        event_data={"reason": "skill_not_found", "skill": explicit_skill_name},
+                    )
 
-        if selected_skill is None:
+        if selected_skill is None and is_explicit_skill_invocation(message):
             matched_skills = skill_registry.match_skill(message)
             if matched_skills:
                 selected_skill = matched_skills[0]
@@ -2355,8 +2361,6 @@ You have access to the following tools. When a user asks you to do something tha
                 budget_state["large_generation_guard_applied"] = large_generation_guard_applied
                 budget_state["output_size_guard_applied"] = large_generation_guard_applied
                 budget_state["large_generation_guard_reason"] = "classifier:skill_or_user_generation_request" if large_generation_guard_applied else ""
-                budget_state["generation_mode"] = "staged" if large_generation_guard_applied else "default"
-                budget_state["current_generation_phase"] = "manifest" if large_generation_guard_applied else ""
                 budget_state["max_chat_output_tokens"] = output_boundary.get("max_chat_output_tokens")
                 budget_state["max_chat_output_chars"] = output_boundary.get("max_chat_output_chars")
                 budget_state["output_risk_level"] = "high" if large_generation_guard_applied else "normal"
@@ -3411,8 +3415,6 @@ You have access to the following tools. When a user asks you to do something tha
                 "large_generation_guard_applied": large_generation_guard_applied,
                 "output_size_guard_applied": large_generation_guard_applied,
                 "large_generation_guard_reason": "classifier:skill_or_user_generation_request" if large_generation_guard_applied else "",
-                "generation_mode": "staged" if large_generation_guard_applied else "default",
-                "current_generation_phase": "manifest" if large_generation_guard_applied else "",
                 "max_chat_output_tokens": output_boundary.get("max_chat_output_tokens"),
                 "max_chat_output_chars": output_boundary.get("max_chat_output_chars"),
                 "request_budget_stage": "skill_generation",

--- a/src/runtime/output_controller.py
+++ b/src/runtime/output_controller.py
@@ -81,15 +81,20 @@ def classify_output_risk(user_text: str, active_skill: Any, system_prompt: str, 
     skill_name = str(getattr(active_skill, "name", "") or getattr(active_skill, "skill_name", "")).lower()
     markers = ("generate", "test", "implementation", "spec", "feature", "all jira", "all confluence", "全部", "生成")
     if any(m in text for m in markers) or any(m in skill_name for m in markers):
-        return "high"
+        return "medium"
     if len(text) > 1200:
         return "medium"
     return "normal"
 
 
 def build_output_guard(risk: str, generation_mode: str) -> str:
-    if generation_mode != "staged" and risk != "high":
-        return ""
+    if generation_mode != "staged":
+        if risk != "high":
+            return ""
+        return (
+            "Large generation output guard: keep this response concise and bounded. "
+            "Avoid dumping very large multi-file content in a single chat reply."
+        )
     return (
         "Large generation output guard: staged mode is enforced. "
         "Return manifest/phase output only; do not emit full multi-file content. "
@@ -441,7 +446,7 @@ async def call_llm_with_output_control(
         system_prompt=str(llm_kwargs.get("system_prompt") or ""),
         source_state=context_state,
     )
-    generation_mode = "staged" if risk == "high" else str((budget or {}).get("generation_mode") or "normal")
+    generation_mode = str((budget or {}).get("generation_mode") or "normal")
     gen_state = get_generation_state(context_state)
     if generation_mode == "staged" or (isinstance(gen_state, dict) and gen_state.get("generation_mode") == "staged"):
         generation_mode = "staged"

--- a/src/skills/active_contract.py
+++ b/src/skills/active_contract.py
@@ -70,6 +70,17 @@ def parse_explicit_skill_switch_name(message: str) -> str:
     return ""
 
 
+def is_explicit_skill_invocation(message: str) -> bool:
+    raw = str(message or "").strip()
+    if not raw:
+        return False
+    if is_clear_active_skill_command(raw):
+        return True
+    if parse_explicit_skill_switch_name(raw):
+        return True
+    return raw.startswith("/")
+
+
 def get_contract_skill_name(contract: Optional[dict]) -> str:
     if not isinstance(contract, dict):
         return ""

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -444,7 +444,8 @@ def test_large_generation_output_guard_applies_to_non_mobilex_generation_skill()
 
     text = core._large_generation_output_guard(None, Skill(), {"skill_name": "api-test-generator"}, "generate all test cases from this Jira")
     assert "Large generation output guard:" in text
-    assert "generation_mode=staged" in text
+    assert "generation_mode=staged" not in text
+    assert "current_phase=manifest" not in text
 
 
 def test_large_generation_output_guard_not_applied_to_normal_chat():
@@ -560,7 +561,7 @@ async def test_output_controller_bounds_huge_content_in_staged_mode():
         async def responses(self, **kwargs):
             return {"content": "X" * 50000, "tool_calls": [], "function_calls": [], "usage": {}}
 
-    state = {"budget": {}}
+    state = {"budget": {"generation_mode": "staged"}}
     result, diag = await call_llm_with_output_control(
         llm_client=_Client(),
         llm_kwargs={"input_items": [], "system_prompt": "generate full implementation", "tools": []},
@@ -763,7 +764,7 @@ async def test_output_controller_generation_state_machine_advances_on_continue()
         async def responses(self, **kwargs):
             return {"content": "phase content", "tool_calls": [], "function_calls": [], "usage": {}}
 
-    state = {"budget": {}}
+    state = {"budget": {"generation_mode": "staged"}}
     _, diag1 = await call_llm_with_output_control(
         llm_client=_Client(),
         llm_kwargs={"input_items": [], "system_prompt": "generate implementation", "tools": []},
@@ -832,7 +833,7 @@ async def test_output_controller_tracks_generated_artifacts_by_phase_when_bounde
         async def responses(self, **kwargs):
             return {"content": "X" * 500000, "tool_calls": [], "function_calls": [], "usage": {}}
 
-    state = {"budget": {}}
+    state = {"budget": {"generation_mode": "staged"}}
     _, diag1 = await call_llm_with_output_control(
         llm_client=_Client(),
         llm_kwargs={"input_items": [], "system_prompt": "generate implementation", "tools": []},

--- a/tests/test_output_controller_behavior.py
+++ b/tests/test_output_controller_behavior.py
@@ -1,0 +1,72 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_keyword_heavy_request_does_not_force_staged_mode_initially():
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    class _Client:
+        async def responses(self, **kwargs):
+            return {"content": "ok", "tool_calls": [], "function_calls": [], "usage": {}}
+
+    state = {"budget": {}}
+    _, diag = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "generate implementation", "tools": []},
+        session_id="s-keyword",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="generate test cases for jira issue",
+    )
+    assert diag.get("generation_mode") == "normal"
+    assert state["budget"].get("generation_mode") == "normal"
+
+
+def test_non_staged_guard_does_not_enforce_manifest_phase_only():
+    from src.runtime.output_controller import build_output_guard
+
+    guard = build_output_guard(risk="medium", generation_mode="normal")
+    assert "manifest/phase output only" not in guard.lower()
+    assert "staged mode is enforced" not in guard.lower()
+
+
+@pytest.mark.asyncio
+async def test_max_output_recovery_enters_staged_and_continue_advances():
+    from src.runtime.output_controller import call_llm_with_output_control
+
+    class _Client:
+        def __init__(self):
+            self.calls = 0
+
+        async def responses(self, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return {"error": {"code": "max_output_tokens_exceeded", "message": "x"}}
+            return {"content": "manifest", "tool_calls": [], "function_calls": [], "usage": {}}
+
+    state = {"budget": {}}
+    _, diag1 = await call_llm_with_output_control(
+        llm_client=_Client(),
+        llm_kwargs={"input_items": [], "system_prompt": "generate implementation", "tools": []},
+        session_id="s-recovery",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="generate full implementation",
+    )
+    assert diag1["max_output_recovery"]["applied"] is True
+    assert state["budget"]["generation_mode"] == "staged"
+
+    class _ContinueClient:
+        async def responses(self, **kwargs):
+            return {"content": "phase", "tool_calls": [], "function_calls": [], "usage": {}}
+
+    _, diag2 = await call_llm_with_output_control(
+        llm_client=_ContinueClient(),
+        llm_kwargs={"input_items": [], "system_prompt": "continue", "tools": []},
+        session_id="s-recovery",
+        stage="tool_loop",
+        context_state=state,
+        latest_user_text="continue",
+    )
+    assert diag2.get("generation", {}).get("generation_mode") == "staged"
+    assert "manifest" in set(diag2.get("generation", {}).get("completed_phases", []))

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -624,7 +624,12 @@ async def test_matched_skill_does_not_route_to_legacy_skill_mode(monkeypatch, ba
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
+        SimpleNamespace(
+            _initialized=True,
+            match_skill=lambda *_: [matched_skill],
+            get_skill=lambda name: matched_skill if name == "runtime-skill" else None,
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names),
+        ),
     )
 
     async def fake_responses(**kwargs):
@@ -701,7 +706,7 @@ async def test_active_skill_contract_continues_without_rematch(monkeypatch, base
     monkeypatch.setattr(agent, "_start_skill_mode", fail_start)
     monkeypatch.setattr(agent, "_continue_skill_mode", fail_continue)
 
-    first = await agent.process("runtime test", session_id="s1")
+    first = await agent.process("/runtime-skill start", session_id="s1")
     second = await agent.process("continue", session_id="s1")
 
     assert first["response"] == "done"
@@ -931,6 +936,88 @@ def test_parse_explicit_skill_switch_name_requires_name_for_switch_use_activate(
     assert parse_explicit_skill_switch_name("/skill use review-pull-request") == "review-pull-request"
 
 
+def test_is_explicit_skill_invocation_only_for_slash_forms():
+    from src.skills.active_contract import is_explicit_skill_invocation
+
+    assert is_explicit_skill_invocation("/skill review-pull-request") is True
+    assert is_explicit_skill_invocation("/review-pull-request MMGFX-1") is True
+    assert is_explicit_skill_invocation("/skill clear") is True
+    assert is_explicit_skill_invocation("please generate test cases for MMGFX-1") is False
+
+
+@pytest.mark.asyncio
+async def test_plain_natural_language_does_not_call_match_skill(monkeypatch, base_agent):
+    agent, _ = base_agent
+    match_calls = {"count": 0}
+
+    class _Registry:
+        _initialized = True
+
+        def match_skill(self, message):
+            match_calls["count"] += 1
+            return []
+
+        def get_skill(self, _name):
+            return None
+
+        def get_skill_runtime_config(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr("src.skills.skill_registry", _Registry())
+
+    async def fake_responses(**kwargs):
+        return {"content": "done", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("please generate test cases for MMGFX-14839", session_id="s1")
+    assert result["response"] == "done"
+    assert match_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_explicit_slash_invocation_calls_match_skill(monkeypatch, base_agent):
+    agent, _ = base_agent
+    matched_skill = SimpleNamespace(
+        name="jira_to_manual_test_cases",
+        description="Generate tests",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Use Jira context.",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+    match_calls = {"count": 0}
+
+    class _Registry:
+        _initialized = True
+
+        def match_skill(self, message):
+            match_calls["count"] += 1
+            return [matched_skill]
+
+        def get_skill(self, _name):
+            return None
+
+        def get_skill_runtime_config(self, skill, globally_allowed_tool_names=None):
+            return build_skill_runtime_config(skill, globally_allowed_tool_names=globally_allowed_tool_names)
+
+    monkeypatch.setattr("src.skills.skill_registry", _Registry())
+
+    async def fake_responses(**kwargs):
+        return {"content": "done", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("/jira_to_manual_test_cases MMGFX-14839", session_id="s1")
+    assert result["response"] == "done"
+    assert match_calls["count"] == 1
+
+
 @pytest.mark.asyncio
 async def test_active_skill_contract_unknown_explicit_switch_returns_without_llm(monkeypatch, base_agent):
     agent, sess = base_agent
@@ -1031,6 +1118,7 @@ async def test_matched_skill_workdir_updates_and_clears_when_path_falsy(monkeypa
         SimpleNamespace(
             _initialized=True,
             match_skill=_match_skill,
+            get_skill=lambda name: skill_with_path if name == "runtime-path" else (skill_without_path if name == "runtime-empty-path" else None),
             get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names),
         ),
     )
@@ -1041,11 +1129,11 @@ async def test_matched_skill_workdir_updates_and_clears_when_path_falsy(monkeypa
     monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
 
     set_skill_workdir(None)
-    first = await agent.process("run with path", session_id="s-workdir-1")
+    first = await agent.process("/runtime-path run with path", session_id="s-workdir-1")
     assert first["response"] == "done"
     assert get_skill_workdir() == str(tmp_path)
 
-    second = await agent.process("run without path", session_id="s-workdir-2")
+    second = await agent.process("/runtime-empty-path run without path", session_id="s-workdir-2")
     assert second["response"] == "done"
     assert get_skill_workdir() is None
 
@@ -1072,7 +1160,12 @@ async def test_disallowed_tool_is_denied_and_allowed_tool_executes(monkeypatch, 
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
+        SimpleNamespace(
+            _initialized=True,
+            match_skill=lambda *_: [matched_skill],
+            get_skill=lambda name: matched_skill if name == "runtime-skill" else None,
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names),
+        ),
     )
 
     calls = {"execute": 0, "names": []}
@@ -1094,7 +1187,7 @@ async def test_disallowed_tool_is_denied_and_allowed_tool_executes(monkeypatch, 
         return responses.pop(0)
 
     monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
-    result = await agent.process("runtime test", session_id="s2", stream_callback=stream_callback)
+    result = await agent.process("/runtime-skill run", session_id="s2", stream_callback=stream_callback)
     assert result["response"] == "done"
     assert calls["execute"] == 1
     assert calls["names"] == ["allowed_tool"]
@@ -1125,6 +1218,7 @@ async def test_skill_declared_tools_empty_intersection_sends_empty_llm_tool_surf
         SimpleNamespace(
             _initialized=True,
             match_skill=lambda *_: [matched_skill],
+            get_skill=lambda name: matched_skill if name == "runtime-skill" else None,
             get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(
                 s,
                 globally_allowed_tool_names=globally_allowed_tool_names,
@@ -1152,7 +1246,7 @@ async def test_skill_declared_tools_empty_intersection_sends_empty_llm_tool_surf
 
     monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=_fake_responses, default_provider="openai"))
 
-    result = await agent.process("runtime test", session_id="s-empty-intersection")
+    result = await agent.process("/runtime-skill run", session_id="s-empty-intersection")
     assert result["response"] == "done"
     assert seen_llm_tools
     assert seen_llm_tools[0] == []
@@ -1181,7 +1275,12 @@ async def test_hooks_and_task_path_emit_events(monkeypatch, base_agent):
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
+        SimpleNamespace(
+            _initialized=True,
+            match_skill=lambda *_: [matched_skill],
+            get_skill=lambda name: matched_skill if name == "runtime-skill" else None,
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names),
+        ),
     )
 
     async def _exec(*args, **kwargs):
@@ -1199,7 +1298,7 @@ async def test_hooks_and_task_path_emit_events(monkeypatch, base_agent):
 
     monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
 
-    result = await agent.process("runtime test", session_id="s3", stream_callback=stream_callback)
+    result = await agent.process("/runtime-skill run", session_id="s3", stream_callback=stream_callback)
     assert result["response"] == "done"
     assert any('"type": "skill_hook"' in e for e in events)
     assert any('"type": "task_started"' in e for e in events)
@@ -1224,7 +1323,12 @@ async def test_hook_failure_does_not_break_request(monkeypatch, base_agent):
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
+        SimpleNamespace(
+            _initialized=True,
+            match_skill=lambda *_: [matched_skill],
+            get_skill=lambda name: matched_skill if name == "runtime-skill" else None,
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names),
+        ),
     )
 
     async def _exec(*args, **kwargs):
@@ -1263,7 +1367,12 @@ async def test_pre_hook_can_modify_args(monkeypatch, base_agent):
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
+        SimpleNamespace(
+            _initialized=True,
+            match_skill=lambda *_: [matched_skill],
+            get_skill=lambda name: matched_skill if name == "runtime-skill" else None,
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names),
+        ),
     )
     captured = {}
 
@@ -1280,7 +1389,7 @@ async def test_pre_hook_can_modify_args(monkeypatch, base_agent):
         return responses.pop(0)
 
     monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=_fake_responses, default_provider="openai"))
-    result = await agent.process("runtime test", session_id="s-mod-args")
+    result = await agent.process("/runtime-skill run", session_id="s-mod-args")
     assert result["response"] == "done"
     assert captured.get("a") == "2"
 
@@ -1308,7 +1417,12 @@ async def test_pre_hook_can_short_circuit(monkeypatch, base_agent):
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
+        SimpleNamespace(
+            _initialized=True,
+            match_skill=lambda *_: [matched_skill],
+            get_skill=lambda name: matched_skill if name == "runtime-skill" else None,
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names),
+        ),
     )
     called = {"tool": 0}
 
@@ -1325,7 +1439,7 @@ async def test_pre_hook_can_short_circuit(monkeypatch, base_agent):
         return responses.pop(0)
 
     monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=_fake_responses, default_provider="openai"))
-    result = await agent.process("runtime test", session_id="s-short", stream_callback=stream_callback)
+    result = await agent.process("/runtime-skill run", session_id="s-short", stream_callback=stream_callback)
     assert result["response"] == "done"
     assert called["tool"] == 0
     assert any('"type": "tool_result"' in e and "allowed_tool" in e for e in events)
@@ -1354,7 +1468,12 @@ async def test_pre_hook_short_circuit_failure_emits_failed_tool_result(monkeypat
     )
     monkeypatch.setattr(
         "src.skills.skill_registry",
-        SimpleNamespace(_initialized=True, match_skill=lambda *_: [matched_skill], get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names)),
+        SimpleNamespace(
+            _initialized=True,
+            match_skill=lambda *_: [matched_skill],
+            get_skill=lambda name: matched_skill if name == "runtime-skill" else None,
+            get_skill_runtime_config=lambda s, globally_allowed_tool_names=None: build_skill_runtime_config(s, globally_allowed_tool_names=globally_allowed_tool_names),
+        ),
     )
     called = {"tool": 0}
 
@@ -1372,7 +1491,7 @@ async def test_pre_hook_short_circuit_failure_emits_failed_tool_result(monkeypat
         return responses.pop(0)
 
     monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=_fake_responses, default_provider="openai"))
-    result = await agent.process("runtime test", session_id="s-short-fail", stream_callback=stream_callback)
+    result = await agent.process("/runtime-skill run", session_id="s-short-fail", stream_callback=stream_callback)
     assert result["response"] == "done"
     assert called["tool"] == 0
     assert any('"type": "tool_result"' in e and '"success": false' in e for e in events)

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -1019,6 +1019,49 @@ async def test_explicit_slash_invocation_calls_match_skill(monkeypatch, base_age
 
 
 @pytest.mark.asyncio
+async def test_over_budget_prompt_guard_does_not_inject_manifest_continue_wording(monkeypatch, base_agent):
+    agent, _ = base_agent
+    captured_prompts = []
+
+    monkeypatch.setattr(
+        "src.skills.skill_registry",
+        SimpleNamespace(
+            _initialized=True,
+            match_skill=lambda *_: [],
+            get_skill=lambda *_: None,
+            get_skill_runtime_config=lambda *_args, **_kwargs: None,
+        ),
+    )
+    monkeypatch.setattr("src.agents.core.estimate_llm_request_tokens", lambda *args, **kwargs: 103)
+    monkeypatch.setattr(
+        "src.agents.core.resolve_prompt_budget",
+        lambda *args, **kwargs: {
+            "prompt_budget_tokens": 100,
+            "reserved_output_tokens": 20,
+            "safety_margin_tokens": 0,
+            "max_prompt_tokens": 100,
+            "max_output_tokens": 256,
+        },
+    )
+
+    async def fake_responses(**kwargs):
+        captured_prompts.append(kwargs.get("system_prompt", ""))
+        return {"content": "done", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("please generate the full implementation for this feature", session_id="s-budget-guard")
+    assert result["response"] == "done"
+    assert captured_prompts
+    prompt = captured_prompts[0].lower()
+    assert "budget guard:" in prompt
+    assert "manifest" not in prompt
+    assert "ask to continue" not in prompt
+    assert "file-by-file" not in prompt
+    assert "phase output" not in prompt
+
+
+@pytest.mark.asyncio
 async def test_active_skill_contract_unknown_explicit_switch_returns_without_llm(monkeypatch, base_agent):
     agent, sess = base_agent
     sess.active_skill_session = {


### PR DESCRIPTION
### Motivation
- Prevent ordinary natural-language chat from being auto-routed into skills while preserving explicit slash-style and active-contract behavior. 
- Avoid proactively forcing staged/manifest-first generation based only on keyword heuristics or risk classification, while keeping real truncation-driven recovery behavior intact.
- Make the smallest, localized runtime changes to address the two UX issues without touching Portal or SkillRegistry matching semantics.

### Description
- Added `is_explicit_skill_invocation(message: str) -> bool` in `src/skills/active_contract.py` to detect true slash-style/explicit skill invocations and clear commands. 
- Tightened skill activation in `src/agents/core.py` so `skill_registry.match_skill(message)` is only called when the message is an explicit invocation or when explicit lookup fails for slash commands, and preserved active-contract continuation logic. 
- Converted `_large_generation_output_guard()` in `src/agents/core.py` to produce a soft bounded-output hint (removed `generation_mode=staged` and `current_phase=manifest` directives) and removed the code paths that wrote staged-mode fields into budget/state just because the guard applied. 
- Updated `src/runtime/output_controller.py` to downgrade keyword-only detection from `"high"` to `"medium"`, to stop deriving `generation_mode` from risk, and to make `build_output_guard()` return non-enforcing soft hints for non-staged mode while keeping strict staged wording when `generation_mode == "staged"`. 
- Added focused regression tests and updated existing tests: added `tests/test_output_controller_behavior.py` and updated `tests/test_skill_runtime_refactor.py` and `tests/test_core_runtime_boundary.py` to reflect explicit-invocation-only matching and to assert non-proactive staged behavior.
- Files changed: `src/skills/active_contract.py`, `src/agents/core.py`, `src/runtime/output_controller.py`, `tests/test_output_controller_behavior.py`, `tests/test_skill_runtime_refactor.py`, and `tests/test_core_runtime_boundary.py`.

### Testing
- Ran a focused subset (examples): `pytest -q tests/test_skill_runtime_refactor.py::test_plain_natural_language_does_not_call_match_skill tests/test_skill_runtime_refactor.py::test_explicit_slash_invocation_calls_match_skill tests/test_skill_runtime_refactor.py::test_active_skill_contract_continues_without_rematch tests/test_core_runtime_boundary.py::test_large_generation_output_guard_applies_to_non_mobilex_generation_skill tests/test_core_runtime_boundary.py::test_output_controller_generation_state_machine_advances_on_continue tests/test_output_controller_behavior.py -q` and the subset passed. 
- Ran the updated test groups `pytest -q tests/test_core_runtime_boundary.py tests/test_output_controller_behavior.py tests/test_skill_runtime_refactor.py -q` and verified all tests in those files passed. 
- Full verification: final run of the updated test set completed with `172 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e1f2175c832a98212b8b6242aecd)