### PR TITLE
Unify parse/materialize flow for uploaded and external attachments

### DIFF
--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -26,7 +26,12 @@ import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from src.utils.file_parser.storage import init_storage, _file_metadata, StoredFileNotFoundError, get_metadata
 init_storage()
-from src.utils.file_parser import parse_file
+from src.utils.file_parser import parse_file, is_parse_supported
+from src.utils.file_parser.context_materializer import (
+    ensure_file_parsed_for_session,
+    ensure_session_file_registered,
+)
+from src.hooks.file_context.storage import storage as file_context_storage
 from src.utils.truncate import truncate
 from src.utils.redaction import safe_preview, safe_log_field, sanitize_exception_message
 from src.utils.logger import clear_log_context, set_log_context
@@ -394,6 +399,45 @@ async def _collect_attached_images(
             await process_file(file_id)
 
     return attached_images
+
+
+async def _collect_attached_file_ids_for_context(
+    *,
+    session_id: str,
+    attachments: Optional[List[str]],
+) -> List[str]:
+    """Collect and lazily parse non-image, parser-supported attached files."""
+    scoped_file_ids: List[str] = []
+    processed: Set[str] = set()
+
+    if not attachments or not isinstance(attachments, list):
+        return scoped_file_ids
+
+    for file_id in attachments:
+        if not isinstance(file_id, str) or not file_id or file_id in processed:
+            continue
+        processed.add(file_id)
+        try:
+            metadata = get_metadata(file_id)
+            if metadata.session_id and metadata.session_id != session_id:
+                logger.warning(f"[api_chat] File {file_id} belongs to different session")
+                continue
+
+            content_type = metadata.content_type or ""
+            if content_type.startswith("image/") or not is_parse_supported(content_type):
+                continue
+
+            ensure_session_file_registered(session_id, file_id)
+            file_meta = file_context_storage.get_file_meta(session_id, file_id)
+            if not file_meta or file_meta.parse_status != "completed":
+                await ensure_file_parsed_for_session(file_id=file_id, session_id=session_id)
+            scoped_file_ids.append(file_id)
+        except StoredFileNotFoundError:
+            logger.warning(f"[api_chat] File {file_id} not found")
+        except Exception as e:
+            logger.warning(f"[api_chat] Failed to prepare attached file {safe_preview(file_id, 80)}: {sanitize_exception_message(e)}")
+
+    return scoped_file_ids
 
 
 def _extract_task_trace_headers(request: web.Request) -> Dict[str, Optional[str]]:
@@ -781,9 +825,15 @@ async def api_chat(request: web.Request) -> web.Response:
             message=message,
             attachments=attachments if isinstance(attachments, list) else None,
         )
+        attached_file_ids = await _collect_attached_file_ids_for_context(
+            session_id=session_id,
+            attachments=attachments if isinstance(attachments, list) else None,
+        )
         
-        # Set placeholder message if only images
-        if attached_images and not message.strip():
+        # Set placeholder message for attachment-only messages
+        if attached_file_ids and not message.strip():
+            message = "Please analyze the attached file(s)."
+        elif attached_images and not message.strip():
             message = "[image]"
         
         # Always ensure input field is present for Copilot API downstream
@@ -804,7 +854,8 @@ async def api_chat(request: web.Request) -> web.Response:
                 session_id=session_id,
                 message=message,
                 top_k=5,
-                max_tokens=4000
+                max_tokens=4000,
+                preferred_file_ids=attached_file_ids if attached_file_ids else None,
             )
             if enhanced_message and enhanced_message != message:
                 logger.info(f"[api_chat] File context injected: status={budget_status}, chunks={len(citations)}")
@@ -1061,12 +1112,31 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             message=message,
             attachments=attachments if isinstance(attachments, list) else None,
         )
-        if attached_images and not message.strip():
+        attached_file_ids = await _collect_attached_file_ids_for_context(
+            session_id=session_id,
+            attachments=attachments if isinstance(attachments, list) else None,
+        )
+        if attached_file_ids and not message.strip():
+            message = "Please analyze the attached file(s)."
+        elif attached_images and not message.strip():
             message = "[image]"
 
         if not message.strip() and not attached_images:
             response = web.json_response({'error': 'Empty message'}, status=400)
             return response
+
+        try:
+            enhanced_message, _, _ = inject_context(
+                session_id=session_id,
+                message=message,
+                top_k=5,
+                max_tokens=4000,
+                preferred_file_ids=attached_file_ids if attached_file_ids else None,
+            )
+            if enhanced_message:
+                message = enhanced_message
+        except Exception as e:
+            logger.warning(f"[api_chat_stream] File context injection failed: {sanitize_exception_message(e)}")
 
         # Create streaming response
         response = web.StreamResponse(
@@ -2798,15 +2868,24 @@ async def api_files_upload(request: web.Request) -> web.Response:
             max_size_mb=max_size_mb
         )
         logger.info(f"[api_files_upload] saved metadata.session_id={metadata.session_id}")
+        parse_status = None
+        if session_id:
+            ensure_session_file_registered(session_id=session_id, file_id=metadata.file_id)
+            parse_status = "pending"
         
-        return web.json_response({
+        payload = {
             'success': True,
             'file_id': metadata.file_id,
             'filename': metadata.original_filename,
             'content_type': metadata.content_type,
             'size': metadata.size,
-            'uploaded_at': metadata.uploaded_at
-        }, status=201)
+            'uploaded_at': metadata.uploaded_at,
+        }
+        if session_id:
+            payload['session_id'] = session_id
+            payload['parse_status'] = parse_status
+
+        return web.json_response(payload, status=201)
         
     except FileTooLargeError as e:
         return web.json_response({
@@ -2874,62 +2953,11 @@ async def api_files_parse(request: web.Request) -> web.Response:
         
         options = data.get('options', {})
         
-        # Parse file
-        result = await parse_file(file_id, options)
-        
-        # Save chunks to file context storage
-        if result.success and result.blocks:
-            try:
-                from src.hooks.file_context import storage
-                from src.hooks.file_context.models import Chunk, SessionFileMeta
-                import hashlib
-                
-                # Update file status to processing
-                storage.update_file_status(
-                    session_id=session_id,
-                    file_id=file_id,
-                    status="processing"
-                )
-                
-                # Save chunks
-                total_chars = 0
-                for block in result.blocks:
-                    # Generate chunk_id if not present
-                    chunk_id = block.get('chunk_id') or f"{file_id}_{block.get('type', 'chunk')}_{block.get('page', 1)}_{block.get('index', 1)}"
-                    
-                    # Compute content hash for deduplication
-                    content = block.get('content', '')
-                    content_hash = hashlib.sha256(content.encode()).hexdigest()
-                    
-                    chunk = Chunk(
-                        chunk_id=chunk_id,
-                        file_id=file_id,
-                        session_id=session_id or '',
-                        type=block.get('type', 'paragraph'),
-                        content=content,
-                        markdown=block.get('markdown'),
-                        page=block.get('page'),
-                        index=block.get('index', 1),
-                        source=block.get('method', 'unknown'),
-                        confidence=block.get('confidence', 0.95),
-                        content_hash=content_hash
-                    )
-                    storage.save_chunk(chunk)
-                    total_chars += len(content)
-                
-                # Update file status to completed
-                storage.update_file_status(
-                    session_id=session_id,
-                    file_id=file_id,
-                    status="completed",
-                    chunk_count=len(result.blocks),
-                    total_chars=total_chars
-                )
-                
-                logger.info(f"[api_files_parse] Saved {len(result.blocks)} chunks for file {file_id}")
-            except Exception as e:
-                logger.error(f"[api_files_parse] Failed to save chunks: {e}")
-                # Continue anyway, parse succeeded
+        # Parse file and optionally materialize into file context storage
+        if session_id:
+            result = await ensure_file_parsed_for_session(file_id=file_id, session_id=session_id, options=options)
+        else:
+            result = await parse_file(file_id, options)
         
         if not result.success:
             return web.json_response({
@@ -3046,9 +3074,25 @@ async def api_files_list(request: web.Request) -> web.Response:
         session_id = request.query.get('session_id') or request.headers.get('X-Session-ID')
         
         files = list_files(session_id) if session_id else list_files()
-        
-        return web.json_response({
-            'files': [
+        file_payloads = []
+        if session_id:
+            session_files = {f.file_id: f for f in file_context_storage.get_session_files(session_id)}
+            for f in files:
+                session_meta = session_files.get(f.file_id)
+                file_payloads.append({
+                    'file_id': f.file_id,
+                    'filename': f.original_filename,
+                    'content_type': f.content_type,
+                    'size': f.size,
+                    'uploaded_at': f.uploaded_at,
+                    'parse_status': session_meta.parse_status if session_meta else 'pending',
+                    'parse_error': session_meta.parse_error if session_meta else None,
+                    'chunk_count': session_meta.chunk_count if session_meta else 0,
+                    'total_chars': session_meta.total_chars if session_meta else 0,
+                    'parsed_at': session_meta.parsed_at if session_meta else None,
+                })
+        else:
+            file_payloads = [
                 {
                     'file_id': f.file_id,
                     'filename': f.original_filename,
@@ -3058,7 +3102,8 @@ async def api_files_list(request: web.Request) -> web.Response:
                 }
                 for f in files
             ]
-        })
+
+        return web.json_response({'files': file_payloads})
         
     except Exception as e:
         logger.error(f"File list error: {e}")

--- a/src/hooks/file_context/injection.py
+++ b/src/hooks/file_context/injection.py
@@ -1,6 +1,6 @@
 """Context injection for AI prompts."""
 
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 
 from .models import Chunk, RetrievalResult
 from .retrieval import retrieval_engine
@@ -112,7 +112,8 @@ def inject_context(
     message: str,
     top_k: int = 5,
     max_tokens: int = 4000,
-    include_images: bool = False
+    include_images: bool = False,
+    preferred_file_ids: Optional[List[str]] = None,
 ) -> Tuple[str, str, List[dict]]:
     """Inject file context into user message.
     
@@ -127,6 +128,7 @@ def inject_context(
     
     # Resolve references to file IDs
     file_ids = CommandParser.resolve_references(references, session_files)
+    effective_file_ids = file_ids if file_ids else (preferred_file_ids or None)
     
     # Check for explicit chunk references
     chunk_ids = CommandParser.extract_chunk_refs(references)
@@ -158,7 +160,7 @@ def inject_context(
             query=cleaned_message,
             top_k=top_k,
             max_tokens=max_tokens,
-            file_ids=file_ids if file_ids else None,
+            file_ids=effective_file_ids,
             include_images=include_images
         )
         retrieval_result = retrieval_engine.retrieve(retrieval_request)

--- a/src/utils/attachment.py
+++ b/src/utils/attachment.py
@@ -15,7 +15,9 @@ from .file_parser import (
     parse_file,
     get_file_path,
     compress_image_for_llm,
+    is_parse_supported,
 )
+from .file_parser.context_materializer import ensure_file_parsed_for_session
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -105,10 +107,13 @@ async def download_and_process_attachment(
         else:
             content = f"[Image: {filename}]"
             content_format = "text"
-    elif content_type.startswith("text/") or _is_text_type(content_type):
-        # Extract text
+    elif is_parse_supported(content_type):
+        # Extract text from parse-supported non-image files
         try:
-            result = await parse_file(metadata.file_id)
+            if session_id:
+                result = await ensure_file_parsed_for_session(metadata.file_id, session_id)
+            else:
+                result = await parse_file(metadata.file_id)
             content = result.markdown[:max_text_chars] if result.markdown else ""
             content_format = "text"
         except Exception as e:
@@ -204,17 +209,6 @@ def _extract_filename(header: str) -> str:
     return ""
 
 
-def _is_text_type(content_type: str) -> bool:
-    """Check if content type is text-based."""
-    text_types = [
-        "text/",
-        "application/json",
-        "application/xml",
-        "application/javascript",
-    ]
-    return any(content_type.startswith(t) for t in text_types)
-
-
 def _detect_content_type(filename: str, content: bytes) -> str:
     """Detect content type from filename or content."""
     try:
@@ -238,8 +232,24 @@ def _detect_content_type(filename: str, content: bytes) -> str:
         "doc": "application/msword",
         "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "txt": "text/plain",
+        "md": "text/markdown",
         "json": "application/json",
+        "yaml": "application/yaml",
+        "yml": "application/yaml",
         "xml": "application/xml",
+        "log": "text/plain",
+        "py": "text/plain",
+        "js": "text/plain",
+        "ts": "text/plain",
+        "tsx": "text/plain",
+        "java": "text/plain",
+        "go": "text/plain",
+        "rs": "text/plain",
+        "sh": "text/plain",
+        "sql": "text/plain",
+        "properties": "text/plain",
+        "ini": "text/plain",
+        "cfg": "text/plain",
     }
     return mapping.get(ext, "application/octet-stream")
 

--- a/src/utils/file_parser/__init__.py
+++ b/src/utils/file_parser/__init__.py
@@ -77,6 +77,40 @@ def _get_excel_module():
     return _async_modules['excel']
 
 
+def _get_text_module():
+    """Lazy load text module."""
+    if 'text' not in _async_modules:
+        from . import text as _text
+        _async_modules['text'] = _text
+    return _async_modules['text']
+
+
+PARSEABLE_EXACT_MIME_TYPES = {
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "text/csv",
+    "text/plain",
+    "text/markdown",
+    "application/json",
+    "application/yaml",
+    "text/yaml",
+    "application/xml",
+    "text/xml",
+}
+
+
+def is_parse_supported(content_type: str) -> bool:
+    """Return whether runtime parser supports this MIME type."""
+    if not content_type:
+        return False
+    if content_type.startswith("image/"):
+        return True
+    if content_type in PARSEABLE_EXACT_MIME_TYPES:
+        return True
+    return content_type.startswith("text/") and content_type != "text/csv"
+
+
 async def upload_file(
     content: bytes,
     filename: str,
@@ -161,6 +195,19 @@ async def parse_file(file_id: str, options: dict = None) -> ParseResult:
         result = await excel_mod.parse_csv(str(path), options)
         result.file_id = file_id
         result.filename = metadata.original_filename
+        return result
+
+    if is_parse_supported(content_type):
+        text_mod = _get_text_module()
+        result = await text_mod.parse_text_file(
+            str(path),
+            {
+                **(options or {}),
+                "file_id": file_id,
+                "filename": metadata.original_filename,
+                "content_type": content_type,
+            },
+        )
         return result
     
     # Unsupported file type
@@ -249,15 +296,34 @@ def _detect_mime_type(content: bytes, filename: str) -> str:
         pass
     
     # Text-based formats
-    if ext in {".txt", ".csv"}:
+    text_ext_to_mime = {
+        ".txt": "text/plain",
+        ".md": "text/markdown",
+        ".json": "application/json",
+        ".yml": "application/yaml",
+        ".yaml": "application/yaml",
+        ".xml": "application/xml",
+        ".log": "text/plain",
+        ".py": "text/plain",
+        ".js": "text/plain",
+        ".ts": "text/plain",
+        ".tsx": "text/plain",
+        ".java": "text/plain",
+        ".go": "text/plain",
+        ".rs": "text/plain",
+        ".sh": "text/plain",
+        ".sql": "text/plain",
+        ".properties": "text/plain",
+        ".ini": "text/plain",
+        ".cfg": "text/plain",
+        ".csv": "text/csv",
+    }
+    if ext in text_ext_to_mime:
         try:
             header.decode("utf-8")
         except UnicodeDecodeError:
             return "application/octet-stream"
-        # If extension is .csv and file decodes as text, treat as CSV
-        if ext == ".csv":
-            return "text/csv"
-        return "text/plain"
+        return text_ext_to_mime[ext]
     
     # Fallback: unknown content, treat as generic binary
     # Don't rely on extension to avoid accepting renamed malware
@@ -306,6 +372,7 @@ __all__ = [
     "parse_file",
     "upload_file",
     "preview_file",
+    "is_parse_supported",
     # Image
     "compress_image_for_llm",
     "get_image_for_llm",

--- a/src/utils/file_parser/context_materializer.py
+++ b/src/utils/file_parser/context_materializer.py
@@ -1,0 +1,90 @@
+"""Helpers for parsing files and materializing into file-context storage."""
+
+from typing import Optional
+
+from src.hooks.file_context.models import Chunk, SessionFileMeta
+from src.hooks.file_context.storage import storage as context_storage
+from src.utils.file_parser.models import ParseResult
+from src.utils.file_parser.storage import get_metadata
+
+
+def ensure_session_file_registered(session_id: str, file_id: str) -> SessionFileMeta:
+    """Ensure SessionFileMeta exists for file in session context storage."""
+    existing = context_storage.get_file_meta(session_id, file_id)
+    if existing:
+        return existing
+
+    metadata = get_metadata(file_id)
+    session_meta = SessionFileMeta(
+        file_id=file_id,
+        session_id=session_id,
+        filename=metadata.original_filename,
+        content_type=metadata.content_type,
+        parse_status="pending",
+    )
+    context_storage.add_file_to_session(session_id, session_meta)
+    return session_meta
+
+
+def materialize_parse_result(session_id: str, file_id: str, result: ParseResult) -> dict:
+    """Persist parse result blocks into file-context chunks and update status."""
+    ensure_session_file_registered(session_id, file_id)
+    if not result.success:
+        context_storage.update_file_status(
+            session_id=session_id,
+            file_id=file_id,
+            status="failed",
+            error=result.error,
+        )
+        return {"status": "failed", "chunk_count": 0, "total_chars": 0}
+
+    context_storage.delete_file_chunks(file_id)
+    chunks = []
+    total_chars = 0
+    for index, block in enumerate(result.blocks or [], start=1):
+        content = block.content or ""
+        total_chars += len(content)
+        chunks.append(
+            Chunk(
+                chunk_id=block.chunk_id,
+                file_id=file_id,
+                session_id=session_id,
+                type=block.type,
+                content=content,
+                markdown=block.markdown,
+                page=block.page,
+                index=index,
+                row_range=block.row_range,
+                source=block.method,
+                confidence=block.confidence,
+                content_hash=context_storage.compute_content_hash(content),
+                bbox=block.bbox,
+            )
+        )
+
+    if chunks:
+        context_storage.save_chunks(chunks)
+    context_storage.update_file_status(
+        session_id=session_id,
+        file_id=file_id,
+        status="completed",
+        chunk_count=len(chunks),
+        total_chars=total_chars,
+    )
+    return {"status": "completed", "chunk_count": len(chunks), "total_chars": total_chars}
+
+
+async def ensure_file_parsed_for_session(
+    file_id: str,
+    session_id: str,
+    options: Optional[dict] = None,
+) -> ParseResult:
+    """Ensure file is parsed+materialized for a session and return parse result."""
+    from src.utils.file_parser import parse_file
+
+    ensure_session_file_registered(session_id, file_id)
+    context_storage.update_file_status(session_id=session_id, file_id=file_id, status="processing")
+
+    result = await parse_file(file_id, options or {})
+    materialize_parse_result(session_id, file_id, result)
+    return result

--- a/src/utils/file_parser/storage.py
+++ b/src/utils/file_parser/storage.py
@@ -284,6 +284,24 @@ def _detect_mime_type(content: bytes, ext: str) -> str:
         ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         ".csv": "text/csv",
         ".txt": "text/plain",
+        ".md": "text/markdown",
+        ".json": "application/json",
+        ".yml": "application/yaml",
+        ".yaml": "application/yaml",
+        ".xml": "application/xml",
+        ".log": "text/plain",
+        ".py": "text/plain",
+        ".js": "text/plain",
+        ".ts": "text/plain",
+        ".tsx": "text/plain",
+        ".java": "text/plain",
+        ".go": "text/plain",
+        ".rs": "text/plain",
+        ".sh": "text/plain",
+        ".sql": "text/plain",
+        ".properties": "text/plain",
+        ".ini": "text/plain",
+        ".cfg": "text/plain",
     }
     
     # Try content-based detection first
@@ -320,5 +338,11 @@ def _mime_to_extension(mime_type: str) -> str:
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
         "text/csv": ".csv",
         "text/plain": ".txt",
+        "text/markdown": ".md",
+        "application/json": ".json",
+        "application/yaml": ".yaml",
+        "text/yaml": ".yaml",
+        "application/xml": ".xml",
+        "text/xml": ".xml",
     }
     return mime_to_ext.get(mime_type, "")

--- a/src/utils/file_parser/text.py
+++ b/src/utils/file_parser/text.py
@@ -1,0 +1,89 @@
+"""Parser for text-like files."""
+
+from datetime import datetime
+import re
+from pathlib import Path
+from typing import Optional
+
+from .models import Block, ParseResult
+
+
+def _decode_text(content: bytes) -> str:
+    """Decode bytes with resilient UTF-8 fallbacks."""
+    for encoding, errors in (("utf-8-sig", "strict"), ("utf-8", "strict"), ("utf-8", "replace")):
+        try:
+            return content.decode(encoding, errors=errors)
+        except UnicodeDecodeError:
+            continue
+    return content.decode("utf-8", errors="replace")
+
+
+def _split_long_paragraph(paragraph: str, target_size: int = 1400) -> list[str]:
+    """Split long paragraph into deterministic chunks."""
+    text = paragraph.strip()
+    if len(text) <= target_size:
+        return [text] if text else []
+
+    chunks: list[str] = []
+    start = 0
+    while start < len(text):
+        end = min(start + target_size, len(text))
+        if end < len(text):
+            split_at = text.rfind(" ", start, end)
+            if split_at > start + (target_size // 2):
+                end = split_at
+        piece = text[start:end].strip()
+        if piece:
+            chunks.append(piece)
+        start = end
+    return chunks
+
+
+async def parse_text_file(path: str, options: Optional[dict] = None) -> ParseResult:
+    """Parse text-like file content into markdown and paragraph blocks."""
+    import asyncio
+    import time
+
+    start = time.time()
+    options = options or {}
+    file_id = options.get("file_id", "unknown")
+    filename = options.get("filename", path.split("/")[-1])
+    content_type = options.get("content_type", "text/plain")
+
+    raw = await asyncio.to_thread(Path(path).read_bytes)
+    text = _decode_text(raw)
+    markdown = text
+
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n+", text) if p and p.strip()]
+    extracted_at = datetime.utcnow().isoformat() + "Z"
+    blocks: list[Block] = []
+
+    chunk_index = 1
+    for paragraph in paragraphs:
+        for piece in _split_long_paragraph(paragraph):
+            blocks.append(
+                Block(
+                    chunk_id=f"{file_id}_text_1_{chunk_index}",
+                    type="paragraph",
+                    content=piece,
+                    markdown=piece,
+                    page=None,
+                    sheet=None,
+                    method="text",
+                    confidence=1.0,
+                    extracted_at=extracted_at,
+                )
+            )
+            chunk_index += 1
+
+    parse_time_ms = int((time.time() - start) * 1000)
+    return ParseResult(
+        success=True,
+        content_type=content_type,
+        file_id=file_id,
+        filename=filename,
+        markdown=markdown,
+        blocks=blocks,
+        json={"blocks": len(blocks), "chars": len(markdown)},
+        parse_time_ms=parse_time_ms,
+    )

--- a/src/utils/file_parser/validators.py
+++ b/src/utils/file_parser/validators.py
@@ -16,7 +16,16 @@ ALLOWED_MIME_TYPES = {
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ],
-    "text": ["text/csv", "text/plain"],
+    "text": [
+        "text/csv",
+        "text/plain",
+        "text/markdown",
+        "application/json",
+        "application/yaml",
+        "text/yaml",
+        "application/xml",
+        "text/xml",
+    ],
 }
 
 # Filename pattern: alphanumeric, dot, underscore, hyphen, 1-200 chars
@@ -127,7 +136,36 @@ def sanitize_filename(filename: str) -> str:
     return name
 
 
-ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".pdf", ".docx", ".xlsx", ".csv", ".txt"}
+ALLOWED_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".webp",
+    ".pdf",
+    ".docx",
+    ".xlsx",
+    ".csv",
+    ".txt",
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".xml",
+    ".log",
+    ".py",
+    ".js",
+    ".ts",
+    ".tsx",
+    ".java",
+    ".go",
+    ".rs",
+    ".sh",
+    ".sql",
+    ".properties",
+    ".ini",
+    ".cfg",
+}
 
 
 def get_safe_extension(filename: str) -> str:
@@ -193,5 +231,23 @@ def get_mime_type(file_path: str) -> str:
         ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         ".csv": "text/csv",
         ".txt": "text/plain",
+        ".md": "text/markdown",
+        ".json": "application/json",
+        ".yml": "application/yaml",
+        ".yaml": "application/yaml",
+        ".xml": "application/xml",
+        ".log": "text/plain",
+        ".py": "text/plain",
+        ".js": "text/plain",
+        ".ts": "text/plain",
+        ".tsx": "text/plain",
+        ".java": "text/plain",
+        ".go": "text/plain",
+        ".rs": "text/plain",
+        ".sh": "text/plain",
+        ".sql": "text/plain",
+        ".properties": "text/plain",
+        ".ini": "text/plain",
+        ".cfg": "text/plain",
     }
     return mime_map.get(ext, "application/octet-stream")

--- a/tests/test_attachment_processing.py
+++ b/tests/test_attachment_processing.py
@@ -69,3 +69,32 @@ async def test_download_and_process_attachment_falls_back_to_base64_when_ocr_emp
 
     assert result.content_format == "base64"
     assert result.content == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_download_and_process_attachment_uses_parser_registry_for_non_image(monkeypatch):
+    from src.utils import attachment
+
+    monkeypatch.setattr(
+        attachment,
+        "_download_file",
+        AsyncMock(return_value=(b"%PDF-1.7", "application/pdf", "spec.pdf")),
+    )
+    metadata = SimpleNamespace(file_id="file-3", size=10, uploaded_at="2026-01-01")
+    monkeypatch.setattr(attachment, "save_uploaded_file", AsyncMock(return_value=metadata))
+    monkeypatch.setattr(attachment, "get_file_path", lambda _file_id: "/tmp/spec.pdf")
+    monkeypatch.setattr(attachment, "is_parse_supported", lambda content_type: content_type == "application/pdf")
+    parser_mock = AsyncMock(return_value=SimpleNamespace(success=True, markdown="parsed content"))
+    materialized_mock = AsyncMock(return_value=SimpleNamespace(success=True, markdown="parsed content"))
+    monkeypatch.setattr(attachment, "parse_file", parser_mock)
+    monkeypatch.setattr(attachment, "ensure_file_parsed_for_session", materialized_mock)
+
+    result = await attachment.download_and_process_attachment(
+        url="https://example.com/spec.pdf",
+        session_id="s-1",
+    )
+
+    assert result.content_format == "text"
+    assert "parsed content" in result.content
+    materialized_mock.assert_awaited_once_with("file-3", "s-1")
+    parser_mock.assert_not_called()

--- a/tests/test_file_parser_text_and_materializer.py
+++ b/tests/test_file_parser_text_and_materializer.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.utils.file_parser.models import Block, ParseResult
+from src.utils.file_parser.text import parse_text_file
+from src.utils.file_parser.context_materializer import materialize_parse_result
+
+
+@pytest.mark.asyncio
+async def test_parse_text_file_supports_plain_text(tmp_path):
+    sample = tmp_path / "notes.txt"
+    sample.write_text("Line one.\n\nLine two.", encoding="utf-8")
+
+    result = await parse_text_file(
+        str(sample),
+        {"file_id": "f-1", "filename": "notes.txt", "content_type": "text/plain"},
+    )
+
+    assert result.success is True
+    assert result.content_type == "text/plain"
+    assert "Line one." in result.markdown
+    assert len(result.blocks) >= 2
+    assert result.blocks[0].method == "text"
+
+
+@pytest.mark.asyncio
+async def test_parse_text_file_supports_json_mime(tmp_path):
+    sample = tmp_path / "data.json"
+    sample.write_text('{"a": 1, "b": 2}', encoding="utf-8")
+
+    result = await parse_text_file(
+        str(sample),
+        {"file_id": "f-2", "filename": "data.json", "content_type": "application/json"},
+    )
+
+    assert result.success is True
+    assert result.content_type == "application/json"
+    assert result.blocks
+
+
+def test_materialize_parse_result_from_pydantic_blocks(monkeypatch):
+    from src.utils.file_parser import context_materializer as cm
+
+    saved_chunks = []
+    statuses = []
+    monkeypatch.setattr(cm, "ensure_session_file_registered", lambda *_args, **_kwargs: SimpleNamespace())
+    monkeypatch.setattr(cm.context_storage, "delete_file_chunks", lambda _file_id: 0)
+    monkeypatch.setattr(cm.context_storage, "save_chunks", lambda chunks: saved_chunks.extend(chunks))
+    monkeypatch.setattr(
+        cm.context_storage,
+        "update_file_status",
+        lambda **kwargs: statuses.append(kwargs),
+    )
+
+    result = ParseResult(
+        success=True,
+        content_type="text/plain",
+        file_id="file-1",
+        filename="notes.txt",
+        blocks=[
+            Block(
+                chunk_id="file-1_text_1_1",
+                type="paragraph",
+                content="hello world",
+                method="text",
+                confidence=1.0,
+                extracted_at="2026-01-01T00:00:00Z",
+            )
+        ],
+    )
+
+    summary = materialize_parse_result("session-1", "file-1", result)
+    assert summary["status"] == "completed"
+    assert summary["chunk_count"] == 1
+    assert saved_chunks[0].chunk_id == "file-1_text_1_1"
+    assert saved_chunks[0].source == "text"
+    assert statuses[-1]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_parse_file_returns_failure_for_unsupported_binary(monkeypatch, tmp_path):
+    from src.utils import file_parser
+
+    binary = tmp_path / "blob.bin"
+    binary.write_bytes(b"\x00\xff\x01\x02")
+    monkeypatch.setattr(file_parser, "get_file_path", lambda _file_id: binary)
+    monkeypatch.setattr(
+        file_parser,
+        "get_metadata",
+        lambda _file_id: SimpleNamespace(content_type="application/octet-stream", original_filename="blob.bin"),
+    )
+
+    result = await file_parser.parse_file("file-bin")
+    assert result.success is False

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import pytest
 from pathlib import Path
+from types import SimpleNamespace
 
 try:
     from src.gateway.webchat import setup_webchat_routes, load_template
@@ -1334,6 +1335,205 @@ async def test_api_chat_stream_forwards_all_attached_images(monkeypatch, tmp_pat
     assert captured["attached_images"][0].endswith("b25l")
     assert captured["attached_images"][1].endswith("dHdv")
     assert captured["attachments"] == ["f1", "f2"]
+
+
+@pytest.mark.asyncio
+async def test_api_chat_attachment_only_non_image_scopes_context(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+    inject_calls = {}
+
+    class _Meta:
+        session_id = "s-doc"
+        content_type = "application/pdf"
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    def _fake_inject_context(**kwargs):
+        inject_calls.update(kwargs)
+        return kwargs["message"], "ok", []
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", _fake_inject_context)
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat.session_manager, "_initialized", True)
+    monkeypatch.setattr(webchat.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(webchat.session_persistence, "save_session", lambda **kwargs: asyncio.sleep(0, result=True))
+    monkeypatch.setattr(webchat, "get_metadata", lambda _file_id: _Meta())
+    monkeypatch.setattr(webchat, "is_parse_supported", lambda _ct: True)
+    monkeypatch.setattr(webchat, "ensure_session_file_registered", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(webchat.file_context_storage, "get_file_meta", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(webchat, "ensure_file_parsed_for_session", lambda *_args, **_kwargs: asyncio.sleep(0, result=SimpleNamespace(success=True, blocks=[])))
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "", "session_id": "s-doc", "attachments": ["file-doc"]}
+
+    response = await webchat.api_chat(_Request())
+    assert response.status == 200
+    assert captured["message"] == "Please analyze the attached file(s)."
+    assert inject_calls["preferred_file_ids"] == ["file-doc"]
+
+
+@pytest.mark.asyncio
+async def test_api_chat_stream_attachment_only_non_image_scopes_context(monkeypatch):
+    from src.gateway import webchat
+
+    captured = {}
+    inject_calls = {}
+
+    class _Meta:
+        session_id = "s-doc-stream"
+        content_type = "application/pdf"
+
+    class _FakeStreamResponse:
+        def __init__(self, status=200, headers=None):
+            self.status = status
+            self.headers = headers or {}
+            self.writes = []
+
+        async def prepare(self, request):
+            return self
+
+        async def write(self, data):
+            self.writes.append(data)
+
+    async def _fake_run_chat_via_execution_bus(**kwargs):
+        captured.update(kwargs)
+        return {"response": "ok", "usage": {}}
+
+    def _fake_inject_context(**kwargs):
+        inject_calls.update(kwargs)
+        return kwargs["message"], "ok", []
+
+    monkeypatch.setattr(webchat, "_run_chat_via_execution_bus", _fake_run_chat_via_execution_bus)
+    monkeypatch.setattr(webchat, "inject_context", _fake_inject_context)
+    monkeypatch.setattr(webchat.web, "StreamResponse", _FakeStreamResponse)
+    monkeypatch.setattr(webchat.global_config, "_config", {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}}, raising=False)
+    monkeypatch.setattr(webchat, "get_metadata", lambda _file_id: _Meta())
+    monkeypatch.setattr(webchat, "is_parse_supported", lambda _ct: True)
+    monkeypatch.setattr(webchat, "ensure_session_file_registered", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(webchat.file_context_storage, "get_file_meta", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(webchat, "ensure_file_parsed_for_session", lambda *_args, **_kwargs: asyncio.sleep(0, result=SimpleNamespace(success=True, blocks=[])))
+
+    class _Request:
+        app = {}
+        headers = {}
+
+        async def json(self):
+            return {"message": "", "session_id": "s-doc-stream", "attachments": ["file-doc"]}
+
+    response = await webchat.api_chat_stream(_Request())
+    assert response.status == 200
+    assert captured["message"] == "Please analyze the attached file(s)."
+    assert inject_calls["preferred_file_ids"] == ["file-doc"]
+
+
+@pytest.mark.asyncio
+async def test_api_files_parse_materializes_via_helper(monkeypatch):
+    from src.gateway import webchat
+
+    parse_result = SimpleNamespace(
+        success=True,
+        content_type="text/plain",
+        file_id="file-parse",
+        filename="note.txt",
+        markdown="hello",
+        blocks=[
+            SimpleNamespace(model_dump=lambda **_kwargs: {"chunk_id": "c1", "content": "hello"})
+        ],
+        json={},
+        parse_time_ms=5,
+    )
+
+    monkeypatch.setattr(webchat, "get_metadata", lambda _file_id: SimpleNamespace(session_id="session-1"))
+    materialize_mock = lambda **_kwargs: asyncio.sleep(0, result=parse_result)
+    monkeypatch.setattr(webchat, "ensure_file_parsed_for_session", materialize_mock)
+
+    class _Request:
+        query = {}
+        headers = {"X-Session-ID": "session-1"}
+
+        async def json(self):
+            return {"file_id": "file-parse", "options": {}}
+
+    response = await webchat.api_files_parse(_Request())
+    payload = json.loads(response.text)
+    assert response.status == 200
+    assert payload["success"] is True
+    assert payload["blocks"][0]["chunk_id"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_api_files_list_with_session_includes_parse_state(monkeypatch):
+    from src.gateway import webchat
+
+    monkeypatch.setattr(
+        webchat,
+        "file_context_storage",
+        SimpleNamespace(
+            get_session_files=lambda _session_id: [
+                SimpleNamespace(
+                    file_id="f1",
+                    parse_status="completed",
+                    parse_error=None,
+                    chunk_count=3,
+                    total_chars=42,
+                    parsed_at="2026-01-01T00:00:00Z",
+                )
+            ]
+        ),
+    )
+
+    class _Meta:
+        file_id = "f1"
+        original_filename = "a.txt"
+        content_type = "text/plain"
+        size = 10
+        uploaded_at = "2026-01-01T00:00:00Z"
+
+    monkeypatch.setattr("src.utils.file_parser.init_storage", lambda: None)
+    monkeypatch.setattr("src.utils.file_parser.list_files", lambda _sid=None: [_Meta()])
+
+    class _Request:
+        query = {"session_id": "session-1"}
+        headers = {}
+
+    response = await webchat.api_files_list(_Request())
+    payload = json.loads(response.text)
+    assert response.status == 200
+    assert payload["files"][0]["parse_status"] == "completed"
+    assert payload["files"][0]["chunk_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_api_files_list_without_session_is_backward_compatible(monkeypatch):
+    from src.gateway import webchat
+
+    class _Meta:
+        file_id = "f2"
+        original_filename = "b.txt"
+        content_type = "text/plain"
+        size = 11
+        uploaded_at = "2026-01-01T00:00:00Z"
+
+    monkeypatch.setattr("src.utils.file_parser.init_storage", lambda: None)
+    monkeypatch.setattr("src.utils.file_parser.list_files", lambda _sid=None: [_Meta()])
+
+    class _Request:
+        query = {}
+        headers = {}
+
+    response = await webchat.api_files_list(_Request())
+    payload = json.loads(response.text)
+    assert response.status == 200
+    assert "parse_status" not in payload["files"][0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Uploaded and externally-downloaded attachments other than images were not entering the same parse/materialize/file-context pipeline and therefore were not usable as chat-scoped retrieval context.
- The file parser lacked robust support for plain text and many common text-like formats, and `api_files_parse(...)` used incorrect access (`block.get(...)`) on Pydantic `Block` objects and did not reliably register session files prior to materialization.
- External attachment processing duplicated narrow text detection and fell back to a generic descriptor for many parseable types, causing inconsistent behavior between Portal uploads and Jira/Confluence downloads.

### Description
- Added a new text parser `src/utils/file_parser/text.py` implementing `parse_text_file(...)` that decodes UTF-8 variants, preserves markdown, splits by blank lines and chunks long paragraphs into deterministic `Block` entries with `method="text"` and confidence `1.0`.
- Extended MIME/extension allowlists and detection in `validators.py` and `storage.py`, added `is_parse_supported(...)` and routed parse dispatch in `src/utils/file_parser/__init__.py` so text-like types (plain/text, md, json, yaml, xml, many code/config files) are handled by the unified parser path while preserving existing CSV/PDF/DOCX/XLSX/image handling.
- Added a reusable materializer helper `src/utils/file_parser/context_materializer.py` to ensure session file registration, set parse lifecycle states (`pending/processing/completed/failed`), convert parser `Block` models into `Chunk` models, save chunks, and compute counts/hashes; updated `api_files_parse(...)`, `api_files_upload(...)`, and `api_files_list(...)` in `src/gateway/webchat.py` to use this helper and expose session parse state for the Portal uploads panel.
- Updated external attachment processing (`src/utils/attachment.py`) to call the parser/materializer for parse-supported non-image files (preserving image + OCR/compression behavior), and updated webchat to collect non-image parseable attached file IDs via `_collect_attached_file_ids_for_context(...)` and to scope `inject_context(...)` via a new `preferred_file_ids` parameter in `src/hooks/file_context/injection.py`, allowing attachment-only non-image turns with a default prompt.
- Tests added/updated to cover text parsing, materialization from Pydantic blocks, attachment parsing path, api_files_parse materialization, chat and stream attachment scoping, and enriched file listing metadata.

### Testing
- Ran targeted parser/materializer and helper tests: `pytest tests/test_file_parser_text_and_materializer.py` and the new assertions passed (new parser and materializer tests succeeded).
- Ran attachment tests including `tests/test_attachment_processing.py` and image OCR/legacy behavior tests, and they passed (new non-image attachment flow verified and existing image behavior retained).
- Ran focused webchat tests `tests/test_webchat.py` (attachment-only non-image chat/stream + files list changes) and they passed; combined targeted runs reported all selected tests passing (`10 passed` for the focused selection, and the image-related selection passed as well).
- All new and updated automated tests added in this PR passed in the CI-local runs described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f6789cec832ab7a5e3c0104cf7cb)