### PR TITLE
Add file_artifacts layer and unify attachment parsing/projection (chat, Jira, Confluence, GitHub V1)

### DIFF
--- a/skills/collect_requirements_to_bundle/skill.py
+++ b/skills/collect_requirements_to_bundle/skill.py
@@ -74,6 +74,9 @@ async def _load_github_doc_sources(bundle_ref: Dict[str, Any], doc_paths: List[s
                     "path": doc_ref.path,
                 },
                 "content": raw,
+                "artifact_refs": [],
+                "context_ref": None,
+                "digest_ref": None,
             }
         )
     return items

--- a/skills/collect_requirements_to_bundle/skill.py
+++ b/skills/collect_requirements_to_bundle/skill.py
@@ -14,7 +14,7 @@ from src.runtime.requirement_bundle_assets import (
     RequirementBundleError,
     load_bundle_manifest,
     parse_bundle_ref,
-    read_github_doc_text,
+    prepare_github_doc_source,
     resolve_bundle_links,
     resolve_target_bundle_ref,
     write_requirements_doc_for_ref,
@@ -61,22 +61,24 @@ async def _load_github_doc_sources(bundle_ref: Dict[str, Any], doc_paths: List[s
     parsed_ref = parse_bundle_ref(bundle_ref)
     items: List[Dict[str, Any]] = []
     for doc_path in doc_paths:
-        doc_ref, raw = await read_github_doc_text(doc_path, parsed_ref)
+        prepared = await prepare_github_doc_source(doc_path, parsed_ref)
+        doc_ref = prepared["doc_ref"]
         kind = "url" if "://" in doc_path else "repo_relative_path"
         items.append(
             {
                 "input": doc_path,
                 "kind": kind,
+                "source_kind": "repo_file",
                 "resolved": {
                     "owner": doc_ref.owner,
                     "repo": doc_ref.repo,
                     "branch": doc_ref.branch,
                     "path": doc_ref.path,
                 },
-                "content": raw,
-                "artifact_refs": [],
-                "context_ref": None,
-                "digest_ref": None,
+                "content": prepared["content_text"],
+                "artifact_refs": prepared["artifact_refs"],
+                "context_ref": prepared["context_ref"],
+                "digest_ref": prepared["digest_ref"],
             }
         )
     return items

--- a/src/confluence/__init__.py
+++ b/src/confluence/__init__.py
@@ -5,7 +5,7 @@ import json
 from typing import Optional
 
 from src.file_artifacts import can_project_to_text
-from src.file_artifacts.service import bind_artifact_to_source_bundle, build_artifact_ref_dict
+from src.file_artifacts.service import attach_source_refs_to_artifact, bind_artifact_to_source_bundle, build_artifact_ref_dict
 from src.utils.attachment import download_and_process_attachment
 
 from .api import (
@@ -441,6 +441,11 @@ async def confluence_prepare_page_context(
                         source_kind="page_attachment",
                         source_locator=f"{page_id}:{att.get('id')}",
                         provider_metadata={"page_id": page_id, "attachment_id": att.get("id")},
+                        persist_text_ref_session_id=_session_id or f"confluence-{page_id}",
+                        persist_text_ref_kind="confluence_attachment_text",
+                        persist_text_ref_source_id=f"{page_id}:{att.get('id')}",
+                        persist_text_ref_title=f"Confluence attachment text {filename}",
+                        persist_text_ref_metadata={"page_id": page_id, "filename": filename, "attachment_id": att.get("id")},
                     )
                     if getattr(result, "artifact_id", None):
                         from src.file_artifacts.storage import storage as artifact_storage
@@ -450,7 +455,7 @@ async def confluence_prepare_page_context(
                             artifact_ref = build_artifact_ref_dict(record)
                             artifact_refs.append(artifact_ref)
                             att["text_preview"] = (result.preview or result.content or "")[:1000]
-                            att["text_ref"] = None
+                            att["text_ref"] = getattr(result, "text_ref", None) or record.text_ref
                 except Exception as att_exc:
                     logger.warning(f"Failed attachment materialization for {filename}: {att_exc}")
 
@@ -547,6 +552,23 @@ async def confluence_prepare_page_context(
             page_id=page_id,
             bundle=bundle,
         )
+        from src.file_artifacts.storage import storage as artifact_storage
+        refreshed_artifact_refs = []
+        for ref in artifact_refs:
+            artifact_id = ref.get("artifact_id")
+            if not artifact_id:
+                continue
+            attach_source_refs_to_artifact(
+                artifact_id,
+                context_ref=persisted.get("context_ref"),
+                digest_ref=persisted.get("digest_ref"),
+            )
+            record = artifact_storage.get_artifact(artifact_id)
+            if record:
+                refreshed_artifact_refs.append(build_artifact_ref_dict(record))
+        if refreshed_artifact_refs:
+            bundle["artifact_refs"] = refreshed_artifact_refs
+            artifact_refs = refreshed_artifact_refs
         manifest = {
             "page_id": page_id,
             "context_ref": persisted["context_ref"],

--- a/src/confluence/__init__.py
+++ b/src/confluence/__init__.py
@@ -4,6 +4,8 @@ import logging
 import json
 from typing import Optional
 
+from src.file_artifacts import can_project_to_text
+from src.file_artifacts.service import bind_artifact_to_source_bundle, build_artifact_ref_dict
 from src.utils.attachment import download_and_process_attachment
 
 from .api import (
@@ -374,6 +376,8 @@ async def confluence_prepare_page_context(
             "attachments_loaded": int(attachments_ledger.get("loaded", len(attachments))),
             "attachments_total": int(attachments_ledger.get("total", len(attachments))),
             "attachments_complete": bool(attachments_ledger.get("complete", False)),
+            "artifact_refs_created": 0,
+            "projectable_attachments_total": 0,
             "children_loaded": int(children_ledger.get("loaded", len(children))),
             "children_total": int(children_ledger.get("total", len(children))),
             "children_complete": bool(children_ledger.get("complete", False)),
@@ -412,6 +416,44 @@ async def confluence_prepare_page_context(
         )
 
         adapter = ConfluenceFormatAdapter(instance_channel)
+        artifact_refs = []
+        if include_attachments and attachments:
+            base_url = instance_channel.base_url.rstrip("/")
+            auth_header = instance_channel._auth_header if instance_channel.is_configured() else None
+            for att in attachments:
+                filename = str(att.get("title") or "unknown")
+                media_type = _infer_attachment_media_type(att, filename)
+                is_image = media_type.startswith("image/")
+                if is_image:
+                    continue
+                if not can_project_to_text(media_type, filename):
+                    continue
+                link = (att.get("_links") or {}).get("download")
+                if not link:
+                    continue
+                try:
+                    result = await download_and_process_attachment(
+                        url=f"{base_url}{link}",
+                        session_id=f"confluence-{page_id}",
+                        options={"include_image_data": False, "prefer_text_for_images": False, "vision_enabled": False},
+                        auth_header=auth_header,
+                        source_type="confluence",
+                        source_kind="page_attachment",
+                        source_locator=f"{page_id}:{att.get('id')}",
+                        provider_metadata={"page_id": page_id, "attachment_id": att.get("id")},
+                    )
+                    if getattr(result, "artifact_id", None):
+                        from src.file_artifacts.storage import storage as artifact_storage
+                        record = artifact_storage.get_artifact(result.artifact_id)
+                        if record:
+                            bind_artifact_to_source_bundle(record.artifact_id, f"confluence:{page_id}")
+                            artifact_ref = build_artifact_ref_dict(record)
+                            artifact_refs.append(artifact_ref)
+                            att["text_preview"] = (result.preview or result.content or "")[:1000]
+                            att["text_ref"] = None
+                except Exception as att_exc:
+                    logger.warning(f"Failed attachment materialization for {filename}: {att_exc}")
+
         bundle = {
             "metadata": {
                 "page_id": page_id,
@@ -421,6 +463,7 @@ async def confluence_prepare_page_context(
             "content_markdown": await adapter._to_markdown(page if isinstance(page, dict) else {}),
             "comments": comments,
             "attachments": attachments,
+            "artifact_refs": artifact_refs,
             "children": children,
             "descendants": descendants,
             "raw_snapshot": page if include_raw_snapshot else {},
@@ -473,6 +516,8 @@ async def confluence_prepare_page_context(
                     descendants_attachments_complete = False
                     ledger["partial_reasons"].append(f"descendant_enrich_failed:{desc_id}:{type(desc_item_exc).__name__}")
             bundle["descendants"] = descendants_enriched
+        ledger["artifact_refs_created"] = len(artifact_refs)
+        ledger["projectable_attachments_total"] = len([a for a in attachments if can_project_to_text(_infer_attachment_media_type(a, str(a.get("title") or "")), str(a.get("title") or "")) and not _is_image_attachment(a, str(a.get("title") or ""))])
         ledger["descendants_pages_complete"] = descendants_pages_complete
         ledger["descendants_comments_complete"] = descendants_comments_complete
         ledger["descendants_attachments_complete"] = descendants_attachments_complete

--- a/src/file_artifacts/__init__.py
+++ b/src/file_artifacts/__init__.py
@@ -1,6 +1,8 @@
 from .capabilities import can_project_to_text, infer_projection_kind, is_text_like_content_type
 from .models import ArtifactBinding, ArtifactRecord
 from .service import (
+    attach_source_refs_to_artifact,
+    attach_text_ref_to_artifact,
     bind_artifact_to_session,
     bind_artifact_to_source_bundle,
     build_artifact_ref_dict,
@@ -17,6 +19,8 @@ __all__ = [
     "is_text_like_content_type",
     "infer_projection_kind",
     "register_existing_file_as_artifact",
+    "attach_text_ref_to_artifact",
+    "attach_source_refs_to_artifact",
     "bind_artifact_to_session",
     "bind_artifact_to_source_bundle",
     "update_projection_from_parse_result",

--- a/src/file_artifacts/__init__.py
+++ b/src/file_artifacts/__init__.py
@@ -1,0 +1,24 @@
+from .capabilities import can_project_to_text, infer_projection_kind, is_text_like_content_type
+from .models import ArtifactBinding, ArtifactRecord
+from .service import (
+    bind_artifact_to_session,
+    bind_artifact_to_source_bundle,
+    build_artifact_ref_dict,
+    register_existing_file_as_artifact,
+    update_projection_from_parse_result,
+)
+from .storage import storage
+
+__all__ = [
+    "ArtifactBinding",
+    "ArtifactRecord",
+    "storage",
+    "can_project_to_text",
+    "is_text_like_content_type",
+    "infer_projection_kind",
+    "register_existing_file_as_artifact",
+    "bind_artifact_to_session",
+    "bind_artifact_to_source_bundle",
+    "update_projection_from_parse_result",
+    "build_artifact_ref_dict",
+]

--- a/src/file_artifacts/capabilities.py
+++ b/src/file_artifacts/capabilities.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+TEXT_LIKE_MIME_TYPES = {
+    "application/json",
+    "application/xml",
+    "text/xml",
+    "application/yaml",
+    "text/yaml",
+    "application/x-yaml",
+    "text/x-yaml",
+}
+
+PROJECTABLE_MIME_TYPES = {
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "text/csv",
+    "text/plain",
+    *TEXT_LIKE_MIME_TYPES,
+}
+
+PROJECTABLE_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".csv", ".txt", ".json", ".xml", ".yaml", ".yml"}
+
+
+def is_text_like_content_type(content_type: str) -> bool:
+    normalized = str(content_type or "").lower()
+    return normalized.startswith("text/") or normalized in TEXT_LIKE_MIME_TYPES
+
+
+def can_project_to_text(content_type: str, filename: str) -> bool:
+    normalized = str(content_type or "").lower()
+    ext = Path(str(filename or "")).suffix.lower()
+    if normalized.startswith("image/"):
+        return False
+    return normalized in PROJECTABLE_MIME_TYPES or normalized.startswith("text/") or ext in PROJECTABLE_EXTENSIONS
+
+
+def infer_projection_kind(content_type: str, filename: str, parsed_markdown: str | None) -> str:
+    normalized = str(content_type or "").lower()
+    ext = Path(str(filename or "")).suffix.lower()
+    if normalized.startswith("image/"):
+        return "image"
+    if normalized == "application/pdf" or ext == ".pdf":
+        return "pdf_markdown"
+    if normalized.endswith("wordprocessingml.document") or ext == ".docx":
+        return "docx_markdown"
+    if normalized.endswith("spreadsheetml.sheet") or ext == ".xlsx":
+        return "xlsx_markdown"
+    if normalized == "text/csv" or ext == ".csv":
+        return "csv_text"
+    if is_text_like_content_type(normalized) or ext in {".txt", ".json", ".xml", ".yaml", ".yml"}:
+        return "text"
+    return "markdown" if parsed_markdown else "metadata"

--- a/src/file_artifacts/models.py
+++ b/src/file_artifacts/models.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ArtifactRecord(BaseModel):
+    artifact_id: str
+    file_id: str
+    source_type: str
+    source_kind: str
+    source_locator: Optional[str] = None
+    filename: str
+    content_type: str
+    size: int
+    session_id: Optional[str] = None
+    parse_status: str = "pending"
+    parse_error: Optional[str] = None
+    projection_kind: Optional[str] = None
+    preview: Optional[str] = None
+    chunk_count: int = 0
+    total_chars: int = 0
+    provider_metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat() + "Z")
+    updated_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat() + "Z")
+
+
+class ArtifactBinding(BaseModel):
+    artifact_id: str
+    scope_type: str
+    scope_id: str
+    role: str = "attachment"

--- a/src/file_artifacts/models.py
+++ b/src/file_artifacts/models.py
@@ -22,6 +22,10 @@ class ArtifactRecord(BaseModel):
     preview: Optional[str] = None
     chunk_count: int = 0
     total_chars: int = 0
+    text_ref: Optional[str] = None
+    context_ref: Optional[str] = None
+    digest_ref: Optional[str] = None
+    full_markdown_chars: int = 0
     provider_metadata: Dict[str, Any] = Field(default_factory=dict)
     created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat() + "Z")
     updated_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat() + "Z")

--- a/src/file_artifacts/service.py
+++ b/src/file_artifacts/service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from src.utils.file_parser import get_metadata
+
+from .capabilities import infer_projection_kind
+from .models import ArtifactBinding, ArtifactRecord
+from .storage import storage
+
+
+def register_existing_file_as_artifact(
+    file_id: str,
+    *,
+    source_type: str,
+    source_kind: str,
+    source_locator: Optional[str] = None,
+    session_id: Optional[str] = None,
+    provider_metadata: Optional[Dict[str, Any]] = None,
+) -> ArtifactRecord:
+    metadata = get_metadata(file_id)
+    existing = storage.get_artifact(file_id)
+    record = ArtifactRecord(
+        artifact_id=file_id,
+        file_id=file_id,
+        source_type=source_type,
+        source_kind=source_kind,
+        source_locator=source_locator,
+        filename=metadata.original_filename,
+        content_type=metadata.content_type,
+        size=int(metadata.size or 0),
+        session_id=session_id or metadata.session_id,
+        parse_status=existing.parse_status if existing else "pending",
+        parse_error=existing.parse_error if existing else None,
+        projection_kind=existing.projection_kind if existing else None,
+        preview=existing.preview if existing else None,
+        chunk_count=existing.chunk_count if existing else 0,
+        total_chars=existing.total_chars if existing else 0,
+        provider_metadata={**(existing.provider_metadata if existing else {}), **(provider_metadata or {})},
+    )
+    return storage.upsert_artifact(record)
+
+
+def bind_artifact_to_session(artifact_id: str, session_id: str, role: str = "attachment") -> ArtifactBinding:
+    return storage.bind_artifact(ArtifactBinding(artifact_id=artifact_id, scope_type="session", scope_id=session_id, role=role))
+
+
+def bind_artifact_to_source_bundle(artifact_id: str, bundle_scope_id: str, role: str = "reference") -> ArtifactBinding:
+    return storage.bind_artifact(ArtifactBinding(artifact_id=artifact_id, scope_type="source_bundle", scope_id=bundle_scope_id, role=role))
+
+
+def update_projection_from_parse_result(artifact_id: str, parse_result, preview: Optional[str] = None) -> Optional[ArtifactRecord]:
+    markdown = getattr(parse_result, "markdown", "") or ""
+    block_count = len(getattr(parse_result, "blocks", []) or [])
+    projection_kind = infer_projection_kind(
+        getattr(parse_result, "content_type", ""),
+        getattr(parse_result, "filename", ""),
+        markdown,
+    )
+    storage.update_artifact_projection(
+        artifact_id,
+        projection_kind=projection_kind,
+        preview=preview if preview is not None else markdown[:2000],
+        chunk_count=block_count,
+        total_chars=len(markdown),
+    )
+    return storage.update_artifact_status(artifact_id, parse_status="completed")
+
+
+def build_artifact_ref_dict(record: ArtifactRecord, *, text_ref: str | None = None) -> dict:
+    return {
+        "artifact_id": record.artifact_id,
+        "file_id": record.file_id,
+        "filename": record.filename,
+        "content_type": record.content_type,
+        "source_type": record.source_type,
+        "source_kind": record.source_kind,
+        "source_locator": record.source_locator,
+        "projection_kind": record.projection_kind,
+        "preview": record.preview,
+        "text_ref": text_ref,
+    }

--- a/src/file_artifacts/service.py
+++ b/src/file_artifacts/service.py
@@ -36,6 +36,10 @@ def register_existing_file_as_artifact(
         preview=existing.preview if existing else None,
         chunk_count=existing.chunk_count if existing else 0,
         total_chars=existing.total_chars if existing else 0,
+        text_ref=existing.text_ref if existing else None,
+        context_ref=existing.context_ref if existing else None,
+        digest_ref=existing.digest_ref if existing else None,
+        full_markdown_chars=existing.full_markdown_chars if existing else 0,
         provider_metadata={**(existing.provider_metadata if existing else {}), **(provider_metadata or {})},
     )
     return storage.upsert_artifact(record)
@@ -64,10 +68,36 @@ def update_projection_from_parse_result(artifact_id: str, parse_result, preview:
         chunk_count=block_count,
         total_chars=len(markdown),
     )
+    storage.update_artifact_references(
+        artifact_id,
+        full_markdown_chars=len(markdown),
+    )
     return storage.update_artifact_status(artifact_id, parse_status="completed")
 
 
+def attach_text_ref_to_artifact(artifact_id: str, text_ref: str, *, full_markdown_chars: Optional[int] = None) -> Optional[ArtifactRecord]:
+    return storage.update_artifact_references(
+        artifact_id,
+        text_ref=text_ref,
+        full_markdown_chars=full_markdown_chars,
+    )
+
+
+def attach_source_refs_to_artifact(
+    artifact_id: str,
+    *,
+    context_ref: Optional[str] = None,
+    digest_ref: Optional[str] = None,
+) -> Optional[ArtifactRecord]:
+    return storage.update_artifact_references(
+        artifact_id,
+        context_ref=context_ref,
+        digest_ref=digest_ref,
+    )
+
+
 def build_artifact_ref_dict(record: ArtifactRecord, *, text_ref: str | None = None) -> dict:
+    effective_text_ref = text_ref if text_ref is not None else record.text_ref
     return {
         "artifact_id": record.artifact_id,
         "file_id": record.file_id,
@@ -78,5 +108,7 @@ def build_artifact_ref_dict(record: ArtifactRecord, *, text_ref: str | None = No
         "source_locator": record.source_locator,
         "projection_kind": record.projection_kind,
         "preview": record.preview,
-        "text_ref": text_ref,
+        "text_ref": effective_text_ref,
+        "context_ref": record.context_ref,
+        "digest_ref": record.digest_ref,
     }

--- a/src/file_artifacts/storage.py
+++ b/src/file_artifacts/storage.py
@@ -108,5 +108,31 @@ class FileArtifactStorage:
         self._save_artifacts(artifacts)
         return ArtifactRecord(**item)
 
+    def update_artifact_references(
+        self,
+        artifact_id: str,
+        *,
+        text_ref: Optional[str] = None,
+        context_ref: Optional[str] = None,
+        digest_ref: Optional[str] = None,
+        full_markdown_chars: Optional[int] = None,
+    ) -> Optional[ArtifactRecord]:
+        artifacts = self._load_artifacts()
+        item = artifacts.get(artifact_id)
+        if not item:
+            return None
+        if text_ref is not None:
+            item["text_ref"] = text_ref
+        if context_ref is not None:
+            item["context_ref"] = context_ref
+        if digest_ref is not None:
+            item["digest_ref"] = digest_ref
+        if full_markdown_chars is not None:
+            item["full_markdown_chars"] = int(full_markdown_chars or 0)
+        item["updated_at"] = datetime.utcnow().isoformat() + "Z"
+        artifacts[artifact_id] = item
+        self._save_artifacts(artifacts)
+        return ArtifactRecord(**item)
+
 
 storage = FileArtifactStorage()

--- a/src/file_artifacts/storage.py
+++ b/src/file_artifacts/storage.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .models import ArtifactBinding, ArtifactRecord
+
+
+class FileArtifactStorage:
+    def __init__(self, base_dir: str = "~/.efp/workspace/file_artifacts"):
+        self.base_dir = Path(base_dir).expanduser()
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.artifacts_path = self.base_dir / "artifacts.json"
+        self.bindings_path = self.base_dir / "bindings.json"
+
+    def _read_json(self, path: Path, default):
+        if not path.exists():
+            return default
+        try:
+            return json.loads(path.read_text())
+        except Exception:
+            return default
+
+    def _write_json(self, path: Path, payload) -> None:
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    def _load_artifacts(self) -> Dict[str, dict]:
+        return self._read_json(self.artifacts_path, {})
+
+    def _save_artifacts(self, payload: Dict[str, dict]) -> None:
+        self._write_json(self.artifacts_path, payload)
+
+    def _load_bindings(self) -> List[dict]:
+        return self._read_json(self.bindings_path, [])
+
+    def _save_bindings(self, payload: List[dict]) -> None:
+        self._write_json(self.bindings_path, payload)
+
+    def upsert_artifact(self, record: ArtifactRecord) -> ArtifactRecord:
+        artifacts = self._load_artifacts()
+        now = datetime.utcnow().isoformat() + "Z"
+        payload = record.model_dump()
+        existing = artifacts.get(record.artifact_id)
+        if existing and existing.get("created_at"):
+            payload["created_at"] = existing["created_at"]
+        payload["updated_at"] = now
+        artifacts[record.artifact_id] = payload
+        self._save_artifacts(artifacts)
+        return ArtifactRecord(**payload)
+
+    def get_artifact(self, artifact_id: str) -> Optional[ArtifactRecord]:
+        payload = self._load_artifacts().get(artifact_id)
+        return ArtifactRecord(**payload) if payload else None
+
+    def bind_artifact(self, binding: ArtifactBinding) -> ArtifactBinding:
+        bindings = self._load_bindings()
+        item = binding.model_dump()
+        for existing in bindings:
+            if existing.get("artifact_id") == binding.artifact_id and existing.get("scope_type") == binding.scope_type and existing.get("scope_id") == binding.scope_id and existing.get("role") == binding.role:
+                return ArtifactBinding(**existing)
+        bindings.append(item)
+        self._save_bindings(bindings)
+        return binding
+
+    def list_scope_artifacts(self, scope_type: str, scope_id: str) -> List[ArtifactRecord]:
+        bindings = self._load_bindings()
+        artifact_ids = [
+            b.get("artifact_id")
+            for b in bindings
+            if b.get("scope_type") == scope_type and b.get("scope_id") == scope_id
+        ]
+        artifacts = self._load_artifacts()
+        return [ArtifactRecord(**artifacts[a]) for a in artifact_ids if a in artifacts]
+
+    def update_artifact_projection(
+        self,
+        artifact_id: str,
+        *,
+        projection_kind: Optional[str],
+        preview: Optional[str],
+        chunk_count: int,
+        total_chars: int,
+    ) -> Optional[ArtifactRecord]:
+        artifacts = self._load_artifacts()
+        item = artifacts.get(artifact_id)
+        if not item:
+            return None
+        item["projection_kind"] = projection_kind
+        item["preview"] = preview
+        item["chunk_count"] = int(chunk_count or 0)
+        item["total_chars"] = int(total_chars or 0)
+        item["updated_at"] = datetime.utcnow().isoformat() + "Z"
+        artifacts[artifact_id] = item
+        self._save_artifacts(artifacts)
+        return ArtifactRecord(**item)
+
+    def update_artifact_status(self, artifact_id: str, *, parse_status: str, parse_error: Optional[str] = None) -> Optional[ArtifactRecord]:
+        artifacts = self._load_artifacts()
+        item = artifacts.get(artifact_id)
+        if not item:
+            return None
+        item["parse_status"] = parse_status
+        item["parse_error"] = parse_error
+        item["updated_at"] = datetime.utcnow().isoformat() + "Z"
+        artifacts[artifact_id] = item
+        self._save_artifacts(artifacts)
+        return ArtifactRecord(**item)
+
+
+storage = FileArtifactStorage()

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -27,6 +27,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from src.utils.file_parser.storage import init_storage, _file_metadata, StoredFileNotFoundError, get_metadata
 init_storage()
 from src.utils.file_parser import parse_file
+from src.file_artifacts.service import (
+    bind_artifact_to_session,
+    register_existing_file_as_artifact,
+    update_projection_from_parse_result,
+)
 from src.utils.truncate import truncate
 from src.utils.redaction import safe_preview, safe_log_field, sanitize_exception_message
 from src.utils.logger import clear_log_context, set_log_context
@@ -2798,6 +2803,28 @@ async def api_files_upload(request: web.Request) -> web.Response:
             max_size_mb=max_size_mb
         )
         logger.info(f"[api_files_upload] saved metadata.session_id={metadata.session_id}")
+
+        if session_id:
+            from src.hooks.file_context.models import SessionFileMeta
+            from src.hooks.file_context.storage import storage as file_context_storage
+
+            file_context_storage.add_file_to_session(
+                session_id,
+                SessionFileMeta(
+                    file_id=metadata.file_id,
+                    session_id=session_id,
+                    filename=metadata.original_filename,
+                    content_type=metadata.content_type,
+                    parse_status="pending",
+                ),
+            )
+            register_existing_file_as_artifact(
+                metadata.file_id,
+                source_type="chat",
+                source_kind="uploaded_file",
+                session_id=session_id,
+            )
+            bind_artifact_to_session(metadata.file_id, session_id, role="attachment")
         
         return web.json_response({
             'success': True,
@@ -2830,113 +2857,107 @@ async def api_files_upload(request: web.Request) -> web.Response:
 
 async def api_files_parse(request: web.Request) -> web.Response:
     """Parse a file.
-    
+
     POST /api/files/parse
     Content-Type: application/json
     Body: {"file_id": "...", "options": {...}}
-    
+
     Returns:
         200: {"success": true, "markdown": "...", "blocks": [...], ...}
         400: {"success": false, "error": "..."}
     """
     try:
-        
-        
+        from src.hooks.file_context.models import Chunk, SessionFileMeta
+        from src.hooks.file_context.retrieval import retrieval_engine
+        from src.hooks.file_context.storage import storage as file_context_storage
+        import hashlib
+
         try:
             data = await request.json()
         except json.JSONDecodeError:
-            return web.json_response({
-                'success': False,
-                'error': 'Invalid JSON body'
-            }, status=400)
-        
+            return web.json_response({'success': False, 'error': 'Invalid JSON body'}, status=400)
+
         file_id = data.get('file_id')
-        
         if not file_id:
-            return web.json_response({
-                'success': False,
-                'error': 'file_id is required'
-            }, status=400)
-        
-        # Validate session ownership
+            return web.json_response({'success': False, 'error': 'file_id is required'}, status=400)
+
         session_id = request.query.get('session_id') or request.headers.get('X-Session-ID')
-        try:
-            metadata = get_metadata(file_id)
-            # If the file is bound to a session, require a matching session_id
-            if metadata.session_id:
-                if not session_id or metadata.session_id != session_id:
-                    return web.json_response({
-                        'success': False,
-                        'error': 'File not found'
-                    }, status=404)
-        except StoredFileNotFoundError:
-            pass  # Will be caught below
-        
-        options = data.get('options', {})
-        
-        # Parse file
-        result = await parse_file(file_id, options)
-        
-        # Save chunks to file context storage
-        if result.success and result.blocks:
-            try:
-                from src.hooks.file_context import storage
-                from src.hooks.file_context.models import Chunk, SessionFileMeta
-                import hashlib
-                
-                # Update file status to processing
-                storage.update_file_status(
-                    session_id=session_id,
-                    file_id=file_id,
-                    status="processing"
-                )
-                
-                # Save chunks
-                total_chars = 0
-                for block in result.blocks:
-                    # Generate chunk_id if not present
-                    chunk_id = block.get('chunk_id') or f"{file_id}_{block.get('type', 'chunk')}_{block.get('page', 1)}_{block.get('index', 1)}"
-                    
-                    # Compute content hash for deduplication
-                    content = block.get('content', '')
-                    content_hash = hashlib.sha256(content.encode()).hexdigest()
-                    
-                    chunk = Chunk(
-                        chunk_id=chunk_id,
+        metadata = get_metadata(file_id)
+        if metadata.session_id and (not session_id or metadata.session_id != session_id):
+            return web.json_response({'success': False, 'error': 'File not found'}, status=404)
+
+        if session_id:
+            if not file_context_storage.get_file_meta(session_id, file_id):
+                file_context_storage.add_file_to_session(
+                    session_id,
+                    SessionFileMeta(
                         file_id=file_id,
-                        session_id=session_id or '',
-                        type=block.get('type', 'paragraph'),
-                        content=content,
-                        markdown=block.get('markdown'),
-                        page=block.get('page'),
-                        index=block.get('index', 1),
-                        source=block.get('method', 'unknown'),
-                        confidence=block.get('confidence', 0.95),
-                        content_hash=content_hash
-                    )
-                    storage.save_chunk(chunk)
-                    total_chars += len(content)
-                
-                # Update file status to completed
-                storage.update_file_status(
-                    session_id=session_id,
-                    file_id=file_id,
-                    status="completed",
-                    chunk_count=len(result.blocks),
-                    total_chars=total_chars
+                        session_id=session_id,
+                        filename=metadata.original_filename,
+                        content_type=metadata.content_type,
+                        parse_status="pending",
+                    ),
                 )
-                
-                logger.info(f"[api_files_parse] Saved {len(result.blocks)} chunks for file {file_id}")
-            except Exception as e:
-                logger.error(f"[api_files_parse] Failed to save chunks: {e}")
-                # Continue anyway, parse succeeded
-        
+            if not register_existing_file_as_artifact(
+                file_id,
+                source_type="chat",
+                source_kind="uploaded_file",
+                session_id=session_id,
+            ):
+                pass
+            bind_artifact_to_session(file_id, session_id, role="attachment")
+            file_context_storage.update_file_status(session_id, file_id, status="processing")
+        from src.file_artifacts.storage import storage as artifact_storage
+        artifact_storage.update_artifact_status(file_id, parse_status="processing")
+
+        options = data.get('options', {})
+        result = await parse_file(file_id, options)
+
         if not result.success:
-            return web.json_response({
-                'success': False,
-                'error': result.error
-            }, status=400)
-        
+            if session_id:
+                file_context_storage.update_file_status(session_id, file_id, status="failed", error=result.error)
+            artifact_storage.update_artifact_status(file_id, parse_status="failed", parse_error=result.error)
+            return web.json_response({'success': False, 'error': result.error}, status=400)
+
+        total_chars = 0
+        saved_chunks = 0
+        for block in (result.blocks or []):
+            block_data = block.model_dump(by_alias=True, exclude_none=True)
+            content = block_data.get('content', '')
+            chunk_id = block_data.get('chunk_id') or f"{file_id}_{block_data.get('type', 'chunk')}_{block_data.get('page', 1)}_{block_data.get('index', saved_chunks + 1)}"
+            chunk = Chunk(
+                chunk_id=chunk_id,
+                file_id=file_id,
+                session_id=session_id or '',
+                type=block_data.get('type', 'paragraph'),
+                content=content,
+                markdown=block_data.get('markdown'),
+                page=block_data.get('page'),
+                index=block_data.get('index', saved_chunks + 1),
+                row_range=block_data.get('row_range'),
+                source=block_data.get('method', 'unknown'),
+                confidence=block_data.get('confidence', 0.95),
+                content_hash=hashlib.sha256(content.encode()).hexdigest(),
+                bbox=block_data.get('bbox'),
+                table_json=json.dumps(block_data.get('json')) if block_data.get('json') is not None else None,
+            )
+            file_context_storage.save_chunk(chunk)
+            total_chars += len(content)
+            saved_chunks += 1
+
+        preview = (result.markdown or '')[:2000]
+        update_projection_from_parse_result(file_id, result, preview=preview)
+
+        if session_id:
+            file_context_storage.update_file_status(
+                session_id=session_id,
+                file_id=file_id,
+                status="completed",
+                chunk_count=saved_chunks,
+                total_chars=total_chars,
+            )
+            retrieval_engine.rebuild_index(session_id)
+
         return web.json_response({
             'success': True,
             'content_type': result.content_type,
@@ -2945,21 +2966,14 @@ async def api_files_parse(request: web.Request) -> web.Response:
             'markdown': result.markdown,
             'blocks': [b.model_dump(by_alias=True, exclude_none=True) for b in result.blocks],
             'json': result.json,
-            'parse_time_ms': result.parse_time_ms
+            'parse_time_ms': result.parse_time_ms,
         })
-        
+
     except StoredFileNotFoundError as e:
-        return web.json_response({
-            'success': False,
-            'error': str(e)
-        }, status=404)
-        
+        return web.json_response({'success': False, 'error': str(e)}, status=404)
     except Exception as e:
         logger.error(f"File parse error: {e}")
-        return web.json_response({
-            'success': False,
-            'error': str(e)
-        }, status=500)
+        return web.json_response({'success': False, 'error': str(e)}, status=500)
 
 
 async def api_files_preview(request: web.Request) -> web.Response:

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -2866,6 +2866,8 @@ async def api_files_parse(request: web.Request) -> web.Response:
         200: {"success": true, "markdown": "...", "blocks": [...], ...}
         400: {"success": false, "error": "..."}
     """
+    session_id = None
+    file_id = None
     try:
         from src.hooks.file_context.models import Chunk, SessionFileMeta
         from src.hooks.file_context.retrieval import retrieval_engine
@@ -2972,6 +2974,18 @@ async def api_files_parse(request: web.Request) -> web.Response:
     except StoredFileNotFoundError as e:
         return web.json_response({'success': False, 'error': str(e)}, status=404)
     except Exception as e:
+        try:
+            if session_id and file_id:
+                from src.hooks.file_context.storage import storage as file_context_storage
+                file_context_storage.update_file_status(session_id, file_id, status="failed", error=str(e))
+        except Exception:
+            logger.exception("Failed to persist file_context failure state for %s/%s", session_id, file_id)
+        try:
+            if file_id:
+                from src.file_artifacts.storage import storage as artifact_storage
+                artifact_storage.update_artifact_status(file_id, parse_status="failed", parse_error=str(e))
+        except Exception:
+            logger.exception("Failed to persist artifact failure state for %s", file_id)
         logger.error(f"File parse error: {e}")
         return web.json_response({'success': False, 'error': str(e)}, status=500)
 

--- a/src/github/doc_refs.py
+++ b/src/github/doc_refs.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from src.github import github_channel
+from src.github.url_utils import normalize_github_api_base_url
+
+
+@dataclass(frozen=True)
+class GitHubDocRef:
+    owner: str
+    repo: str
+    branch: str
+    path: str
+
+
+def _allowed_github_hosts() -> set[str]:
+    hosts = {"github.com"}
+    base_url = str(getattr(github_channel, "base_url", "") or "").strip()
+    if base_url:
+        parsed_base_url = urlparse(normalize_github_api_base_url(base_url))
+        if parsed_base_url.netloc:
+            hosts.add(parsed_base_url.netloc.lower())
+    return hosts
+
+
+def parse_github_doc_ref(raw: str, default_ref) -> GitHubDocRef:
+    normalized = str(raw or "").strip()
+    if not normalized:
+        raise ValueError("github_doc_ref is required")
+
+    if normalized.startswith("http://") or normalized.startswith("https://"):
+        parsed = urlparse(normalized)
+        if parsed.netloc.lower() not in _allowed_github_hosts():
+            raise ValueError(f"Unsupported GitHub doc URL host: {parsed.netloc}")
+        parts = [part for part in parsed.path.split("/") if part]
+        if len(parts) < 5 or parts[2] != "blob":
+            raise ValueError("GitHub doc URL must be in /owner/repo/blob/<branch>/<path> format")
+        return GitHubDocRef(owner=parts[0], repo=parts[1], branch=parts[3], path="/".join(parts[4:]).strip("/"))
+
+    return GitHubDocRef(
+        owner=default_ref.owner,
+        repo=default_ref.repo,
+        branch=default_ref.branch,
+        path=normalized.strip("/"),
+    )

--- a/src/github/source_service.py
+++ b/src/github/source_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from src.file_artifacts import can_project_to_text
+from src.file_artifacts.service import bind_artifact_to_source_bundle, build_artifact_ref_dict, register_existing_file_as_artifact, update_projection_from_parse_result
+from src.github import github_channel
+from src.github.doc_refs import parse_github_doc_ref
+from src.source_context import persist_github_source_bundle_and_digest
+from src.utils.file_parser import parse_file, save_uploaded_file
+
+
+async def prepare_github_file_source(raw: str, default_ref, *, session_id: str | None = None) -> dict:
+    doc_ref = parse_github_doc_ref(raw, default_ref)
+    file_data = await github_channel.get_file(doc_ref.owner, doc_ref.repo, doc_ref.path, doc_ref.branch)
+    encoded = file_data.get("content")
+    if not isinstance(encoded, str) or not encoded.strip():
+        raise ValueError(f"File not found or empty: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}")
+
+    content_bytes = base64.b64decode(encoded)
+    file_meta = await save_uploaded_file(content_bytes, original_filename=doc_ref.path.split("/")[-1], session_id=session_id)
+    artifact = register_existing_file_as_artifact(
+        file_meta.file_id,
+        source_type="github",
+        source_kind="repo_file",
+        source_locator=f"{doc_ref.owner}/{doc_ref.repo}:{doc_ref.path}@{doc_ref.branch}",
+        session_id=session_id,
+        provider_metadata={"sha": file_data.get("sha")},
+    )
+
+    content_markdown = ""
+    source_complete = False
+    partial_reasons: list[str] = []
+    if can_project_to_text(file_meta.content_type, file_meta.original_filename):
+        parsed = await parse_file(file_meta.file_id)
+        if getattr(parsed, "success", False):
+            content_markdown = parsed.markdown or ""
+            update_projection_from_parse_result(artifact.artifact_id, parsed, preview=content_markdown[:2000])
+            source_complete = True
+        else:
+            partial_reasons.append(f"parse_failed:{parsed.error}")
+    else:
+        partial_reasons.append("non_projectable_file")
+
+    from src.file_artifacts.storage import storage as artifact_storage
+    record = artifact_storage.get_artifact(artifact.artifact_id) or artifact
+    bundle_scope_id = f"github:{doc_ref.owner}/{doc_ref.repo}:{doc_ref.path}@{doc_ref.branch}"
+    bind_artifact_to_source_bundle(record.artifact_id, bundle_scope_id)
+    artifact_refs = [build_artifact_ref_dict(record)]
+
+    bundle = {
+        "metadata": {
+            "owner": doc_ref.owner,
+            "repo": doc_ref.repo,
+            "branch": doc_ref.branch,
+            "path": doc_ref.path,
+            "content_type": file_meta.content_type,
+        },
+        "content_markdown": content_markdown,
+        "artifact_refs": artifact_refs,
+        "completeness_ledger": {
+            "file_loaded": True,
+            "file_projectable": can_project_to_text(file_meta.content_type, file_meta.original_filename),
+            "source_complete": source_complete,
+            "partial_reasons": partial_reasons,
+        },
+        "raw_snapshot": {
+            "path": doc_ref.path,
+            "sha": file_data.get("sha"),
+            "size": file_data.get("size"),
+            "branch": doc_ref.branch,
+        },
+    }
+    persisted = persist_github_source_bundle_and_digest(
+        session_id=session_id or "unknown_session",
+        source_id=f"{doc_ref.owner}/{doc_ref.repo}:{doc_ref.path}@{doc_ref.branch}",
+        bundle=bundle,
+    )
+    bundle["context_ref"] = persisted["context_ref"]
+    bundle["digest_ref"] = persisted["digest_ref"]
+    return {"doc_ref": doc_ref, "bundle": bundle, "persisted": persisted}

--- a/src/github/source_service.py
+++ b/src/github/source_service.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import base64
+import mimetypes
 from typing import Any
 
 from src.file_artifacts import can_project_to_text
-from src.file_artifacts.service import bind_artifact_to_source_bundle, build_artifact_ref_dict, register_existing_file_as_artifact, update_projection_from_parse_result
+from src.file_artifacts.service import (
+    attach_source_refs_to_artifact,
+    bind_artifact_to_source_bundle,
+    build_artifact_ref_dict,
+    register_existing_file_as_artifact,
+    update_projection_from_parse_result,
+)
+from src.file_artifacts.storage import storage as artifact_storage
 from src.github import github_channel
 from src.github.doc_refs import parse_github_doc_ref
 from src.source_context import persist_github_source_bundle_and_digest
@@ -19,7 +27,19 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
         raise ValueError(f"File not found or empty: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}")
 
     content_bytes = base64.b64decode(encoded)
-    file_meta = await save_uploaded_file(content_bytes, original_filename=doc_ref.path.split("/")[-1], session_id=session_id)
+    guessed_content_type = mimetypes.guess_type(doc_ref.path)[0]
+    if not guessed_content_type:
+        try:
+            content_bytes.decode("utf-8")
+            guessed_content_type = "text/plain"
+        except Exception:
+            guessed_content_type = None
+    file_meta = await save_uploaded_file(
+        content_bytes,
+        original_filename=doc_ref.path.split("/")[-1],
+        session_id=session_id,
+        content_type=guessed_content_type,
+    )
     artifact = register_existing_file_as_artifact(
         file_meta.file_id,
         source_type="github",
@@ -33,17 +53,31 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
     source_complete = False
     partial_reasons: list[str] = []
     if can_project_to_text(file_meta.content_type, file_meta.original_filename):
-        parsed = await parse_file(file_meta.file_id)
-        if getattr(parsed, "success", False):
-            content_markdown = parsed.markdown or ""
-            update_projection_from_parse_result(artifact.artifact_id, parsed, preview=content_markdown[:2000])
-            source_complete = True
-        else:
-            partial_reasons.append(f"parse_failed:{parsed.error}")
+        try:
+            parsed = await parse_file(file_meta.file_id)
+            if getattr(parsed, "success", False):
+                content_markdown = parsed.markdown or ""
+                update_projection_from_parse_result(artifact.artifact_id, parsed, preview=content_markdown[:2000])
+                source_complete = True
+            else:
+                parse_error = str(getattr(parsed, "error", "parse failed"))
+                artifact_storage.update_artifact_status(
+                    artifact.artifact_id,
+                    parse_status="failed",
+                    parse_error=parse_error,
+                )
+                partial_reasons.append(f"parse_failed:{parse_error}")
+        except Exception as exc:
+            artifact_storage.update_artifact_status(
+                artifact.artifact_id,
+                parse_status="failed",
+                parse_error=str(exc),
+            )
+            partial_reasons.append(f"parse_failed:{type(exc).__name__}")
     else:
+        artifact_storage.update_artifact_status(artifact.artifact_id, parse_status="skipped")
         partial_reasons.append("non_projectable_file")
 
-    from src.file_artifacts.storage import storage as artifact_storage
     record = artifact_storage.get_artifact(artifact.artifact_id) or artifact
     bundle_scope_id = f"github:{doc_ref.owner}/{doc_ref.repo}:{doc_ref.path}@{doc_ref.branch}"
     bind_artifact_to_source_bundle(record.artifact_id, bundle_scope_id)
@@ -56,6 +90,9 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
             "branch": doc_ref.branch,
             "path": doc_ref.path,
             "content_type": file_meta.content_type,
+            "source_kind": "repo_file",
+            "attachments_supported": False,
+            "issue_pr_assets_supported": False,
         },
         "content_markdown": content_markdown,
         "artifact_refs": artifact_refs,
@@ -63,6 +100,9 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
             "file_loaded": True,
             "file_projectable": can_project_to_text(file_meta.content_type, file_meta.original_filename),
             "source_complete": source_complete,
+            "source_kind": "repo_file",
+            "attachments_supported": False,
+            "issue_pr_assets_supported": False,
             "partial_reasons": partial_reasons,
         },
         "raw_snapshot": {
@@ -79,4 +119,12 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
     )
     bundle["context_ref"] = persisted["context_ref"]
     bundle["digest_ref"] = persisted["digest_ref"]
+    attach_source_refs_to_artifact(
+        artifact.artifact_id,
+        context_ref=bundle["context_ref"],
+        digest_ref=bundle["digest_ref"],
+    )
+    refreshed = artifact_storage.get_artifact(artifact.artifact_id)
+    if refreshed:
+        bundle["artifact_refs"] = [build_artifact_ref_dict(refreshed)]
     return {"doc_ref": doc_ref, "bundle": bundle, "persisted": persisted}

--- a/src/jira/source_service.py
+++ b/src/jira/source_service.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from src.context_blob_store import put_text
 from src.source_context import persist_jira_source_bundle_and_digest
+from src.file_artifacts import can_project_to_text
+from src.file_artifacts.service import bind_artifact_to_source_bundle, build_artifact_ref_dict
 from src.utils.attachment import download_and_process_attachment as _default_download_and_process_attachment
 
 from .adapter import JiraFormatAdapter
@@ -76,13 +78,16 @@ async def prepare_jira_issue_source(
     attachment_list = fields.get("attachment", []) if isinstance(fields, dict) else []
     binary_attachments_count = 0
     binary_attachment_bodies_skipped_count = 0
+    artifact_refs: list[dict] = []
+    projectable_attachments_total = 0
 
     for att in attachment_list:
         mime = str(att.get("mimeType") or "")
         filename = str(att.get("filename") or "unknown")
-        is_text = mime.startswith("text/") or filename.lower().endswith((".txt", ".md", ".csv", ".json", ".yaml", ".yml", ".xml", ".log"))
-        if is_text:
+        is_projectable = can_project_to_text(mime, filename)
+        if is_projectable:
             text_attachments_total += 1
+            projectable_attachments_total += 1
         else:
             binary_attachments_count += 1
             binary_attachment_bodies_skipped_count += 1
@@ -103,7 +108,7 @@ async def prepare_jira_issue_source(
         should_load_text_body = (
             include_attachments
             and attachment_body_policy == "source_complete"
-            and is_text
+            and is_projectable
             and att.get("content")
         )
 
@@ -115,6 +120,10 @@ async def prepare_jira_issue_source(
                     session_id=f"jira-source-{issue_key}",
                     options={"include_image_data": False},
                     auth_header=auth_header,
+                    source_type="jira",
+                    source_kind="issue_attachment",
+                    source_locator=f"{issue_key}:{att.get('id')}",
+                    provider_metadata={"issue_key": issue_key, "attachment_id": att.get("id")},
                 )
                 if getattr(result, "content_format", "") == "text":
                     text_content = str(getattr(result, "content", "") or "")
@@ -136,10 +145,16 @@ async def prepare_jira_issue_source(
                         text_attachments_with_full_ref += 1
                         attachment_body_partial_reasons.append(f"text_attachment_preview_only:{filename}")
                     text_attachments_loaded += 1
+                if getattr(result, "artifact_id", None):
+                    from src.file_artifacts.storage import storage as artifact_storage
+                    record = artifact_storage.get_artifact(result.artifact_id)
+                    if record:
+                        bind_artifact_to_source_bundle(record.artifact_id, f"jira:{issue_key}")
+                        artifact_refs.append(build_artifact_ref_dict(record, text_ref=item.get("text_ref")))
             except Exception as exc:
                 partial_reasons.append(f"attachment_text_processing_failed:{filename}:{type(exc).__name__}")
                 attachment_body_partial_reasons.append(f"attachment_text_processing_failed:{filename}:{type(exc).__name__}")
-        elif include_attachments and attachment_body_policy == "metadata_only" and is_text:
+        elif include_attachments and attachment_body_policy == "metadata_only" and is_projectable:
             partial_reasons.append(f"text_attachment_body_metadata_only:{filename}")
             attachment_body_partial_reasons.append(f"text_attachment_body_metadata_only:{filename}")
         attachments.append(item)
@@ -170,6 +185,7 @@ async def prepare_jira_issue_source(
             for c in comments
         ],
         "attachments": attachments,
+        "artifact_refs": artifact_refs,
         "raw_snapshot": issue if include_raw_snapshot else {},
         "names": issue.get("names") if isinstance(issue, dict) else {},
         "renderedFields": issue.get("renderedFields") if isinstance(issue, dict) else {},
@@ -187,6 +203,8 @@ async def prepare_jira_issue_source(
             "attachment_metadata_complete": len(attachments) >= len(attachment_list),
             "text_attachments_loaded": text_attachments_loaded,
             "text_attachments_total": text_attachments_total,
+            "projectable_attachments_total": projectable_attachments_total,
+            "artifact_refs_created": len(artifact_refs),
             "text_attachments_complete": text_attachments_loaded >= text_attachments_total,
             "text_attachment_bodies_complete": text_attachments_loaded >= text_attachments_total and text_attachments_with_full_ref >= text_attachments_preview_only,
             "text_attachments_full_loaded": text_attachments_full_loaded,

--- a/src/jira/source_service.py
+++ b/src/jira/source_service.py
@@ -5,10 +5,9 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from src.context_blob_store import put_text
 from src.source_context import persist_jira_source_bundle_and_digest
 from src.file_artifacts import can_project_to_text
-from src.file_artifacts.service import bind_artifact_to_source_bundle, build_artifact_ref_dict
+from src.file_artifacts.service import attach_source_refs_to_artifact, bind_artifact_to_source_bundle, build_artifact_ref_dict
 from src.utils.attachment import download_and_process_attachment as _default_download_and_process_attachment
 
 from .adapter import JiraFormatAdapter
@@ -40,7 +39,6 @@ async def prepare_jira_issue_source(
 
     channel = getattr(jira_module, "jira_channel", None)
     downloader = getattr(jira_module, "download_and_process_attachment", _default_download_and_process_attachment)
-    put_text_fn = getattr(jira_module, "put_text", put_text)
 
     if not channel or not channel.is_configured():
         raise RuntimeError("Jira is not configured.")
@@ -124,6 +122,11 @@ async def prepare_jira_issue_source(
                     source_kind="issue_attachment",
                     source_locator=f"{issue_key}:{att.get('id')}",
                     provider_metadata={"issue_key": issue_key, "attachment_id": att.get("id")},
+                    persist_text_ref_session_id=session_id,
+                    persist_text_ref_kind="jira_attachment_text",
+                    persist_text_ref_source_id=f"{issue_key}:{att.get('id')}",
+                    persist_text_ref_title=f"Jira attachment text {filename}",
+                    persist_text_ref_metadata={"issue_key": issue_key, "filename": filename, "attachment_id": att.get("id")},
                 )
                 if getattr(result, "content_format", "") == "text":
                     text_content = str(getattr(result, "content", "") or "")
@@ -134,16 +137,10 @@ async def prepare_jira_issue_source(
                         item["text_preview"] = text_content[:1000]
                         item["attachment_text_preview_only"] = True
                         text_attachments_preview_only += 1
-                        item["text_ref"] = put_text_fn(
-                            session_id=session_id,
-                            kind="jira_attachment_text",
-                            source_id=f"{issue_key}_{filename}",
-                            title=f"Jira attachment text {filename}",
-                            content=text_content,
-                            metadata={"issue_key": issue_key, "filename": filename},
-                        )
-                        text_attachments_with_full_ref += 1
                         attachment_body_partial_reasons.append(f"text_attachment_preview_only:{filename}")
+                    item["text_ref"] = getattr(result, "text_ref", None)
+                    if item["text_ref"]:
+                        text_attachments_with_full_ref += 1
                     text_attachments_loaded += 1
                 if getattr(result, "artifact_id", None):
                     from src.file_artifacts.storage import storage as artifact_storage
@@ -259,6 +256,23 @@ async def prepare_jira_issue_source(
     )
 
     persisted = persist_jira_source_bundle_and_digest(session_id=session_id, issue_key=issue_key, bundle=bundle)
+    from src.file_artifacts.storage import storage as artifact_storage
+    refreshed_artifact_refs: list[dict] = []
+    for ref in artifact_refs:
+        artifact_id = ref.get("artifact_id")
+        if not artifact_id:
+            continue
+        attach_source_refs_to_artifact(
+            artifact_id,
+            context_ref=persisted.get("context_ref"),
+            digest_ref=persisted.get("digest_ref"),
+        )
+        record = artifact_storage.get_artifact(artifact_id)
+        if record:
+            refreshed_artifact_refs.append(build_artifact_ref_dict(record))
+    if refreshed_artifact_refs:
+        bundle["artifact_refs"] = refreshed_artifact_refs
+        artifact_refs = refreshed_artifact_refs
     manifest = {
         "issue_key": issue_key,
         "title": (fields.get("summary") if isinstance(fields, dict) else "") or "",

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -5,11 +5,11 @@ import io
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, Tuple
-from urllib.parse import urlparse
-
 from ruamel.yaml import YAML
 
 from src.github import github_channel
+from src.github.doc_refs import GitHubDocRef, parse_github_doc_ref as _parse_github_doc_ref
+from src.github.source_service import prepare_github_file_source
 from src.github.url_utils import normalize_github_api_base_url
 from src.runtime.bundle_template_registry import require_bundle_template, resolve_bundle_template_id_from_manifest
 from src.utils.redaction import safe_preview, sanitize_exception_message
@@ -76,24 +76,6 @@ class RequirementBundleError(ValueError):
     """Validation or IO error for requirement bundle assets."""
 
 
-@dataclass(frozen=True)
-class GitHubDocRef:
-    owner: str
-    repo: str
-    branch: str
-    path: str
-
-
-def _allowed_github_hosts() -> set[str]:
-    hosts = {"github.com"}
-
-    base_url = str(getattr(github_channel, "base_url", "") or "").strip()
-    if base_url:
-        parsed_base_url = urlparse(normalize_github_api_base_url(base_url))
-        if parsed_base_url.netloc:
-            hosts.add(parsed_base_url.netloc.lower())
-
-    return hosts
 
 
 def parse_bundle_ref(bundle_ref: Dict[str, Any]) -> BundleRef:
@@ -137,32 +119,11 @@ async def read_repo_text(ref: BundleRef, repo_relative_file: str) -> str:
 
 
 def parse_github_doc_ref(raw: str, default_ref: BundleRef) -> GitHubDocRef:
-    normalized = str(raw or "").strip()
-    if not normalized:
-        raise RequirementBundleError("github_doc_ref is required")
+    try:
+        return _parse_github_doc_ref(raw, default_ref)
+    except Exception as exc:
+        raise RequirementBundleError(str(exc)) from exc
 
-    if normalized.startswith("http://") or normalized.startswith("https://"):
-        parsed = urlparse(normalized)
-        if parsed.netloc.lower() not in _allowed_github_hosts():
-            raise RequirementBundleError(f"Unsupported GitHub doc URL host: {parsed.netloc}")
-        parts = [part for part in parsed.path.split("/") if part]
-        # /owner/repo/blob/branch/path/to/file
-        if len(parts) < 5 or parts[2] != "blob":
-            raise RequirementBundleError("GitHub doc URL must be in /owner/repo/blob/<branch>/<path> format")
-        owner = parts[0]
-        repo = parts[1]
-        branch = parts[3]
-        path = "/".join(parts[4:]).strip("/")
-        if not owner or not repo or not branch or not path:
-            raise RequirementBundleError("GitHub doc URL is missing owner/repo/branch/path")
-        return GitHubDocRef(owner=owner, repo=repo, branch=branch, path=path)
-
-    return GitHubDocRef(
-        owner=default_ref.owner,
-        repo=default_ref.repo,
-        branch=default_ref.branch,
-        path=normalized.strip("/"),
-    )
 
 
 async def read_github_doc_text(raw: str, default_ref: BundleRef) -> tuple[GitHubDocRef, str]:
@@ -170,56 +131,44 @@ async def read_github_doc_text(raw: str, default_ref: BundleRef) -> tuple[GitHub
     logger.debug("Read GitHub doc start | input_kind=%s", input_kind)
     doc_ref: GitHubDocRef | None = None
     try:
-        doc_ref = parse_github_doc_ref(raw, default_ref)
-        logger.debug(
-            "Read GitHub doc resolved | owner=%s repo=%s branch=%s path=%s",
-            doc_ref.owner,
-            doc_ref.repo,
-            doc_ref.branch,
-            doc_ref.path,
-        )
-        file_data = await github_channel.get_file(doc_ref.owner, doc_ref.repo, doc_ref.path, doc_ref.branch)
-        content = file_data.get("content")
-        if not isinstance(content, str) or not content.strip():
-            logger.warning("Read GitHub doc missing content | owner=%s repo=%s branch=%s path=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path)
-            raise RequirementBundleError(f"File not found or empty: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}")
-        try:
-            decoded = base64.b64decode(content).decode("utf-8")
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warning("Read GitHub doc decode failed | owner=%s repo=%s branch=%s path=%s error=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path, exc.__class__.__name__)
+        prepared = await prepare_github_file_source(raw, default_ref)
+        doc_ref = prepared["doc_ref"]
+        bundle = prepared["bundle"]
+        text = str(bundle.get("content_markdown") or "").strip()
+        if not text:
             raise RequirementBundleError(
-                f"Failed to decode file content: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}"
-            ) from exc
+                f"GitHub file is not projectable to text: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}"
+            )
         logger.info("Read GitHub doc success | owner=%s repo=%s branch=%s path=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path)
-        return doc_ref, decoded
+        return doc_ref, text
     except RequirementBundleError as exc:
         _log_bundle_asset_failure(
-            "read_github_doc_text",
-            exc,
-            raw=raw if doc_ref is None else None,
+            "read_github_doc_text", exc, raw=raw if doc_ref is None else None,
             extra={
                 "input_kind": input_kind,
-                "owner": doc_ref.owner if doc_ref is not None else None,
-                "repo_name": doc_ref.repo if doc_ref is not None else None,
-                "doc_branch": doc_ref.branch if doc_ref is not None else None,
-                "doc_path": doc_ref.path if doc_ref is not None else None,
-            },
+                "owner": doc_ref.owner if doc_ref else None,
+                "repo_name": doc_ref.repo if doc_ref else None,
+                "doc_branch": doc_ref.branch if doc_ref else None,
+                "doc_path": doc_ref.path if doc_ref else None,
+            }
         )
         raise
     except Exception as exc:
         _log_bundle_asset_failure(
-            "read_github_doc_text",
-            exc,
-            raw=raw if doc_ref is None else None,
+            "read_github_doc_text", exc, raw=raw if doc_ref is None else None,
             extra={
                 "input_kind": input_kind,
-                "owner": doc_ref.owner if doc_ref is not None else None,
-                "repo_name": doc_ref.repo if doc_ref is not None else None,
-                "doc_branch": doc_ref.branch if doc_ref is not None else None,
-                "doc_path": doc_ref.path if doc_ref is not None else None,
-            },
+                "owner": doc_ref.owner if doc_ref else None,
+                "repo_name": doc_ref.repo if doc_ref else None,
+                "doc_branch": doc_ref.branch if doc_ref else None,
+                "doc_path": doc_ref.path if doc_ref else None,
+            }
         )
-        raise
+        if doc_ref:
+            raise RequirementBundleError(
+                f"Failed to materialize GitHub doc: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}"
+            ) from exc
+        raise RequirementBundleError(str(exc)) from exc
 
 
 async def read_bundle_yaml(ref: BundleRef, relative_file: str) -> Dict[str, Any]:

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -127,23 +127,41 @@ def parse_github_doc_ref(raw: str, default_ref: BundleRef) -> GitHubDocRef:
 
 
 async def read_github_doc_text(raw: str, default_ref: BundleRef) -> tuple[GitHubDocRef, str]:
+    doc_ref: GitHubDocRef | None = None
+    try:
+        prepared = await prepare_github_doc_source(raw, default_ref)
+        doc_ref = prepared["doc_ref"]
+        return prepared["doc_ref"], prepared["content_text"]
+    except RequirementBundleError as exc:
+        _log_bundle_asset_failure("read_github_doc_text", exc, raw=raw if doc_ref is None else None)
+        raise
+
+
+async def prepare_github_doc_source(raw: str, default_ref: BundleRef) -> dict:
     input_kind = "url" if "://" in str(raw or "") else "repo_relative_path"
-    logger.debug("Read GitHub doc start | input_kind=%s", input_kind)
+    logger.debug("Prepare GitHub doc source start | input_kind=%s", input_kind)
     doc_ref: GitHubDocRef | None = None
     try:
         prepared = await prepare_github_file_source(raw, default_ref)
         doc_ref = prepared["doc_ref"]
         bundle = prepared["bundle"]
-        text = str(bundle.get("content_markdown") or "").strip()
-        if not text:
+        content_text = str(bundle.get("content_markdown") or "").strip()
+        if not content_text:
             raise RequirementBundleError(
                 f"GitHub file is not projectable to text: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}"
             )
-        logger.info("Read GitHub doc success | owner=%s repo=%s branch=%s path=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path)
-        return doc_ref, text
+        logger.info("Prepare GitHub doc source success | owner=%s repo=%s branch=%s path=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path)
+        return {
+            "doc_ref": doc_ref,
+            "bundle": bundle,
+            "context_ref": bundle.get("context_ref"),
+            "digest_ref": bundle.get("digest_ref"),
+            "artifact_refs": bundle.get("artifact_refs") or [],
+            "content_text": content_text,
+        }
     except RequirementBundleError as exc:
         _log_bundle_asset_failure(
-            "read_github_doc_text", exc, raw=raw if doc_ref is None else None,
+            "prepare_github_doc_source", exc, raw=raw if doc_ref is None else None,
             extra={
                 "input_kind": input_kind,
                 "owner": doc_ref.owner if doc_ref else None,
@@ -155,7 +173,7 @@ async def read_github_doc_text(raw: str, default_ref: BundleRef) -> tuple[GitHub
         raise
     except Exception as exc:
         _log_bundle_asset_failure(
-            "read_github_doc_text", exc, raw=raw if doc_ref is None else None,
+            "prepare_github_doc_source", exc, raw=raw if doc_ref is None else None,
             extra={
                 "input_kind": input_kind,
                 "owner": doc_ref.owner if doc_ref else None,

--- a/src/source_context.py
+++ b/src/source_context.py
@@ -40,6 +40,7 @@ def build_jira_source_bundle_text(bundle: Dict[str, Any]) -> str:
         _heading_block("validation_rules", bundle.get("validation_rules") or ""),
         _heading_block("comments", "\n\n".join(comments_lines)),
         _heading_block("attachments", "\n".join(attachment_lines)),
+        _heading_block("artifact_refs", json.dumps(bundle.get("artifact_refs") or [], ensure_ascii=False, indent=2)),
         _heading_block("coverage_ledger", json.dumps(ledger, ensure_ascii=False, indent=2)),
         _heading_block("raw_snapshot", json.dumps(bundle.get("raw_snapshot") or {}, ensure_ascii=False, indent=2)),
     ]
@@ -93,6 +94,7 @@ def build_jira_source_digest(bundle: Dict[str, Any], *, max_chars: int = 7000) -
         "comment_indexes": comment_index_text,
         "attachments_metadata": f"{ledger.get('attachments_metadata_loaded', len(attachments))}/{ledger.get('attachments_total', len(attachments))} covered",
         "text_attachments": f"{ledger.get('text_attachments_loaded', 0)}/{ledger.get('text_attachments_total', 0)} covered",
+        "artifact_refs": len(bundle.get("artifact_refs") or []),
     }
 
     digest_text = "\n".join(
@@ -218,6 +220,7 @@ def persist_confluence_source_bundle_and_digest(
             _heading_block("content", str(bundle.get("content_markdown") or "")),
             _heading_block("comments", json.dumps(bundle.get("comments") or [], ensure_ascii=False, indent=2)),
             _heading_block("attachments", json.dumps(bundle.get("attachments") or [], ensure_ascii=False, indent=2)),
+            _heading_block("artifact_refs", json.dumps(bundle.get("artifact_refs") or [], ensure_ascii=False, indent=2)),
             _heading_block("children", json.dumps(bundle.get("children") or [], ensure_ascii=False, indent=2)),
             _heading_block("descendants", json.dumps(bundle.get("descendants") or [], ensure_ascii=False, indent=2)),
             _heading_block("coverage_ledger", json.dumps(bundle.get("completeness_ledger") or {}, ensure_ascii=False, indent=2)),
@@ -239,6 +242,7 @@ def persist_confluence_source_bundle_and_digest(
                 "metadata": bundle.get("metadata") or {},
                 "coverage": bundle.get("completeness_ledger") or {},
                 "open_questions": bundle.get("open_questions") or [],
+                "artifact_refs": len(bundle.get("artifact_refs") or []),
             },
             ensure_ascii=False,
             indent=2,
@@ -258,3 +262,42 @@ def persist_confluence_source_bundle_and_digest(
         "digest_ref": digest_ref,
         "source_complete": bool((bundle.get("completeness_ledger") or {}).get("source_complete")),
     }
+
+
+
+def build_github_source_bundle_text(bundle: Dict[str, Any]) -> str:
+    return "\n".join([
+        "# GitHub Source Bundle",
+        _heading_block("metadata", json.dumps(bundle.get("metadata") or {}, ensure_ascii=False, indent=2)),
+        _heading_block("content", str(bundle.get("content_markdown") or "")),
+        _heading_block("artifact_refs", json.dumps(bundle.get("artifact_refs") or [], ensure_ascii=False, indent=2)),
+        _heading_block("coverage_ledger", json.dumps(bundle.get("completeness_ledger") or {}, ensure_ascii=False, indent=2)),
+        _heading_block("raw_snapshot", json.dumps(bundle.get("raw_snapshot") or {}, ensure_ascii=False, indent=2)),
+    ])
+
+
+def persist_github_source_bundle_and_digest(*, session_id: str, source_id: str, bundle: Dict[str, Any]) -> Dict[str, Any]:
+    bundle_text = build_github_source_bundle_text(bundle)
+    context_ref = put_text(
+        session_id=session_id,
+        kind="github_source_bundle",
+        source_id=source_id,
+        title=f"GitHub source bundle {source_id}",
+        content=bundle_text,
+        metadata={"source_id": source_id, "source_complete": bundle.get("completeness_ledger", {}).get("source_complete")},
+    )
+    digest_text = truncate(json.dumps({
+        "source_ref": context_ref,
+        "metadata": bundle.get("metadata") or {},
+        "coverage": bundle.get("completeness_ledger") or {},
+        "artifact_refs": len(bundle.get("artifact_refs") or []),
+    }, ensure_ascii=False, indent=2), 7000)
+    digest_ref = put_text(
+        session_id=session_id,
+        kind="github_source_digest",
+        source_id=source_id,
+        title=f"GitHub source digest {source_id}",
+        content=digest_text,
+        metadata={"source_id": source_id, "source_ref": context_ref},
+    )
+    return {"context_ref": context_ref, "digest_ref": digest_ref, "source_complete": bool((bundle.get("completeness_ledger") or {}).get("source_complete"))}

--- a/src/source_context.py
+++ b/src/source_context.py
@@ -291,6 +291,9 @@ def persist_github_source_bundle_and_digest(*, session_id: str, source_id: str, 
         "metadata": bundle.get("metadata") or {},
         "coverage": bundle.get("completeness_ledger") or {},
         "artifact_refs": len(bundle.get("artifact_refs") or []),
+        "source_kind": (bundle.get("metadata") or {}).get("source_kind", "repo_file"),
+        "attachments_supported": bool((bundle.get("metadata") or {}).get("attachments_supported", False)),
+        "issue_pr_assets_supported": bool((bundle.get("metadata") or {}).get("issue_pr_assets_supported", False)),
     }, ensure_ascii=False, indent=2), 7000)
     digest_ref = put_text(
         session_id=session_id,

--- a/src/utils/attachment.py
+++ b/src/utils/attachment.py
@@ -11,7 +11,9 @@ from dataclasses import dataclass
 from typing import Optional, Dict, Any
 
 from src.file_artifacts import can_project_to_text
-from src.file_artifacts.service import register_existing_file_as_artifact, update_projection_from_parse_result
+from src.context_blob_store import put_text
+from src.file_artifacts.service import attach_text_ref_to_artifact, register_existing_file_as_artifact, update_projection_from_parse_result
+from src.file_artifacts.storage import storage as artifact_storage
 from .file_parser import (
     save_uploaded_file,
     parse_file,
@@ -34,6 +36,7 @@ class AttachmentResult:
     artifact_id: Optional[str] = None
     projection_kind: Optional[str] = None
     preview: Optional[str] = None
+    text_ref: Optional[str] = None
 
 
 async def download_and_process_attachment(
@@ -45,6 +48,11 @@ async def download_and_process_attachment(
     source_kind: str = "issue_attachment",
     source_locator: str | None = None,
     provider_metadata: dict | None = None,
+    persist_text_ref_session_id: Optional[str] = None,
+    persist_text_ref_kind: Optional[str] = None,
+    persist_text_ref_source_id: Optional[str] = None,
+    persist_text_ref_title: Optional[str] = None,
+    persist_text_ref_metadata: Optional[dict] = None,
 ) -> AttachmentResult:
     options = options or {}
     include_image = options.get("include_image_data", True)
@@ -74,6 +82,7 @@ async def download_and_process_attachment(
     file_path = str(get_file_path(metadata.file_id))
     projection_kind = None
     preview = None
+    text_ref = None
 
     should_parse_image = content_type.startswith("image/") and (prefer_text_for_images or vision_enabled)
     should_parse_non_image = not content_type.startswith("image/") and can_project_to_text(content_type, filename)
@@ -95,15 +104,40 @@ async def download_and_process_attachment(
                 updated = update_projection_from_parse_result(artifact.artifact_id, parsed, preview=full_text[:2000])
                 if updated:
                     artifact = updated
+                if (
+                    persist_text_ref_session_id
+                    and persist_text_ref_kind
+                    and persist_text_ref_source_id
+                    and persist_text_ref_title
+                    and full_text
+                ):
+                    text_ref = put_text(
+                        session_id=persist_text_ref_session_id,
+                        kind=persist_text_ref_kind,
+                        source_id=persist_text_ref_source_id,
+                        title=persist_text_ref_title,
+                        content=full_text,
+                        metadata=persist_text_ref_metadata or {},
+                    )
+                    updated_refs = attach_text_ref_to_artifact(artifact.artifact_id, text_ref, full_markdown_chars=len(full_text))
+                    if updated_refs:
+                        artifact = updated_refs
                 projection_kind = artifact.projection_kind
             else:
                 content = f"[{content_type}: {filename}]"
                 content_format = "text"
+                artifact_storage.update_artifact_status(
+                    artifact.artifact_id,
+                    parse_status="failed",
+                    parse_error=str(getattr(parsed, "error", "parse failed")),
+                )
         except Exception as e:
             logger.warning(f"Failed to parse attachment: {e}")
             content = f"[{content_type}: {filename}]"
             content_format = "text"
+            artifact_storage.update_artifact_status(artifact.artifact_id, parse_status="failed", parse_error=str(e))
     elif content_type.startswith("image/"):
+        artifact_storage.update_artifact_status(artifact.artifact_id, parse_status="skipped")
         if include_image:
             try:
                 content = compress_image_for_llm(file_path, max_dimension=max_image_size)
@@ -118,6 +152,7 @@ async def download_and_process_attachment(
     else:
         content = f"[{content_type}: {filename}]"
         content_format = "text"
+        artifact_storage.update_artifact_status(artifact.artifact_id, parse_status="skipped")
 
     return AttachmentResult(
         file_id=metadata.file_id,
@@ -132,6 +167,7 @@ async def download_and_process_attachment(
         artifact_id=artifact.artifact_id,
         projection_kind=projection_kind or artifact.projection_kind,
         preview=preview or artifact.preview,
+        text_ref=text_ref or artifact.text_ref,
     )
 
 

--- a/src/utils/attachment.py
+++ b/src/utils/attachment.py
@@ -10,6 +10,8 @@ import httpx
 from dataclasses import dataclass
 from typing import Optional, Dict, Any
 
+from src.file_artifacts import can_project_to_text
+from src.file_artifacts.service import register_existing_file_as_artifact, update_projection_from_parse_result
 from .file_parser import (
     save_uploaded_file,
     parse_file,
@@ -17,7 +19,6 @@ from .file_parser import (
     compress_image_for_llm,
 )
 
-# Configure logging
 logger = logging.getLogger(__name__)
 
 
@@ -30,28 +31,21 @@ class AttachmentResult:
     content_format: str  # "base64" or "text"
     filename: str
     metadata: Dict[str, Any]
+    artifact_id: Optional[str] = None
+    projection_kind: Optional[str] = None
+    preview: Optional[str] = None
 
 
 async def download_and_process_attachment(
     url: str,
     session_id: str = None,
     options: dict = None,
-    auth_header: dict = None
+    auth_header: dict = None,
+    source_type: str = "jira",
+    source_kind: str = "issue_attachment",
+    source_locator: str | None = None,
+    provider_metadata: dict | None = None,
 ) -> AttachmentResult:
-    """Download attachment from external URL and process for LLM.
-    
-    Args:
-        url: Attachment URL (Jira/Confluence, etc.)
-        session_id: Optional session ID
-        options: Processing options
-            - include_image_data: bool = True
-            - max_image_size: int = 1024
-            - max_text_chars: int = 5000
-        auth_header: Optional auth headers dict
-    
-    Returns:
-        AttachmentResult with content ready for LLM
-    """
     options = options or {}
     include_image = options.get("include_image_data", True)
     max_image_size = options.get("max_image_size", 1024)
@@ -59,42 +53,58 @@ async def download_and_process_attachment(
     prefer_text_for_images = options.get("prefer_text_for_images", False)
     vision_enabled = options.get("vision_enabled", False)
     ocr_engine = options.get("ocr_engine", "paddleocr")
-    
-    # Download file
-    content, content_type, filename = await _download_file(url, auth_header=auth_header)
-    
-    # Save to storage
+
+    content_bytes, content_type, filename = await _download_file(url, auth_header=auth_header)
+
     metadata = await save_uploaded_file(
-        content=content,
+        content=content_bytes,
         original_filename=filename,
         session_id=session_id,
-        content_type=content_type
+        content_type=content_type,
     )
-    
-    # Process based on type
-    file_path = str(get_file_path(metadata.file_id))
-    
-    if content_type.startswith("image/"):
-        extracted_text = ""
-        if prefer_text_for_images:
-            try:
-                parsed = await parse_file(
-                    metadata.file_id,
-                    options={
-                        "vision_enabled": vision_enabled,
-                        "ocr_engine": ocr_engine,
-                    },
-                )
-                if getattr(parsed, "success", False):
-                    extracted_text = (getattr(parsed, "markdown", "") or "").strip()
-            except Exception as e:
-                logger.warning(f"Failed to OCR image attachment: {e}")
+    artifact = register_existing_file_as_artifact(
+        metadata.file_id,
+        source_type=source_type,
+        source_kind=source_kind,
+        source_locator=source_locator,
+        session_id=session_id,
+        provider_metadata=provider_metadata,
+    )
 
-        if extracted_text:
-            content = extracted_text[:max_text_chars]
+    file_path = str(get_file_path(metadata.file_id))
+    projection_kind = None
+    preview = None
+
+    should_parse_image = content_type.startswith("image/") and (prefer_text_for_images or vision_enabled)
+    should_parse_non_image = not content_type.startswith("image/") and can_project_to_text(content_type, filename)
+
+    if should_parse_image or should_parse_non_image:
+        try:
+            parsed = await parse_file(
+                metadata.file_id,
+                options={
+                    "vision_enabled": vision_enabled,
+                    "ocr_engine": ocr_engine,
+                },
+            )
+            if getattr(parsed, "success", False):
+                full_text = (getattr(parsed, "markdown", "") or "")
+                preview = full_text[:max_text_chars]
+                content = preview
+                content_format = "text"
+                updated = update_projection_from_parse_result(artifact.artifact_id, parsed, preview=full_text[:2000])
+                if updated:
+                    artifact = updated
+                projection_kind = artifact.projection_kind
+            else:
+                content = f"[{content_type}: {filename}]"
+                content_format = "text"
+        except Exception as e:
+            logger.warning(f"Failed to parse attachment: {e}")
+            content = f"[{content_type}: {filename}]"
             content_format = "text"
-        elif include_image:
-            # Compress and convert to base64
+    elif content_type.startswith("image/"):
+        if include_image:
             try:
                 content = compress_image_for_llm(file_path, max_dimension=max_image_size)
                 content_format = "base64"
@@ -105,21 +115,10 @@ async def download_and_process_attachment(
         else:
             content = f"[Image: {filename}]"
             content_format = "text"
-    elif content_type.startswith("text/") or _is_text_type(content_type):
-        # Extract text
-        try:
-            result = await parse_file(metadata.file_id)
-            content = result.markdown[:max_text_chars] if result.markdown else ""
-            content_format = "text"
-        except Exception as e:
-            logger.warning(f"Failed to parse text: {e}")
-            content = f"[Text file: {filename}]"
-            content_format = "text"
     else:
-        # Other file types - just return description
         content = f"[{content_type}: {filename}]"
         content_format = "text"
-    
+
     return AttachmentResult(
         file_id=metadata.file_id,
         content_type=content_type,
@@ -129,105 +128,59 @@ async def download_and_process_attachment(
         metadata={
             "size": metadata.size,
             "uploaded_at": metadata.uploaded_at,
-        }
+        },
+        artifact_id=artifact.artifact_id,
+        projection_kind=projection_kind or artifact.projection_kind,
+        preview=preview or artifact.preview,
     )
 
 
 async def _download_file(url: str, auth_header: dict = None) -> tuple[bytes, str, str]:
-    """Download file from URL.
-    
-    Args:
-        url: URL to download
-        auth_header: Optional auth headers dict (e.g., {"Authorization": "Basic ..."})
-        
-    Returns:
-        (content, content_type, filename)
-    """
     logger.info(f"Downloading attachment from: {url}")
-    
-    # For Jira Cloud, the first request returns a redirect to api.media.atlassian.com
-    # We need to handle this: first request with auth, then follow redirect without auth
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
         headers = auth_header or {}
-        
-        # First request - get redirect response
         response = await client.get(url, headers=headers)
-        
-        # Check for redirect (303 for Jira Cloud attachments)
         if response.status_code in (301, 302, 303, 307, 308):
             redirect_url = response.headers.get("location", "")
             if not redirect_url:
                 raise ValueError("Redirect response missing Location header")
-            # Mask tokens in URL for logging
             safe_url = redirect_url.split("?")[0] if "?" in redirect_url else redirect_url
             logger.info(f"Following redirect to: {safe_url}")
-            
-            # For redirect to media server, don't pass auth (token is in URL)
             async with httpx.AsyncClient(timeout=30.0) as client2:
                 response = await client2.get(redirect_url)
                 response.raise_for_status()
         else:
             response.raise_for_status()
-        
+
         content = response.content
-        
-        # Get content type from header or detect
         content_type = response.headers.get("Content-Type", "")
         if ";" in content_type:
             content_type = content_type.split(";")[0].strip()
-        
-        # Get filename from header
         filename = _extract_filename(response.headers.get("Content-Disposition", ""))
-        
-        # Fallback: detect from URL
         if not filename:
             filename = url.split("/")[-1].split("?")[0]
-        
-        # Fallback: detect content type
         if not content_type or content_type == "application/octet-stream":
             content_type = _detect_content_type(filename, content)
-        
         logger.info(f"Downloaded: {filename}, type: {content_type}, size: {len(content)}")
-        
         return content, content_type, filename
 
 
 def _extract_filename(header: str) -> str:
-    """Extract filename from Content-Disposition header."""
     if not header:
         return ""
-    
     match = re.search(r'filename[^;=\n]*=(([\'"]).*?\2|[^;\n]*)', header)
     if match:
-        filename = match.group(1).strip('"\'')
-        return filename
+        return match.group(1).strip('"\'')
     return ""
 
 
-def _is_text_type(content_type: str) -> bool:
-    """Check if content type is text-based."""
-    text_types = [
-        "text/",
-        "application/json",
-        "application/xml",
-        "application/javascript",
-    ]
-    return any(content_type.startswith(t) for t in text_types)
-
-
 def _detect_content_type(filename: str, content: bytes) -> str:
-    """Detect content type from filename or content."""
     try:
         import magic
         mime = magic.Magic(mime=True)
         return mime.from_buffer(content)
-    except ImportError:
-        # magic not installed, fall back to extension-based
-        pass
     except Exception:
         pass
-    
-    # Fallback: extension-based
     ext = filename.lower().split(".")[-1] if "." in filename else ""
     mapping = {
         "jpg": "image/jpeg",
@@ -237,6 +190,8 @@ def _detect_content_type(filename: str, content: bytes) -> str:
         "pdf": "application/pdf",
         "doc": "application/msword",
         "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "csv": "text/csv",
         "txt": "text/plain",
         "json": "application/json",
         "xml": "application/xml",
@@ -244,7 +199,4 @@ def _detect_content_type(filename: str, content: bytes) -> str:
     return mapping.get(ext, "application/octet-stream")
 
 
-__all__ = [
-    "download_and_process_attachment",
-    "AttachmentResult",
-]
+__all__ = ["download_and_process_attachment", "AttachmentResult"]

--- a/src/utils/file_parser/__init__.py
+++ b/src/utils/file_parser/__init__.py
@@ -77,6 +77,14 @@ def _get_excel_module():
     return _async_modules['excel']
 
 
+def _get_text_module():
+    """Lazy load generic text parser module."""
+    if 'text' not in _async_modules:
+        from . import text as _text
+        _async_modules['text'] = _text
+    return _async_modules['text']
+
+
 async def upload_file(
     content: bytes,
     filename: str,
@@ -162,6 +170,25 @@ async def parse_file(file_id: str, options: dict = None) -> ParseResult:
         result.file_id = file_id
         result.filename = metadata.original_filename
         return result
+
+    text_types = {
+        "application/json",
+        "application/xml",
+        "text/xml",
+        "application/yaml",
+        "text/yaml",
+        "application/x-yaml",
+        "text/x-yaml",
+        "text/plain",
+    }
+    if content_type.startswith("text/") or content_type in text_types:
+        text_mod = _get_text_module()
+        return await text_mod.parse_text_file(
+            str(path),
+            file_id=file_id,
+            filename=metadata.original_filename,
+            content_type=content_type,
+        )
     
     # Unsupported file type
     return ParseResult(

--- a/src/utils/file_parser/text.py
+++ b/src/utils/file_parser/text.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from .models import Block, ParseResult
+
+
+def _split_paragraphs(text: str, max_block_chars: int = 1200) -> list[str]:
+    parts: list[str] = []
+    for para in [p.strip() for p in text.split("\n\n") if p.strip()]:
+        if len(para) <= max_block_chars:
+            parts.append(para)
+            continue
+        lines = [line for line in para.split("\n") if line.strip()]
+        if len(lines) > 1:
+            current = ""
+            for line in lines:
+                candidate = f"{current}\n{line}".strip()
+                if current and len(candidate) > max_block_chars:
+                    parts.append(current)
+                    current = line
+                else:
+                    current = candidate
+            if current:
+                parts.append(current)
+        else:
+            for i in range(0, len(para), max_block_chars):
+                parts.append(para[i : i + max_block_chars])
+    return parts
+
+
+async def parse_text_file(path: str, *, file_id: str, filename: str, content_type: str) -> ParseResult:
+    raw = Path(path).read_bytes()
+    text = raw.decode("utf-8", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+    blocks = []
+    for idx, para in enumerate(_split_paragraphs(text), 1):
+        blocks.append(
+            Block(
+                chunk_id=f"{file_id}_text_1_{idx}",
+                type="paragraph",
+                content=para,
+                markdown=para,
+                method="text",
+                confidence=1.0,
+                extracted_at=datetime.utcnow().isoformat() + "Z",
+            )
+        )
+
+    return ParseResult(
+        success=True,
+        content_type=content_type,
+        file_id=file_id,
+        filename=filename,
+        markdown=text,
+        blocks=blocks,
+    )

--- a/tests/test_attachment_projection.py
+++ b/tests/test_attachment_projection.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.utils import attachment as attachment_mod
+from src.file_artifacts.storage import storage as artifact_storage
 
 
 @pytest.mark.asyncio
@@ -35,3 +36,43 @@ async def test_attachment_binary_stays_metadata_only(monkeypatch):
     monkeypatch.setattr(attachment_mod, "_download_file", _fake_download)
     out = await attachment_mod.download_and_process_attachment("u")
     assert out.content.startswith("[application/octet-stream")
+    record = artifact_storage.get_artifact(out.artifact_id)
+    assert record is not None
+    assert record.parse_status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_attachment_parse_failure_sets_failed(monkeypatch):
+    async def _fake_download(url, auth_header=None):
+        return (b"hello", "text/plain", "a.txt")
+
+    async def _fake_parse(file_id, options=None):
+        class R:
+            success = False
+            error = "parse failed"
+        return R()
+
+    monkeypatch.setattr(attachment_mod, "_download_file", _fake_download)
+    monkeypatch.setattr(attachment_mod, "parse_file", _fake_parse)
+
+    out = await attachment_mod.download_and_process_attachment("u")
+    record = artifact_storage.get_artifact(out.artifact_id)
+    assert record is not None
+    assert record.parse_status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_attachment_parse_exception_sets_failed(monkeypatch):
+    async def _fake_download(url, auth_header=None):
+        return (b"hello", "text/plain", "a.txt")
+
+    async def _fake_parse(file_id, options=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(attachment_mod, "_download_file", _fake_download)
+    monkeypatch.setattr(attachment_mod, "parse_file", _fake_parse)
+
+    out = await attachment_mod.download_and_process_attachment("u")
+    record = artifact_storage.get_artifact(out.artifact_id)
+    assert record is not None
+    assert record.parse_status == "failed"

--- a/tests/test_attachment_projection.py
+++ b/tests/test_attachment_projection.py
@@ -1,0 +1,37 @@
+import pytest
+
+from src.utils import attachment as attachment_mod
+
+
+@pytest.mark.asyncio
+async def test_attachment_pdf_projects_to_text(monkeypatch):
+    async def _fake_download(url, auth_header=None):
+        return (b"%PDF-1.4 fake", "application/pdf", "a.pdf")
+
+    async def _fake_parse(file_id, options=None):
+        class R:
+            success = True
+            markdown = "parsed pdf"
+            blocks = []
+            content_type = "application/pdf"
+            filename = "a.pdf"
+        return R()
+
+    monkeypatch.setattr(attachment_mod, "_download_file", _fake_download)
+    monkeypatch.setattr(attachment_mod, "parse_file", _fake_parse)
+
+    out = await attachment_mod.download_and_process_attachment("u", source_type="jira", source_kind="issue_attachment")
+    assert out.content_format == "text"
+    assert out.content == "parsed pdf"
+    assert out.artifact_id
+    assert out.projection_kind
+
+
+@pytest.mark.asyncio
+async def test_attachment_binary_stays_metadata_only(monkeypatch):
+    async def _fake_download(url, auth_header=None):
+        return (b"\x00\x01\x02", "application/octet-stream", "a.bin")
+
+    monkeypatch.setattr(attachment_mod, "_download_file", _fake_download)
+    out = await attachment_mod.download_and_process_attachment("u")
+    assert out.content.startswith("[application/octet-stream")

--- a/tests/test_confluence_attachment_text_ref.py
+++ b/tests/test_confluence_attachment_text_ref.py
@@ -1,0 +1,76 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_confluence_attachment_builds_text_ref_and_artifact_ref(monkeypatch):
+    import src.confluence as confluence
+
+    class _Channel:
+        base_url = "https://c"
+        _auth_header = {}
+
+        def is_configured(self):
+            return True
+
+        def get_instance_client(self, **kwargs):
+            return self
+
+        async def get_page(self, page_id):
+            return {"id": page_id, "title": "T", "space": {"key": "ENG"}, "body": {"storage": {"value": "<p>x</p>"}}}
+
+        async def get_all_comments_with_ledger(self, page_id):
+            return [], {"loaded": 0, "total": 0, "complete": True}
+
+        async def get_all_attachments_with_ledger(self, page_id):
+            return [
+                {"id": "d1", "title": "a.pdf", "metadata": {"mediaType": "application/pdf"}, "_links": {"download": "/d"}}
+            ], {"loaded": 1, "total": 1, "complete": True}
+
+        async def get_all_page_children_with_ledger(self, page_id):
+            return [], {"loaded": 0, "total": 0, "complete": True}
+
+        async def get_all_descendants_with_ledger(self, page_id):
+            return [], {"loaded": 0, "total": 0, "complete": True, "partial_reasons": []}
+
+    class _Adapter:
+        def __init__(self, _):
+            pass
+
+        async def _to_markdown(self, page):
+            return "x"
+
+    class _Res:
+        artifact_id = "a1"
+        preview = "doc"
+        content = "doc"
+        text_ref = "txt-ref"
+
+    monkeypatch.setattr(confluence, "confluence_channel", _Channel())
+    monkeypatch.setattr(confluence, "ConfluenceFormatAdapter", _Adapter)
+
+    async def _fake_download(**kwargs):
+        return _Res()
+
+    monkeypatch.setattr(confluence, "download_and_process_attachment", _fake_download)
+    captured = {}
+
+    def _fake_persist(**kwargs):
+        captured["bundle"] = kwargs["bundle"]
+        return {"context_ref": "c", "digest_ref": "d"}
+
+    monkeypatch.setattr(confluence, "persist_confluence_source_bundle_and_digest", _fake_persist)
+
+    from src.file_artifacts.storage import storage as artifact_storage
+    from src.file_artifacts.models import ArtifactRecord
+
+    def _fake_get_artifact(_artifact_id):
+        return ArtifactRecord(
+            artifact_id="a1", file_id="a1", source_type="confluence", source_kind="page_attachment", filename="a.pdf", content_type="application/pdf", size=1, text_ref="txt-ref"
+        )
+
+    monkeypatch.setattr(artifact_storage, "get_artifact", _fake_get_artifact)
+
+    out = await confluence.confluence_prepare_page_context("1", _session_id="s")
+    assert "[confluence source bundle prepared]" in out
+    assert captured["bundle"]["attachments"][0]["text_ref"] == "txt-ref"
+    assert captured["bundle"]["artifact_refs"][0]["text_ref"] == "txt-ref"

--- a/tests/test_confluence_source_artifacts.py
+++ b/tests/test_confluence_source_artifacts.py
@@ -1,0 +1,42 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_confluence_bundle_has_artifact_refs_and_image_policy(monkeypatch):
+    import src.confluence as confluence
+
+    class _Channel:
+        base_url = "https://c"
+        _auth_header = {}
+        def is_configured(self): return True
+        def get_instance_client(self, **kwargs): return self
+        async def get_page(self, page_id): return {"id": page_id, "title": "T", "body": {"storage": {"value": "<p>x</p>"}}}
+        async def get_all_comments_with_ledger(self, page_id): return [], {"loaded": 0, "total": 0, "complete": True}
+        async def get_all_attachments_with_ledger(self, page_id):
+            return [
+                {"id": "i1", "title": "a.png", "metadata": {"mediaType": "image/png"}, "_links": {"download": "/i"}},
+                {"id": "d1", "title": "a.pdf", "metadata": {"mediaType": "application/pdf"}, "_links": {"download": "/d"}},
+            ], {"loaded": 2, "total": 2, "complete": True}
+        async def get_all_page_children_with_ledger(self, page_id): return [], {"loaded": 0, "total": 0, "complete": True}
+        async def get_all_descendants_with_ledger(self, page_id): return [], {"loaded": 0, "total": 0, "complete": True, "partial_reasons": []}
+
+    class _Adapter:
+        def __init__(self, _): pass
+        async def _to_markdown(self, page): return "x"
+
+    class _Res:
+        artifact_id = "a1"
+        preview = "doc"
+        content = "doc"
+
+    monkeypatch.setattr(confluence, "confluence_channel", _Channel())
+    monkeypatch.setattr(confluence, "ConfluenceFormatAdapter", _Adapter)
+    
+    async def _fake_download(**kwargs):
+        return _Res()
+    monkeypatch.setattr(confluence, "download_and_process_attachment", _fake_download)
+    monkeypatch.setattr(confluence, "persist_confluence_source_bundle_and_digest", lambda **kwargs: {"context_ref": "c", "digest_ref": "d"})
+
+    out = await confluence.confluence_prepare_page_context("1", _session_id="s")
+    assert "[confluence source bundle prepared]" in out
+    assert "attachments_loaded: 2/2" in out

--- a/tests/test_file_parser_text_projection.py
+++ b/tests/test_file_parser_text_projection.py
@@ -1,0 +1,20 @@
+import pytest
+
+from src.utils.file_parser import save_uploaded_file, parse_file
+
+
+@pytest.mark.asyncio
+async def test_text_plain_parse_supported():
+    meta = await save_uploaded_file(b"hello\n\nworld", "a.txt", session_id="s1", content_type="text/plain")
+    result = await parse_file(meta.file_id)
+    assert result.success is True
+    assert "hello" in result.markdown
+    assert result.blocks
+
+
+@pytest.mark.asyncio
+async def test_application_json_parse_supported():
+    meta = await save_uploaded_file(b'{"a":1}', "a.json", session_id="s1", content_type="application/json")
+    result = await parse_file(meta.file_id)
+    assert result.success is True
+    assert '"a":1' in result.markdown

--- a/tests/test_github_source_service.py
+++ b/tests/test_github_source_service.py
@@ -34,3 +34,46 @@ async def test_read_github_doc_text_non_projectable(monkeypatch):
     ref = BundleRef(owner="o", repo="r", path="p", branch="main")
     with pytest.raises(RequirementBundleError):
         await read_github_doc_text("docs/a.bin", ref)
+
+
+@pytest.mark.asyncio
+async def test_prepare_github_file_source_marks_non_projectable_skipped(monkeypatch):
+    from src.github.source_service import prepare_github_file_source
+    from src.file_artifacts.storage import storage as artifact_storage
+
+    async def _fake_get_file(owner, repo, path, ref):
+        return {"content": base64.b64encode(b"\x00\x01").decode(), "sha": "s", "size": 2}
+
+    monkeypatch.setattr("src.github.source_service.github_channel.get_file", _fake_get_file)
+
+    ref = BundleRef(owner="o", repo="r", path="p", branch="main")
+    prepared = await prepare_github_file_source("docs/a.bin", ref, session_id="s1")
+    artifact_id = prepared["bundle"]["artifact_refs"][0]["artifact_id"]
+    artifact = artifact_storage.get_artifact(artifact_id)
+    assert artifact is not None
+    assert artifact.parse_status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_prepare_github_file_source_marks_parse_failed(monkeypatch):
+    from src.github.source_service import prepare_github_file_source
+    from src.file_artifacts.storage import storage as artifact_storage
+
+    async def _fake_get_file(owner, repo, path, ref):
+        return {"content": base64.b64encode(b"hello").decode(), "sha": "s", "size": 5}
+
+    async def _fake_parse(file_id, options=None):
+        class R:
+            success = False
+            error = "parse error"
+        return R()
+
+    monkeypatch.setattr("src.github.source_service.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.github.source_service.parse_file", _fake_parse)
+
+    ref = BundleRef(owner="o", repo="r", path="p", branch="main")
+    prepared = await prepare_github_file_source("docs/a.txt", ref, session_id="s1")
+    artifact_id = prepared["bundle"]["artifact_refs"][0]["artifact_id"]
+    artifact = artifact_storage.get_artifact(artifact_id)
+    assert artifact is not None
+    assert artifact.parse_status == "failed"

--- a/tests/test_github_source_service.py
+++ b/tests/test_github_source_service.py
@@ -1,0 +1,36 @@
+import base64
+
+import pytest
+
+from src.runtime.requirement_bundle_assets import BundleRef, RequirementBundleError, read_github_doc_text
+
+
+@pytest.mark.asyncio
+async def test_prepare_github_file_source_and_read_text(monkeypatch):
+    from src.github.source_service import prepare_github_file_source
+
+    async def _fake_get_file(owner, repo, path, ref):
+        return {"content": base64.b64encode(b"hello").decode(), "sha": "s", "size": 5}
+
+    monkeypatch.setattr("src.github.source_service.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.runtime.requirement_bundle_assets.github_channel.get_file", _fake_get_file)
+
+    ref = BundleRef(owner="o", repo="r", path="p", branch="main")
+    prepared = await prepare_github_file_source("docs/a.txt", ref, session_id="s1")
+    assert prepared["bundle"]["artifact_refs"]
+    assert prepared["bundle"]["context_ref"]
+    doc_ref, text = await read_github_doc_text("docs/a.txt", ref)
+    assert doc_ref.path == "docs/a.txt"
+    assert "hello" in text
+
+
+@pytest.mark.asyncio
+async def test_read_github_doc_text_non_projectable(monkeypatch):
+    async def _fake_get_file(owner, repo, path, ref):
+        return {"content": base64.b64encode(b"\x00\x01").decode(), "sha": "s", "size": 2}
+
+    monkeypatch.setattr("src.github.source_service.github_channel.get_file", _fake_get_file)
+
+    ref = BundleRef(owner="o", repo="r", path="p", branch="main")
+    with pytest.raises(RequirementBundleError):
+        await read_github_doc_text("docs/a.bin", ref)

--- a/tests/test_jira_attachment_text_ref.py
+++ b/tests/test_jira_attachment_text_ref.py
@@ -1,0 +1,76 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_jira_attachment_always_persists_text_ref(monkeypatch):
+    from src.jira.source_service import prepare_jira_issue_source
+
+    class _Channel:
+        api_version = "3"
+        _auth_header = {}
+
+        def is_configured(self):
+            return True
+
+        def get_instance_client(self, **kwargs):
+            return self
+
+    class _Adapter:
+        def __init__(self, _):
+            pass
+
+        async def get_issue(self, **kwargs):
+            return {
+                "key": "P-1",
+                "fields": {
+                    "summary": "S",
+                    "comment": {"comments": [], "total": 0},
+                    "attachment": [{"id": "1", "filename": "a.pdf", "mimeType": "application/pdf", "content": "u"}],
+                },
+            }
+
+        def _get_comments_list(self, *a, **k):
+            return []
+
+        def _convert_description_to_markdown(self, x):
+            return ""
+
+        def _extract_acceptance_criteria(self, x):
+            return ""
+
+    class _Result:
+        content_format = "text"
+        content = "abc"
+        artifact_id = "art-1"
+        preview = "abc"
+        text_ref = "text-1"
+
+    monkeypatch.setattr("src.jira.jira_channel", _Channel())
+    monkeypatch.setattr("src.jira.source_service.JiraFormatAdapter", _Adapter)
+
+    captured = {}
+
+    def _fake_persist(**kwargs):
+        captured["bundle"] = kwargs["bundle"]
+        return {"context_ref": "c", "digest_ref": "d", "source_digest_chunk_count": 0}
+
+    monkeypatch.setattr("src.jira.source_service.persist_jira_source_bundle_and_digest", _fake_persist)
+
+    async def _fake_download(**kwargs):
+        return _Result()
+
+    monkeypatch.setattr("src.jira.download_and_process_attachment", _fake_download)
+
+    from src.file_artifacts.storage import storage as artifact_storage
+    from src.file_artifacts.models import ArtifactRecord
+
+    def _fake_get_artifact(_artifact_id):
+        return ArtifactRecord(
+            artifact_id="art-1", file_id="art-1", source_type="jira", source_kind="issue_attachment", filename="a.pdf", content_type="application/pdf", size=1, text_ref="text-1"
+        )
+
+    monkeypatch.setattr(artifact_storage, "get_artifact", _fake_get_artifact)
+
+    result = await prepare_jira_issue_source("P-1")
+    assert result.bundle["attachments"][0]["text_ref"] == "text-1"
+    assert captured["bundle"]["artifact_refs"][0]["text_ref"] == "text-1"

--- a/tests/test_jira_source_artifacts.py
+++ b/tests/test_jira_source_artifacts.py
@@ -1,0 +1,38 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_jira_bundle_contains_artifact_refs(monkeypatch):
+    from src.jira.source_service import prepare_jira_issue_source
+
+    class _Channel:
+        api_version = "3"
+        _auth_header = {}
+        def is_configured(self): return True
+        def get_instance_client(self, **kwargs): return self
+
+    class _Adapter:
+        def __init__(self, _): pass
+        async def get_issue(self, **kwargs):
+            return {"key": "P-1", "fields": {"summary": "S", "comment": {"comments": [], "total": 0}, "attachment": [{"id": "1", "filename": "a.pdf", "mimeType": "application/pdf", "content": "u"}]}}
+        def _get_comments_list(self, *a, **k): return []
+        def _convert_description_to_markdown(self, x): return ""
+        def _extract_acceptance_criteria(self, x): return ""
+
+    class _Result:
+        content_format = "text"
+        content = "abc"
+        artifact_id = "art-1"
+        preview = "abc"
+
+    monkeypatch.setattr("src.jira.source_service.persist_jira_source_bundle_and_digest", lambda **kwargs: {"context_ref": "c", "digest_ref": "d", "source_digest_chunk_count": 0})
+    monkeypatch.setattr("src.jira.jira_channel", _Channel())
+    monkeypatch.setattr("src.jira.source_service.JiraFormatAdapter", _Adapter)
+    
+    async def _fake_download(**kwargs):
+        return _Result()
+    monkeypatch.setattr("src.jira.download_and_process_attachment", _fake_download)
+    result = await prepare_jira_issue_source("P-1")
+    assert "artifact_refs" in result.bundle
+    assert "completeness_ledger" in result.bundle
+    assert "text_preview" in result.bundle["attachments"][0]

--- a/tests/test_requirements_skill_github_source_refs.py
+++ b/tests/test_requirements_skill_github_source_refs.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_load_github_doc_sources_returns_real_refs(monkeypatch):
+    from skills.collect_requirements_to_bundle.skill import _load_github_doc_sources
+
+    class _DocRef:
+        owner = "acme"
+        repo = "repo"
+        branch = "main"
+        path = "docs/spec.md"
+
+    async def _fake_prepare(raw, default_ref):
+        return {
+            "doc_ref": _DocRef(),
+            "bundle": {},
+            "context_ref": "ctx-1",
+            "digest_ref": "dig-1",
+            "artifact_refs": [{"artifact_id": "a-1"}],
+            "content_text": "hello",
+        }
+
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.prepare_github_doc_source", _fake_prepare)
+
+    out = await _load_github_doc_sources(
+        {"repo": "acme/repo", "path": "bundles/a", "branch": "main"},
+        ["docs/spec.md"],
+    )
+
+    assert out[0]["content"] == "hello"
+    assert out[0]["artifact_refs"] == [{"artifact_id": "a-1"}]
+    assert out[0]["context_ref"] == "ctx-1"
+    assert out[0]["digest_ref"] == "dig-1"
+    assert out[0]["source_kind"] == "repo_file"

--- a/tests/test_webchat_file_upload_parse_binding.py
+++ b/tests/test_webchat_file_upload_parse_binding.py
@@ -53,3 +53,38 @@ async def test_upload_and_parse_binds_session_and_rebuilds(monkeypatch):
     assert meta2.parse_status == "completed"
     assert storage.get_file_chunks(fid)
     assert called["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_parse_exception_marks_file_and_artifact_failed(monkeypatch):
+    req = make_mocked_request("POST", "/api/files/upload?session_id=s-bind-err", headers=CIMultiDict())
+
+    async def _multipart():
+        return _Multipart(_Field())
+
+    req.multipart = _multipart
+    upload_resp = await webchat.api_files_upload(req)
+    file_id = json.loads(upload_resp.text)["file_id"]
+
+    async def _raise_parse(file_id, options=None):
+        raise RuntimeError("parse crash")
+
+    monkeypatch.setattr(webchat, "parse_file", _raise_parse)
+
+    parse_req = make_mocked_request("POST", "/api/files/parse?session_id=s-bind-err", headers=CIMultiDict())
+
+    async def _json():
+        return {"file_id": file_id}
+
+    parse_req.json = _json
+    parse_resp = await webchat.api_files_parse(parse_req)
+    assert parse_resp.status == 500
+
+    meta = storage.get_file_meta("s-bind-err", file_id)
+    assert meta is not None
+    assert meta.parse_status == "failed"
+
+    from src.file_artifacts.storage import storage as artifact_storage
+    artifact = artifact_storage.get_artifact(file_id)
+    assert artifact is not None
+    assert artifact.parse_status == "failed"

--- a/tests/test_webchat_file_upload_parse_binding.py
+++ b/tests/test_webchat_file_upload_parse_binding.py
@@ -1,0 +1,55 @@
+import io
+import json
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+from multidict import CIMultiDict
+
+from src.gateway import webchat
+from src.hooks.file_context.storage import storage
+
+
+class _Multipart:
+    def __init__(self, field):
+        self._field = field
+    async def next(self):
+        return self._field
+
+
+class _Field:
+    name = "file"
+    filename = "a.txt"
+    async def read(self, *args, **kwargs):
+        return b"hello world"
+
+
+@pytest.mark.asyncio
+async def test_upload_and_parse_binds_session_and_rebuilds(monkeypatch):
+    req = make_mocked_request("POST", "/api/files/upload?session_id=s-bind", headers=CIMultiDict())
+    async def _multipart():
+        return _Multipart(_Field())
+    req.multipart = _multipart
+
+    resp = await webchat.api_files_upload(req)
+    payload = json.loads(resp.text)
+    fid = payload["file_id"]
+
+    meta = storage.get_file_meta("s-bind", fid)
+    assert meta is not None
+    assert meta.parse_status == "pending"
+
+    called = {"n": 0}
+    monkeypatch.setattr("src.hooks.file_context.retrieval.retrieval_engine.rebuild_index", lambda sid: called.__setitem__("n", called["n"] + 1))
+
+    parse_req = make_mocked_request("POST", "/api/files/parse?session_id=s-bind", headers=CIMultiDict())
+    async def _json():
+        return {"file_id": fid}
+    parse_req.json = _json
+
+    parse_resp = await webchat.api_files_parse(parse_req)
+    parse_payload = json.loads(parse_resp.text)
+    assert parse_payload["success"] is True
+    meta2 = storage.get_file_meta("s-bind", fid)
+    assert meta2.parse_status == "completed"
+    assert storage.get_file_chunks(fid)
+    assert called["n"] == 1


### PR DESCRIPTION
### Motivation
- Provide a minimal unified Artifact abstraction so chat uploads, Jira/Confluence attachments and GitHub repo files share projection metadata without creating a separate blob store. 
- Fix real bugs in the chat upload->parse->file_context chain (missing session binding and incorrect `Block` access). 
- Ensure external attachments (PDF/DOCX/XLSX/CSV/TXT and text-like JSON/XML/YAML) can be projected to text using a single capability-driven path so bundles can reference artifacts consistently.

### Description
- Added a minimal artifact capability in `src/file_artifacts/` with `models.py`, `storage.py` (JSON-backed), `service.py` and `capabilities.py` and exported via `__init__.py`; `artifact_id` == `file_id` and storage reuses existing uploaded files. 
- Fixed chat upload/parse flow in `src/gateway/webchat.py` so `api_files_upload()` writes a `SessionFileMeta(..., parse_status='pending')` and registers/binds an artifact for session files, and `api_files_parse()` ensures artifact/session meta, uses `block.model_dump(...)` instead of `block.get(...)`, updates `processing/completed/failed` states, rebuilds retrieval index, and updates artifact projection via `update_projection_from_parse_result()`. 
- Implemented a generic text parser at `src/utils/file_parser/text.py` and extended `parse_file()` dispatch to support `text/*`, `application/json`, `application/xml`, and YAML variants so external files can be parsed as text. 
- Reworked `src/utils/attachment.py` to register downloaded files as artifacts immediately and to drive parsing by `can_project_to_text(content_type, filename)`; attachments now return `artifact_id`, `projection_kind` and `preview` when projection occurs. 
- Kept Jira/Confluence bundle shapes but made attachment materialization capability-driven: `src/jira/source_service.py` and `src/confluence/__init__.py` add `artifact_refs` to bundle roots, record artifact counts in completeness ledgers, and preserve existing compatibility fields (`text_preview`, `text_ref`, `mime_type`, `size`, ledger fields). 
- Added GitHub V1 support: `src/github/doc_refs.py` for doc ref parsing and `src/github/source_service.py` to materialize a repo file into storage, register artifact, parse if projectable, and persist a minimal GitHub source bundle via new helpers in `src/source_context.py` (`build_github_source_bundle_text`, `persist_github_source_bundle_and_digest`). 
- Kept existing storage/backends: reused `src/utils/file_parser/storage.py` for file blobs and `src/hooks/file_context/*` for session chunk storage and retrieval; did not introduce vectors/embeddings or new blob stores. 

### Testing
- Added focused unit tests: `tests/test_webchat_file_upload_parse_binding.py`, `tests/test_file_parser_text_projection.py`, `tests/test_attachment_projection.py`, `tests/test_jira_source_artifacts.py`, `tests/test_confluence_source_artifacts.py`, and `tests/test_github_source_service.py`. 
- Ran the targeted test sets locally including `tests/test_file_parser_text_projection.py`, `tests/test_attachment_projection.py`, `tests/test_webchat_file_upload_parse_binding.py`, `tests/test_github_source_service.py`, `tests/test_confluence_source_artifacts.py`, `tests/test_jira_source_artifacts.py`, plus `tests/test_confluence_attachment_policy.py`, `tests/test_file_context_retrieval.py`, and the requirement-bundle GitHub error test; all targeted tests passed locally. 
- Also compiled modified modules (`python -m compileall ...`) and ran the focused requirement-bundle task test confirming `read_github_doc_text` logging/behavior; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2a54edc4832aa33ac10ef8645f4e)