### PR TITLE
Refine active-skill continuation, decouple plan vs staging, and wire initial skill-budget for plan-first

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -99,6 +99,10 @@ llm:
     staging_policy: "explicit_or_complex"
     default_skill_execution_style: "direct"
     ask_user_policy: "blocked_only"
+    # direct active skill conflict policy:
+    # - auto_switch_direct: clear new request leaves old direct skill automatically
+    # - always_ask: keep active direct skill context and ask continue-vs-switch
+    active_skill_conflict_policy: "auto_switch_direct"
     # Staging/planning activates only on explicit request or true budget pressure.
     complexity_prompt_budget_ratio: 0.85
     complexity_min_request_tokens: 24000

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -79,7 +79,7 @@ from src.runtime.progressive_context import (
 from src.context_blob_store import build_section_map, put_text
 from src.agents.compaction import estimate_tokens
 from src.runtime.output_controller import call_llm_with_output_control, recover_max_output_tokens
-from src.runtime.response_flow_policy import decide_response_flow
+from src.runtime.response_flow_policy import decide_response_flow, resolve_skill_behavior_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +136,15 @@ def _should_continue_existing_active_skill(
         return False
 
     if _is_effectively_direct_skill_contract(existing_contract):
+        response_flow_cfg = (
+            config.llm.get("response_flow", {}) if isinstance(config.llm, dict) and isinstance(config.llm.get("response_flow"), dict) else {}
+        )
+        _, _, resolved_conflict_policy = resolve_skill_behavior_defaults(
+            response_flow_cfg,
+            active_skill_conflict_policy=str(existing_contract.get("active_skill_conflict_policy") or ""),
+        )
+        if resolved_conflict_policy == "always_ask":
+            return True
         return _is_explicit_skill_continuation_message(message)
 
     try:
@@ -1949,6 +1958,13 @@ You have access to the following tools. When a user asks you to do something tha
 
         if selected_skill:
             logger.info(f"[Skill] Active skill selected: {selected_skill.name} ({activation_reason})")
+            if activation_reason == "continued" and isinstance(existing_active_skill_contract, dict):
+                continued_conflict_policy = str(existing_active_skill_contract.get("active_skill_conflict_policy") or "").strip()
+                if continued_conflict_policy:
+                    try:
+                        setattr(selected_skill, "active_skill_conflict_policy", continued_conflict_policy)
+                    except Exception:
+                        pass
             
             # Set skill workdir for exec tool (async-safe via contextvars)
             set_skill_workdir(selected_skill.path or None)
@@ -3129,11 +3145,19 @@ You have access to the following tools. When a user asks you to do something tha
         send_skill_event("skill_mode_start", {"skill": skill.name, "message": safe_preview(message, 100)})
 
         initial_skill_session = SkillSession(skill_name=skill.name, original_user_request=message)
+        response_flow_cfg = (
+            config.llm.get("response_flow", {}) if isinstance(config.llm, dict) and isinstance(config.llm.get("response_flow"), dict) else {}
+        )
+        resolved_execution_style, resolved_ask_user_policy, _ = resolve_skill_behavior_defaults(
+            response_flow_cfg,
+            execution_style=str(getattr(skill, "execution_style", "") or ""),
+            ask_user_policy=str(getattr(skill, "ask_user_policy", "") or ""),
+        )
         initial_system_prompt = _build_skill_mode_system_prompt(
             skill,
             initial_skill_session,
-            execution_style=str(getattr(skill, "execution_style", "direct") or "direct"),
-            ask_user_policy=str(getattr(skill, "ask_user_policy", "blocked_only") or "blocked_only"),
+            execution_style=resolved_execution_style,
+            ask_user_policy=resolved_ask_user_policy,
         )
         initial_user_prompt = _build_skill_mode_user_prompt(message, initial_skill_session)
         initial_input_items = [{"role": "user", "content": [{"type": "input_text", "text": initial_user_prompt}]}]

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -96,6 +96,59 @@ def _run_post_tool_hooks_via_governance(**kwargs):
     return run_post_tool_hooks(**kwargs)
 
 
+_EXPLICIT_SKILL_CONTINUATION_MESSAGES = {
+    "continue",
+    "next",
+    "go on",
+    "继续",
+    "继续生成",
+    "下一步",
+    "接着来",
+}
+
+
+def _is_explicit_skill_continuation_message(message: str) -> bool:
+    normalized = str(message or "").strip().lower()
+    if not normalized:
+        return False
+    return normalized in _EXPLICIT_SKILL_CONTINUATION_MESSAGES
+
+
+def _is_effectively_direct_skill_contract(existing_contract: Optional[Dict[str, Any]]) -> bool:
+    if not isinstance(existing_contract, dict):
+        return True
+    execution_style = str(existing_contract.get("execution_style") or "direct").strip().lower()
+    planning_mode = str(existing_contract.get("planning_mode") or "auto").strip().lower()
+    staging_mode = str(existing_contract.get("staging_mode") or "auto").strip().lower()
+    return execution_style == "direct" and planning_mode != "required" and staging_mode != "required"
+
+
+def _should_continue_existing_active_skill(
+    existing_contract: Optional[Dict[str, Any]],
+    message: str,
+    skill_registry: Any,
+) -> bool:
+    if not is_active_skill_contract_usable(existing_contract):
+        return False
+
+    existing_skill_name = get_contract_skill_name(existing_contract)
+    if not existing_skill_name:
+        return False
+
+    if _is_effectively_direct_skill_contract(existing_contract):
+        return _is_explicit_skill_continuation_message(message)
+
+    try:
+        matched_skills = skill_registry.match_skill(message) or []
+    except Exception:
+        matched_skills = []
+    if matched_skills:
+        top_match_name = str(getattr(matched_skills[0], "name", "") or "").strip()
+        if top_match_name and top_match_name != existing_skill_name:
+            return False
+    return True
+
+
 
 def _enrich_runtime_event_context(
     data: Dict[str, Any],
@@ -1850,10 +1903,14 @@ You have access to the following tools. When a user asks you to do something tha
                         event_data={"reason": "skill_not_found", "skill": explicit_skill_name},
                     )
             else:
-                continued_skill = skill_registry.get_skill(existing_skill_name)
-                if continued_skill and not getattr(continued_skill, "deprecated", False):
-                    selected_skill = continued_skill
-                    activation_reason = "continued"
+                if _should_continue_existing_active_skill(existing_active_skill_contract, message, skill_registry):
+                    continued_skill = skill_registry.get_skill(existing_skill_name)
+                    if continued_skill and not getattr(continued_skill, "deprecated", False):
+                        selected_skill = continued_skill
+                        activation_reason = "continued"
+                    else:
+                        await session_manager.set_active_skill_session(session_id, None)
+                        set_skill_workdir(None)
                 else:
                     await session_manager.set_active_skill_session(session_id, None)
                     set_skill_workdir(None)
@@ -3071,7 +3128,28 @@ You have access to the following tools. When a user asks you to do something tha
         tracer.log_skill_mode_entry(skill.name, message, session_id)
         send_skill_event("skill_mode_start", {"skill": skill.name, "message": safe_preview(message, 100)})
 
-        flow = resolve_skill_response_flow(skill, message)
+        initial_skill_session = SkillSession(skill_name=skill.name, original_user_request=message)
+        initial_system_prompt = _build_skill_mode_system_prompt(
+            skill,
+            initial_skill_session,
+            execution_style=str(getattr(skill, "execution_style", "direct") or "direct"),
+            ask_user_policy=str(getattr(skill, "ask_user_policy", "blocked_only") or "blocked_only"),
+        )
+        initial_user_prompt = _build_skill_mode_user_prompt(message, initial_skill_session)
+        initial_input_items = [{"role": "user", "content": [{"type": "input_text", "text": initial_user_prompt}]}]
+        initial_request_estimated_tokens = estimate_llm_request_tokens(
+            input_items=initial_input_items,
+            system_prompt=initial_system_prompt,
+            tools=[],
+        )
+        initial_prompt_budget = resolve_prompt_budget(stage="skill_generation", model=(self.model or config.llm.get("model", "gpt-5-mini")))
+        initial_prompt_budget_tokens = int(initial_prompt_budget.get("prompt_budget_tokens", 0) or 0)
+        flow = resolve_skill_response_flow(
+            skill,
+            message,
+            request_estimated_tokens=initial_request_estimated_tokens,
+            prompt_budget_tokens=initial_prompt_budget_tokens,
+        )
         if flow.get("plan_required"):
             tracer.log_skill_mode_step("GENERATE_PLAN", "started", f"Creating plan for: {safe_preview(message, 50)}")
             send_skill_event("skill_step", {"step": "GENERATE_PLAN", "status": "started", "detail": "Creating plan..."})

--- a/src/agents/skill_mode.py
+++ b/src/agents/skill_mode.py
@@ -190,7 +190,8 @@ def _build_skill_plan_system_prompt(skill: Skill) -> str:
 
 
 def _build_skill_plan_user_prompt(skill: Skill, user_message: str) -> str:
-    strategy_hint = "\n".join(f"- {s}" for s in skill.strategy) if skill.strategy else "(none)"
+    strategy = getattr(skill, "strategy", None) or []
+    strategy_hint = "\n".join(f"- {s}" for s in strategy) if strategy else "(none)"
     return (
         f"User request: {user_message}\n"
         f"Skill strategy hints:\n{strategy_hint}\n"
@@ -220,7 +221,8 @@ def _build_skill_mode_system_prompt(
     ) or "(none)"
 
     # Include skill strategy for ongoing sessions
-    strategy_hint = "\n".join(f"- {s}" for s in skill.strategy) if skill.strategy else "(none)"
+    strategy = getattr(skill, "strategy", None) or []
+    strategy_hint = "\n".join(f"- {s}" for s in strategy) if strategy else "(none)"
     artifacts_summary = _build_artifacts_summary(skill_session)
     
     # Load skill references

--- a/src/runtime/response_flow_policy.py
+++ b/src/runtime/response_flow_policy.py
@@ -17,17 +17,11 @@ DEFAULT_RESPONSE_FLOW_CONFIG: Dict[str, Any] = {
 _PLAN_PHRASES = (
     "plan first",
     "preview first",
-    "manifest first",
-    "step by step",
     "先给计划",
     "先做计划",
     "先预览",
     "先给大纲",
-    "先给 manifest",
     "先不要直接生成",
-    "分步骤",
-    "按阶段",
-    "逐步",
 )
 
 _STAGING_PHRASES = (
@@ -181,7 +175,7 @@ def decide_response_flow(
     elif staging_policy == "never":
         staging_required = False
     else:
-        if explicit_staging or explicit_plan:
+        if explicit_staging:
             staging_required = True
             reasons.append("explicit_user_request")
         elif complex_request:

--- a/src/runtime/response_flow_policy.py
+++ b/src/runtime/response_flow_policy.py
@@ -10,6 +10,7 @@ DEFAULT_RESPONSE_FLOW_CONFIG: Dict[str, Any] = {
     "staging_policy": "explicit_or_complex",
     "default_skill_execution_style": "direct",
     "ask_user_policy": "blocked_only",
+    "active_skill_conflict_policy": "auto_switch_direct",
     "complexity_prompt_budget_ratio": 0.85,
     "complexity_min_request_tokens": 24000,
 }
@@ -99,6 +100,38 @@ def is_truly_complex_request(
     return bool(near_limit and meets_floor)
 
 
+def resolve_skill_behavior_defaults(
+    config_block: Optional[Dict[str, Any]] = None,
+    *,
+    execution_style: str = "",
+    ask_user_policy: str = "",
+    active_skill_conflict_policy: str = "",
+) -> tuple[str, str, str]:
+    cfg = resolve_response_flow_config(config_block)
+
+    resolved_execution_style = (
+        execution_style if execution_style in {"direct", "stepwise"} else str(cfg.get("default_skill_execution_style") or "direct")
+    )
+    if resolved_execution_style not in {"direct", "stepwise"}:
+        resolved_execution_style = "direct"
+
+    resolved_ask_policy = (
+        ask_user_policy if ask_user_policy in {"blocked_only", "permissive"} else str(cfg.get("ask_user_policy") or "blocked_only")
+    )
+    if resolved_ask_policy not in {"blocked_only", "permissive"}:
+        resolved_ask_policy = "blocked_only"
+
+    resolved_conflict_policy = (
+        active_skill_conflict_policy
+        if active_skill_conflict_policy in {"auto_switch_direct", "always_ask"}
+        else str(cfg.get("active_skill_conflict_policy") or "auto_switch_direct")
+    )
+    if resolved_conflict_policy not in {"auto_switch_direct", "always_ask"}:
+        resolved_conflict_policy = "auto_switch_direct"
+
+    return resolved_execution_style, resolved_ask_policy, resolved_conflict_policy
+
+
 def decide_response_flow(
     *,
     config_block: Optional[Dict[str, Any]] = None,
@@ -123,15 +156,13 @@ def decide_response_flow(
         complexity_min_request_tokens=int(cfg["complexity_min_request_tokens"]),
     )
 
-    resolved_execution_style = execution_style if execution_style in {"direct", "stepwise"} else str(
-        cfg.get("default_skill_execution_style") or "direct"
+    resolved_execution_style, resolved_ask_policy, _ = resolve_skill_behavior_defaults(
+        cfg,
+        execution_style=execution_style,
+        ask_user_policy=ask_user_policy,
     )
     if resolved_execution_style == "stepwise":
         reasons.append("skill_execution_stepwise")
-
-    resolved_ask_policy = ask_user_policy if ask_user_policy in {"blocked_only", "permissive"} else str(
-        cfg.get("ask_user_policy") or "blocked_only"
-    )
 
     plan_required = False
     plan_policy = str(cfg.get("plan_policy") or "explicit_or_complex")

--- a/src/skills/README.md
+++ b/src/skills/README.md
@@ -118,6 +118,8 @@ ask_user_policy: blocked_only  # blocked_only|permissive
 - `execution_style`: `direct` completes in one turn when possible; `stepwise` keeps one-step progression.
 - `ask_user_policy`: `blocked_only` asks only for truly blocking inputs; `permissive` allows broader clarification.
 
+When `execution_style` or `ask_user_policy` is omitted from skill frontmatter, runtime falls back to `llm.response_flow.default_skill_execution_style` and `llm.response_flow.ask_user_policy` respectively. If the skill explicitly sets either field, the skill value takes precedence over global defaults.
+
 ## Development Guide
 
 1. Create a new directory in `skills/`

--- a/src/skills/active_contract.py
+++ b/src/skills/active_contract.py
@@ -154,6 +154,9 @@ def build_active_skill_contract(
         "staging_mode": str(getattr(runtime_config, "staging_mode", "auto") or "auto"),
         "execution_style": str(getattr(runtime_config, "execution_style", "direct") or "direct"),
         "ask_user_policy": str(getattr(runtime_config, "ask_user_policy", "blocked_only") or "blocked_only"),
+        "active_skill_conflict_policy": str(
+            getattr(runtime_config, "active_skill_conflict_policy", "auto_switch_direct") or "auto_switch_direct"
+        ),
         "references": list(runtime_config.references or []),
         "prompt_contract_summary": _shorten(runtime_config.prompt_blocks.developer_instructions, 2000),
         "created_at": created_at or now,

--- a/src/skills/registry.py
+++ b/src/skills/registry.py
@@ -46,8 +46,8 @@ class Skill:
     risk_level: str = ""
     planning_mode: str = "auto"
     staging_mode: str = "auto"
-    execution_style: str = "direct"
-    ask_user_policy: str = "blocked_only"
+    execution_style: str = ""
+    ask_user_policy: str = ""
 
     # Compiled patterns for fast matching
     trigger_patterns: List[re.Pattern] = field(default_factory=list)
@@ -77,8 +77,8 @@ class Skill:
             risk_level=data.get("risk_level", "") or "",
             planning_mode=str(data.get("planning_mode", "auto") or "auto"),
             staging_mode=str(data.get("staging_mode", "auto") or "auto"),
-            execution_style=str(data.get("execution_style", "direct") or "direct"),
-            ask_user_policy=str(data.get("ask_user_policy", "blocked_only") or "blocked_only"),
+            execution_style=str(data.get("execution_style", "") or ""),
+            ask_user_policy=str(data.get("ask_user_policy", "") or ""),
             trigger_patterns=patterns,
         )
 

--- a/src/skills/runtime.py
+++ b/src/skills/runtime.py
@@ -373,11 +373,20 @@ def build_skill_prompt_blocks(
     else:
         allowed_tools_text = "all currently available tools"
     task_tools_text = ", ".join(effective_task_tools) if effective_task_tools else "none"
+    resolved_execution_style = str((runtime_config.execution_style if runtime_config else getattr(skill, "execution_style", "direct")) or "direct")
+    resolved_planning_mode = str((runtime_config.planning_mode if runtime_config else getattr(skill, "planning_mode", "auto")) or "auto")
+    resolved_staging_mode = str((runtime_config.staging_mode if runtime_config else getattr(skill, "staging_mode", "auto")) or "auto")
+    direct_mode = resolved_execution_style == "direct" and resolved_planning_mode != "required" and resolved_staging_mode != "required"
+    continuity_rule = (
+        "For direct skills, if the user gives a clear new request, treat that as leaving this prior skill and handle the new request directly without asking for switch permission."
+        if direct_mode
+        else "For stepwise/required-plan/required-staging skills, continue the flow when the user clearly continues; only ask continue-vs-switch if the latest user turn is genuinely ambiguous."
+    )
     system_rules = (
         f"Active skill: {skill.name}.\n"
-        "You are operating under this active skill contract until the user explicitly clears or switches skill.\n"
-        "Stay within the skill's instructions, constraints, output contract, reference usage, and allowed tool policy.\n"
-        "If the user request conflicts with the active skill, ask whether to clear/switch the skill instead of silently ignoring it.\n"
+        "Stay within the skill's instructions, constraints, output contract, reference usage, and allowed tool policy while this skill is active.\n"
+        f"{continuity_rule}\n"
+        "If the user's latest request is clearly different, allow switching/leaving this skill instead of forcing confirmation.\n"
         "Do not invent tool results, references, or external facts that were not provided.\n"
         f"Runtime policy: only use allowed tools ({allowed_tools_text}).\n"
         f"Task-capable tools: {task_tools_text}."

--- a/src/skills/runtime.py
+++ b/src/skills/runtime.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, List, Optional, Set
 
+from src.config import config
+from src.runtime.response_flow_policy import resolve_skill_behavior_defaults
 from src.skills.registry import Skill
 
 logger = logging.getLogger(__name__)
@@ -58,6 +60,7 @@ class SkillRuntimeConfig:
     staging_mode: str = "auto"
     execution_style: str = "direct"
     ask_user_policy: str = "blocked_only"
+    active_skill_conflict_policy: str = "auto_switch_direct"
     prompt_blocks: SkillPromptBlocks = field(default_factory=SkillPromptBlocks)
     references: List[str] = field(default_factory=list)
 
@@ -376,12 +379,29 @@ def build_skill_prompt_blocks(
     resolved_execution_style = str((runtime_config.execution_style if runtime_config else getattr(skill, "execution_style", "direct")) or "direct")
     resolved_planning_mode = str((runtime_config.planning_mode if runtime_config else getattr(skill, "planning_mode", "auto")) or "auto")
     resolved_staging_mode = str((runtime_config.staging_mode if runtime_config else getattr(skill, "staging_mode", "auto")) or "auto")
-    direct_mode = resolved_execution_style == "direct" and resolved_planning_mode != "required" and resolved_staging_mode != "required"
-    continuity_rule = (
-        "For direct skills, if the user gives a clear new request, treat that as leaving this prior skill and handle the new request directly without asking for switch permission."
-        if direct_mode
-        else "For stepwise/required-plan/required-staging skills, continue the flow when the user clearly continues; only ask continue-vs-switch if the latest user turn is genuinely ambiguous."
+    resolved_conflict_policy = str(
+        (
+            runtime_config.active_skill_conflict_policy
+            if runtime_config
+            else getattr(skill, "active_skill_conflict_policy", "auto_switch_direct")
+        )
+        or "auto_switch_direct"
     )
+    direct_mode = resolved_execution_style == "direct" and resolved_planning_mode != "required" and resolved_staging_mode != "required"
+    if direct_mode and resolved_conflict_policy == "always_ask":
+        continuity_rule = (
+            "For direct skills with active_skill_conflict_policy=always_ask, do not auto-switch on a clear new request. "
+            "Keep this active skill context and ask the user to choose: continue current skill or switch to the new request. "
+            "Proceed only after the user clearly confirms continue/switch."
+        )
+    elif direct_mode:
+        continuity_rule = (
+            "For direct skills, if the user gives a clear new request, treat that as leaving this prior skill and handle the new request directly without asking for switch permission."
+        )
+    else:
+        continuity_rule = (
+            "For stepwise/required-plan/required-staging skills, continue the flow when the user clearly continues; only ask continue-vs-switch if the latest user turn is genuinely ambiguous."
+        )
     system_rules = (
         f"Active skill: {skill.name}.\n"
         "Stay within the skill's instructions, constraints, output contract, reference usage, and allowed tool policy while this skill is active.\n"
@@ -396,11 +416,13 @@ def build_skill_prompt_blocks(
         or runtime_config.planning_mode != "auto"
         or runtime_config.staging_mode != "auto"
         or runtime_config.ask_user_policy != "blocked_only"
+        or runtime_config.active_skill_conflict_policy != "auto_switch_direct"
     ):
         system_rules += (
             f"\nSkill behavior: execution_style={runtime_config.execution_style}, "
             f"planning_mode={runtime_config.planning_mode}, staging_mode={runtime_config.staging_mode}, "
-            f"ask_user_policy={runtime_config.ask_user_policy}."
+            f"ask_user_policy={runtime_config.ask_user_policy}, "
+            f"active_skill_conflict_policy={runtime_config.active_skill_conflict_policy}."
         )
 
     strategy = "\n".join(f"- {item}" for item in (skill.strategy or []))
@@ -472,6 +494,14 @@ def build_skill_runtime_config(
     skill: Skill,
     globally_allowed_tool_names: Optional[Iterable[str]] = None,
 ) -> SkillRuntimeConfig:
+    llm_cfg = config.llm if isinstance(config.llm, dict) else {}
+    response_flow_cfg = llm_cfg.get("response_flow") if isinstance(llm_cfg.get("response_flow"), dict) else {}
+    resolved_execution_style, resolved_ask_user_policy, resolved_conflict_policy = resolve_skill_behavior_defaults(
+        response_flow_cfg,
+        execution_style=str(getattr(skill, "execution_style", "") or ""),
+        ask_user_policy=str(getattr(skill, "ask_user_policy", "") or ""),
+        active_skill_conflict_policy=str(getattr(skill, "active_skill_conflict_policy", "") or ""),
+    )
     references = summarize_skill_references(skill)
     raw_skill_tools = list(skill.tools or [])
     raw_task_tools = list(skill.task_tools or [])
@@ -506,8 +536,9 @@ def build_skill_runtime_config(
         workdir=skill.path or "",
         planning_mode=str(getattr(skill, "planning_mode", "auto") or "auto"),
         staging_mode=str(getattr(skill, "staging_mode", "auto") or "auto"),
-        execution_style=str(getattr(skill, "execution_style", "direct") or "direct"),
-        ask_user_policy=str(getattr(skill, "ask_user_policy", "blocked_only") or "blocked_only"),
+        execution_style=resolved_execution_style,
+        ask_user_policy=resolved_ask_user_policy,
+        active_skill_conflict_policy=resolved_conflict_policy,
         references=references,
     )
     prompt_blocks = build_skill_prompt_blocks(

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -6,6 +6,64 @@ import pytest
 from src.runtime.contracts import make_execution_result
 
 
+def test_direct_active_skill_contract_non_continuation_does_not_auto_continue():
+    from src.agents import core
+
+    contract = {
+        "skill_name": "alpha",
+        "status": "active",
+        "execution_style": "direct",
+        "planning_mode": "auto",
+        "staging_mode": "auto",
+    }
+    registry = type("Registry", (), {"match_skill": lambda self, message: []})()
+    assert core._should_continue_existing_active_skill(contract, "write a release note", registry) is False
+
+
+def test_direct_active_skill_contract_explicit_continue_message_continues():
+    from src.agents import core
+
+    contract = {
+        "skill_name": "alpha",
+        "status": "active",
+        "execution_style": "direct",
+        "planning_mode": "auto",
+        "staging_mode": "auto",
+    }
+    registry = type("Registry", (), {"match_skill": lambda self, message: []})()
+    assert core._should_continue_existing_active_skill(contract, "continue", registry) is True
+
+
+def test_stepwise_active_skill_contract_clear_continuation_keeps_skill():
+    from src.agents import core
+
+    contract = {
+        "skill_name": "alpha",
+        "status": "active",
+        "execution_style": "stepwise",
+        "planning_mode": "required",
+        "staging_mode": "required",
+    }
+    matched = [type("Skill", (), {"name": "alpha"})()]
+    registry = type("Registry", (), {"match_skill": lambda self, message: matched})()
+    assert core._should_continue_existing_active_skill(contract, "next", registry) is True
+
+
+def test_stepwise_active_skill_contract_yields_when_new_skill_matches():
+    from src.agents import core
+
+    contract = {
+        "skill_name": "alpha",
+        "status": "active",
+        "execution_style": "stepwise",
+        "planning_mode": "required",
+        "staging_mode": "required",
+    }
+    matched = [type("Skill", (), {"name": "beta"})()]
+    registry = type("Registry", (), {"match_skill": lambda self, message: matched})()
+    assert core._should_continue_existing_active_skill(contract, "use beta skill", registry) is False
+
+
 @pytest.mark.asyncio
 async def test_execute_tool_via_runtime_bus_propagates_governance_passthrough_hint(monkeypatch):
     from src.agents import core

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -34,6 +34,21 @@ def test_direct_active_skill_contract_explicit_continue_message_continues():
     assert core._should_continue_existing_active_skill(contract, "continue", registry) is True
 
 
+def test_direct_active_skill_contract_always_ask_keeps_active_on_ordinary_new_request():
+    from src.agents import core
+
+    contract = {
+        "skill_name": "alpha",
+        "status": "active",
+        "execution_style": "direct",
+        "planning_mode": "auto",
+        "staging_mode": "auto",
+        "active_skill_conflict_policy": "always_ask",
+    }
+    registry = type("Registry", (), {"match_skill": lambda self, message: [type("Skill", (), {"name": "beta"})()]})()
+    assert core._should_continue_existing_active_skill(contract, "write a release note", registry) is True
+
+
 def test_stepwise_active_skill_contract_clear_continuation_keeps_skill():
     from src.agents import core
 

--- a/tests/test_response_flow_policy.py
+++ b/tests/test_response_flow_policy.py
@@ -4,6 +4,7 @@ from src.runtime.response_flow_policy import decide_response_flow
 def test_explicit_plan_request_chinese_sets_plan_required():
     decision = decide_response_flow(user_text="先给计划，再继续")
     assert decision.plan_required is True
+    assert decision.staging_required is False
 
 
 def test_explicit_staged_request_chinese_sets_staging_required():
@@ -13,6 +14,16 @@ def test_explicit_staged_request_chinese_sets_staging_required():
 
 def test_generic_generate_implementation_not_staged_without_budget_pressure():
     decision = decide_response_flow(user_text="generate implementation")
+    assert decision.staging_required is False
+
+
+def test_generic_step_by_step_does_not_force_staging():
+    decision = decide_response_flow(user_text="Please do this step by step")
+    assert decision.staging_required is False
+
+
+def test_generic_zh_stepwise_does_not_force_staging():
+    decision = decide_response_flow(user_text="请逐步处理")
     assert decision.staging_required is False
 
 

--- a/tests/test_response_flow_policy.py
+++ b/tests/test_response_flow_policy.py
@@ -1,4 +1,4 @@
-from src.runtime.response_flow_policy import decide_response_flow
+from src.runtime.response_flow_policy import decide_response_flow, resolve_skill_behavior_defaults
 
 
 def test_explicit_plan_request_chinese_sets_plan_required():
@@ -39,3 +39,41 @@ def test_budget_near_limit_sets_staging_required():
         prompt_budget_tokens=32000,
     )
     assert decision.staging_required is True
+
+
+def test_resolve_skill_behavior_defaults_uses_config_active_skill_conflict_policy():
+    execution_style, ask_policy, conflict_policy = resolve_skill_behavior_defaults(
+        {"active_skill_conflict_policy": "always_ask"}
+    )
+    assert execution_style == "direct"
+    assert ask_policy == "blocked_only"
+    assert conflict_policy == "always_ask"
+
+
+def test_resolve_skill_behavior_defaults_skill_explicit_values_override_config():
+    execution_style, ask_policy, conflict_policy = resolve_skill_behavior_defaults(
+        {
+            "default_skill_execution_style": "stepwise",
+            "ask_user_policy": "permissive",
+            "active_skill_conflict_policy": "auto_switch_direct",
+        },
+        execution_style="direct",
+        ask_user_policy="blocked_only",
+        active_skill_conflict_policy="always_ask",
+    )
+    assert execution_style == "direct"
+    assert ask_policy == "blocked_only"
+    assert conflict_policy == "always_ask"
+
+
+def test_resolve_skill_behavior_defaults_skill_omission_uses_config_defaults():
+    execution_style, ask_policy, conflict_policy = resolve_skill_behavior_defaults(
+        {
+            "default_skill_execution_style": "stepwise",
+            "ask_user_policy": "permissive",
+            "active_skill_conflict_policy": "always_ask",
+        }
+    )
+    assert execution_style == "stepwise"
+    assert ask_policy == "permissive"
+    assert conflict_policy == "always_ask"

--- a/tests/test_skill_mode_termination.py
+++ b/tests/test_skill_mode_termination.py
@@ -9,6 +9,9 @@ class FakeTracer:
     def log_tool_call(self, *args, **kwargs):
         return None
 
+    def log_skill_mode_entry(self, *args, **kwargs):
+        return None
+
     def log_skill_mode_action(self, *args, **kwargs):
         return None
 
@@ -29,6 +32,93 @@ def make_agent():
     agent.agent_id = None
     return agent
 
+
+def test_direct_skill_prompt_no_clear_switch_confirmation_bias():
+    from src.skills.runtime import build_skill_prompt_blocks
+
+    skill = SimpleNamespace(
+        name="direct-skill",
+        description="Direct skill",
+        path="",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body="Do the thing",
+        execution_style="direct",
+        planning_mode="auto",
+        staging_mode="auto",
+    )
+    blocks = build_skill_prompt_blocks(skill)
+    assert "ask whether to clear/switch" not in blocks.system_rules.lower()
+    assert "without asking for switch permission" in blocks.system_rules
+
+
+@pytest.mark.asyncio
+async def test_start_skill_mode_skips_initial_plan_when_not_explicit_or_complex(monkeypatch):
+    from src.agents import core as core_mod
+
+    captured = {}
+
+    def fake_resolve(skill, message, *, request_estimated_tokens=None, prompt_budget_tokens=None):
+        captured["request_estimated_tokens"] = request_estimated_tokens
+        captured["prompt_budget_tokens"] = prompt_budget_tokens
+        return {"plan_required": False, "execution_style": "direct", "ask_user_policy": "blocked_only"}
+
+    async def fake_continue(self, **kwargs):
+        return {"response": "ok", "usage": {}, "events": []}
+
+    async def fake_set_active(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(core_mod, "resolve_skill_response_flow", fake_resolve)
+    monkeypatch.setattr(core_mod, "estimate_llm_request_tokens", lambda **kwargs: 3000)
+    monkeypatch.setattr(core_mod, "resolve_prompt_budget", lambda **kwargs: {"prompt_budget_tokens": 32000})
+    monkeypatch.setattr(core_mod.Agent, "_continue_skill_mode", fake_continue)
+    monkeypatch.setattr(core_mod.session_manager, "set_active_skill_session", fake_set_active)
+    monkeypatch.setattr("src.skills.get_tracer", lambda: FakeTracer())
+
+    agent = make_agent()
+    skill = SimpleNamespace(name="lookup", description="search issue", path="")
+    await agent._start_skill_mode("small request", "s1", "u1", skill)
+    assert captured["request_estimated_tokens"] == 3000
+    assert captured["prompt_budget_tokens"] == 32000
+
+
+@pytest.mark.asyncio
+async def test_start_skill_mode_complex_first_turn_can_trigger_initial_plan(monkeypatch):
+    from src.agents import core as core_mod
+
+    plan_calls = {"n": 0}
+
+    async def fake_continue(self, **kwargs):
+        return {"response": "ok", "usage": {}, "events": []}
+
+    async def fake_set_active(*args, **kwargs):
+        return None
+
+    async def fake_generate_initial_plan(*args, **kwargs):
+        plan_calls["n"] += 1
+        return "goal", [{"id": "s1", "type": "execute", "title": "step"}], {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+
+    monkeypatch.setattr(core_mod, "estimate_llm_request_tokens", lambda **kwargs: 30000)
+    monkeypatch.setattr(core_mod, "resolve_prompt_budget", lambda **kwargs: {"prompt_budget_tokens": 32000})
+    monkeypatch.setattr(core_mod.Agent, "_continue_skill_mode", fake_continue)
+    monkeypatch.setattr(core_mod.session_manager, "set_active_skill_session", fake_set_active)
+    monkeypatch.setattr(core_mod, "generate_initial_skill_plan", fake_generate_initial_plan)
+    monkeypatch.setattr("src.skills.get_tracer", lambda: FakeTracer())
+
+    agent = make_agent()
+    skill = SimpleNamespace(
+        name="lookup",
+        description="search issue",
+        path="",
+        planning_mode="auto",
+        staging_mode="auto",
+        execution_style="direct",
+        ask_user_policy="blocked_only",
+    )
+    await agent._start_skill_mode("big request", "s1", "u1", skill)
+    assert plan_calls["n"] == 1
 
 async def run_replay_case(
     monkeypatch,

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -586,6 +586,70 @@ def test_build_skill_runtime_config_task_tools_trimmed_by_global_allowlist():
     assert runtime_config.task_tools == []
 
 
+def test_build_skill_runtime_config_skill_omission_uses_response_flow_defaults(monkeypatch):
+    from src.config import config
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "response_flow": {
+                "default_skill_execution_style": "stepwise",
+                "ask_user_policy": "permissive",
+            }
+        },
+    )
+    skill = SimpleNamespace(
+        name="demo",
+        description="demo",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body="",
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+        execution_style="",
+        ask_user_policy="",
+    )
+    runtime_config = build_skill_runtime_config(skill)
+    assert runtime_config.execution_style == "stepwise"
+    assert runtime_config.ask_user_policy == "permissive"
+
+
+def test_build_skill_runtime_config_skill_explicit_values_override_response_flow_defaults(monkeypatch):
+    from src.config import config
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "response_flow": {
+                "default_skill_execution_style": "stepwise",
+                "ask_user_policy": "permissive",
+            }
+        },
+    )
+    skill = SimpleNamespace(
+        name="demo",
+        description="demo",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body="",
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+        execution_style="direct",
+        ask_user_policy="blocked_only",
+    )
+    runtime_config = build_skill_runtime_config(skill)
+    assert runtime_config.execution_style == "direct"
+    assert runtime_config.ask_user_policy == "blocked_only"
+
+
 def test_build_skill_tool_denied_result_contains_policy():
     runtime_config = build_skill_runtime_config(
         SimpleNamespace(
@@ -715,7 +779,7 @@ async def test_active_skill_contract_continues_without_rematch(monkeypatch, base
 
 
 @pytest.mark.asyncio
-async def test_active_skill_contract_does_not_soft_switch_on_ordinary_match(monkeypatch, base_agent):
+async def test_active_skill_contract_auto_switches_direct_skill_on_ordinary_new_request(monkeypatch, base_agent):
     agent, sess = base_agent
     review_skill = SimpleNamespace(
         name="review-pull-request",
@@ -780,8 +844,82 @@ async def test_active_skill_contract_does_not_soft_switch_on_ordinary_match(monk
     result = await agent.process("ordinary message that matches create", session_id="s1")
     assert result["response"] == "done"
     assert captured_prompts
+    assert "Active skill: create-pull-request" in captured_prompts[0]
+    assert "Active skill: review-pull-request" not in captured_prompts[0]
+    assert sess.active_skill_session["skill_name"] == "create-pull-request"
+    assert sess.active_skill_session["activation_reason"] == "matched"
+
+
+@pytest.mark.asyncio
+async def test_active_skill_contract_always_ask_keeps_direct_skill_context_on_ordinary_new_request(monkeypatch, base_agent):
+    agent, sess = base_agent
+    review_skill = SimpleNamespace(
+        name="review-pull-request",
+        description="review",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Review instructions",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+    create_skill = SimpleNamespace(
+        name="create-pull-request",
+        description="create",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Create instructions",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+    sess.active_skill_session = {
+        "schema_version": "active_skill_contract.v1",
+        "skill_name": "review-pull-request",
+        "status": "active",
+        "turn_count": 1,
+        "execution_style": "direct",
+        "active_skill_conflict_policy": "always_ask",
+    }
+
+    class _Registry:
+        _initialized = True
+
+        def match_skill(self, message):
+            if "ordinary message that matches create" in message:
+                return [create_skill]
+            return []
+
+        def get_skill(self, name):
+            if name == review_skill.name:
+                return review_skill
+            if name == create_skill.name:
+                return create_skill
+            return None
+
+        def get_skill_runtime_config(self, skill, globally_allowed_tool_names=None):
+            return build_skill_runtime_config(skill, globally_allowed_tool_names=globally_allowed_tool_names)
+
+    monkeypatch.setattr("src.skills.skill_registry", _Registry())
+    captured_prompts = []
+
+    async def fake_responses(**kwargs):
+        captured_prompts.append(kwargs.get("system_prompt", ""))
+        return {"content": "done", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("ordinary message that matches create", session_id="s1")
+    assert result["response"] == "done"
+    assert captured_prompts
     assert "Active skill: review-pull-request" in captured_prompts[0]
-    assert "Active skill: create-pull-request" not in captured_prompts[0]
+    assert "continue current skill or switch to the new request" in captured_prompts[0]
     assert sess.active_skill_session["skill_name"] == "review-pull-request"
     assert sess.active_skill_session["activation_reason"] == "continued"
 


### PR DESCRIPTION
### Motivation
- Remove aggressive auto-continuation of previously active direct skills that hijacks new user turns and causes unnecessary confirmation loops. 
- Stop prompting the model to ask permission to clear/switch away from ordinary direct-skill follow-ups. 
- Allow complexity-based plan-first decisions on the initial skill turn by estimating a first-turn request budget. 
- Decouple explicit "plan-first" from "staging/file-by-file" triggers so plan-only phrases do not imply staged generation. 

### Description
- Add deterministic continuation guards in `src/agents/core.py` by introducing `_is_explicit_skill_continuation_message(...)`, `_is_effectively_direct_skill_contract(...)`, and `_should_continue_existing_active_skill(...)`, and use the helper before the previous unconditional continued-path so direct skills only auto-continue on explicit continuation phrases. (Fixes hole #1)
- In `src/agents/core.py::_start_skill_mode(...)` compute a lightweight first-turn estimate using `estimate_llm_request_tokens(...)` and `resolve_prompt_budget(...)` and pass `request_estimated_tokens`/`prompt_budget_tokens` into `resolve_skill_response_flow(...)` so complexity-based plan-first can trigger on the initial turn. (Fixes hole #3)
- Narrow and separate phrase handling in `src/runtime/response_flow_policy.py` by: reducing `_PLAN_PHRASES` to plan-only terms and leaving `_STAGING_PHRASES` for explicit staging; and changing the decision logic so `explicit_plan` sets `plan_required` while only `explicit_staging` (not `explicit_plan`) triggers `staging_required`. (Fixes hole #4)
- Rewrite the active-skill system-rule wording in `src/skills/runtime.py` so direct skills do not bias the model to ask "clear/switch" permission and stepwise/required skills still preserve ambiguity-handling language. (Fixes hole #2)
- Make skill prompt assembly more defensive in `src/agents/skill_mode.py` by using `getattr(..., 'strategy', [])` to avoid test/compatibility failures with minimal skill objects. (Robustness)
- Tests added/updated:
  - `tests/test_response_flow_policy.py` asserts plan-only phrases do not imply staging and generic "step by step/逐步" does not force staging.
  - `tests/test_core_runtime_boundary.py` covers direct skill non-continuation, explicit continuation, and stepwise yielding when a different skill clearly matches.
  - `tests/test_skill_mode_termination.py` checks skill prompt wording, first-turn token/budget plumbing, and complex-first-turn plan triggering.

Files changed (high-level mapping):
- `src/agents/core.py` — continuation heuristics and initial-turn budget plumbing (holes #1 & #3).
- `src/runtime/response_flow_policy.py` — narrowed phrase lists and decoupled plan/staging logic (hole #4).
- `src/skills/runtime.py` — updated active-skill prompt wording to avoid switch-confirmation bias (hole #2).
- `src/agents/skill_mode.py` — defensive `strategy` access (test robustness / compatibility).
- `tests/...` — new/updated regression tests validating the above behaviors (hole #5).

### Testing
- Ran targeted tests `tests/test_response_flow_policy.py`, `tests/test_core_runtime_boundary.py`, and `tests/test_skill_mode_termination.py` and they passed locally. 
- Ran the full test suite; result: all tests passed (`148 passed`, `1 warning`). 
- The changes are covered by the added/updated tests listed above and the full-suite run confirms no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2ef8e1d4832a8dce2a5dcef55f54)