### PR TITLE
Close artifact projection/status gaps and wire GitHub bundle refs into skills

### DIFF
--- a/skills/collect_requirements_to_bundle/skill.py
+++ b/skills/collect_requirements_to_bundle/skill.py
@@ -14,7 +14,7 @@ from src.runtime.requirement_bundle_assets import (
     RequirementBundleError,
     load_bundle_manifest,
     parse_bundle_ref,
-    read_github_doc_text,
+    prepare_github_doc_source,
     resolve_bundle_links,
     resolve_target_bundle_ref,
     write_requirements_doc_for_ref,
@@ -61,22 +61,24 @@ async def _load_github_doc_sources(bundle_ref: Dict[str, Any], doc_paths: List[s
     parsed_ref = parse_bundle_ref(bundle_ref)
     items: List[Dict[str, Any]] = []
     for doc_path in doc_paths:
-        doc_ref, raw = await read_github_doc_text(doc_path, parsed_ref)
+        prepared = await prepare_github_doc_source(doc_path, parsed_ref)
+        doc_ref = prepared["doc_ref"]
         kind = "url" if "://" in doc_path else "repo_relative_path"
         items.append(
             {
                 "input": doc_path,
                 "kind": kind,
+                "source_kind": "repo_file",
                 "resolved": {
                     "owner": doc_ref.owner,
                     "repo": doc_ref.repo,
                     "branch": doc_ref.branch,
                     "path": doc_ref.path,
                 },
-                "content": raw,
-                "artifact_refs": [],
-                "context_ref": None,
-                "digest_ref": None,
+                "content": prepared["content_text"],
+                "artifact_refs": prepared["artifact_refs"],
+                "context_ref": prepared["context_ref"],
+                "digest_ref": prepared["digest_ref"],
             }
         )
     return items

--- a/src/confluence/__init__.py
+++ b/src/confluence/__init__.py
@@ -5,7 +5,7 @@ import json
 from typing import Optional
 
 from src.file_artifacts import can_project_to_text
-from src.file_artifacts.service import bind_artifact_to_source_bundle, build_artifact_ref_dict
+from src.file_artifacts.service import attach_source_refs_to_artifact, bind_artifact_to_source_bundle, build_artifact_ref_dict
 from src.utils.attachment import download_and_process_attachment
 
 from .api import (
@@ -441,6 +441,11 @@ async def confluence_prepare_page_context(
                         source_kind="page_attachment",
                         source_locator=f"{page_id}:{att.get('id')}",
                         provider_metadata={"page_id": page_id, "attachment_id": att.get("id")},
+                        persist_text_ref_session_id=_session_id or f"confluence-{page_id}",
+                        persist_text_ref_kind="confluence_attachment_text",
+                        persist_text_ref_source_id=f"{page_id}:{att.get('id')}",
+                        persist_text_ref_title=f"Confluence attachment text {filename}",
+                        persist_text_ref_metadata={"page_id": page_id, "filename": filename, "attachment_id": att.get("id")},
                     )
                     if getattr(result, "artifact_id", None):
                         from src.file_artifacts.storage import storage as artifact_storage
@@ -450,7 +455,7 @@ async def confluence_prepare_page_context(
                             artifact_ref = build_artifact_ref_dict(record)
                             artifact_refs.append(artifact_ref)
                             att["text_preview"] = (result.preview or result.content or "")[:1000]
-                            att["text_ref"] = None
+                            att["text_ref"] = getattr(result, "text_ref", None) or record.text_ref
                 except Exception as att_exc:
                     logger.warning(f"Failed attachment materialization for {filename}: {att_exc}")
 
@@ -547,6 +552,23 @@ async def confluence_prepare_page_context(
             page_id=page_id,
             bundle=bundle,
         )
+        from src.file_artifacts.storage import storage as artifact_storage
+        refreshed_artifact_refs = []
+        for ref in artifact_refs:
+            artifact_id = ref.get("artifact_id")
+            if not artifact_id:
+                continue
+            attach_source_refs_to_artifact(
+                artifact_id,
+                context_ref=persisted.get("context_ref"),
+                digest_ref=persisted.get("digest_ref"),
+            )
+            record = artifact_storage.get_artifact(artifact_id)
+            if record:
+                refreshed_artifact_refs.append(build_artifact_ref_dict(record))
+        if refreshed_artifact_refs:
+            bundle["artifact_refs"] = refreshed_artifact_refs
+            artifact_refs = refreshed_artifact_refs
         manifest = {
             "page_id": page_id,
             "context_ref": persisted["context_ref"],

--- a/src/file_artifacts/__init__.py
+++ b/src/file_artifacts/__init__.py
@@ -1,6 +1,8 @@
 from .capabilities import can_project_to_text, infer_projection_kind, is_text_like_content_type
 from .models import ArtifactBinding, ArtifactRecord
 from .service import (
+    attach_source_refs_to_artifact,
+    attach_text_ref_to_artifact,
     bind_artifact_to_session,
     bind_artifact_to_source_bundle,
     build_artifact_ref_dict,
@@ -17,6 +19,8 @@ __all__ = [
     "is_text_like_content_type",
     "infer_projection_kind",
     "register_existing_file_as_artifact",
+    "attach_text_ref_to_artifact",
+    "attach_source_refs_to_artifact",
     "bind_artifact_to_session",
     "bind_artifact_to_source_bundle",
     "update_projection_from_parse_result",

--- a/src/file_artifacts/models.py
+++ b/src/file_artifacts/models.py
@@ -22,6 +22,10 @@ class ArtifactRecord(BaseModel):
     preview: Optional[str] = None
     chunk_count: int = 0
     total_chars: int = 0
+    text_ref: Optional[str] = None
+    context_ref: Optional[str] = None
+    digest_ref: Optional[str] = None
+    full_markdown_chars: int = 0
     provider_metadata: Dict[str, Any] = Field(default_factory=dict)
     created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat() + "Z")
     updated_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat() + "Z")

--- a/src/file_artifacts/service.py
+++ b/src/file_artifacts/service.py
@@ -36,6 +36,10 @@ def register_existing_file_as_artifact(
         preview=existing.preview if existing else None,
         chunk_count=existing.chunk_count if existing else 0,
         total_chars=existing.total_chars if existing else 0,
+        text_ref=existing.text_ref if existing else None,
+        context_ref=existing.context_ref if existing else None,
+        digest_ref=existing.digest_ref if existing else None,
+        full_markdown_chars=existing.full_markdown_chars if existing else 0,
         provider_metadata={**(existing.provider_metadata if existing else {}), **(provider_metadata or {})},
     )
     return storage.upsert_artifact(record)
@@ -64,10 +68,36 @@ def update_projection_from_parse_result(artifact_id: str, parse_result, preview:
         chunk_count=block_count,
         total_chars=len(markdown),
     )
+    storage.update_artifact_references(
+        artifact_id,
+        full_markdown_chars=len(markdown),
+    )
     return storage.update_artifact_status(artifact_id, parse_status="completed")
 
 
+def attach_text_ref_to_artifact(artifact_id: str, text_ref: str, *, full_markdown_chars: Optional[int] = None) -> Optional[ArtifactRecord]:
+    return storage.update_artifact_references(
+        artifact_id,
+        text_ref=text_ref,
+        full_markdown_chars=full_markdown_chars,
+    )
+
+
+def attach_source_refs_to_artifact(
+    artifact_id: str,
+    *,
+    context_ref: Optional[str] = None,
+    digest_ref: Optional[str] = None,
+) -> Optional[ArtifactRecord]:
+    return storage.update_artifact_references(
+        artifact_id,
+        context_ref=context_ref,
+        digest_ref=digest_ref,
+    )
+
+
 def build_artifact_ref_dict(record: ArtifactRecord, *, text_ref: str | None = None) -> dict:
+    effective_text_ref = text_ref if text_ref is not None else record.text_ref
     return {
         "artifact_id": record.artifact_id,
         "file_id": record.file_id,
@@ -78,5 +108,7 @@ def build_artifact_ref_dict(record: ArtifactRecord, *, text_ref: str | None = No
         "source_locator": record.source_locator,
         "projection_kind": record.projection_kind,
         "preview": record.preview,
-        "text_ref": text_ref,
+        "text_ref": effective_text_ref,
+        "context_ref": record.context_ref,
+        "digest_ref": record.digest_ref,
     }

--- a/src/file_artifacts/storage.py
+++ b/src/file_artifacts/storage.py
@@ -108,5 +108,31 @@ class FileArtifactStorage:
         self._save_artifacts(artifacts)
         return ArtifactRecord(**item)
 
+    def update_artifact_references(
+        self,
+        artifact_id: str,
+        *,
+        text_ref: Optional[str] = None,
+        context_ref: Optional[str] = None,
+        digest_ref: Optional[str] = None,
+        full_markdown_chars: Optional[int] = None,
+    ) -> Optional[ArtifactRecord]:
+        artifacts = self._load_artifacts()
+        item = artifacts.get(artifact_id)
+        if not item:
+            return None
+        if text_ref is not None:
+            item["text_ref"] = text_ref
+        if context_ref is not None:
+            item["context_ref"] = context_ref
+        if digest_ref is not None:
+            item["digest_ref"] = digest_ref
+        if full_markdown_chars is not None:
+            item["full_markdown_chars"] = int(full_markdown_chars or 0)
+        item["updated_at"] = datetime.utcnow().isoformat() + "Z"
+        artifacts[artifact_id] = item
+        self._save_artifacts(artifacts)
+        return ArtifactRecord(**item)
+
 
 storage = FileArtifactStorage()

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -2866,6 +2866,8 @@ async def api_files_parse(request: web.Request) -> web.Response:
         200: {"success": true, "markdown": "...", "blocks": [...], ...}
         400: {"success": false, "error": "..."}
     """
+    session_id = None
+    file_id = None
     try:
         from src.hooks.file_context.models import Chunk, SessionFileMeta
         from src.hooks.file_context.retrieval import retrieval_engine
@@ -2972,6 +2974,18 @@ async def api_files_parse(request: web.Request) -> web.Response:
     except StoredFileNotFoundError as e:
         return web.json_response({'success': False, 'error': str(e)}, status=404)
     except Exception as e:
+        try:
+            if session_id and file_id:
+                from src.hooks.file_context.storage import storage as file_context_storage
+                file_context_storage.update_file_status(session_id, file_id, status="failed", error=str(e))
+        except Exception:
+            logger.exception("Failed to persist file_context failure state for %s/%s", session_id, file_id)
+        try:
+            if file_id:
+                from src.file_artifacts.storage import storage as artifact_storage
+                artifact_storage.update_artifact_status(file_id, parse_status="failed", parse_error=str(e))
+        except Exception:
+            logger.exception("Failed to persist artifact failure state for %s", file_id)
         logger.error(f"File parse error: {e}")
         return web.json_response({'success': False, 'error': str(e)}, status=500)
 

--- a/src/github/source_service.py
+++ b/src/github/source_service.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import base64
+import mimetypes
 from typing import Any
 
 from src.file_artifacts import can_project_to_text
-from src.file_artifacts.service import bind_artifact_to_source_bundle, build_artifact_ref_dict, register_existing_file_as_artifact, update_projection_from_parse_result
+from src.file_artifacts.service import (
+    attach_source_refs_to_artifact,
+    bind_artifact_to_source_bundle,
+    build_artifact_ref_dict,
+    register_existing_file_as_artifact,
+    update_projection_from_parse_result,
+)
+from src.file_artifacts.storage import storage as artifact_storage
 from src.github import github_channel
 from src.github.doc_refs import parse_github_doc_ref
 from src.source_context import persist_github_source_bundle_and_digest
@@ -19,7 +27,19 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
         raise ValueError(f"File not found or empty: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}")
 
     content_bytes = base64.b64decode(encoded)
-    file_meta = await save_uploaded_file(content_bytes, original_filename=doc_ref.path.split("/")[-1], session_id=session_id)
+    guessed_content_type = mimetypes.guess_type(doc_ref.path)[0]
+    if not guessed_content_type:
+        try:
+            content_bytes.decode("utf-8")
+            guessed_content_type = "text/plain"
+        except Exception:
+            guessed_content_type = None
+    file_meta = await save_uploaded_file(
+        content_bytes,
+        original_filename=doc_ref.path.split("/")[-1],
+        session_id=session_id,
+        content_type=guessed_content_type,
+    )
     artifact = register_existing_file_as_artifact(
         file_meta.file_id,
         source_type="github",
@@ -33,17 +53,31 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
     source_complete = False
     partial_reasons: list[str] = []
     if can_project_to_text(file_meta.content_type, file_meta.original_filename):
-        parsed = await parse_file(file_meta.file_id)
-        if getattr(parsed, "success", False):
-            content_markdown = parsed.markdown or ""
-            update_projection_from_parse_result(artifact.artifact_id, parsed, preview=content_markdown[:2000])
-            source_complete = True
-        else:
-            partial_reasons.append(f"parse_failed:{parsed.error}")
+        try:
+            parsed = await parse_file(file_meta.file_id)
+            if getattr(parsed, "success", False):
+                content_markdown = parsed.markdown or ""
+                update_projection_from_parse_result(artifact.artifact_id, parsed, preview=content_markdown[:2000])
+                source_complete = True
+            else:
+                parse_error = str(getattr(parsed, "error", "parse failed"))
+                artifact_storage.update_artifact_status(
+                    artifact.artifact_id,
+                    parse_status="failed",
+                    parse_error=parse_error,
+                )
+                partial_reasons.append(f"parse_failed:{parse_error}")
+        except Exception as exc:
+            artifact_storage.update_artifact_status(
+                artifact.artifact_id,
+                parse_status="failed",
+                parse_error=str(exc),
+            )
+            partial_reasons.append(f"parse_failed:{type(exc).__name__}")
     else:
+        artifact_storage.update_artifact_status(artifact.artifact_id, parse_status="skipped")
         partial_reasons.append("non_projectable_file")
 
-    from src.file_artifacts.storage import storage as artifact_storage
     record = artifact_storage.get_artifact(artifact.artifact_id) or artifact
     bundle_scope_id = f"github:{doc_ref.owner}/{doc_ref.repo}:{doc_ref.path}@{doc_ref.branch}"
     bind_artifact_to_source_bundle(record.artifact_id, bundle_scope_id)
@@ -56,6 +90,9 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
             "branch": doc_ref.branch,
             "path": doc_ref.path,
             "content_type": file_meta.content_type,
+            "source_kind": "repo_file",
+            "attachments_supported": False,
+            "issue_pr_assets_supported": False,
         },
         "content_markdown": content_markdown,
         "artifact_refs": artifact_refs,
@@ -63,6 +100,9 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
             "file_loaded": True,
             "file_projectable": can_project_to_text(file_meta.content_type, file_meta.original_filename),
             "source_complete": source_complete,
+            "source_kind": "repo_file",
+            "attachments_supported": False,
+            "issue_pr_assets_supported": False,
             "partial_reasons": partial_reasons,
         },
         "raw_snapshot": {
@@ -79,4 +119,12 @@ async def prepare_github_file_source(raw: str, default_ref, *, session_id: str |
     )
     bundle["context_ref"] = persisted["context_ref"]
     bundle["digest_ref"] = persisted["digest_ref"]
+    attach_source_refs_to_artifact(
+        artifact.artifact_id,
+        context_ref=bundle["context_ref"],
+        digest_ref=bundle["digest_ref"],
+    )
+    refreshed = artifact_storage.get_artifact(artifact.artifact_id)
+    if refreshed:
+        bundle["artifact_refs"] = [build_artifact_ref_dict(refreshed)]
     return {"doc_ref": doc_ref, "bundle": bundle, "persisted": persisted}

--- a/src/jira/source_service.py
+++ b/src/jira/source_service.py
@@ -5,10 +5,9 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from src.context_blob_store import put_text
 from src.source_context import persist_jira_source_bundle_and_digest
 from src.file_artifacts import can_project_to_text
-from src.file_artifacts.service import bind_artifact_to_source_bundle, build_artifact_ref_dict
+from src.file_artifacts.service import attach_source_refs_to_artifact, bind_artifact_to_source_bundle, build_artifact_ref_dict
 from src.utils.attachment import download_and_process_attachment as _default_download_and_process_attachment
 
 from .adapter import JiraFormatAdapter
@@ -40,7 +39,6 @@ async def prepare_jira_issue_source(
 
     channel = getattr(jira_module, "jira_channel", None)
     downloader = getattr(jira_module, "download_and_process_attachment", _default_download_and_process_attachment)
-    put_text_fn = getattr(jira_module, "put_text", put_text)
 
     if not channel or not channel.is_configured():
         raise RuntimeError("Jira is not configured.")
@@ -124,6 +122,11 @@ async def prepare_jira_issue_source(
                     source_kind="issue_attachment",
                     source_locator=f"{issue_key}:{att.get('id')}",
                     provider_metadata={"issue_key": issue_key, "attachment_id": att.get("id")},
+                    persist_text_ref_session_id=session_id,
+                    persist_text_ref_kind="jira_attachment_text",
+                    persist_text_ref_source_id=f"{issue_key}:{att.get('id')}",
+                    persist_text_ref_title=f"Jira attachment text {filename}",
+                    persist_text_ref_metadata={"issue_key": issue_key, "filename": filename, "attachment_id": att.get("id")},
                 )
                 if getattr(result, "content_format", "") == "text":
                     text_content = str(getattr(result, "content", "") or "")
@@ -134,16 +137,10 @@ async def prepare_jira_issue_source(
                         item["text_preview"] = text_content[:1000]
                         item["attachment_text_preview_only"] = True
                         text_attachments_preview_only += 1
-                        item["text_ref"] = put_text_fn(
-                            session_id=session_id,
-                            kind="jira_attachment_text",
-                            source_id=f"{issue_key}_{filename}",
-                            title=f"Jira attachment text {filename}",
-                            content=text_content,
-                            metadata={"issue_key": issue_key, "filename": filename},
-                        )
-                        text_attachments_with_full_ref += 1
                         attachment_body_partial_reasons.append(f"text_attachment_preview_only:{filename}")
+                    item["text_ref"] = getattr(result, "text_ref", None)
+                    if item["text_ref"]:
+                        text_attachments_with_full_ref += 1
                     text_attachments_loaded += 1
                 if getattr(result, "artifact_id", None):
                     from src.file_artifacts.storage import storage as artifact_storage
@@ -259,6 +256,23 @@ async def prepare_jira_issue_source(
     )
 
     persisted = persist_jira_source_bundle_and_digest(session_id=session_id, issue_key=issue_key, bundle=bundle)
+    from src.file_artifacts.storage import storage as artifact_storage
+    refreshed_artifact_refs: list[dict] = []
+    for ref in artifact_refs:
+        artifact_id = ref.get("artifact_id")
+        if not artifact_id:
+            continue
+        attach_source_refs_to_artifact(
+            artifact_id,
+            context_ref=persisted.get("context_ref"),
+            digest_ref=persisted.get("digest_ref"),
+        )
+        record = artifact_storage.get_artifact(artifact_id)
+        if record:
+            refreshed_artifact_refs.append(build_artifact_ref_dict(record))
+    if refreshed_artifact_refs:
+        bundle["artifact_refs"] = refreshed_artifact_refs
+        artifact_refs = refreshed_artifact_refs
     manifest = {
         "issue_key": issue_key,
         "title": (fields.get("summary") if isinstance(fields, dict) else "") or "",

--- a/src/runtime/requirement_bundle_assets.py
+++ b/src/runtime/requirement_bundle_assets.py
@@ -127,23 +127,41 @@ def parse_github_doc_ref(raw: str, default_ref: BundleRef) -> GitHubDocRef:
 
 
 async def read_github_doc_text(raw: str, default_ref: BundleRef) -> tuple[GitHubDocRef, str]:
+    doc_ref: GitHubDocRef | None = None
+    try:
+        prepared = await prepare_github_doc_source(raw, default_ref)
+        doc_ref = prepared["doc_ref"]
+        return prepared["doc_ref"], prepared["content_text"]
+    except RequirementBundleError as exc:
+        _log_bundle_asset_failure("read_github_doc_text", exc, raw=raw if doc_ref is None else None)
+        raise
+
+
+async def prepare_github_doc_source(raw: str, default_ref: BundleRef) -> dict:
     input_kind = "url" if "://" in str(raw or "") else "repo_relative_path"
-    logger.debug("Read GitHub doc start | input_kind=%s", input_kind)
+    logger.debug("Prepare GitHub doc source start | input_kind=%s", input_kind)
     doc_ref: GitHubDocRef | None = None
     try:
         prepared = await prepare_github_file_source(raw, default_ref)
         doc_ref = prepared["doc_ref"]
         bundle = prepared["bundle"]
-        text = str(bundle.get("content_markdown") or "").strip()
-        if not text:
+        content_text = str(bundle.get("content_markdown") or "").strip()
+        if not content_text:
             raise RequirementBundleError(
                 f"GitHub file is not projectable to text: {doc_ref.owner}/{doc_ref.repo}/{doc_ref.path}@{doc_ref.branch}"
             )
-        logger.info("Read GitHub doc success | owner=%s repo=%s branch=%s path=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path)
-        return doc_ref, text
+        logger.info("Prepare GitHub doc source success | owner=%s repo=%s branch=%s path=%s", doc_ref.owner, doc_ref.repo, doc_ref.branch, doc_ref.path)
+        return {
+            "doc_ref": doc_ref,
+            "bundle": bundle,
+            "context_ref": bundle.get("context_ref"),
+            "digest_ref": bundle.get("digest_ref"),
+            "artifact_refs": bundle.get("artifact_refs") or [],
+            "content_text": content_text,
+        }
     except RequirementBundleError as exc:
         _log_bundle_asset_failure(
-            "read_github_doc_text", exc, raw=raw if doc_ref is None else None,
+            "prepare_github_doc_source", exc, raw=raw if doc_ref is None else None,
             extra={
                 "input_kind": input_kind,
                 "owner": doc_ref.owner if doc_ref else None,
@@ -155,7 +173,7 @@ async def read_github_doc_text(raw: str, default_ref: BundleRef) -> tuple[GitHub
         raise
     except Exception as exc:
         _log_bundle_asset_failure(
-            "read_github_doc_text", exc, raw=raw if doc_ref is None else None,
+            "prepare_github_doc_source", exc, raw=raw if doc_ref is None else None,
             extra={
                 "input_kind": input_kind,
                 "owner": doc_ref.owner if doc_ref else None,

--- a/src/source_context.py
+++ b/src/source_context.py
@@ -291,6 +291,9 @@ def persist_github_source_bundle_and_digest(*, session_id: str, source_id: str, 
         "metadata": bundle.get("metadata") or {},
         "coverage": bundle.get("completeness_ledger") or {},
         "artifact_refs": len(bundle.get("artifact_refs") or []),
+        "source_kind": (bundle.get("metadata") or {}).get("source_kind", "repo_file"),
+        "attachments_supported": bool((bundle.get("metadata") or {}).get("attachments_supported", False)),
+        "issue_pr_assets_supported": bool((bundle.get("metadata") or {}).get("issue_pr_assets_supported", False)),
     }, ensure_ascii=False, indent=2), 7000)
     digest_ref = put_text(
         session_id=session_id,

--- a/src/utils/attachment.py
+++ b/src/utils/attachment.py
@@ -11,7 +11,9 @@ from dataclasses import dataclass
 from typing import Optional, Dict, Any
 
 from src.file_artifacts import can_project_to_text
-from src.file_artifacts.service import register_existing_file_as_artifact, update_projection_from_parse_result
+from src.context_blob_store import put_text
+from src.file_artifacts.service import attach_text_ref_to_artifact, register_existing_file_as_artifact, update_projection_from_parse_result
+from src.file_artifacts.storage import storage as artifact_storage
 from .file_parser import (
     save_uploaded_file,
     parse_file,
@@ -34,6 +36,7 @@ class AttachmentResult:
     artifact_id: Optional[str] = None
     projection_kind: Optional[str] = None
     preview: Optional[str] = None
+    text_ref: Optional[str] = None
 
 
 async def download_and_process_attachment(
@@ -45,6 +48,11 @@ async def download_and_process_attachment(
     source_kind: str = "issue_attachment",
     source_locator: str | None = None,
     provider_metadata: dict | None = None,
+    persist_text_ref_session_id: Optional[str] = None,
+    persist_text_ref_kind: Optional[str] = None,
+    persist_text_ref_source_id: Optional[str] = None,
+    persist_text_ref_title: Optional[str] = None,
+    persist_text_ref_metadata: Optional[dict] = None,
 ) -> AttachmentResult:
     options = options or {}
     include_image = options.get("include_image_data", True)
@@ -74,6 +82,7 @@ async def download_and_process_attachment(
     file_path = str(get_file_path(metadata.file_id))
     projection_kind = None
     preview = None
+    text_ref = None
 
     should_parse_image = content_type.startswith("image/") and (prefer_text_for_images or vision_enabled)
     should_parse_non_image = not content_type.startswith("image/") and can_project_to_text(content_type, filename)
@@ -95,15 +104,40 @@ async def download_and_process_attachment(
                 updated = update_projection_from_parse_result(artifact.artifact_id, parsed, preview=full_text[:2000])
                 if updated:
                     artifact = updated
+                if (
+                    persist_text_ref_session_id
+                    and persist_text_ref_kind
+                    and persist_text_ref_source_id
+                    and persist_text_ref_title
+                    and full_text
+                ):
+                    text_ref = put_text(
+                        session_id=persist_text_ref_session_id,
+                        kind=persist_text_ref_kind,
+                        source_id=persist_text_ref_source_id,
+                        title=persist_text_ref_title,
+                        content=full_text,
+                        metadata=persist_text_ref_metadata or {},
+                    )
+                    updated_refs = attach_text_ref_to_artifact(artifact.artifact_id, text_ref, full_markdown_chars=len(full_text))
+                    if updated_refs:
+                        artifact = updated_refs
                 projection_kind = artifact.projection_kind
             else:
                 content = f"[{content_type}: {filename}]"
                 content_format = "text"
+                artifact_storage.update_artifact_status(
+                    artifact.artifact_id,
+                    parse_status="failed",
+                    parse_error=str(getattr(parsed, "error", "parse failed")),
+                )
         except Exception as e:
             logger.warning(f"Failed to parse attachment: {e}")
             content = f"[{content_type}: {filename}]"
             content_format = "text"
+            artifact_storage.update_artifact_status(artifact.artifact_id, parse_status="failed", parse_error=str(e))
     elif content_type.startswith("image/"):
+        artifact_storage.update_artifact_status(artifact.artifact_id, parse_status="skipped")
         if include_image:
             try:
                 content = compress_image_for_llm(file_path, max_dimension=max_image_size)
@@ -118,6 +152,7 @@ async def download_and_process_attachment(
     else:
         content = f"[{content_type}: {filename}]"
         content_format = "text"
+        artifact_storage.update_artifact_status(artifact.artifact_id, parse_status="skipped")
 
     return AttachmentResult(
         file_id=metadata.file_id,
@@ -132,6 +167,7 @@ async def download_and_process_attachment(
         artifact_id=artifact.artifact_id,
         projection_kind=projection_kind or artifact.projection_kind,
         preview=preview or artifact.preview,
+        text_ref=text_ref or artifact.text_ref,
     )
 
 

--- a/tests/test_attachment_projection.py
+++ b/tests/test_attachment_projection.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.utils import attachment as attachment_mod
+from src.file_artifacts.storage import storage as artifact_storage
 
 
 @pytest.mark.asyncio
@@ -35,3 +36,43 @@ async def test_attachment_binary_stays_metadata_only(monkeypatch):
     monkeypatch.setattr(attachment_mod, "_download_file", _fake_download)
     out = await attachment_mod.download_and_process_attachment("u")
     assert out.content.startswith("[application/octet-stream")
+    record = artifact_storage.get_artifact(out.artifact_id)
+    assert record is not None
+    assert record.parse_status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_attachment_parse_failure_sets_failed(monkeypatch):
+    async def _fake_download(url, auth_header=None):
+        return (b"hello", "text/plain", "a.txt")
+
+    async def _fake_parse(file_id, options=None):
+        class R:
+            success = False
+            error = "parse failed"
+        return R()
+
+    monkeypatch.setattr(attachment_mod, "_download_file", _fake_download)
+    monkeypatch.setattr(attachment_mod, "parse_file", _fake_parse)
+
+    out = await attachment_mod.download_and_process_attachment("u")
+    record = artifact_storage.get_artifact(out.artifact_id)
+    assert record is not None
+    assert record.parse_status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_attachment_parse_exception_sets_failed(monkeypatch):
+    async def _fake_download(url, auth_header=None):
+        return (b"hello", "text/plain", "a.txt")
+
+    async def _fake_parse(file_id, options=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(attachment_mod, "_download_file", _fake_download)
+    monkeypatch.setattr(attachment_mod, "parse_file", _fake_parse)
+
+    out = await attachment_mod.download_and_process_attachment("u")
+    record = artifact_storage.get_artifact(out.artifact_id)
+    assert record is not None
+    assert record.parse_status == "failed"

--- a/tests/test_confluence_attachment_text_ref.py
+++ b/tests/test_confluence_attachment_text_ref.py
@@ -1,0 +1,76 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_confluence_attachment_builds_text_ref_and_artifact_ref(monkeypatch):
+    import src.confluence as confluence
+
+    class _Channel:
+        base_url = "https://c"
+        _auth_header = {}
+
+        def is_configured(self):
+            return True
+
+        def get_instance_client(self, **kwargs):
+            return self
+
+        async def get_page(self, page_id):
+            return {"id": page_id, "title": "T", "space": {"key": "ENG"}, "body": {"storage": {"value": "<p>x</p>"}}}
+
+        async def get_all_comments_with_ledger(self, page_id):
+            return [], {"loaded": 0, "total": 0, "complete": True}
+
+        async def get_all_attachments_with_ledger(self, page_id):
+            return [
+                {"id": "d1", "title": "a.pdf", "metadata": {"mediaType": "application/pdf"}, "_links": {"download": "/d"}}
+            ], {"loaded": 1, "total": 1, "complete": True}
+
+        async def get_all_page_children_with_ledger(self, page_id):
+            return [], {"loaded": 0, "total": 0, "complete": True}
+
+        async def get_all_descendants_with_ledger(self, page_id):
+            return [], {"loaded": 0, "total": 0, "complete": True, "partial_reasons": []}
+
+    class _Adapter:
+        def __init__(self, _):
+            pass
+
+        async def _to_markdown(self, page):
+            return "x"
+
+    class _Res:
+        artifact_id = "a1"
+        preview = "doc"
+        content = "doc"
+        text_ref = "txt-ref"
+
+    monkeypatch.setattr(confluence, "confluence_channel", _Channel())
+    monkeypatch.setattr(confluence, "ConfluenceFormatAdapter", _Adapter)
+
+    async def _fake_download(**kwargs):
+        return _Res()
+
+    monkeypatch.setattr(confluence, "download_and_process_attachment", _fake_download)
+    captured = {}
+
+    def _fake_persist(**kwargs):
+        captured["bundle"] = kwargs["bundle"]
+        return {"context_ref": "c", "digest_ref": "d"}
+
+    monkeypatch.setattr(confluence, "persist_confluence_source_bundle_and_digest", _fake_persist)
+
+    from src.file_artifacts.storage import storage as artifact_storage
+    from src.file_artifacts.models import ArtifactRecord
+
+    def _fake_get_artifact(_artifact_id):
+        return ArtifactRecord(
+            artifact_id="a1", file_id="a1", source_type="confluence", source_kind="page_attachment", filename="a.pdf", content_type="application/pdf", size=1, text_ref="txt-ref"
+        )
+
+    monkeypatch.setattr(artifact_storage, "get_artifact", _fake_get_artifact)
+
+    out = await confluence.confluence_prepare_page_context("1", _session_id="s")
+    assert "[confluence source bundle prepared]" in out
+    assert captured["bundle"]["attachments"][0]["text_ref"] == "txt-ref"
+    assert captured["bundle"]["artifact_refs"][0]["text_ref"] == "txt-ref"

--- a/tests/test_github_source_service.py
+++ b/tests/test_github_source_service.py
@@ -34,3 +34,46 @@ async def test_read_github_doc_text_non_projectable(monkeypatch):
     ref = BundleRef(owner="o", repo="r", path="p", branch="main")
     with pytest.raises(RequirementBundleError):
         await read_github_doc_text("docs/a.bin", ref)
+
+
+@pytest.mark.asyncio
+async def test_prepare_github_file_source_marks_non_projectable_skipped(monkeypatch):
+    from src.github.source_service import prepare_github_file_source
+    from src.file_artifacts.storage import storage as artifact_storage
+
+    async def _fake_get_file(owner, repo, path, ref):
+        return {"content": base64.b64encode(b"\x00\x01").decode(), "sha": "s", "size": 2}
+
+    monkeypatch.setattr("src.github.source_service.github_channel.get_file", _fake_get_file)
+
+    ref = BundleRef(owner="o", repo="r", path="p", branch="main")
+    prepared = await prepare_github_file_source("docs/a.bin", ref, session_id="s1")
+    artifact_id = prepared["bundle"]["artifact_refs"][0]["artifact_id"]
+    artifact = artifact_storage.get_artifact(artifact_id)
+    assert artifact is not None
+    assert artifact.parse_status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_prepare_github_file_source_marks_parse_failed(monkeypatch):
+    from src.github.source_service import prepare_github_file_source
+    from src.file_artifacts.storage import storage as artifact_storage
+
+    async def _fake_get_file(owner, repo, path, ref):
+        return {"content": base64.b64encode(b"hello").decode(), "sha": "s", "size": 5}
+
+    async def _fake_parse(file_id, options=None):
+        class R:
+            success = False
+            error = "parse error"
+        return R()
+
+    monkeypatch.setattr("src.github.source_service.github_channel.get_file", _fake_get_file)
+    monkeypatch.setattr("src.github.source_service.parse_file", _fake_parse)
+
+    ref = BundleRef(owner="o", repo="r", path="p", branch="main")
+    prepared = await prepare_github_file_source("docs/a.txt", ref, session_id="s1")
+    artifact_id = prepared["bundle"]["artifact_refs"][0]["artifact_id"]
+    artifact = artifact_storage.get_artifact(artifact_id)
+    assert artifact is not None
+    assert artifact.parse_status == "failed"

--- a/tests/test_jira_attachment_text_ref.py
+++ b/tests/test_jira_attachment_text_ref.py
@@ -1,0 +1,76 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_jira_attachment_always_persists_text_ref(monkeypatch):
+    from src.jira.source_service import prepare_jira_issue_source
+
+    class _Channel:
+        api_version = "3"
+        _auth_header = {}
+
+        def is_configured(self):
+            return True
+
+        def get_instance_client(self, **kwargs):
+            return self
+
+    class _Adapter:
+        def __init__(self, _):
+            pass
+
+        async def get_issue(self, **kwargs):
+            return {
+                "key": "P-1",
+                "fields": {
+                    "summary": "S",
+                    "comment": {"comments": [], "total": 0},
+                    "attachment": [{"id": "1", "filename": "a.pdf", "mimeType": "application/pdf", "content": "u"}],
+                },
+            }
+
+        def _get_comments_list(self, *a, **k):
+            return []
+
+        def _convert_description_to_markdown(self, x):
+            return ""
+
+        def _extract_acceptance_criteria(self, x):
+            return ""
+
+    class _Result:
+        content_format = "text"
+        content = "abc"
+        artifact_id = "art-1"
+        preview = "abc"
+        text_ref = "text-1"
+
+    monkeypatch.setattr("src.jira.jira_channel", _Channel())
+    monkeypatch.setattr("src.jira.source_service.JiraFormatAdapter", _Adapter)
+
+    captured = {}
+
+    def _fake_persist(**kwargs):
+        captured["bundle"] = kwargs["bundle"]
+        return {"context_ref": "c", "digest_ref": "d", "source_digest_chunk_count": 0}
+
+    monkeypatch.setattr("src.jira.source_service.persist_jira_source_bundle_and_digest", _fake_persist)
+
+    async def _fake_download(**kwargs):
+        return _Result()
+
+    monkeypatch.setattr("src.jira.download_and_process_attachment", _fake_download)
+
+    from src.file_artifacts.storage import storage as artifact_storage
+    from src.file_artifacts.models import ArtifactRecord
+
+    def _fake_get_artifact(_artifact_id):
+        return ArtifactRecord(
+            artifact_id="art-1", file_id="art-1", source_type="jira", source_kind="issue_attachment", filename="a.pdf", content_type="application/pdf", size=1, text_ref="text-1"
+        )
+
+    monkeypatch.setattr(artifact_storage, "get_artifact", _fake_get_artifact)
+
+    result = await prepare_jira_issue_source("P-1")
+    assert result.bundle["attachments"][0]["text_ref"] == "text-1"
+    assert captured["bundle"]["artifact_refs"][0]["text_ref"] == "text-1"

--- a/tests/test_requirements_skill_github_source_refs.py
+++ b/tests/test_requirements_skill_github_source_refs.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_load_github_doc_sources_returns_real_refs(monkeypatch):
+    from skills.collect_requirements_to_bundle.skill import _load_github_doc_sources
+
+    class _DocRef:
+        owner = "acme"
+        repo = "repo"
+        branch = "main"
+        path = "docs/spec.md"
+
+    async def _fake_prepare(raw, default_ref):
+        return {
+            "doc_ref": _DocRef(),
+            "bundle": {},
+            "context_ref": "ctx-1",
+            "digest_ref": "dig-1",
+            "artifact_refs": [{"artifact_id": "a-1"}],
+            "content_text": "hello",
+        }
+
+    monkeypatch.setattr("skills.collect_requirements_to_bundle.skill.prepare_github_doc_source", _fake_prepare)
+
+    out = await _load_github_doc_sources(
+        {"repo": "acme/repo", "path": "bundles/a", "branch": "main"},
+        ["docs/spec.md"],
+    )
+
+    assert out[0]["content"] == "hello"
+    assert out[0]["artifact_refs"] == [{"artifact_id": "a-1"}]
+    assert out[0]["context_ref"] == "ctx-1"
+    assert out[0]["digest_ref"] == "dig-1"
+    assert out[0]["source_kind"] == "repo_file"

--- a/tests/test_webchat_file_upload_parse_binding.py
+++ b/tests/test_webchat_file_upload_parse_binding.py
@@ -53,3 +53,38 @@ async def test_upload_and_parse_binds_session_and_rebuilds(monkeypatch):
     assert meta2.parse_status == "completed"
     assert storage.get_file_chunks(fid)
     assert called["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_parse_exception_marks_file_and_artifact_failed(monkeypatch):
+    req = make_mocked_request("POST", "/api/files/upload?session_id=s-bind-err", headers=CIMultiDict())
+
+    async def _multipart():
+        return _Multipart(_Field())
+
+    req.multipart = _multipart
+    upload_resp = await webchat.api_files_upload(req)
+    file_id = json.loads(upload_resp.text)["file_id"]
+
+    async def _raise_parse(file_id, options=None):
+        raise RuntimeError("parse crash")
+
+    monkeypatch.setattr(webchat, "parse_file", _raise_parse)
+
+    parse_req = make_mocked_request("POST", "/api/files/parse?session_id=s-bind-err", headers=CIMultiDict())
+
+    async def _json():
+        return {"file_id": file_id}
+
+    parse_req.json = _json
+    parse_resp = await webchat.api_files_parse(parse_req)
+    assert parse_resp.status == 500
+
+    meta = storage.get_file_meta("s-bind-err", file_id)
+    assert meta is not None
+    assert meta.parse_status == "failed"
+
+    from src.file_artifacts.storage import storage as artifact_storage
+    artifact = artifact_storage.get_artifact(file_id)
+    assert artifact is not None
+    assert artifact.parse_status == "failed"


### PR DESCRIPTION
### Motivation
- Artifacts only stored previews and status, so artifact refs from Jira/Confluence/GitHub could not reliably point to full projection entries or bundle context/digest refs.
- Failure/exception paths left file_context and artifact states stuck in `processing`, causing incorrect downstream behavior.
- Skills that load GitHub docs were discarding the richer bundle surface (artifact refs/context/digest) and returning placeholders instead of real refs.

### Description
- Extend `ArtifactRecord` with `text_ref`, `context_ref`, `digest_ref`, and `full_markdown_chars`, and add `update_artifact_references(...)` in `src/file_artifacts/storage.py` to persist those refs without embedding full markdown. 
- Add service helpers `attach_text_ref_to_artifact(...)` and `attach_source_refs_to_artifact(...)` and make `build_artifact_ref_dict(...)` emit `text_ref/context_ref/digest_ref` in `src/file_artifacts/service.py`/`__init__.py` so artifact refs can point at full content. 
- Harden parse failure handling in `src/gateway/webchat.py::api_files_parse()` to always write `file_context` and artifact status `failed` on exceptions so no processing state is left hanging. 
- Enhance `src/utils/attachment.py` to accept text-ref persistence parameters, to persist `text_ref` when full text is available, and to explicitly set artifact parse statuses to `completed`/`failed`/`skipped` (new `skipped` state for non-projectable/metadata-only attachments). 
- Wire Jira and Confluence attachment flows to request/persist `text_ref` for document attachments and to include `text_ref` in bundle attachments and artifact refs; after bundle digest persistence their artifacts get `context_ref`/`digest_ref` attached. 
- Make GitHub repo-file ingestion (`src/github/source_service.py`) propagate parse failure and non-projectable outcomes into artifact status (`failed`/`skipped`), add repo-file capability boundary metadata (`source_kind: "repo_file"`, `attachments_supported: false`, `issue_pr_assets_supported: false`), and persist context/digest refs back onto artifacts. 
- Add `prepare_github_doc_source(...)` in `src/runtime/requirement_bundle_assets.py` as a thin wrapper around `prepare_github_file_source(...)` that returns a unified structure (`doc_ref`, `bundle`, `context_ref`, `digest_ref`, `artifact_refs`, `content_text`), and make `read_github_doc_text()` call it for backward compatibility. 
- Update the skill `_load_github_doc_sources()` in `skills/collect_requirements_to_bundle/skill.py` to use `prepare_github_doc_source()` and return real `artifact_refs/context_ref/digest_ref` and `source_kind: "repo_file"` instead of placeholders. 
- Update `src/source_context.py` to include GitHub capability boundary fields in the digest metadata. 
- Added/modified tests to assert correct states and ref propagation without increasing integration scope.

### Testing
- Modified/added unit tests: `tests/test_attachment_projection.py` (non-projectable -> `skipped`, parse failure/exception -> `failed`), `tests/test_webchat_file_upload_parse_binding.py` (parse exception -> file_context/artifact `failed`), `tests/test_github_source_service.py` (non-projectable -> `skipped`, parse failed -> `failed`), `tests/test_requirements_skill_github_source_refs.py` (skill returns real `artifact_refs/context_ref/digest_ref`), `tests/test_confluence_attachment_text_ref.py` and `tests/test_jira_attachment_text_ref.py` (attachment `text_ref` persisted and present on artifact refs), plus existing `tests/test_jira_source_artifacts.py` and `tests/test_confluence_source_artifacts.py` exercised and left intact. 
- Ran the targeted suites locally: the changed/added tests and the larger requirement-bundle and adapter suites were executed; the run reported all tests passing (multiple test runs culminating in full-suite runs reporting passing results). 
- Observed only an unrelated `UserWarning` about `ParseResult.json` field shadowing a BaseModel attribute which does not affect behavior; no additional external dependencies were required to run the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaae4ec47c832aa35b81b38236eb02)