### PR TITLE
Wire response-flow conflict policy and skill behavior defaults into runtime

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -99,6 +99,10 @@ llm:
     staging_policy: "explicit_or_complex"
     default_skill_execution_style: "direct"
     ask_user_policy: "blocked_only"
+    # direct active skill conflict policy:
+    # - auto_switch_direct: clear new request leaves old direct skill automatically
+    # - always_ask: keep active direct skill context and ask continue-vs-switch
+    active_skill_conflict_policy: "auto_switch_direct"
     # Staging/planning activates only on explicit request or true budget pressure.
     complexity_prompt_budget_ratio: 0.85
     complexity_min_request_tokens: 24000

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -79,7 +79,7 @@ from src.runtime.progressive_context import (
 from src.context_blob_store import build_section_map, put_text
 from src.agents.compaction import estimate_tokens
 from src.runtime.output_controller import call_llm_with_output_control, recover_max_output_tokens
-from src.runtime.response_flow_policy import decide_response_flow
+from src.runtime.response_flow_policy import decide_response_flow, resolve_skill_behavior_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +136,15 @@ def _should_continue_existing_active_skill(
         return False
 
     if _is_effectively_direct_skill_contract(existing_contract):
+        response_flow_cfg = (
+            config.llm.get("response_flow", {}) if isinstance(config.llm, dict) and isinstance(config.llm.get("response_flow"), dict) else {}
+        )
+        _, _, resolved_conflict_policy = resolve_skill_behavior_defaults(
+            response_flow_cfg,
+            active_skill_conflict_policy=str(existing_contract.get("active_skill_conflict_policy") or ""),
+        )
+        if resolved_conflict_policy == "always_ask":
+            return True
         return _is_explicit_skill_continuation_message(message)
 
     try:
@@ -1949,6 +1958,13 @@ You have access to the following tools. When a user asks you to do something tha
 
         if selected_skill:
             logger.info(f"[Skill] Active skill selected: {selected_skill.name} ({activation_reason})")
+            if activation_reason == "continued" and isinstance(existing_active_skill_contract, dict):
+                continued_conflict_policy = str(existing_active_skill_contract.get("active_skill_conflict_policy") or "").strip()
+                if continued_conflict_policy:
+                    try:
+                        setattr(selected_skill, "active_skill_conflict_policy", continued_conflict_policy)
+                    except Exception:
+                        pass
             
             # Set skill workdir for exec tool (async-safe via contextvars)
             set_skill_workdir(selected_skill.path or None)
@@ -3129,11 +3145,19 @@ You have access to the following tools. When a user asks you to do something tha
         send_skill_event("skill_mode_start", {"skill": skill.name, "message": safe_preview(message, 100)})
 
         initial_skill_session = SkillSession(skill_name=skill.name, original_user_request=message)
+        response_flow_cfg = (
+            config.llm.get("response_flow", {}) if isinstance(config.llm, dict) and isinstance(config.llm.get("response_flow"), dict) else {}
+        )
+        resolved_execution_style, resolved_ask_user_policy, _ = resolve_skill_behavior_defaults(
+            response_flow_cfg,
+            execution_style=str(getattr(skill, "execution_style", "") or ""),
+            ask_user_policy=str(getattr(skill, "ask_user_policy", "") or ""),
+        )
         initial_system_prompt = _build_skill_mode_system_prompt(
             skill,
             initial_skill_session,
-            execution_style=str(getattr(skill, "execution_style", "direct") or "direct"),
-            ask_user_policy=str(getattr(skill, "ask_user_policy", "blocked_only") or "blocked_only"),
+            execution_style=resolved_execution_style,
+            ask_user_policy=resolved_ask_user_policy,
         )
         initial_user_prompt = _build_skill_mode_user_prompt(message, initial_skill_session)
         initial_input_items = [{"role": "user", "content": [{"type": "input_text", "text": initial_user_prompt}]}]

--- a/src/runtime/response_flow_policy.py
+++ b/src/runtime/response_flow_policy.py
@@ -10,6 +10,7 @@ DEFAULT_RESPONSE_FLOW_CONFIG: Dict[str, Any] = {
     "staging_policy": "explicit_or_complex",
     "default_skill_execution_style": "direct",
     "ask_user_policy": "blocked_only",
+    "active_skill_conflict_policy": "auto_switch_direct",
     "complexity_prompt_budget_ratio": 0.85,
     "complexity_min_request_tokens": 24000,
 }
@@ -99,6 +100,38 @@ def is_truly_complex_request(
     return bool(near_limit and meets_floor)
 
 
+def resolve_skill_behavior_defaults(
+    config_block: Optional[Dict[str, Any]] = None,
+    *,
+    execution_style: str = "",
+    ask_user_policy: str = "",
+    active_skill_conflict_policy: str = "",
+) -> tuple[str, str, str]:
+    cfg = resolve_response_flow_config(config_block)
+
+    resolved_execution_style = (
+        execution_style if execution_style in {"direct", "stepwise"} else str(cfg.get("default_skill_execution_style") or "direct")
+    )
+    if resolved_execution_style not in {"direct", "stepwise"}:
+        resolved_execution_style = "direct"
+
+    resolved_ask_policy = (
+        ask_user_policy if ask_user_policy in {"blocked_only", "permissive"} else str(cfg.get("ask_user_policy") or "blocked_only")
+    )
+    if resolved_ask_policy not in {"blocked_only", "permissive"}:
+        resolved_ask_policy = "blocked_only"
+
+    resolved_conflict_policy = (
+        active_skill_conflict_policy
+        if active_skill_conflict_policy in {"auto_switch_direct", "always_ask"}
+        else str(cfg.get("active_skill_conflict_policy") or "auto_switch_direct")
+    )
+    if resolved_conflict_policy not in {"auto_switch_direct", "always_ask"}:
+        resolved_conflict_policy = "auto_switch_direct"
+
+    return resolved_execution_style, resolved_ask_policy, resolved_conflict_policy
+
+
 def decide_response_flow(
     *,
     config_block: Optional[Dict[str, Any]] = None,
@@ -123,15 +156,13 @@ def decide_response_flow(
         complexity_min_request_tokens=int(cfg["complexity_min_request_tokens"]),
     )
 
-    resolved_execution_style = execution_style if execution_style in {"direct", "stepwise"} else str(
-        cfg.get("default_skill_execution_style") or "direct"
+    resolved_execution_style, resolved_ask_policy, _ = resolve_skill_behavior_defaults(
+        cfg,
+        execution_style=execution_style,
+        ask_user_policy=ask_user_policy,
     )
     if resolved_execution_style == "stepwise":
         reasons.append("skill_execution_stepwise")
-
-    resolved_ask_policy = ask_user_policy if ask_user_policy in {"blocked_only", "permissive"} else str(
-        cfg.get("ask_user_policy") or "blocked_only"
-    )
 
     plan_required = False
     plan_policy = str(cfg.get("plan_policy") or "explicit_or_complex")

--- a/src/skills/README.md
+++ b/src/skills/README.md
@@ -118,6 +118,8 @@ ask_user_policy: blocked_only  # blocked_only|permissive
 - `execution_style`: `direct` completes in one turn when possible; `stepwise` keeps one-step progression.
 - `ask_user_policy`: `blocked_only` asks only for truly blocking inputs; `permissive` allows broader clarification.
 
+When `execution_style` or `ask_user_policy` is omitted from skill frontmatter, runtime falls back to `llm.response_flow.default_skill_execution_style` and `llm.response_flow.ask_user_policy` respectively. If the skill explicitly sets either field, the skill value takes precedence over global defaults.
+
 ## Development Guide
 
 1. Create a new directory in `skills/`

--- a/src/skills/active_contract.py
+++ b/src/skills/active_contract.py
@@ -154,6 +154,9 @@ def build_active_skill_contract(
         "staging_mode": str(getattr(runtime_config, "staging_mode", "auto") or "auto"),
         "execution_style": str(getattr(runtime_config, "execution_style", "direct") or "direct"),
         "ask_user_policy": str(getattr(runtime_config, "ask_user_policy", "blocked_only") or "blocked_only"),
+        "active_skill_conflict_policy": str(
+            getattr(runtime_config, "active_skill_conflict_policy", "auto_switch_direct") or "auto_switch_direct"
+        ),
         "references": list(runtime_config.references or []),
         "prompt_contract_summary": _shorten(runtime_config.prompt_blocks.developer_instructions, 2000),
         "created_at": created_at or now,

--- a/src/skills/registry.py
+++ b/src/skills/registry.py
@@ -46,8 +46,8 @@ class Skill:
     risk_level: str = ""
     planning_mode: str = "auto"
     staging_mode: str = "auto"
-    execution_style: str = "direct"
-    ask_user_policy: str = "blocked_only"
+    execution_style: str = ""
+    ask_user_policy: str = ""
 
     # Compiled patterns for fast matching
     trigger_patterns: List[re.Pattern] = field(default_factory=list)
@@ -77,8 +77,8 @@ class Skill:
             risk_level=data.get("risk_level", "") or "",
             planning_mode=str(data.get("planning_mode", "auto") or "auto"),
             staging_mode=str(data.get("staging_mode", "auto") or "auto"),
-            execution_style=str(data.get("execution_style", "direct") or "direct"),
-            ask_user_policy=str(data.get("ask_user_policy", "blocked_only") or "blocked_only"),
+            execution_style=str(data.get("execution_style", "") or ""),
+            ask_user_policy=str(data.get("ask_user_policy", "") or ""),
             trigger_patterns=patterns,
         )
 

--- a/src/skills/runtime.py
+++ b/src/skills/runtime.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, List, Optional, Set
 
+from src.config import config
+from src.runtime.response_flow_policy import resolve_skill_behavior_defaults
 from src.skills.registry import Skill
 
 logger = logging.getLogger(__name__)
@@ -58,6 +60,7 @@ class SkillRuntimeConfig:
     staging_mode: str = "auto"
     execution_style: str = "direct"
     ask_user_policy: str = "blocked_only"
+    active_skill_conflict_policy: str = "auto_switch_direct"
     prompt_blocks: SkillPromptBlocks = field(default_factory=SkillPromptBlocks)
     references: List[str] = field(default_factory=list)
 
@@ -376,12 +379,29 @@ def build_skill_prompt_blocks(
     resolved_execution_style = str((runtime_config.execution_style if runtime_config else getattr(skill, "execution_style", "direct")) or "direct")
     resolved_planning_mode = str((runtime_config.planning_mode if runtime_config else getattr(skill, "planning_mode", "auto")) or "auto")
     resolved_staging_mode = str((runtime_config.staging_mode if runtime_config else getattr(skill, "staging_mode", "auto")) or "auto")
-    direct_mode = resolved_execution_style == "direct" and resolved_planning_mode != "required" and resolved_staging_mode != "required"
-    continuity_rule = (
-        "For direct skills, if the user gives a clear new request, treat that as leaving this prior skill and handle the new request directly without asking for switch permission."
-        if direct_mode
-        else "For stepwise/required-plan/required-staging skills, continue the flow when the user clearly continues; only ask continue-vs-switch if the latest user turn is genuinely ambiguous."
+    resolved_conflict_policy = str(
+        (
+            runtime_config.active_skill_conflict_policy
+            if runtime_config
+            else getattr(skill, "active_skill_conflict_policy", "auto_switch_direct")
+        )
+        or "auto_switch_direct"
     )
+    direct_mode = resolved_execution_style == "direct" and resolved_planning_mode != "required" and resolved_staging_mode != "required"
+    if direct_mode and resolved_conflict_policy == "always_ask":
+        continuity_rule = (
+            "For direct skills with active_skill_conflict_policy=always_ask, do not auto-switch on a clear new request. "
+            "Keep this active skill context and ask the user to choose: continue current skill or switch to the new request. "
+            "Proceed only after the user clearly confirms continue/switch."
+        )
+    elif direct_mode:
+        continuity_rule = (
+            "For direct skills, if the user gives a clear new request, treat that as leaving this prior skill and handle the new request directly without asking for switch permission."
+        )
+    else:
+        continuity_rule = (
+            "For stepwise/required-plan/required-staging skills, continue the flow when the user clearly continues; only ask continue-vs-switch if the latest user turn is genuinely ambiguous."
+        )
     system_rules = (
         f"Active skill: {skill.name}.\n"
         "Stay within the skill's instructions, constraints, output contract, reference usage, and allowed tool policy while this skill is active.\n"
@@ -396,11 +416,13 @@ def build_skill_prompt_blocks(
         or runtime_config.planning_mode != "auto"
         or runtime_config.staging_mode != "auto"
         or runtime_config.ask_user_policy != "blocked_only"
+        or runtime_config.active_skill_conflict_policy != "auto_switch_direct"
     ):
         system_rules += (
             f"\nSkill behavior: execution_style={runtime_config.execution_style}, "
             f"planning_mode={runtime_config.planning_mode}, staging_mode={runtime_config.staging_mode}, "
-            f"ask_user_policy={runtime_config.ask_user_policy}."
+            f"ask_user_policy={runtime_config.ask_user_policy}, "
+            f"active_skill_conflict_policy={runtime_config.active_skill_conflict_policy}."
         )
 
     strategy = "\n".join(f"- {item}" for item in (skill.strategy or []))
@@ -472,6 +494,14 @@ def build_skill_runtime_config(
     skill: Skill,
     globally_allowed_tool_names: Optional[Iterable[str]] = None,
 ) -> SkillRuntimeConfig:
+    llm_cfg = config.llm if isinstance(config.llm, dict) else {}
+    response_flow_cfg = llm_cfg.get("response_flow") if isinstance(llm_cfg.get("response_flow"), dict) else {}
+    resolved_execution_style, resolved_ask_user_policy, resolved_conflict_policy = resolve_skill_behavior_defaults(
+        response_flow_cfg,
+        execution_style=str(getattr(skill, "execution_style", "") or ""),
+        ask_user_policy=str(getattr(skill, "ask_user_policy", "") or ""),
+        active_skill_conflict_policy=str(getattr(skill, "active_skill_conflict_policy", "") or ""),
+    )
     references = summarize_skill_references(skill)
     raw_skill_tools = list(skill.tools or [])
     raw_task_tools = list(skill.task_tools or [])
@@ -506,8 +536,9 @@ def build_skill_runtime_config(
         workdir=skill.path or "",
         planning_mode=str(getattr(skill, "planning_mode", "auto") or "auto"),
         staging_mode=str(getattr(skill, "staging_mode", "auto") or "auto"),
-        execution_style=str(getattr(skill, "execution_style", "direct") or "direct"),
-        ask_user_policy=str(getattr(skill, "ask_user_policy", "blocked_only") or "blocked_only"),
+        execution_style=resolved_execution_style,
+        ask_user_policy=resolved_ask_user_policy,
+        active_skill_conflict_policy=resolved_conflict_policy,
         references=references,
     )
     prompt_blocks = build_skill_prompt_blocks(

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -34,6 +34,21 @@ def test_direct_active_skill_contract_explicit_continue_message_continues():
     assert core._should_continue_existing_active_skill(contract, "continue", registry) is True
 
 
+def test_direct_active_skill_contract_always_ask_keeps_active_on_ordinary_new_request():
+    from src.agents import core
+
+    contract = {
+        "skill_name": "alpha",
+        "status": "active",
+        "execution_style": "direct",
+        "planning_mode": "auto",
+        "staging_mode": "auto",
+        "active_skill_conflict_policy": "always_ask",
+    }
+    registry = type("Registry", (), {"match_skill": lambda self, message: [type("Skill", (), {"name": "beta"})()]})()
+    assert core._should_continue_existing_active_skill(contract, "write a release note", registry) is True
+
+
 def test_stepwise_active_skill_contract_clear_continuation_keeps_skill():
     from src.agents import core
 

--- a/tests/test_response_flow_policy.py
+++ b/tests/test_response_flow_policy.py
@@ -1,4 +1,4 @@
-from src.runtime.response_flow_policy import decide_response_flow
+from src.runtime.response_flow_policy import decide_response_flow, resolve_skill_behavior_defaults
 
 
 def test_explicit_plan_request_chinese_sets_plan_required():
@@ -39,3 +39,41 @@ def test_budget_near_limit_sets_staging_required():
         prompt_budget_tokens=32000,
     )
     assert decision.staging_required is True
+
+
+def test_resolve_skill_behavior_defaults_uses_config_active_skill_conflict_policy():
+    execution_style, ask_policy, conflict_policy = resolve_skill_behavior_defaults(
+        {"active_skill_conflict_policy": "always_ask"}
+    )
+    assert execution_style == "direct"
+    assert ask_policy == "blocked_only"
+    assert conflict_policy == "always_ask"
+
+
+def test_resolve_skill_behavior_defaults_skill_explicit_values_override_config():
+    execution_style, ask_policy, conflict_policy = resolve_skill_behavior_defaults(
+        {
+            "default_skill_execution_style": "stepwise",
+            "ask_user_policy": "permissive",
+            "active_skill_conflict_policy": "auto_switch_direct",
+        },
+        execution_style="direct",
+        ask_user_policy="blocked_only",
+        active_skill_conflict_policy="always_ask",
+    )
+    assert execution_style == "direct"
+    assert ask_policy == "blocked_only"
+    assert conflict_policy == "always_ask"
+
+
+def test_resolve_skill_behavior_defaults_skill_omission_uses_config_defaults():
+    execution_style, ask_policy, conflict_policy = resolve_skill_behavior_defaults(
+        {
+            "default_skill_execution_style": "stepwise",
+            "ask_user_policy": "permissive",
+            "active_skill_conflict_policy": "always_ask",
+        }
+    )
+    assert execution_style == "stepwise"
+    assert ask_policy == "permissive"
+    assert conflict_policy == "always_ask"

--- a/tests/test_skill_runtime_refactor.py
+++ b/tests/test_skill_runtime_refactor.py
@@ -586,6 +586,70 @@ def test_build_skill_runtime_config_task_tools_trimmed_by_global_allowlist():
     assert runtime_config.task_tools == []
 
 
+def test_build_skill_runtime_config_skill_omission_uses_response_flow_defaults(monkeypatch):
+    from src.config import config
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "response_flow": {
+                "default_skill_execution_style": "stepwise",
+                "ask_user_policy": "permissive",
+            }
+        },
+    )
+    skill = SimpleNamespace(
+        name="demo",
+        description="demo",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body="",
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+        execution_style="",
+        ask_user_policy="",
+    )
+    runtime_config = build_skill_runtime_config(skill)
+    assert runtime_config.execution_style == "stepwise"
+    assert runtime_config.ask_user_policy == "permissive"
+
+
+def test_build_skill_runtime_config_skill_explicit_values_override_response_flow_defaults(monkeypatch):
+    from src.config import config
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "response_flow": {
+                "default_skill_execution_style": "stepwise",
+                "ask_user_policy": "permissive",
+            }
+        },
+    )
+    skill = SimpleNamespace(
+        name="demo",
+        description="demo",
+        tools=[],
+        task_tools=[],
+        strategy=[],
+        body="",
+        references=[],
+        model="",
+        hooks=[],
+        path="",
+        execution_style="direct",
+        ask_user_policy="blocked_only",
+    )
+    runtime_config = build_skill_runtime_config(skill)
+    assert runtime_config.execution_style == "direct"
+    assert runtime_config.ask_user_policy == "blocked_only"
+
+
 def test_build_skill_tool_denied_result_contains_policy():
     runtime_config = build_skill_runtime_config(
         SimpleNamespace(
@@ -715,7 +779,7 @@ async def test_active_skill_contract_continues_without_rematch(monkeypatch, base
 
 
 @pytest.mark.asyncio
-async def test_active_skill_contract_does_not_soft_switch_on_ordinary_match(monkeypatch, base_agent):
+async def test_active_skill_contract_auto_switches_direct_skill_on_ordinary_new_request(monkeypatch, base_agent):
     agent, sess = base_agent
     review_skill = SimpleNamespace(
         name="review-pull-request",
@@ -780,8 +844,82 @@ async def test_active_skill_contract_does_not_soft_switch_on_ordinary_match(monk
     result = await agent.process("ordinary message that matches create", session_id="s1")
     assert result["response"] == "done"
     assert captured_prompts
+    assert "Active skill: create-pull-request" in captured_prompts[0]
+    assert "Active skill: review-pull-request" not in captured_prompts[0]
+    assert sess.active_skill_session["skill_name"] == "create-pull-request"
+    assert sess.active_skill_session["activation_reason"] == "matched"
+
+
+@pytest.mark.asyncio
+async def test_active_skill_contract_always_ask_keeps_direct_skill_context_on_ordinary_new_request(monkeypatch, base_agent):
+    agent, sess = base_agent
+    review_skill = SimpleNamespace(
+        name="review-pull-request",
+        description="review",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Review instructions",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+    create_skill = SimpleNamespace(
+        name="create-pull-request",
+        description="create",
+        path="",
+        tools=["allowed_tool"],
+        task_tools=[],
+        strategy=[],
+        body="Create instructions",
+        references=[],
+        model="",
+        hooks=[],
+        deprecated=False,
+    )
+    sess.active_skill_session = {
+        "schema_version": "active_skill_contract.v1",
+        "skill_name": "review-pull-request",
+        "status": "active",
+        "turn_count": 1,
+        "execution_style": "direct",
+        "active_skill_conflict_policy": "always_ask",
+    }
+
+    class _Registry:
+        _initialized = True
+
+        def match_skill(self, message):
+            if "ordinary message that matches create" in message:
+                return [create_skill]
+            return []
+
+        def get_skill(self, name):
+            if name == review_skill.name:
+                return review_skill
+            if name == create_skill.name:
+                return create_skill
+            return None
+
+        def get_skill_runtime_config(self, skill, globally_allowed_tool_names=None):
+            return build_skill_runtime_config(skill, globally_allowed_tool_names=globally_allowed_tool_names)
+
+    monkeypatch.setattr("src.skills.skill_registry", _Registry())
+    captured_prompts = []
+
+    async def fake_responses(**kwargs):
+        captured_prompts.append(kwargs.get("system_prompt", ""))
+        return {"content": "done", "function_calls": [], "usage": {}}
+
+    monkeypatch.setattr("src.agents.core.llm_client", SimpleNamespace(responses=fake_responses, default_provider="openai"))
+
+    result = await agent.process("ordinary message that matches create", session_id="s1")
+    assert result["response"] == "done"
+    assert captured_prompts
     assert "Active skill: review-pull-request" in captured_prompts[0]
-    assert "Active skill: create-pull-request" not in captured_prompts[0]
+    assert "continue current skill or switch to the new request" in captured_prompts[0]
     assert sess.active_skill_session["skill_name"] == "review-pull-request"
     assert sess.active_skill_session["activation_reason"] == "continued"
 


### PR DESCRIPTION
### Motivation
- Portal added `llm.response_flow.active_skill_conflict_policy` and global defaults for skill behavior, but the runtime was not consuming them so active-skill continuation and omission semantics were inconsistent. 
- The runtime must distinguish between a skill omitting vs explicitly declaring `execution_style`/`ask_user_policy` and persist the active policy so follow-up turns behave according to the policy chosen at activation.

### Description
- Added `active_skill_conflict_policy` to `DEFAULT_RESPONSE_FLOW_CONFIG` and introduced `resolve_skill_behavior_defaults(...)` to centralize resolution of `execution_style`, `ask_user_policy`, and `active_skill_conflict_policy` with validation and safe fallbacks in `src/runtime/response_flow_policy.py`.
- Changed `src/skills/registry.py` so `Skill.execution_style` and `Skill.ask_user_policy` preserve omission (default to `""`) instead of pre-resolving to values, allowing runtime fallback to global defaults when frontmatter is absent.
- Updated `src/skills/runtime.py` to read `config.llm.response_flow`, use the new helper to resolve final runtime behavior, add `active_skill_conflict_policy` to `SkillRuntimeConfig`, and embed the resolved policy into prompt continuity rules (three-way behavior for direct+auto_switch, direct+always_ask, and stepwise/required modes).
- Persisted `active_skill_conflict_policy` into the active skill contract in `src/skills/active_contract.py` so continuation decisions use the policy that was active at activation time.
- Wired `src/agents/core.py` to consult the resolved conflict policy when deciding whether to continue an active direct skill (policy precedence: contract → config → default), to inject contract policy into the selected skill on continued activations, and to use the helper when building the initial skill-mode system prompt so first-turn prompt generation is consistent with resolved defaults.
- Updated docs/config: added `active_skill_conflict_policy` example and comment in `config.yaml.example` and added a short note to `src/skills/README.md` explaining omission → runtime default fallback and explicit override precedence.
- Tests adjusted/added: replaced the old direct-skill continuation regression test with two tests covering the new default `auto_switch_direct` behavior and the `always_ask` behavior; added unit tests for the new helper and for runtime fallback/override semantics; added a core boundary test anchoring `direct + always_ask` continuation behavior.

### Testing
- Ran targeted test suites with: `pytest -q tests/test_response_flow_policy.py tests/test_core_runtime_boundary.py tests/test_skill_runtime_refactor.py tests/test_skill_mode_termination.py` and then a full test run; all tests passed (`220 passed`) locally. 
- Updated/added tests include: helper resolution tests (`tests/test_response_flow_policy.py`), core boundary test for `always_ask` (`tests/test_core_runtime_boundary.py`), runtime omission/override tests and the two new active-skill behavior tests (`tests/test_skill_runtime_refactor.py`), and these tests passed in the run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac2343eb4832ab7fc75f72950a7bf)