### PR TITLE
Unify default LLM to gpt-5.4-mini and wire runtime llm.temperature through LLM stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Access the web UI at `http://localhost:8000/`
 llm:
   provider: "openai"  # openai (default), github_copilot
   api_key: "sk-..."
-  model: "gpt-4o"
+  model: "gpt-5.4-mini"
 ```
 
 ### Control-Plane Runtime Settings

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -29,7 +29,7 @@ llm:
   # provider: "github_copilot"
   # api_base: "https://api.githubcopilot.com"
   # api_key: "ghp_YOUR_GITHUB_TOKEN"
-  # model: "gpt-5-mini"
+  # model: "gpt-5.4-mini"
   
   # Or Anthropic Claude Configuration
   # provider: "anthropic"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -200,10 +200,10 @@ cost_tracking:
 #   storage_dir: "~/.efp/usage"
 #   retention_days: 30
 
-# Supported providers and models (built-in pricing):
-# - openai: gpt-4o, gpt-4o-mini, gpt-4, gpt-3.5-turbo, o1-preview, o1-mini
+# Supported providers and common models:
+# - openai: gpt-5.4-mini, gpt-5, gpt-5-mini, gpt-4.1, gpt-4o, gpt-4o-mini, gpt-4, gpt-3.5-turbo
 # - anthropic: claude-sonnet-4, claude-opus-4, claude-haiku-4
-# - github_copilot: gpt-4, gpt-4o
+# - github_copilot: gpt-5.4-mini, gpt-5.4, gpt-5.3-codex, gpt-5-mini, gpt-4.1, gpt-4o, gemini-2.5-pro
 # - ollama: free (local)
 
 # ============================================

--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -34,7 +34,7 @@ from src.agents.llm import (
 from src.agents.memory import memory_system
 from src.memory.update_manager import MemoryUpdateManager
 from src.agents.thinking import ThinkLevel, normalize_think_level, format_runtime_info
-from src.config import config, resolve_output_boundary
+from src.config import config, resolve_output_boundary, DEFAULT_LLM_MODEL
 from src.utils.truncate import truncate, truncate_with_count
 from src.utils.redaction import safe_preview, redact_value, sanitize_exception_message
 from src.sessions.manager import session_manager
@@ -2128,7 +2128,7 @@ You have access to the following tools. When a user asks you to do something tha
         # ===== END SKILL MATCHING =====
 
         # ===== MESSAGE COMPACTION =====
-        model = self.model or config.llm.get("model", "gpt-5-mini")
+        model = self.model or config.llm.get("model", DEFAULT_LLM_MODEL)
         messages, pre_request_context_state = await prepare_progressive_messages(
             messages=messages,
             model=model,
@@ -2373,7 +2373,7 @@ You have access to the following tools. When a user asks you to do something tha
             if iteration > 1:
                 loop_messages, loop_context_state = await prepare_progressive_messages(
                     messages=loop_messages,
-                    model=self.model or config.llm.get("model", "gpt-5-mini"),
+                    model=self.model or config.llm.get("model", DEFAULT_LLM_MODEL),
                     session_id=session_id,
                     stage="tool_loop",
                     recent_count=5,
@@ -3302,7 +3302,7 @@ You have access to the following tools. When a user asks you to do something tha
             system_prompt=initial_system_prompt,
             tools=[],
         )
-        initial_prompt_budget = resolve_prompt_budget(stage="skill_generation", model=(self.model or config.llm.get("model", "gpt-5-mini")))
+        initial_prompt_budget = resolve_prompt_budget(stage="skill_generation", model=(self.model or config.llm.get("model", DEFAULT_LLM_MODEL)))
         initial_prompt_budget_tokens = int(initial_prompt_budget.get("prompt_budget_tokens", 0) or 0)
         flow = resolve_skill_response_flow(
             skill,
@@ -3462,7 +3462,7 @@ You have access to the following tools. When a user asks you to do something tha
         max_skill_compaction_budget = 32000  # 12% of 264K context for completed_steps
         
         # Resolve skill mode context window (similar to regular chat)
-        model = self.model or config.llm.get("model", "gpt-5-mini")
+        model = self.model or config.llm.get("model", DEFAULT_LLM_MODEL)
         context_window = resolve_context_window_tokens(model)
         # Trigger compaction at 80% of context window
         skill_max_tokens = int(context_window * 0.8)

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
-from src.config import config
+from src.config import config, DEFAULT_LLM_MODEL, resolve_llm_temperature, service_reload_manager
 from src.utils.redaction import redact_value, safe_preview, sanitize_exception_message
 from src.sessions.usage import usage_tracker, estimate_cost
 from .errors import (
@@ -406,7 +406,7 @@ class OpenAIProvider(BaseProvider):
             api_base=config.llm.get('api_base', 'https://api.openai.com/v1'),
             api_key_env='EFP_LLM_API_KEY'
         )
-        self.default_model = config.llm.get('model', 'gpt-3.5-turbo')
+        self.default_model = config.llm.get('model', DEFAULT_LLM_MODEL)
     
     async def chat(
         self,
@@ -414,7 +414,7 @@ class OpenAIProvider(BaseProvider):
         system_prompt: Optional[str] = None,
         tools: Optional[List[Dict]] = None,
         model: Optional[str] = None,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         reasoning_replay: Optional[bool] = None,
     ) -> Dict[str, Any]:
@@ -431,6 +431,7 @@ class OpenAIProvider(BaseProvider):
         
         # Use config setting if not explicitly provided
         enable_reasoning = reasoning_replay if reasoning_replay is not None else config.llm.get('reasoning_replay', False)
+        resolved_temperature = resolve_llm_temperature(temperature)
         
         # GPT-5 models require max_completion_tokens instead of max_tokens
         model_name = (model or self.default_model).lower()
@@ -447,7 +448,7 @@ class OpenAIProvider(BaseProvider):
             "messages": all_messages,
         }
         if include_temperature:
-            payload["temperature"] = temperature
+            payload["temperature"] = resolved_temperature
         payload[max_tokens_key] = max_tokens or config.llm.get('max_tokens', 64000)
         
         # Add reasoning_replay if enabled (for o1/o3 style reasoning)
@@ -556,6 +557,7 @@ class OpenAIProvider(BaseProvider):
         system_prompt: Optional[str] = None,
         tools: Optional[List[Dict]] = None,
         model: Optional[str] = None,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         reasoning_replay: Optional[bool] = None,
     ) -> Dict[str, Any]:
@@ -568,9 +570,10 @@ class OpenAIProvider(BaseProvider):
                 for item in input_items:
                     if item.get("type") == "message":
                         chat_messages.append({"role": item.get("role", "user"), "content": item.get("content", "")})
-            return await self.chat(messages=chat_messages, system_prompt=system_prompt, tools=tools, model=model, max_tokens=max_tokens, reasoning_replay=reasoning_replay)
+            return await self.chat(messages=chat_messages, system_prompt=system_prompt, tools=tools, model=model, temperature=temperature, max_tokens=max_tokens, reasoning_replay=reasoning_replay)
         
         model_name = model or self.default_model
+        resolved_temperature = resolve_llm_temperature(temperature)
         
         # Convert messages to input_items if provided
         if input_items is None and messages is not None:
@@ -592,6 +595,8 @@ class OpenAIProvider(BaseProvider):
             "max_output_tokens": max_tokens or config.llm.get('max_tokens', 64000),
             "text": {"format": {"type": "text"}},
         }
+        if not model_name.lower().startswith("gpt-5"):
+            payload["temperature"] = resolved_temperature
         
         # Add tools if provided (Responses API format)
         if converted_tools:
@@ -785,6 +790,7 @@ class OpenAIProvider(BaseProvider):
             "input": input_items,
             "tools": converted_tools,
             "max_output_tokens": max_tokens or config.llm.get('max_tokens', 64000),
+            "temperature": payload.get("temperature"),
         })
         
         # Calculate cost and record usage
@@ -823,7 +829,7 @@ class GitHubCopilotProvider(BaseProvider):
             api_base=config.llm.get('api_base', 'https://api.githubcopilot.com'),
             api_key_env='GITHUB_COPILOT_TOKEN'
         )
-        self.default_model = config.llm.get('model', 'gpt-5-mini')
+        self.default_model = config.llm.get('model', DEFAULT_LLM_MODEL)
     
     def _get_headers(self) -> Dict[str, str]:
         """Override to include Copilot-specific headers."""
@@ -841,7 +847,7 @@ class GitHubCopilotProvider(BaseProvider):
         system_prompt: Optional[str] = None,
         tools: Optional[List[Dict]] = None,
         model: Optional[str] = None,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         reasoning_replay: Optional[bool] = None,
     ) -> Dict[str, Any]:
@@ -864,9 +870,11 @@ class GitHubCopilotProvider(BaseProvider):
             all_messages.append({"role": "system", "content": system_prompt})
         all_messages.extend(messages)
         
+        resolved_temperature = resolve_llm_temperature(temperature)
         payload = {
             "model": model or self.default_model,
             "messages": all_messages,
+            "temperature": resolved_temperature,
         }
         
         # Add tools support (similar to OpenAI)
@@ -962,6 +970,7 @@ class GitHubCopilotProvider(BaseProvider):
         system_prompt: Optional[str] = None,
         tools: Optional[List[Dict]] = None,
         model: Optional[str] = None,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         reasoning_replay: Optional[bool] = None,
     ) -> Dict[str, Any]:
@@ -985,6 +994,7 @@ class GitHubCopilotProvider(BaseProvider):
                 system_prompt=system_prompt,
                 tools=tools,
                 model=model,
+                temperature=temperature,
                 max_tokens=max_tokens,
                 reasoning_replay=reasoning_replay,
             )
@@ -1001,6 +1011,7 @@ class GitHubCopilotProvider(BaseProvider):
             }
         
         model_name = model or self.default_model
+        resolved_temperature = resolve_llm_temperature(temperature)
         
         # Convert messages to input_items if provided
         if input_items is None and messages is not None:
@@ -1021,6 +1032,7 @@ class GitHubCopilotProvider(BaseProvider):
             "input": input_items,
             "max_output_tokens": max_tokens or config.llm.get('max_tokens', 64000),
             "text": {"format": {"type": "text"}},
+            "temperature": resolved_temperature,
         }
         
         # Add tools if provided (Responses API format)
@@ -1213,6 +1225,7 @@ class GitHubCopilotProvider(BaseProvider):
             "input": input_items,
             "tools": converted_tools,
             "max_output_tokens": max_tokens or config.llm.get('max_tokens', 64000),
+            "temperature": payload.get("temperature"),
         })
 
         # Calculate cost and record usage
@@ -1236,6 +1249,7 @@ class GitHubCopilotProvider(BaseProvider):
             "input": input_items,
             "tools": converted_tools,  # Use converted tools (same as actual request)
             "max_output_tokens": max_tokens or config.llm.get('max_tokens', 64000),  # Match actual default
+            "temperature": payload.get("temperature"),
         })
         
         return result
@@ -1270,7 +1284,7 @@ class ClaudeProvider(BaseProvider):
         system_prompt: Optional[str] = None,
         tools: Optional[List[Dict]] = None,
         model: Optional[str] = None,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         reasoning_replay: Optional[bool] = None,
     ) -> Dict[str, Any]:
@@ -1292,11 +1306,12 @@ class ClaudeProvider(BaseProvider):
                 continue
             all_messages.append({"role": msg["role"], "content": msg["content"]})
         
+        resolved_temperature = resolve_llm_temperature(temperature)
         payload = {
             "model": model or self.default_model,
             "messages": all_messages,
             "max_tokens": max_tokens or 4096,
-            "temperature": temperature,
+            "temperature": resolved_temperature,
         }
         
         if system_prompt:
@@ -1442,7 +1457,7 @@ class OllamaProvider(BaseProvider):
         system_prompt: Optional[str] = None,
         tools: Optional[List[Dict]] = None,
         model: Optional[str] = None,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         reasoning_replay: Optional[bool] = None,
     ) -> Dict[str, Any]:
@@ -1452,12 +1467,13 @@ class OllamaProvider(BaseProvider):
             full_messages.append({"role": "system", "content": system_prompt})
         full_messages.extend(messages)
         
+        resolved_temperature = resolve_llm_temperature(temperature)
         payload = {
             "model": model or self.default_model,
             "messages": full_messages,
             "stream": False,
             "options": {
-                "temperature": temperature,
+                "temperature": resolved_temperature,
                 "num_predict": max_tokens or config.llm.get('max_tokens', 64000),
             }
         }
@@ -1668,7 +1684,7 @@ class LLMClient:
         tools: Optional[List[Dict]] = None,
         model: Optional[str] = None,
         provider: Optional[str] = None,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         reasoning_replay: Optional[bool] = None,
     ) -> Dict[str, Any]:
@@ -1702,6 +1718,7 @@ class LLMClient:
         system_prompt: Optional[str] = None,
         tools: Optional[List[Dict]] = None,
         model: Optional[str] = None,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         provider: Optional[str] = None,
         reasoning_replay: Optional[bool] = None,
@@ -1723,6 +1740,7 @@ class LLMClient:
                 system_prompt=system_prompt,
                 tools=tools,
                 model=model,
+                temperature=temperature,
                 max_tokens=max_tokens,
                 provider=provider,
                 reasoning_replay=reasoning_replay,
@@ -1871,6 +1889,7 @@ class LLMClient:
                     system_prompt=system_prompt,
                     tools=tools,
                     model=effective_model,
+                    temperature=temperature,
                     max_tokens=max_tokens,
                     provider=provider,
                     reasoning_replay=reasoning_replay,
@@ -1896,6 +1915,7 @@ class LLMClient:
             system_prompt=system_prompt,
             tools=tools,
             model=model,
+            temperature=temperature,
             max_tokens=max_tokens,
             reasoning_replay=reasoning_replay,
         )
@@ -1939,13 +1959,12 @@ class LLMClient:
 llm_client = LLMClient()
 
 # Register for config reload
-from src.config import service_reload_manager
 service_reload_manager.register('llm', llm_client.reinit)
 
 # Models that support vision/image input
 USE_VISION_MODELS = {
-    "openai": {"gpt-5-mini", "gpt-5", "gpt-4o"},
-    "github_copilot": {"gpt-5-mini", "gpt-5", "gemini-2.5-pro", "gpt-4o"},
+    "openai": {"gpt-5.4-mini", "gpt-5-mini", "gpt-5", "gpt-4o"},
+    "github_copilot": {"gpt-5.4-mini", "gpt-5-mini", "gpt-5", "gemini-2.5-pro", "gpt-4o"},
     "claude": {"claude-sonnet", "claude-haiku", "claude-opus"},
     "ollama": set(),  # Ollama vision support varies
 }
@@ -1978,8 +1997,8 @@ def get_vision_fallback_model(provider: str) -> Optional[str]:
         return None
     
     vision_fallbacks = {
-        "openai": "gpt-5-mini",
-        "github_copilot": "gpt-5-mini",
+        "openai": "gpt-5.4-mini",
+        "github_copilot": "gpt-5.4-mini",
         "claude": "claude-haiku-4-20250514",
         "ollama": None,
     }

--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -811,12 +811,16 @@ class OpenAIProvider(BaseProvider):
 
     def list_models(self) -> List[str]:
         return [
-            "gpt-3.5-turbo",
-            "gpt-3.5-turbo-16k",
-            "gpt-4",
-            "gpt-4-turbo",
+            "gpt-5.4-mini",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-4.1",
             "gpt-4o",
             "gpt-4o-mini",
+            "gpt-4",
+            "gpt-4-turbo",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-16k",
         ]
 
 
@@ -1255,7 +1259,18 @@ class GitHubCopilotProvider(BaseProvider):
         return result
     
     def list_models(self) -> List[str]:
-        return ["gpt-4", "gpt-4-turbo"]
+        return [
+            "gpt-5.4-mini",
+            "gpt-5.4",
+            "gpt-5.3-codex",
+            "gpt-5-mini",
+            "gpt-5",
+            "gpt-4.1",
+            "gpt-4o",
+            "gemini-2.5-pro",
+            "gpt-4",
+            "gpt-4-turbo",
+        ]
 
 
 class ClaudeProvider(BaseProvider):

--- a/src/agents/model_fallback.py
+++ b/src/agents/model_fallback.py
@@ -18,6 +18,8 @@ import asyncio
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Type, Union
 
+from src.config import DEFAULT_LLM_MODEL
+
 logger = logging.getLogger(__name__)
 
 
@@ -243,16 +245,18 @@ async def with_model_fallback(
 
 # Predefined fallback order for common scenarios
 FALLBACK_ORDER: List[ModelCandidate] = [
-    ModelCandidate(provider="openai", model="gpt-4o", priority=0, weight=1.0),
-    ModelCandidate(provider="openai", model="gpt-4o-mini", priority=1, weight=0.5),
-    ModelCandidate(provider="anthropic", model="claude-sonnet-4", priority=2, weight=0.8),
-    ModelCandidate(provider="anthropic", model="claude-haiku-3-5", priority=3, weight=0.4),
+    ModelCandidate(provider="openai", model=DEFAULT_LLM_MODEL, priority=0, weight=1.0),
+    ModelCandidate(provider="openai", model="gpt-4o", priority=1, weight=0.8),
+    ModelCandidate(provider="openai", model="gpt-4o-mini", priority=2, weight=0.5),
+    ModelCandidate(provider="anthropic", model="claude-sonnet-4", priority=3, weight=0.8),
+    ModelCandidate(provider="anthropic", model="claude-haiku-3-5", priority=4, weight=0.4),
 ]
 
 # Fast fallback (less aggressive)
 FAST_FALLBACK: List[ModelCandidate] = [
-    ModelCandidate(provider="openai", model="gpt-4o", priority=0, weight=1.0),
-    ModelCandidate(provider="openai", model="gpt-4o-mini", priority=1, weight=0.5),
+    ModelCandidate(provider="openai", model=DEFAULT_LLM_MODEL, priority=0, weight=1.0),
+    ModelCandidate(provider="openai", model="gpt-4o", priority=1, weight=0.8),
+    ModelCandidate(provider="openai", model="gpt-4o-mini", priority=2, weight=0.5),
 ]
 
 # Budget fallback (prioritize cheaper models)

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,9 @@ _yaml = YAML()
 _yaml.preserve_quotes = True
 _yaml.indent(mapping=2, sequence=4, offset=2)
 
+DEFAULT_LLM_MODEL = "gpt-5.4-mini"
+DEFAULT_LLM_TEMPERATURE = 0.7
+
 
 class ServiceReloadManager:
     """Manager for services that need to be reinitialized when config changes."""
@@ -737,6 +740,25 @@ def _safe_positive_int(value: Any, default: int) -> int:
         return parsed if parsed > 0 else default
     except Exception:
         return default
+
+
+def resolve_llm_temperature(explicit: Optional[Any] = None) -> float:
+    source = explicit if explicit is not None else config.llm.get("temperature", DEFAULT_LLM_TEMPERATURE)
+    if isinstance(source, bool):
+        return float(DEFAULT_LLM_TEMPERATURE)
+    if source is None:
+        return float(DEFAULT_LLM_TEMPERATURE)
+    if isinstance(source, str):
+        source = source.strip()
+        if not source:
+            return float(DEFAULT_LLM_TEMPERATURE)
+    try:
+        parsed = float(source)
+    except (TypeError, ValueError):
+        return float(DEFAULT_LLM_TEMPERATURE)
+    if parsed < 0 or parsed > 2:
+        return float(DEFAULT_LLM_TEMPERATURE)
+    return float(parsed)
 
 
 def resolve_model_limits(model: Optional[str] = None) -> Dict[str, int]:

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,7 @@
 """Configuration loader for Engineering Flow Platform."""
 
 import logging
+import math
 import os
 import time
 import copy
@@ -756,14 +757,14 @@ def resolve_llm_temperature(explicit: Optional[Any] = None) -> float:
         parsed = float(source)
     except (TypeError, ValueError):
         return float(DEFAULT_LLM_TEMPERATURE)
-    if parsed < 0 or parsed > 2:
+    if not math.isfinite(parsed) or parsed < 0 or parsed > 2:
         return float(DEFAULT_LLM_TEMPERATURE)
     return float(parsed)
 
 
 def resolve_model_limits(model: Optional[str] = None) -> Dict[str, int]:
     llm_cfg = config.llm if isinstance(config.llm, dict) else {}
-    configured_model = str(model or llm_cfg.get("model") or "").strip()
+    configured_model = str(model or llm_cfg.get("model") or DEFAULT_LLM_MODEL).strip()
     configured_limits = llm_cfg.get("model_limits") if isinstance(llm_cfg.get("model_limits"), dict) else {}
     candidates: Dict[str, Dict[str, int]] = dict(DEFAULT_MODEL_LIMITS)
     for key, raw in configured_limits.items():

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -2643,6 +2643,7 @@
     const providerModels = {
         github_copilot: [
             { value: 'gpt-4o', label: 'GPT-4o' },
+            { value: 'gpt-5.4-mini', label: 'GPT-5.4 mini' },
             { value: 'gpt-5-mini', label: 'GPT-5 mini' },
             { value: 'gpt-5', label: 'GPT-5' },
             { value: 'gpt-5.1-codex', label: 'GPT-5.1-Codex' },
@@ -2973,7 +2974,7 @@
                 // LLM settings
                 if (config.llm) {
                     const provider = config.llm.provider || 'github_copilot';
-                    const model = config.llm.model || 'gpt-5-mini';
+                    const model = config.llm.model || 'gpt-5.4-mini';
                     llmProvider.value = provider;
                     // Update model dropdown with current provider and model
                     updateModelDropdown(provider, model);
@@ -2986,7 +2987,7 @@
                 } else {
                     // Default to github_copilot with gpt-4o
                     llmProvider.value = 'github_copilot';
-                    updateModelDropdown('github_copilot', 'gpt-5-mini');
+                    updateModelDropdown('github_copilot', 'gpt-5.4-mini');
                     if (copilotAuthSection) copilotAuthSection.style.display = 'block';
                 }
 

--- a/src/gateway/static/js/webchat.js
+++ b/src/gateway/static/js/webchat.js
@@ -2642,22 +2642,28 @@
     // Provider to Model mapping
     const providerModels = {
         github_copilot: [
-            { value: 'gpt-4o', label: 'GPT-4o' },
             { value: 'gpt-5.4-mini', label: 'GPT-5.4 mini' },
+            { value: 'gpt-5.4', label: 'GPT-5.4' },
+            { value: 'gpt-5.3-codex', label: 'GPT-5.3-Codex' },
             { value: 'gpt-5-mini', label: 'GPT-5 mini' },
             { value: 'gpt-5', label: 'GPT-5' },
+            { value: 'gpt-4.1', label: 'GPT-4.1' },
+            { value: 'gpt-4o', label: 'GPT-4o' },
             { value: 'gpt-5.1-codex', label: 'GPT-5.1-Codex' },
             { value: 'gpt-5.1-codex-max', label: 'GPT-5.1-Codex-Max' },
             { value: 'gpt-5.2', label: 'GPT-5.2' },
             { value: 'gpt-5.3-codex-max', label: 'GPT-5.3-Codex-Max' },
-            { value: 'gpt-5.4', label: 'GPT-5.4' },
             { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
         ],
         openai: [
-            { value: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo' },
-            { value: 'gpt-4', label: 'GPT-4' },
+            { value: 'gpt-5.4-mini', label: 'GPT-5.4 mini' },
+            { value: 'gpt-5', label: 'GPT-5' },
+            { value: 'gpt-5-mini', label: 'GPT-5 mini' },
+            { value: 'gpt-4.1', label: 'GPT-4.1' },
             { value: 'gpt-4o', label: 'GPT-4o' },
             { value: 'gpt-4o-mini', label: 'GPT-4o Mini' },
+            { value: 'gpt-4', label: 'GPT-4' },
+            { value: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo' },
         ],
         anthropic: [
             { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
@@ -2985,7 +2991,7 @@
                         copilotAuthSection.style.display = 'block';
                     }
                 } else {
-                    // Default to github_copilot with gpt-4o
+                    // Default to github_copilot with gpt-5.4-mini
                     llmProvider.value = 'github_copilot';
                     updateModelDropdown('github_copilot', 'gpt-5.4-mini');
                     if (copilotAuthSection) copilotAuthSection.style.display = 'block';

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -42,7 +42,7 @@ from src.agents.core import run_chat_execution
 from src.hooks.session_memory import save_session_summary
 from src.agents.errors import extract_error_details, LLMError
 from src.hooks.file_context import inject_context
-from src.config import config as global_config
+from src.config import config as global_config, DEFAULT_LLM_MODEL
 from src.github.url_utils import normalize_github_api_base_url
 from src.runtime.chat_orchestration_adapter import execute_chat_orchestration, execute_runtime_task_request
 from src.runtime.runtime_task_tracker import RuntimeTaskTracker
@@ -834,7 +834,7 @@ async def api_chat(request: web.Request) -> web.Response:
         
         # Get request-scoped model (trusted portal override only)
         model_override = _extract_trusted_model_override(request, data)
-        model = model_override or global_config.llm.get('model', 'gpt-5-mini')
+        model = model_override or global_config.llm.get('model', DEFAULT_LLM_MODEL)
         
         # Run agent (history is managed internally by session_manager)
         runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
@@ -1096,7 +1096,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
 
         # Get request-scoped model (trusted portal override only)
         model_override = _extract_trusted_model_override(request, data)
-        model = model_override or global_config.llm.get('model', 'gpt-5-mini')
+        model = model_override or global_config.llm.get('model', DEFAULT_LLM_MODEL)
 
         # Run agent and stream response
         runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)

--- a/src/hooks/file_context/retrieval.py
+++ b/src/hooks/file_context/retrieval.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 from typing import List, Dict, Set, Tuple
 
-from src.config import config, resolve_model_limits
+from src.config import config, resolve_model_limits, DEFAULT_LLM_MODEL
 
 from .models import Chunk, RetrievalRequest, RetrievalResult
 from .storage import storage
@@ -94,7 +94,7 @@ class RetrievalEngine:
     def _resolve_budget_thresholds(self, request: RetrievalRequest) -> Tuple[int, int, int]:
         """Resolve retrieval thresholds from model prompt limits, with emergency legacy fallback."""
         llm_cfg = config.llm if isinstance(config.llm, dict) else {}
-        model = str(llm_cfg.get("model") or "").strip()
+        model = str(llm_cfg.get("model") or DEFAULT_LLM_MODEL).strip()
         known_model_keys = ("gpt-4o", "gpt-4.1", "gpt-5-mini", "gpt-5.3-codex", "gpt-5.4-mini", "gemini-2.5-pro")
         model_limits = resolve_model_limits(model or None)
         prompt_budget = int(model_limits.get("max_prompt_tokens") or 0) if any(k in model.lower() for k in known_model_keys) else 0

--- a/src/skills/README.md
+++ b/src/skills/README.md
@@ -98,7 +98,7 @@ when_to_use:
   - For triage workflows
 references:
   - references/playbook.md
-model: gpt-5-mini
+model: gpt-5.4-mini
 hooks:
   - precheck
 task_tools:

--- a/tests/test_config_runtime_profile_automation_removed.py
+++ b/tests/test_config_runtime_profile_automation_removed.py
@@ -98,3 +98,22 @@ def test_set_managed_overlay_ignores_provider_automation_subtrees(tmp_path):
 
     assert effective["confluence"]["enabled"] is True
     assert "automation" not in effective["confluence"]
+
+
+def test_set_managed_overlay_applies_and_clears_llm_temperature(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    _write_base_config(config_path)
+
+    cfg = Config(str(config_path))
+    cfg.set_managed_overlay("rp1", 1, {"llm": {"temperature": 0.2}})
+    cfg.load()
+
+    effective = cfg.get_effective_config()
+    assert effective["llm"]["temperature"] == 0.2
+    raw_text = config_path.read_text(encoding="utf-8")
+    assert "temperature: 0.2" in raw_text
+
+    cfg.clear_managed_overlay()
+    cfg.load()
+    cleared = cfg.get_effective_config()
+    assert "temperature" not in cleared.get("llm", {})

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -310,7 +310,7 @@ def test_agent_process_source_prefers_self_model_in_multiple_paths():
     from src.agents import core
 
     source = inspect.getsource(core.Agent.process)
-    expected = 'self.model or config.llm.get("model", "gpt-5-mini")'
+    expected = 'self.model or config.llm.get("model", DEFAULT_LLM_MODEL)'
     assert source.count(expected) >= 2
 
 

--- a/tests/test_core_runtime_boundary.py
+++ b/tests/test_core_runtime_boundary.py
@@ -757,6 +757,28 @@ def test_resolve_output_boundary_uses_model_limit_tokens(monkeypatch):
     assert boundary["max_chat_output_chars"] == 120000 * 4
 
 
+def test_resolve_model_limits_defaults_to_default_llm_model_when_missing(monkeypatch):
+    from src.config import config, resolve_model_limits
+
+    monkeypatch.setitem(
+        config._config,
+        "llm",
+        {
+            "model_limits": {
+                "gpt-5.4-mini": {
+                    "max_context_window_tokens": 400000,
+                    "max_prompt_tokens": 272000,
+                    "max_output_tokens": 128000,
+                }
+            }
+        },
+    )
+    limits = resolve_model_limits(None)
+    assert limits["max_context_window_tokens"] == 400000
+    assert limits["max_prompt_tokens"] == 272000
+    assert limits["max_output_tokens"] == 128000
+
+
 @pytest.mark.parametrize(
     ("model", "expected_output", "expected_chat_tokens", "expected_chars"),
     [

--- a/tests/test_file_context_retrieval.py
+++ b/tests/test_file_context_retrieval.py
@@ -61,3 +61,25 @@ def test_retrieval_engine_fallback_thresholds_for_unknown_model(monkeypatch):
             config.llm.pop("model", None)
         else:
             config.llm["model"] = original_model
+
+
+def test_retrieval_engine_uses_default_llm_model_when_config_model_missing(monkeypatch):
+    engine = RetrievalEngine()
+
+    had_model = "model" in config.llm
+    original_model = config.llm.get("model")
+    try:
+        config.llm.pop("model", None)
+
+        direct, topk, summarize = engine._resolve_budget_thresholds(
+            RetrievalRequest(session_id="s1", query="A", top_k=1)
+        )
+
+        assert direct == 13600
+        assert topk == 54400
+        assert summarize == 128000
+    finally:
+        if had_model:
+            config.llm["model"] = original_model
+        else:
+            config.llm.pop("model", None)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -11,6 +11,7 @@ import httpx
 
 # Import after path setup
 from src.agents.llm import LLMClient
+from src.config import config, resolve_llm_temperature, DEFAULT_LLM_TEMPERATURE
 
 
 class MockResponse:
@@ -1014,6 +1015,104 @@ class TestGitHubCopilotProvider:
             assert headers["Accept"] == "application/vnd.github.copilot-chat-preview+json"
 
 
+class TestTemperatureResolution:
+    def test_resolve_llm_temperature_prefers_config_when_explicit_missing(self, monkeypatch):
+        monkeypatch.setitem(config._config, "llm", {"temperature": 0.23})
+        assert resolve_llm_temperature() == 0.23
+
+    def test_resolve_llm_temperature_explicit_wins(self, monkeypatch):
+        monkeypatch.setitem(config._config, "llm", {"temperature": 0.23})
+        assert resolve_llm_temperature(0.11) == 0.11
+
+    @pytest.mark.parametrize("value", [None, "", "not-a-number", -0.1, 2.1, True, False])
+    def test_resolve_llm_temperature_invalid_values_fallback_default(self, monkeypatch, value):
+        monkeypatch.setitem(config._config, "llm", {"temperature": value})
+        assert resolve_llm_temperature() == DEFAULT_LLM_TEMPERATURE
+
+    @pytest.mark.asyncio
+    async def test_openai_chat_temperature_from_config_non_gpt5(self, monkeypatch):
+        from src.agents.llm import OpenAIProvider
+
+        monkeypatch.setitem(config._config, "llm", {"temperature": 0.23, "max_tokens": 256})
+        provider = OpenAIProvider()
+        provider._check_api_key = lambda: None
+
+        with patch.object(provider, "_call_api", new_callable=AsyncMock) as mock_call_api:
+            mock_call_api.return_value = {"choices": [{"message": {"content": "ok"}}], "usage": {}}
+            await provider.chat(messages=[{"role": "user", "content": "hi"}], model="gpt-4o")
+            payload = mock_call_api.call_args.args[1]
+            assert payload["temperature"] == 0.23
+
+    @pytest.mark.asyncio
+    async def test_openai_chat_gpt5_omits_temperature(self, monkeypatch):
+        from src.agents.llm import OpenAIProvider
+
+        monkeypatch.setitem(config._config, "llm", {"temperature": 0.23, "max_tokens": 256})
+        provider = OpenAIProvider()
+        provider._check_api_key = lambda: None
+
+        with patch.object(provider, "_call_api", new_callable=AsyncMock) as mock_call_api:
+            mock_call_api.return_value = {"choices": [{"message": {"content": "ok"}}], "usage": {}}
+            await provider.chat(messages=[{"role": "user", "content": "hi"}], model="gpt-5.4-mini")
+            payload = mock_call_api.call_args.args[1]
+            assert "temperature" not in payload
+
+    @pytest.mark.asyncio
+    async def test_github_copilot_chat_temperature_config_and_explicit(self, monkeypatch):
+        from src.agents.llm import GitHubCopilotProvider
+
+        monkeypatch.setitem(config._config, "llm", {"temperature": 0.23, "api_key": "k", "max_tokens": 256})
+        provider = GitHubCopilotProvider()
+
+        with patch.object(provider, "_call_api", new_callable=AsyncMock) as mock_call_api:
+            mock_call_api.return_value = {"choices": [{"message": {"content": "ok"}}], "usage": {}}
+            await provider.chat(messages=[{"role": "user", "content": "hi"}], model="gpt-5.4-mini")
+            payload = mock_call_api.call_args.args[1]
+            assert payload["temperature"] == 0.23
+
+            await provider.chat(messages=[{"role": "user", "content": "hi"}], model="gpt-5.4-mini", temperature=0.12)
+            payload = mock_call_api.call_args.args[1]
+            assert payload["temperature"] == 0.12
+
+    @pytest.mark.asyncio
+    async def test_github_copilot_responses_temperature_config_and_explicit(self, monkeypatch):
+        from src.agents.llm import GitHubCopilotProvider
+
+        monkeypatch.setitem(config._config, "llm", {"temperature": 0.23, "api_key": "k", "max_tokens": 256})
+        provider = GitHubCopilotProvider()
+
+        with patch.object(provider, "_call_api", new_callable=AsyncMock) as mock_call_api:
+            mock_call_api.return_value = {
+                "output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }
+            await provider.responses(input_items=[{"type": "message", "role": "user", "content": "hello"}], model="gpt-5.4-mini")
+            payload = mock_call_api.call_args.args[1]
+            assert payload["temperature"] == 0.23
+
+            await provider.responses(
+                input_items=[{"type": "message", "role": "user", "content": "hello"}],
+                model="gpt-5.4-mini",
+                temperature=0.12,
+            )
+            payload = mock_call_api.call_args.args[1]
+            assert payload["temperature"] == 0.12
+
+    @pytest.mark.asyncio
+    async def test_llmclient_responses_chat_fallback_forwards_temperature(self):
+        client = LLMClient()
+        client.providers = {"openai": object()}
+        client.default_provider = "openai"
+        client.chat = AsyncMock(return_value={"content": "ok"})
+
+        await client.responses(
+            messages=[{"role": "user", "content": "hi"}],
+            provider="openai",
+            temperature=0.19,
+        )
+        assert client.chat.call_args.kwargs["temperature"] == 0.19
+
+
 class TestOllamaProvider:
     """Tests for Ollama provider."""
 
@@ -1089,6 +1188,7 @@ class TestVisionModelSelection:
         # Vision models
         assert is_vision_model("openai", "gpt-4o") is True
         assert is_vision_model("openai", "gpt-4o-mini") is True
+        assert is_vision_model("openai", "gpt-5.4-mini") is True
         assert is_vision_model("openai", "gpt-5-mini") is True
         assert is_vision_model("openai", "gpt-5") is True
         # Non-vision models
@@ -1101,6 +1201,7 @@ class TestVisionModelSelection:
         from src.agents.llm import is_vision_model
         # Vision models
         assert is_vision_model("github_copilot", "gpt-4o") is True
+        assert is_vision_model("github_copilot", "gpt-5.4-mini") is True
         assert is_vision_model("github_copilot", "gpt-5-mini") is True
         assert is_vision_model("github_copilot", "gpt-5") is True
         assert is_vision_model("github_copilot", "gemini-2.5-pro") is True
@@ -1130,13 +1231,13 @@ class TestVisionModelSelection:
     def test_get_vision_fallback_model_openai(self):
         """Test fallback model for OpenAI."""
         from src.agents.llm import get_vision_fallback_model
-        assert get_vision_fallback_model("openai") == "gpt-5-mini"
+        assert get_vision_fallback_model("openai") == "gpt-5.4-mini"
 
     def test_get_vision_fallback_model_github_copilot(self):
         """Test fallback model for GitHub Copilot."""
         from src.agents.llm import get_vision_fallback_model
-        assert get_vision_fallback_model("github_copilot") == "gpt-5-mini"
-        assert get_vision_fallback_model("github") == "gpt-5-mini"
+        assert get_vision_fallback_model("github_copilot") == "gpt-5.4-mini"
+        assert get_vision_fallback_model("github") == "gpt-5.4-mini"
 
     def test_get_vision_fallback_model_claude(self):
         """Test fallback model for Claude."""

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1024,7 +1024,7 @@ class TestTemperatureResolution:
         monkeypatch.setitem(config._config, "llm", {"temperature": 0.23})
         assert resolve_llm_temperature(0.11) == 0.11
 
-    @pytest.mark.parametrize("value", [None, "", "not-a-number", -0.1, 2.1, True, False])
+    @pytest.mark.parametrize("value", [None, "", "not-a-number", -0.1, 2.1, True, False, "nan", "NaN", float("nan"), "inf", float("inf")])
     def test_resolve_llm_temperature_invalid_values_fallback_default(self, monkeypatch, value):
         monkeypatch.setitem(config._config, "llm", {"temperature": value})
         assert resolve_llm_temperature() == DEFAULT_LLM_TEMPERATURE
@@ -1054,6 +1054,40 @@ class TestTemperatureResolution:
         with patch.object(provider, "_call_api", new_callable=AsyncMock) as mock_call_api:
             mock_call_api.return_value = {"choices": [{"message": {"content": "ok"}}], "usage": {}}
             await provider.chat(messages=[{"role": "user", "content": "hi"}], model="gpt-5.4-mini")
+            payload = mock_call_api.call_args.args[1]
+            assert "temperature" not in payload
+
+    @pytest.mark.asyncio
+    async def test_openai_responses_temperature_from_config_non_gpt5(self, monkeypatch):
+        from src.agents.llm import OpenAIProvider
+
+        monkeypatch.setitem(config._config, "llm", {"temperature": 0.23, "max_tokens": 256})
+        provider = OpenAIProvider()
+        provider._check_api_key = lambda: None
+
+        with patch.object(provider, "_call_api", new_callable=AsyncMock) as mock_call_api:
+            mock_call_api.return_value = {
+                "output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }
+            await provider.responses(input_items=[{"type": "message", "role": "user", "content": "hello"}], model="gpt-4o")
+            payload = mock_call_api.call_args.args[1]
+            assert payload["temperature"] == 0.23
+
+    @pytest.mark.asyncio
+    async def test_openai_responses_gpt5_omits_temperature(self, monkeypatch):
+        from src.agents.llm import OpenAIProvider
+
+        monkeypatch.setitem(config._config, "llm", {"temperature": 0.23, "max_tokens": 256})
+        provider = OpenAIProvider()
+        provider._check_api_key = lambda: None
+
+        with patch.object(provider, "_call_api", new_callable=AsyncMock) as mock_call_api:
+            mock_call_api.return_value = {
+                "output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }
+            await provider.responses(input_items=[{"type": "message", "role": "user", "content": "hello"}], model="gpt-5.4-mini")
             payload = mock_call_api.call_args.args[1]
             assert "temperature" not in payload
 
@@ -1111,6 +1145,17 @@ class TestTemperatureResolution:
             temperature=0.19,
         )
         assert client.chat.call_args.kwargs["temperature"] == 0.19
+
+    def test_provider_list_models_default_first(self):
+        from src.agents.llm import OpenAIProvider, GitHubCopilotProvider
+
+        openai_models = OpenAIProvider().list_models()
+        copilot_models = GitHubCopilotProvider().list_models()
+
+        assert openai_models[0] == "gpt-5.4-mini"
+        assert "gpt-5-mini" in openai_models
+        assert copilot_models[0] == "gpt-5.4-mini"
+        assert "gpt-5-mini" in copilot_models
 
 
 class TestOllamaProvider:

--- a/tests/test_model_fallback.py
+++ b/tests/test_model_fallback.py
@@ -3,6 +3,7 @@
 import pytest
 import asyncio
 from typing import Any
+from pathlib import Path
 
 from src.agents.model_fallback import (
     ModelCandidate,
@@ -17,6 +18,7 @@ from src.agents.model_fallback import (
     LOCAL_FALLBACK,
     get_fallback_order,
 )
+from src.config import DEFAULT_LLM_MODEL
 
 
 class TestModelCandidate:
@@ -253,6 +255,20 @@ class TestPredefinedOrders:
         """Test get_fallback_order with unknown returns default."""
         result = get_fallback_order("unknown")
         assert result == FALLBACK_ORDER
+
+    def test_default_fallback_order_prefers_default_llm_model(self):
+        assert FALLBACK_ORDER[0].provider == "openai"
+        assert FALLBACK_ORDER[0].model == DEFAULT_LLM_MODEL
+        assert FALLBACK_ORDER[0].priority == 0
+
+    def test_fast_fallback_order_prefers_default_llm_model(self):
+        assert FAST_FALLBACK[0].provider == "openai"
+        assert FAST_FALLBACK[0].model == DEFAULT_LLM_MODEL
+        assert FAST_FALLBACK[0].priority == 0
+
+    def test_unknown_fallback_order_uses_default_llm_model_first(self):
+        result = get_fallback_order("unknown")
+        assert result[0].model == DEFAULT_LLM_MODEL
     
     def test_fallback_order_priority(self):
         """Test that FALLBACK_ORDER is ordered by priority."""
@@ -287,7 +303,7 @@ class TestFallbackAttempt:
             "success": False,
             "duration_ms": 1500.0,
         }
-    
+
     def test_successful_attempt(self):
         """Test successful attempt."""
         candidate = ModelCandidate(provider="openai", model="gpt-4o")
@@ -296,9 +312,16 @@ class TestFallbackAttempt:
             success=True,
             duration_ms=500.0
         )
-        
+
         assert attempt.error is None
         assert attempt.success is True
+
+
+def test_readme_llm_example_uses_default_llm_model():
+    text = Path("README.md").read_text(encoding="utf-8")
+    llm_section = text[text.find("### LLM Providers"): text.find("### Control-Plane Runtime Settings")]
+    assert 'model: "gpt-5.4-mini"' in llm_section
+    assert 'model: "gpt-4o"' not in llm_section
 
 
 class TestIntegration:

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -3676,6 +3676,24 @@ console.log('ok');
     assert result.returncode == 0, result.stderr
 
 
+def test_webchat_js_provider_model_defaults_default_to_gpt_5_4_mini():
+    repo_root = Path(__file__).parent.parent
+    js = (repo_root / "src" / "gateway" / "static" / "js" / "webchat.js").read_text(encoding="utf-8")
+
+    github_start = js.find("github_copilot: [")
+    openai_start = js.find("openai: [")
+    assert github_start >= 0 and openai_start >= 0
+
+    github_block = js[github_start:openai_start]
+    openai_end = js.find("],", openai_start)
+    openai_block = js[openai_start:openai_end]
+
+    assert "{ value: 'gpt-5.4-mini', label: 'GPT-5.4 mini' }" in github_block
+    assert "{ value: 'gpt-5.4-mini', label: 'GPT-5.4 mini' }" in openai_block
+    assert "{ value: 'gpt-5-mini', label: 'GPT-5 mini' }" in github_block
+    assert "{ value: 'gpt-5-mini', label: 'GPT-5 mini' }" in openai_block
+
+
 @pytest.mark.asyncio
 async def test_assistant_persist_and_result_payload_share_display_blocks(monkeypatch):
     from src.agents.core import Agent


### PR DESCRIPTION
### Motivation
- Standardize EFP global default/fallback model to `gpt-5.4-mini` instead of legacy `gpt-5-mini`/`gpt-3.5-turbo`. 
- Ensure `llm.temperature` pushed from Portal runtime profiles actually controls LLM calls by making temperature resolution and propagation consistent across providers and client paths.

### Description
- Added `DEFAULT_LLM_MODEL = "gpt-5.4-mini"`, `DEFAULT_LLM_TEMPERATURE = 0.7` and `resolve_llm_temperature(explicit=None)` to `src/config.py` to parse/validate explicit and config temperatures (reject bool, accept numeric/string, clamp to [0,2], fallback to default). 
- Replaced literal fallback occurrences (`'gpt-5-mini'`/`'gpt-3.5-turbo'`) with `DEFAULT_LLM_MODEL` in runtime code paths including `src/gateway/webchat.py`, `src/agents/core.py`, and provider defaults in `src/agents/llm.py`. 
- Wired temperature through the LLM call chain by changing provider `chat()`/`responses()` signatures and `LLMClient.chat()`/`LLMClient.responses()` to accept `temperature: Optional[float] = None`, resolving with `resolve_llm_temperature()` inside providers, and forwarding temperature through all fallback paths. 
- Preserved OpenAI GPT-5 guard behavior by not sending a `temperature` payload for GPT-5 family models while sending resolved temperature for other providers/models. 
- Updated vision-capable models to include `gpt-5.4-mini` and switched vision fallback for OpenAI/GitHub Copilot to `gpt-5.4-mini`; added `gpt-5.4-mini` to the webchat settings dropdown and default UI selection. 
- Updated docs example (`src/skills/README.md`) and adjusted tests to assert `DEFAULT_LLM_MODEL` usage and the new temperature behavior. 

### Testing
- Ran targeted tests with `python -m pytest tests/test_llm_client.py tests/test_core_runtime_boundary.py tests/test_webchat.py tests/test_config_runtime_profile_automation_removed.py -q` and observed all tests pass (`306 passed`). 
- Added/updated unit tests to cover `resolve_llm_temperature` parsing and precedence, OpenAI temperature omission for GPT-5 vs inclusion for non-GPT-5, GitHub Copilot chat/responses temperature behavior (config and explicit override), forwarding of `temperature` when `responses()` falls back to `chat()`, vision fallback assertions, and runtime profile managed overlay for `llm.temperature` apply/clear behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee1012fec832a9eb6a97f6062710b)