### PR TITLE
Inject runtime GitHub credentials into shell `git`/`gh`; add credential resolver and git reload hook

### DIFF
--- a/src/bash_tools/api.py
+++ b/src/bash_tools/api.py
@@ -6,13 +6,14 @@ Two tools:
 """
 
 import asyncio
-import importlib.util
 import logging
 import os
 import subprocess
-import sys
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.runtime.credential_resolver import ToolCredentialEnv
 
 logger = logging.getLogger(__name__)
 
@@ -208,15 +209,25 @@ def _validate_cwd(cwd: str = None) -> str:
     return cwd
 
 
+def _empty_credential_env():
+    from src.runtime.credential_resolver import ToolCredentialEnv
+
+    return ToolCredentialEnv()
+
+
+def build_env_for_command(cmd: str, args: List[str] = None, cwd: str = None):
+    from src.runtime.credential_resolver import build_env_for_command as _build_env_for_command
+
+    return _build_env_for_command(cmd, args=args, cwd=cwd)
+
+
 def _build_credential_env(cmd: str, args: List[str], cwd: str):
-    module_path = Path(__file__).parent.parent / "runtime" / "credential_resolver.py"
-    spec = importlib.util.spec_from_file_location("efp_runtime_credential_resolver", module_path)
-    if not spec or not spec.loader:
-        raise RuntimeError("Failed to load credential resolver")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["efp_runtime_credential_resolver"] = module
-    spec.loader.exec_module(module)
-    return module.build_env_for_command(cmd, args=args, cwd=cwd)
+    from src.runtime.credential_resolver import ToolCredentialEnv
+
+    normalized_cmd = (cmd or "").strip()
+    if normalized_cmd not in {"git", "gh"}:
+        return ToolCredentialEnv()
+    return build_env_for_command(normalized_cmd, args=args, cwd=cwd)
 
 
 async def run_command(
@@ -309,7 +320,20 @@ async def run_command(
             if k in allowed_keys:
                 safe_env[k] = v
     
-    credential_env = _build_credential_env(cmd, args=args, cwd=cwd)
+    credential_env = _empty_credential_env()
+    try:
+        credential_env = _build_credential_env(cmd, args=args, cwd=cwd)
+    except Exception as exc:
+        logger.exception("Failed to prepare credential environment for command: %s", cmd)
+        return {
+            "ok": False,
+            "error": "E_CREDENTIAL_ENV_FAILED",
+            "exit_code": -1,
+            "stdout": "",
+            "stderr": credential_env.redact_text(str(exc)),
+            "duration_ms": 0,
+            "truncated": {"stdout": False, "stderr": False},
+        }
     safe_env.update(credential_env.env)
 
     # Execute
@@ -345,12 +369,12 @@ async def run_command(
 
             duration_ms = int((asyncio.get_running_loop().time() - start_time) * 1000)
 
-            # Truncate if needed
-            stdout_bytes = stdout[:max_output_bytes]
-            stderr_bytes = stderr[:max_output_bytes]
-
-            stdout_text = credential_env.redact_text(stdout_bytes.decode("utf-8", errors="replace"))
-            stderr_text = credential_env.redact_text(stderr_bytes.decode("utf-8", errors="replace"))
+            stdout_full_text = stdout.decode("utf-8", errors="replace")
+            stderr_full_text = stderr.decode("utf-8", errors="replace")
+            stdout_redacted = credential_env.redact_text(stdout_full_text)
+            stderr_redacted = credential_env.redact_text(stderr_full_text)
+            stdout_text = stdout_redacted[:max_output_bytes]
+            stderr_text = stderr_redacted[:max_output_bytes]
 
             is_success = process.returncode == 0
             return {

--- a/src/bash_tools/api.py
+++ b/src/bash_tools/api.py
@@ -6,9 +6,11 @@ Two tools:
 """
 
 import asyncio
+import importlib.util
 import logging
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import List, Dict, Any
 
@@ -206,6 +208,17 @@ def _validate_cwd(cwd: str = None) -> str:
     return cwd
 
 
+def _build_credential_env(cmd: str, args: List[str], cwd: str):
+    module_path = Path(__file__).parent.parent / "runtime" / "credential_resolver.py"
+    spec = importlib.util.spec_from_file_location("efp_runtime_credential_resolver", module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError("Failed to load credential resolver")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["efp_runtime_credential_resolver"] = module
+    spec.loader.exec_module(module)
+    return module.build_env_for_command(cmd, args=args, cwd=cwd)
+
+
 async def run_command(
     cmd: str,
     args: List[str] = None,
@@ -296,71 +309,75 @@ async def run_command(
             if k in allowed_keys:
                 safe_env[k] = v
     
+    credential_env = _build_credential_env(cmd, args=args, cwd=cwd)
+    safe_env.update(credential_env.env)
+
     # Execute
     start_time = asyncio.get_event_loop().time()
-    
+
     try:
-        process = await asyncio.create_subprocess_exec(
-            cmd, *args,
-            cwd=cwd,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=safe_env,
-        )
-        
         try:
-            stdout, stderr = await asyncio.wait_for(
-                process.communicate(),
-                timeout=timeout_ms / 1000
+            process = await asyncio.create_subprocess_exec(
+                cmd, *args,
+                cwd=cwd,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=safe_env,
             )
-        except asyncio.TimeoutError:
-            process.kill()
-            await process.wait()
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=timeout_ms / 1000
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                return {
+                    "ok": False,
+                    "error": "E_TIMEOUT",
+                    "exit_code": -1,
+                    "stdout": "",
+                    "stderr": credential_env.redact_text("Command timed out"),
+                    "duration_ms": timeout_ms,
+                    "truncated": {"stdout": False, "stderr": False},
+                }
+
+            duration_ms = int((asyncio.get_running_loop().time() - start_time) * 1000)
+
+            # Truncate if needed
+            stdout_bytes = stdout[:max_output_bytes]
+            stderr_bytes = stderr[:max_output_bytes]
+
+            stdout_text = credential_env.redact_text(stdout_bytes.decode("utf-8", errors="replace"))
+            stderr_text = credential_env.redact_text(stderr_bytes.decode("utf-8", errors="replace"))
+
+            is_success = process.returncode == 0
             return {
-                "ok": False,
-                "error": "E_TIMEOUT",
-                "exit_code": -1,
-                "stdout": "",
-                "stderr": "Command timed out",
-                "duration_ms": timeout_ms,
-                "truncated": {"stdout": False, "stderr": False},
+                "ok": is_success,
+                "exit_code": process.returncode,
+                "stdout": stdout_text,
+                "stderr": stderr_text,
+                "duration_ms": duration_ms,
+                "truncated": {
+                    "stdout": len(stdout) > max_output_bytes,
+                    "stderr": len(stderr) > max_output_bytes,
+                },
+                "meta": {
+                    "cmd": credential_env.redact_text(cmd),
+                    "args": credential_env.redact_args(args),
+                    "cwd": cwd,
+                }
             }
-        
-        duration_ms = int((asyncio.get_running_loop().time() - start_time) * 1000)
-        
-        # Truncate if needed
-        stdout_bytes = stdout[:max_output_bytes]
-        stderr_bytes = stderr[:max_output_bytes]
-        
-        stdout_text = stdout_bytes.decode("utf-8", errors="replace")
-        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
-        
-        is_success = process.returncode == 0
-        return {
-            "ok": is_success,
-            "exit_code": process.returncode,
-            "stdout": stdout_text,
-            "stderr": stderr_text,
-            "duration_ms": duration_ms,
-            "truncated": {
-                "stdout": len(stdout) > max_output_bytes,
-                "stderr": len(stderr) > max_output_bytes,
-            },
-            "meta": {
-                "cmd": cmd,
-                "args": args,
-                "cwd": cwd,
-            }
-        }
-        
+        finally:
+            credential_env.cleanup()
     except FileNotFoundError:
         return {
             "ok": False,
             "error": "E_NOT_FOUND",
             "exit_code": 127,
             "stdout": "",
-            "stderr": f"Command not found: {cmd}",
+            "stderr": credential_env.redact_text(f"Command not found: {cmd}"),
             "duration_ms": 0,
             "truncated": {"stdout": False, "stderr": False},
         }
@@ -371,7 +388,7 @@ async def run_command(
             "error": "E_EXEC_FAILED",
             "exit_code": -1,
             "stdout": "",
-            "stderr": str(e),
+            "stderr": credential_env.redact_text(str(e)),
             "duration_ms": 0,
             "truncated": {"stdout": False, "stderr": False},
         }

--- a/src/bash_tools/api.py
+++ b/src/bash_tools/api.py
@@ -10,10 +10,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import List, Dict, Any, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.runtime.credential_resolver import ToolCredentialEnv
+from typing import List, Dict, Any
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +30,19 @@ COMMON_COMMANDS = [
     "vi", "vim", "nano", "code",
     "echo", "printf", "date", "whoami", "id",
 ]
+
+
+class _NoopCredentialEnv:
+    env: Dict[str, str] = {}
+
+    def cleanup(self) -> None:
+        return None
+
+    def redact_text(self, value: Any) -> str:
+        return "" if value is None else str(value)
+
+    def redact_args(self, args: List[str]) -> List[str]:
+        return [self.redact_text(arg) for arg in args]
 
 
 def get_workspace_dir() -> str:
@@ -209,12 +219,6 @@ def _validate_cwd(cwd: str = None) -> str:
     return cwd
 
 
-def _empty_credential_env():
-    from src.runtime.credential_resolver import ToolCredentialEnv
-
-    return ToolCredentialEnv()
-
-
 def build_env_for_command(cmd: str, args: List[str] = None, cwd: str = None):
     from src.runtime.credential_resolver import build_env_for_command as _build_env_for_command
 
@@ -222,11 +226,9 @@ def build_env_for_command(cmd: str, args: List[str] = None, cwd: str = None):
 
 
 def _build_credential_env(cmd: str, args: List[str], cwd: str):
-    from src.runtime.credential_resolver import ToolCredentialEnv
-
     normalized_cmd = (cmd or "").strip()
     if normalized_cmd not in {"git", "gh"}:
-        return ToolCredentialEnv()
+        return _NoopCredentialEnv()
     return build_env_for_command(normalized_cmd, args=args, cwd=cwd)
 
 
@@ -320,7 +322,7 @@ async def run_command(
             if k in allowed_keys:
                 safe_env[k] = v
     
-    credential_env = _empty_credential_env()
+    credential_env = _NoopCredentialEnv()
     try:
         credential_env = _build_credential_env(cmd, args=args, cwd=cwd)
     except Exception as exc:

--- a/src/config.py
+++ b/src/config.py
@@ -61,6 +61,7 @@ class ServiceReloadManager:
             'jira': ['jira'],
             'confluence': ['confluence'],
             'github': ['github'],
+            'git': ['git'],
             'session': ['session'],
         }
         

--- a/src/git/__init__.py
+++ b/src/git/__init__.py
@@ -1,8 +1,8 @@
 """Git Integration - Single source of truth for Git operations."""
 
-from .api import GitClient, setup_git_user
+from .api import GitClient, reinit_git_config, setup_git_user, setup_git_user_sync
 
-__all__ = ["GitClient", "setup_git_user"]
+__all__ = ["GitClient", "setup_git_user", "setup_git_user_sync", "reinit_git_config"]
 
 
 # ========== Tool Functions ==========

--- a/src/git/api.py
+++ b/src/git/api.py
@@ -7,12 +7,13 @@ import logging
 import os
 import re
 import stat
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Callable, Optional
 from urllib.parse import urlsplit, urlunsplit
 
-from src.config import config
+from src.config import config, service_reload_manager
 
 logger = logging.getLogger(__name__)
 
@@ -211,4 +212,29 @@ async def setup_git_user() -> bool:
     return True
 
 
-__all__ = ["GitClient", "setup_git_user"]
+def setup_git_user_sync() -> bool:
+    """Setup git user from config (sync version for config reload hooks)."""
+    git_config = config.get("git", {}) or {}
+    user = git_config.get("user", {}) or {}
+    user_name = str(user.get("name") or "").strip()
+    user_email = str(user.get("email") or "").strip()
+
+    if not user_name or not user_email:
+        return False
+
+    subprocess.run(["git", "config", "--global", "user.name", user_name], check=False)
+    subprocess.run(["git", "config", "--global", "user.email", user_email], check=False)
+
+    logger.info("Git user configured: %s <%s>", user_name, user_email)
+    return True
+
+
+def reinit_git_config() -> None:
+    """Reload hook for git-related config updates."""
+    setup_git_user_sync()
+
+
+service_reload_manager.register("git", reinit_git_config)
+
+
+__all__ = ["GitClient", "setup_git_user", "setup_git_user_sync", "reinit_git_config"]

--- a/src/git/api.py
+++ b/src/git/api.py
@@ -136,7 +136,12 @@ class GitClient:
             cleanup()
 
     def _get_github_token(self) -> str:
-        return (config.get("github", {}) or {}).get("api_token", "")
+        github_config = config.get("github", {}) or {}
+        if not isinstance(github_config, dict):
+            return ""
+        if not bool(github_config.get("enabled")):
+            return ""
+        return str(github_config.get("api_token") or "").strip()
 
     def _build_askpass_env(self) -> tuple[Optional[dict], Callable[[], None]]:
         token = self._get_github_token()
@@ -222,8 +227,30 @@ def setup_git_user_sync() -> bool:
     if not user_name or not user_email:
         return False
 
-    subprocess.run(["git", "config", "--global", "user.name", user_name], check=False)
-    subprocess.run(["git", "config", "--global", "user.email", user_email], check=False)
+    try:
+        name_result = subprocess.run(
+            ["git", "config", "--global", "user.name", user_name],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        email_result = subprocess.run(
+            ["git", "config", "--global", "user.email", user_email],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except Exception as exc:
+        logger.warning("Failed to configure git user: %s", exc)
+        return False
+
+    if name_result.returncode != 0 or email_result.returncode != 0:
+        logger.warning(
+            "Failed to configure git user: name_rc=%s email_rc=%s",
+            name_result.returncode,
+            email_result.returncode,
+        )
+        return False
 
     logger.info("Git user configured: %s <%s>", user_name, user_email)
     return True

--- a/src/github/__init__.py
+++ b/src/github/__init__.py
@@ -397,26 +397,6 @@ def get_tools_schemas() -> list:
         {
             "type": "function",
             "function": {
-                "name": "github_create_or_update_file",
-                "description": "Create or update a file in a repository",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "owner": {"type": "string", "description": "Repository owner"},
-                        "repo": {"type": "string", "description": "Repository name"},
-                        "path": {"type": "string", "description": "File path"},
-                        "content": {"type": "string", "description": "File content"},
-                        "message": {"type": "string", "description": "Commit message"},
-                        "sha": {"type": "string", "description": "SHA of file being updated (optional)"},
-                        "branch": {"type": "string", "description": "Branch name (optional)"}
-                    },
-                    "required": ["owner", "repo", "path", "content", "message"]
-                }
-            }
-        },
-        {
-            "type": "function",
-            "function": {
                 "name": "github_search_issues",
                 "description": "Search GitHub issues and PRs",
                 "parameters": {

--- a/src/github/api.py
+++ b/src/github/api.py
@@ -115,6 +115,11 @@ class GitHubChannel:
         **kwargs
     ) -> Any:
         """Make an API request with rate limit handling and exponential backoff."""
+        if not self.enabled:
+            raise RuntimeError("GitHub integration is disabled")
+        if not self.token:
+            raise RuntimeError("GitHub token is not configured")
+
         base_url = normalize_github_api_base_url(self.base_url)
         url = f"{base_url}{endpoint}"
         

--- a/src/runtime/credential_resolver.py
+++ b/src/runtime/credential_resolver.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import tempfile
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Iterable
+from urllib.parse import urlsplit
+
+from src.config import config
+from src.github.url_utils import PUBLIC_GITHUB_API_BASE, normalize_github_api_base_url
+
+REDACTED_SECRET = "[REDACTED_GITHUB_TOKEN]"
+
+
+@dataclass
+class ToolCredentialEnv:
+    env: Dict[str, str] = field(default_factory=dict)
+    cleanup: Callable[[], None] = lambda: None
+    secrets: tuple[str, ...] = ()
+    sensitive_keys: frozenset[str] = frozenset()
+
+    def redact_text(self, value: str | None) -> str:
+        if value is None:
+            return ""
+        text = str(value)
+        for secret in self.secrets:
+            if secret:
+                text = text.replace(secret, REDACTED_SECRET)
+        return text
+
+    def redact_args(self, args: Iterable[str]) -> list[str]:
+        return [self.redact_text(str(arg)) for arg in args]
+
+
+def _github_config() -> dict:
+    value = config.get("github", {}) or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _github_enabled_and_token() -> tuple[bool, str, str]:
+    github_cfg = _github_config()
+    enabled = bool(github_cfg.get("enabled"))
+    token = str(github_cfg.get("api_token") or "").strip()
+    base_url = str(github_cfg.get("base_url") or "").strip()
+    return enabled, token, base_url
+
+
+def _host_from_github_api_base_url(base_url: str) -> str:
+    normalized = normalize_github_api_base_url(base_url)
+    parsed = urlsplit(normalized)
+    return parsed.netloc or "api.github.com"
+
+
+def _is_public_github_api(base_url: str) -> bool:
+    normalized = normalize_github_api_base_url(base_url)
+    return normalized == PUBLIC_GITHUB_API_BASE
+
+
+def build_git_askpass_env() -> ToolCredentialEnv:
+    enabled, token, _base_url = _github_enabled_and_token()
+    if not enabled or not token:
+        return ToolCredentialEnv()
+
+    fd, askpass_path = tempfile.mkstemp(prefix="efp_git_askpass_")
+    script = """#!/bin/sh
+prompt="$1"
+case "$prompt" in
+  *Username*|*username*) printf '%s\\n' 'x-access-token' ;;
+  *) printf '%s\\n' "$EFP_GITHUB_TOKEN" ;;
+esac
+"""
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(script)
+    os.chmod(askpass_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+    def cleanup() -> None:
+        try:
+            os.remove(askpass_path)
+        except FileNotFoundError:
+            pass
+
+    return ToolCredentialEnv(
+        env={
+            "GIT_ASKPASS": askpass_path,
+            "GIT_TERMINAL_PROMPT": "0",
+            "EFP_GITHUB_TOKEN": token,
+        },
+        cleanup=cleanup,
+        secrets=(token,),
+        sensitive_keys=frozenset({"EFP_GITHUB_TOKEN"}),
+    )
+
+
+def build_gh_cli_env() -> ToolCredentialEnv:
+    enabled, token, base_url = _github_enabled_and_token()
+    if not enabled or not token:
+        return ToolCredentialEnv()
+
+    gh_config_dir = tempfile.mkdtemp(prefix="efp_gh_config_")
+    env = {
+        "GH_PROMPT_DISABLED": "1",
+        "GH_CONFIG_DIR": gh_config_dir,
+    }
+
+    if _is_public_github_api(base_url):
+        env["GH_TOKEN"] = token
+        env["GITHUB_TOKEN"] = token
+        sensitive = {"GH_TOKEN", "GITHUB_TOKEN"}
+    else:
+        host = _host_from_github_api_base_url(base_url)
+        env["GH_HOST"] = host
+        env["GH_ENTERPRISE_TOKEN"] = token
+        env["GITHUB_ENTERPRISE_TOKEN"] = token
+        sensitive = {"GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"}
+
+    def cleanup() -> None:
+        shutil.rmtree(gh_config_dir, ignore_errors=True)
+
+    return ToolCredentialEnv(
+        env=env,
+        cleanup=cleanup,
+        secrets=(token,),
+        sensitive_keys=frozenset(sensitive),
+    )
+
+
+def build_env_for_command(cmd: str, args: list[str] | None = None, cwd: str | None = None) -> ToolCredentialEnv:
+    _ = (args, cwd)
+    normalized_cmd = (cmd or "").strip()
+    if normalized_cmd == "git":
+        return build_git_askpass_env()
+    if normalized_cmd == "gh":
+        return build_gh_cli_env()
+    return ToolCredentialEnv()

--- a/tests/test_bash_tools_github_credentials.py
+++ b/tests/test_bash_tools_github_credentials.py
@@ -1,0 +1,139 @@
+import asyncio
+
+import pytest
+
+from src.bash_tools.api import run_command
+
+
+class ToolCredentialEnv:
+    def __init__(self, env=None, cleanup=lambda: None, secrets=()):
+        self.env = env or {}
+        self.cleanup = cleanup
+        self.secrets = secrets
+
+    def redact_text(self, value):
+        text = "" if value is None else str(value)
+        for secret in self.secrets:
+            if secret:
+                text = text.replace(secret, "[REDACTED_GITHUB_TOKEN]")
+        return text
+
+    def redact_args(self, args):
+        return [self.redact_text(arg) for arg in args]
+
+
+@pytest.mark.asyncio
+async def test_run_command_gh_injects_token_and_redacts_output(monkeypatch):
+    token = "ghp_secret_token"
+    captured_env = {}
+
+    class Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return f"stdout {token}".encode("utf-8"), f"stderr {token}".encode("utf-8")
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        "src.bash_tools.api._build_credential_env",
+        lambda cmd, args=None, cwd=None: ToolCredentialEnv(
+            env={"GH_TOKEN": token},
+            secrets=(token,),
+        ),
+    )
+
+    result = await run_command("gh", ["auth", "status"])
+    assert captured_env["GH_TOKEN"] == token
+    assert token not in result["stdout"]
+    assert token not in result["stderr"]
+    assert "[REDACTED_GITHUB_TOKEN]" in result["stdout"]
+
+
+@pytest.mark.asyncio
+async def test_run_command_git_injects_askpass_and_meta_redacted(monkeypatch):
+    token = "ghp_secret_token"
+    captured_env = {}
+
+    class Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b"done"
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        "src.bash_tools.api._build_credential_env",
+        lambda cmd, args=None, cwd=None: ToolCredentialEnv(
+            env={
+                "GIT_ASKPASS": "/tmp/askpass",
+                "GIT_TERMINAL_PROMPT": "0",
+                "EFP_GITHUB_TOKEN": token,
+            },
+            secrets=(token,),
+        ),
+    )
+
+    result = await run_command("git", ["fetch"])
+    assert captured_env["GIT_ASKPASS"] == "/tmp/askpass"
+    assert captured_env["GIT_TERMINAL_PROMPT"] == "0"
+    assert captured_env["EFP_GITHUB_TOKEN"] == token
+    assert token not in str(result["meta"])
+
+
+@pytest.mark.asyncio
+async def test_run_command_non_git_non_gh_does_not_inject_tokens(monkeypatch):
+    captured_env = {}
+
+    class Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    result = await run_command("ls", ["-la"])
+    assert result["ok"] is True
+    assert "GH_TOKEN" not in captured_env
+    assert "GITHUB_TOKEN" not in captured_env
+    assert "GIT_ASKPASS" not in captured_env
+    assert "EFP_GITHUB_TOKEN" not in captured_env
+
+
+@pytest.mark.asyncio
+async def test_run_command_cleanup_always_called(monkeypatch):
+    cleanup_called = {"value": False}
+
+    class Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        "src.bash_tools.api._build_credential_env",
+        lambda cmd, args=None, cwd=None: ToolCredentialEnv(
+            env={"GH_TOKEN": "x"},
+            cleanup=lambda: cleanup_called.__setitem__("value", True),
+            secrets=("x",),
+        ),
+    )
+
+    await run_command("gh", ["repo", "view"])
+    assert cleanup_called["value"] is True

--- a/tests/test_bash_tools_github_credentials.py
+++ b/tests/test_bash_tools_github_credentials.py
@@ -142,6 +142,41 @@ async def test_run_command_non_git_non_gh_does_not_call_credential_resolver(monk
 
 
 @pytest.mark.asyncio
+async def test_run_command_non_git_non_gh_does_not_import_credential_resolver(monkeypatch):
+    import builtins
+
+    captured_env = {}
+
+    class Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return Proc()
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "src.runtime.credential_resolver":
+            raise AssertionError("credential_resolver should not be imported for non git/gh commands")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    result = await run_command("ls", ["-la"])
+
+    assert result["ok"] is True
+    assert "GH_TOKEN" not in captured_env
+    assert "GITHUB_TOKEN" not in captured_env
+    assert "GIT_ASKPASS" not in captured_env
+    assert "EFP_GITHUB_TOKEN" not in captured_env
+
+
+@pytest.mark.asyncio
 async def test_run_command_cleanup_always_called(monkeypatch):
     cleanup_called = {"value": False}
 

--- a/tests/test_bash_tools_github_credentials.py
+++ b/tests/test_bash_tools_github_credentials.py
@@ -113,6 +113,35 @@ async def test_run_command_non_git_non_gh_does_not_inject_tokens(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_command_non_git_non_gh_does_not_call_credential_resolver(monkeypatch):
+    captured_env = {}
+
+    class Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return Proc()
+
+    def should_not_be_called(*args, **kwargs):
+        raise AssertionError("credential resolver should not be called for non git/gh commands")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("src.bash_tools.api.build_env_for_command", should_not_be_called)
+
+    result = await run_command("ls", ["-la"])
+
+    assert result["ok"] is True
+    assert "GH_TOKEN" not in captured_env
+    assert "GITHUB_TOKEN" not in captured_env
+    assert "GIT_ASKPASS" not in captured_env
+    assert "EFP_GITHUB_TOKEN" not in captured_env
+
+
+@pytest.mark.asyncio
 async def test_run_command_cleanup_always_called(monkeypatch):
     cleanup_called = {"value": False}
 
@@ -137,3 +166,67 @@ async def test_run_command_cleanup_always_called(monkeypatch):
 
     await run_command("gh", ["repo", "view"])
     assert cleanup_called["value"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_command_redacts_before_truncation_boundary(monkeypatch):
+    token = "ghp_secret_boundary_token"
+    captured_env = {}
+
+    class Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return f"prefix-{token}-suffix".encode("utf-8"), b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        "src.bash_tools.api._build_credential_env",
+        lambda cmd, args=None, cwd=None: ToolCredentialEnv(
+            env={"GH_TOKEN": token},
+            secrets=(token,),
+        ),
+    )
+
+    result = await run_command("gh", ["auth", "status"], max_output_bytes=12)
+
+    assert token not in result["stdout"]
+    assert "ghp_" not in result["stdout"]
+    assert result["stdout"].startswith("prefix-")
+
+
+@pytest.mark.asyncio
+async def test_run_command_gh_uses_real_credential_resolver_config(monkeypatch):
+    token = "ghp_real_resolver_token"
+    captured_env = {}
+
+    class Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return Proc()
+
+    def fake_get(key, default=None):
+        if key == "github":
+            return {"enabled": True, "api_token": token, "base_url": ""}
+        return default
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("src.runtime.credential_resolver.config.get", fake_get)
+
+    result = await run_command("gh", ["auth", "status"])
+
+    assert result["ok"] is True
+    assert captured_env["GH_TOKEN"] == token
+    assert captured_env["GITHUB_TOKEN"] == token
+    assert captured_env["GH_PROMPT_DISABLED"] == "1"
+    assert "GH_CONFIG_DIR" in captured_env
+    assert token not in str(result.get("meta", {}))

--- a/tests/test_git_https_auth.py
+++ b/tests/test_git_https_auth.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 import src.git as git_module
-from src.git.api import GitClient
+from src.git.api import GitClient, setup_git_user_sync
 from src.gateway.webchat import _remove_legacy_ssh_config
 
 
@@ -95,3 +95,25 @@ def test_git_module_public_surface_includes_expected_tools():
     assert callable(git_module.git_commit)
     assert callable(git_module.git_push)
     assert callable(git_module.git_clone)
+    assert callable(git_module.setup_git_user_sync)
+    assert callable(git_module.reinit_git_config)
+
+
+def test_setup_git_user_sync_uses_profile_config(monkeypatch):
+    calls = []
+
+    def fake_get(key, default=None):
+        if key == "git":
+            return {"user": {"name": "Bot", "email": "bot@example.com"}}
+        return default
+
+    def fake_run(cmd, check=False):
+        calls.append((cmd, check))
+        return None
+
+    monkeypatch.setattr("src.git.api.config.get", fake_get)
+    monkeypatch.setattr("src.git.api.subprocess.run", fake_run)
+
+    assert setup_git_user_sync() is True
+    assert (["git", "config", "--global", "user.name", "Bot"], False) in calls
+    assert (["git", "config", "--global", "user.email", "bot@example.com"], False) in calls

--- a/tests/test_git_https_auth.py
+++ b/tests/test_git_https_auth.py
@@ -107,13 +107,71 @@ def test_setup_git_user_sync_uses_profile_config(monkeypatch):
             return {"user": {"name": "Bot", "email": "bot@example.com"}}
         return default
 
-    def fake_run(cmd, check=False):
-        calls.append((cmd, check))
-        return None
+    class FakeCompleted:
+        returncode = 0
+
+    def fake_run(cmd, check=False, capture_output=False, text=False):
+        calls.append((cmd, check, capture_output, text))
+        return FakeCompleted()
 
     monkeypatch.setattr("src.git.api.config.get", fake_get)
     monkeypatch.setattr("src.git.api.subprocess.run", fake_run)
 
     assert setup_git_user_sync() is True
-    assert (["git", "config", "--global", "user.name", "Bot"], False) in calls
-    assert (["git", "config", "--global", "user.email", "bot@example.com"], False) in calls
+    assert (["git", "config", "--global", "user.name", "Bot"], False, True, True) in calls
+    assert (["git", "config", "--global", "user.email", "bot@example.com"], False, True, True) in calls
+
+
+def test_setup_git_user_sync_returns_false_on_git_config_failure(monkeypatch):
+    class FakeCompleted:
+        returncode = 1
+
+    def fake_get(key, default=None):
+        if key == "git":
+            return {"user": {"name": "Bot", "email": "bot@example.com"}}
+        return default
+
+    def fake_run(cmd, check=False, capture_output=False, text=False):
+        return FakeCompleted()
+
+    monkeypatch.setattr("src.git.api.config.get", fake_get)
+    monkeypatch.setattr("src.git.api.subprocess.run", fake_run)
+
+    assert setup_git_user_sync() is False
+
+
+def test_git_client_askpass_respects_github_enabled_false(monkeypatch):
+    def fake_get(key, default=None):
+        if key == "github":
+            return {"enabled": False, "api_token": "ghp_should_not_be_used", "base_url": ""}
+        return default
+
+    monkeypatch.setattr("src.git.api.config.get", fake_get)
+
+    client = GitClient(workspace=".")
+    env, cleanup = client._build_askpass_env()
+    try:
+        assert env is None
+    finally:
+        cleanup()
+
+
+def test_git_client_askpass_uses_token_only_when_enabled(monkeypatch):
+    token = "ghp_test_token"
+
+    def fake_get(key, default=None):
+        if key == "github":
+            return {"enabled": True, "api_token": token, "base_url": ""}
+        return default
+
+    monkeypatch.setattr("src.git.api.config.get", fake_get)
+
+    client = GitClient(workspace=".")
+    env, cleanup = client._build_askpass_env()
+    try:
+        assert env is not None
+        assert env["EFP_GITHUB_TOKEN"] == token
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
+        assert env["GIT_ASKPASS"]
+    finally:
+        cleanup()

--- a/tests/test_github_api_config.py
+++ b/tests/test_github_api_config.py
@@ -1,5 +1,6 @@
 import pytest
 
+from src.github.api import GitHubChannel
 from tests._lightweight_runtime_loaders import load_github_url_utils_lightweight
 
 
@@ -16,3 +17,29 @@ from tests._lightweight_runtime_loaders import load_github_url_utils_lightweight
 def test_normalize_github_api_base_url_config_semantics(raw, expected):
     module = load_github_url_utils_lightweight()
     assert module.normalize_github_api_base_url(raw) == expected
+
+
+@pytest.mark.asyncio
+async def test_github_channel_request_rejects_when_disabled():
+    channel = GitHubChannel()
+    try:
+        channel.enabled = False
+        channel.token = "token"
+
+        with pytest.raises(RuntimeError, match="disabled"):
+            await channel._request("GET", "/rate_limit")
+    finally:
+        await channel.client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_github_channel_request_rejects_when_token_missing():
+    channel = GitHubChannel()
+    try:
+        channel.enabled = True
+        channel.token = ""
+
+        with pytest.raises(RuntimeError, match="token"):
+            await channel._request("GET", "/rate_limit")
+    finally:
+        await channel.client.aclose()

--- a/tests/test_github_tools_schema.py
+++ b/tests/test_github_tools_schema.py
@@ -1,0 +1,8 @@
+from src.github import get_tools_schemas
+
+
+def test_github_tool_schema_names_are_unique():
+    schemas = get_tools_schemas()
+    names = [tool["function"]["name"] for tool in schemas]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    assert duplicates == []

--- a/tests/test_tool_credential_resolver.py
+++ b/tests/test_tool_credential_resolver.py
@@ -1,0 +1,122 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_resolver():
+    spec = importlib.util.spec_from_file_location(
+        "test_credential_resolver_module",
+        Path("src/runtime/credential_resolver.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["test_credential_resolver_module"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_gh_env_public_github(monkeypatch):
+    resolver = _load_resolver()
+    token = "ghp_test_token"
+
+    def fake_get(key, default=None):
+        if key == "github":
+            return {"enabled": True, "api_token": token, "base_url": ""}
+        return default
+
+    monkeypatch.setattr(resolver.config, "get", fake_get)
+    env = resolver.build_env_for_command("gh", [], None)
+    gh_config_dir = env.env.get("GH_CONFIG_DIR")
+
+    assert env.env["GH_TOKEN"] == token
+    assert env.env["GITHUB_TOKEN"] == token
+    assert env.env["GH_PROMPT_DISABLED"] == "1"
+    assert gh_config_dir and Path(gh_config_dir).exists()
+    assert "GH_ENTERPRISE_TOKEN" not in env.env
+
+    env.cleanup()
+    assert not Path(gh_config_dir).exists()
+
+
+def test_build_gh_env_enterprise(monkeypatch):
+    resolver = _load_resolver()
+    token = "ghe_test_token"
+
+    def fake_get(key, default=None):
+        if key == "github":
+            return {
+                "enabled": True,
+                "api_token": token,
+                "base_url": "https://github.company.com/api/v3",
+            }
+        return default
+
+    monkeypatch.setattr(resolver.config, "get", fake_get)
+    env = resolver.build_env_for_command("gh", [], None)
+    gh_config_dir = env.env.get("GH_CONFIG_DIR")
+
+    assert env.env["GH_HOST"] == "github.company.com"
+    assert env.env["GH_ENTERPRISE_TOKEN"] == token
+    assert env.env["GITHUB_ENTERPRISE_TOKEN"] == token
+    assert "GH_TOKEN" not in env.env
+    assert gh_config_dir and Path(gh_config_dir).exists()
+
+    env.cleanup()
+    assert not Path(gh_config_dir).exists()
+
+
+def test_build_git_askpass_env(monkeypatch):
+    resolver = _load_resolver()
+    token = "ghp_test_token"
+
+    def fake_get(key, default=None):
+        if key == "github":
+            return {"enabled": True, "api_token": token, "base_url": ""}
+        return default
+
+    monkeypatch.setattr(resolver.config, "get", fake_get)
+    env = resolver.build_env_for_command("git", ["fetch"], None)
+    askpass_path = env.env.get("GIT_ASKPASS")
+
+    assert askpass_path and Path(askpass_path).exists()
+    assert env.env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env.env["EFP_GITHUB_TOKEN"] == token
+
+    env.cleanup()
+    assert not Path(askpass_path).exists()
+
+
+def test_disabled_or_empty_token_gets_no_env(monkeypatch):
+    resolver = _load_resolver()
+    def fake_get_disabled(key, default=None):
+        if key == "github":
+            return {"enabled": False, "api_token": "ghp_test_token", "base_url": ""}
+        return default
+
+    monkeypatch.setattr(resolver.config, "get", fake_get_disabled)
+    assert resolver.build_env_for_command("gh", [], None).env == {}
+    assert resolver.build_env_for_command("git", [], None).env == {}
+
+    def fake_get_empty(key, default=None):
+        if key == "github":
+            return {"enabled": True, "api_token": "", "base_url": ""}
+        return default
+
+    monkeypatch.setattr(resolver.config, "get", fake_get_empty)
+    assert resolver.build_env_for_command("gh", [], None).env == {}
+    assert resolver.build_env_for_command("git", [], None).env == {}
+
+
+def test_redact_text(monkeypatch):
+    resolver = _load_resolver()
+    token = "ghp_test_token"
+
+    def fake_get(key, default=None):
+        if key == "github":
+            return {"enabled": True, "api_token": token, "base_url": ""}
+        return default
+
+    monkeypatch.setattr(resolver.config, "get", fake_get)
+    env = resolver.build_env_for_command("gh", [], None)
+    assert env.redact_text(f"hello {token}") == "hello [REDACTED_GITHUB_TOKEN]"
+    env.cleanup()


### PR DESCRIPTION
### Motivation
- Allow runtime profile GitHub credentials (enabled/api_token/base_url) to be usable by the generic shell tool for `git` and `gh` invocations without changing Portal or introducing credential vaults. 
- Keep existing dedicated git/github tools behavior while ensuring runtime-managed tokens are never leaked to model outputs or persisted on disk.

### Description
- Added `src/runtime/credential_resolver.py` which builds per-command temporary envs for `git` and `gh` (askpass scripts, `GH_TOKEN`/enterprise tokens, `GH_CONFIG_DIR`), provides `ToolCredentialEnv` with `redact_text`/`redact_args` and a `cleanup` callback, and enforces `github.enabled` + non-empty token before injecting secrets.
- Updated `src/bash_tools/api.py` `run_command()` to dynamically load and use the resolver for `git`/`gh` only, merge the temporary env into the subprocess env, redact stdout/stderr/meta using the resolver, and guarantee `cleanup()` in `try/finally` on all code paths (normal, timeout, FileNotFoundError, exceptions).
- Hardened `src/github/api.py` by gating `_request()` to raise `RuntimeError` if `github.enabled` is false or the token is missing so REST tool will not issue anonymous/disabled requests.
- Added synchronous git profile application in `src/git/api.py`: `setup_git_user_sync()` and `reinit_git_config()` and registered `reinit_git_config` with the global `service_reload_manager` so `git.user.name`/`git.user.email` from runtime profile are applied via `git config --global` on reload; exported new symbols in `src/git/__init__.py`.
- Added `git` entry to reload mapping in `src/config.py` so `git` section changes trigger the registered reload hook.
- Tests: added `tests/test_tool_credential_resolver.py` and `tests/test_bash_tools_github_credentials.py`, and extended existing tests to cover the new git sync export and GitHub `_request` gate.

### Testing
- Ran unit tests for the new and impacted areas; the following were executed and succeeded locally:
  - `pytest tests/test_tool_credential_resolver.py -q` (passed)
  - `pytest tests/test_bash_tools_github_credentials.py -q` (passed)
  - `pytest tests/test_git_https_auth.py tests/test_github_api_config.py tests/test_runtime_profile_overlay.py -q` (passed)
  - Extended smoke run: `pytest tests/test_git_https_auth.py tests/test_github_tools.py tests/test_github_api_config.py tests/test_runtime_profile_client.py tests/test_runtime_profile_overlay.py -q` (passed)
- Tests exercise public vs enterprise GH envs, git askpass env, disabled/empty token behavior, redaction of token in outputs/meta, credential cleanup, and GitHub `_request` gating; all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00c1f3a44832ab5826f6ef494a69c)