### PR TITLE
Add Task Template Registry and route bundle tasks by task_template_id

### DIFF
--- a/src/runtime/bundle_template_registry.py
+++ b/src/runtime/bundle_template_registry.py
@@ -5,19 +5,11 @@ from typing import Any, Dict
 
 
 @dataclass(frozen=True)
-class BundleActionDefinition:
-    action_id: str
-    skill_name: str
-    requires_sources: bool = False
-    required_artifacts: tuple[str, ...] = ()
-
-
-@dataclass(frozen=True)
 class BundleTemplateDefinition:
     template_id: str
     display_name: str
     artifact_files: dict[str, str]
-    actions: dict[str, BundleActionDefinition]
+    compatible_task_template_ids: tuple[str, ...] = ()
 
 
 _BUNDLE_TEMPLATE_REGISTRY: Dict[str, BundleTemplateDefinition] = {
@@ -28,18 +20,10 @@ _BUNDLE_TEMPLATE_REGISTRY: Dict[str, BundleTemplateDefinition] = {
             "requirements": "requirements.yaml",
             "test_cases": "test-cases.yaml",
         },
-        actions={
-            "collect_requirements": BundleActionDefinition(
-                action_id="collect_requirements",
-                skill_name="collect_requirements_to_bundle",
-                requires_sources=True,
-            ),
-            "design_test_cases": BundleActionDefinition(
-                action_id="design_test_cases",
-                skill_name="design_test_cases_from_bundle",
-                required_artifacts=("requirements",),
-            ),
-        },
+        compatible_task_template_ids=(
+            "collect_requirements_to_bundle",
+            "design_test_cases_from_bundle",
+        ),
     ),
     "research.v1": BundleTemplateDefinition(
         template_id="research.v1",
@@ -47,13 +31,7 @@ _BUNDLE_TEMPLATE_REGISTRY: Dict[str, BundleTemplateDefinition] = {
         artifact_files={
             "research_notes": "research-notes.yaml",
         },
-        actions={
-            "collect_research_notes": BundleActionDefinition(
-                action_id="collect_research_notes",
-                skill_name="collect_research_notes_to_bundle",
-                requires_sources=True,
-            ),
-        },
+        compatible_task_template_ids=("collect_research_notes_to_bundle",),
     ),
     "development.v1": BundleTemplateDefinition(
         template_id="development.v1",
@@ -61,12 +39,7 @@ _BUNDLE_TEMPLATE_REGISTRY: Dict[str, BundleTemplateDefinition] = {
         artifact_files={
             "implementation_plan": "implementation-plan.yaml",
         },
-        actions={
-            "generate_implementation_plan": BundleActionDefinition(
-                action_id="generate_implementation_plan",
-                skill_name="generate_implementation_plan_from_bundle",
-            ),
-        },
+        compatible_task_template_ids=("generate_implementation_plan_from_bundle",),
     ),
     "operations.v1": BundleTemplateDefinition(
         template_id="operations.v1",
@@ -74,12 +47,7 @@ _BUNDLE_TEMPLATE_REGISTRY: Dict[str, BundleTemplateDefinition] = {
         artifact_files={
             "runbook": "runbook.yaml",
         },
-        actions={
-            "generate_runbook": BundleActionDefinition(
-                action_id="generate_runbook",
-                skill_name="generate_runbook_from_bundle",
-            ),
-        },
+        compatible_task_template_ids=("generate_runbook_from_bundle",),
     ),
 }
 
@@ -102,23 +70,6 @@ def require_bundle_template(template_id: str) -> BundleTemplateDefinition:
     if resolved is None:
         raise _bundle_error(f"Unsupported bundle template_id: {template_id}")
     return resolved
-
-
-def get_bundle_action(template_id: str, action_id: str) -> BundleActionDefinition | None:
-    template = get_bundle_template(template_id)
-    if template is None:
-        return None
-    normalized_action_id = str(action_id or "").strip().lower()
-    if not normalized_action_id:
-        return None
-    return template.actions.get(normalized_action_id)
-
-
-def require_bundle_action(template_id: str, action_id: str) -> BundleActionDefinition:
-    action = get_bundle_action(template_id, action_id)
-    if action is None:
-        raise _bundle_error(f"Unsupported bundle action '{action_id}' for template '{template_id}'")
-    return action
 
 
 def resolve_bundle_template_id_from_manifest(manifest: Dict[str, Any]) -> str:

--- a/src/runtime/capability_registry.py
+++ b/src/runtime/capability_registry.py
@@ -171,6 +171,64 @@ class _CapabilityBuilder:
                 )
             )
 
+        self._register_required_runtime_skill_capabilities()
+
+
+    def _register_required_runtime_skill_capabilities(self) -> None:
+        required_descriptors = [
+            CapabilityDescriptor(
+                capability_id="skill:collect_requirements_to_bundle",
+                type="skill",
+                name="collect_requirements_to_bundle",
+                policy_tags=["skill", "bundle"],
+                requires_identity_binding=False,
+                metadata={"runtime_required": True},
+            ),
+            CapabilityDescriptor(
+                capability_id="skill:design_test_cases_from_bundle",
+                type="skill",
+                name="design_test_cases_from_bundle",
+                policy_tags=["skill", "bundle"],
+                requires_identity_binding=False,
+                metadata={"runtime_required": True},
+            ),
+            CapabilityDescriptor(
+                capability_id="skill:collect_research_notes_to_bundle",
+                type="skill",
+                name="collect_research_notes_to_bundle",
+                policy_tags=["skill", "bundle"],
+                requires_identity_binding=False,
+                metadata={"runtime_required": True},
+            ),
+            CapabilityDescriptor(
+                capability_id="skill:generate_implementation_plan_from_bundle",
+                type="skill",
+                name="generate_implementation_plan_from_bundle",
+                policy_tags=["skill", "bundle"],
+                requires_identity_binding=False,
+                metadata={"runtime_required": True},
+            ),
+            CapabilityDescriptor(
+                capability_id="skill:generate_runbook_from_bundle",
+                type="skill",
+                name="generate_runbook_from_bundle",
+                policy_tags=["skill", "bundle"],
+                requires_identity_binding=False,
+                metadata={"runtime_required": True},
+            ),
+            CapabilityDescriptor(
+                capability_id="skill:review-pull-request",
+                type="skill",
+                name="review-pull-request",
+                policy_tags=["skill", "review", "github"],
+                requires_identity_binding=True,
+                metadata={"runtime_required": True, "provider": "github"},
+            ),
+        ]
+        for descriptor in required_descriptors:
+            if not self.registry.exists(descriptor.capability_id):
+                self.registry.register(descriptor)
+
     def _register_adapter_actions(self) -> None:
         adapter_descriptors = [
             *build_github_adapter_capabilities(),

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -10,7 +10,6 @@ from src.agents.executor import SkillResult, ToolResult, execute_tool_by_name, r
 from src.agents.subagent import run_subagent_execution
 from src.agents.tasks import task_manager
 from src.runtime.adapter_executor import execute_adapter_action
-from src.runtime.bundle_template_registry import get_bundle_action
 from src.runtime.capability_registry import get_capability_registry
 from src.runtime.contracts import (
     DelegationResult,
@@ -34,6 +33,7 @@ from src.runtime.governance_bus import (
 from src.runtime.github_review import run_github_review_task
 from src.runtime.jira_workflow_review import run_jira_workflow_review
 from src.runtime.leader_orchestration import dispatch_task_breakdown_as_delegations, run_delegation_cycle
+from src.runtime.task_template_registry import resolve_task_template_from_payload
 from src.runtime.triggered_event_task import run_triggered_event_task
 from src.utils.redaction import safe_preview, sanitize_exception_message
 
@@ -620,6 +620,38 @@ def _as_list_of_strings(value: Any) -> list[str]:
                     normalized.append(text)
         return normalized
     return []
+
+
+def _validate_bundle_action_task_payload(payload: Dict[str, Any], task_template: Any) -> Optional[str]:
+    if not str(getattr(task_template, "default_skill_name", "") or "").strip():
+        return f"task_template_id '{task_template.template_id}' is missing default_skill_name"
+
+    if bool(getattr(task_template, "requires_bundle", False)):
+        bundle_ref = payload.get("bundle_ref") if isinstance(payload.get("bundle_ref"), dict) else None
+        manifest_ref = payload.get("manifest_ref") if isinstance(payload.get("manifest_ref"), dict) else None
+        if not bundle_ref:
+            return "bundle_action_task requires bundle_ref"
+        if not manifest_ref:
+            return "bundle_action_task requires manifest_ref"
+
+    compatible_bundle_templates = tuple(getattr(task_template, "compatible_bundle_templates", ()) or ())
+    if compatible_bundle_templates:
+        bundle_template_id = str(payload.get("bundle_template_id") or "").strip().lower()
+        if not bundle_template_id:
+            return "bundle_action_task requires bundle_template_id"
+        if bundle_template_id not in compatible_bundle_templates:
+            return (
+                f"bundle_template_id '{bundle_template_id}' is incompatible with task_template_id "
+                f"'{task_template.template_id}'"
+            )
+
+    if bool(getattr(task_template, "requires_sources", False)):
+        sources = payload.get("sources") if isinstance(payload.get("sources"), dict) else {}
+        has_sources = any(_as_list_of_strings(value) for value in sources.values())
+        if not has_sources:
+            return "bundle_action_task requires non-empty sources"
+
+    return None
 
 
 def resolve_task_capability_plan(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -1253,6 +1285,7 @@ def build_default_execution_bus(
                 task_id=task_id,
                 detail_payload={
                     "task_type": task_type,
+                    "task_template_id": str(request.input_payload.get("task_template_id") or "").strip().lower() or None,
                     "skill_name": skill_name,
                     "success": skill_success,
                     "capability_id": capability.get("capability_id"),
@@ -1270,6 +1303,7 @@ def build_default_execution_bus(
             status="success" if skill_success else normalized_skill.status,
             output_payload={
                 "task_type": task_type,
+                "task_template_id": str(request.input_payload.get("task_template_id") or "").strip().lower() or None,
                 "success": skill_success,
                 "bundle_ref": bundle_ref,
                 "updated_files": updated_files,
@@ -2125,6 +2159,7 @@ def build_default_execution_bus(
                         "owner": owner,
                         "repo": repo,
                         "pull_number": pull_number,
+                        "task_template_id": str(request.input_payload.get("task_template_id") or "").strip().lower() or None,
                         "comment_written": comment_written,
                         "review_written": review_written,
                         "review_event": review_event,
@@ -2150,6 +2185,7 @@ def build_default_execution_bus(
                     "owner": owner,
                     "repo": repo,
                     "pull_number": pull_number,
+                    "task_template_id": str(request.input_payload.get("task_template_id") or "").strip().lower() or None,
                     "review_summary": review_summary,
                     "review_event": review_event,
                     "review_written": review_written,
@@ -2377,38 +2413,43 @@ def build_default_execution_bus(
                 runtime_events=runtime_events,
             )
 
-        if task_type == "requirement_bundle_collect_task":
-            return await _execute_skill_backed_task(
-                request,
-                task_id=task_id,
-                task_type=task_type,
-                default_skill_name="collect_requirements_to_bundle",
-                event_prefix="task.requirement_bundle_collect",
-            )
-
-        if task_type == "requirement_bundle_design_test_cases_task":
-            return await _execute_skill_backed_task(
-                request,
-                task_id=task_id,
-                task_type=task_type,
-                default_skill_name="design_test_cases_from_bundle",
-                event_prefix="task.requirement_bundle_design_test_cases",
-            )
-
         if task_type == "bundle_action_task":
-            template_id = str(request.input_payload.get("template_id") or "").strip().lower()
-            action_id = str(request.input_payload.get("action_id") or "").strip().lower()
-            action = get_bundle_action(template_id, action_id)
-            if action is None:
+            task_template = resolve_task_template_from_payload(request.input_payload)
+            task_template_id = str(request.input_payload.get("task_template_id") or "").strip().lower()
+            if task_template is None:
                 return make_execution_result(
                     request_id=request.request_id,
                     status="blocked",
                     output_payload={
                         "task_type": task_type,
-                        "template_id": template_id,
-                        "action_id": action_id,
+                        "task_template_id": task_template_id or None,
                         "success": False,
-                        "error": f"Unsupported bundle action '{action_id}' for template '{template_id}'",
+                        "error": f"Unsupported task_template_id for bundle_action_task: {task_template_id or 'missing'}",
+                        "task_boundary": True,
+                    },
+                )
+            if task_template.task_type != "bundle_action_task":
+                return make_execution_result(
+                    request_id=request.request_id,
+                    status="blocked",
+                    output_payload={
+                        "task_type": task_type,
+                        "task_template_id": task_template.template_id,
+                        "success": False,
+                        "error": f"task_template_id '{task_template.template_id}' is incompatible with task_type '{task_type}'",
+                        "task_boundary": True,
+                    },
+                )
+            validation_error = _validate_bundle_action_task_payload(request.input_payload, task_template)
+            if validation_error:
+                return make_execution_result(
+                    request_id=request.request_id,
+                    status="blocked",
+                    output_payload={
+                        "task_type": task_type,
+                        "task_template_id": task_template.template_id,
+                        "success": False,
+                        "error": validation_error,
                         "task_boundary": True,
                     },
                 )
@@ -2416,8 +2457,8 @@ def build_default_execution_bus(
                 request,
                 task_id=task_id,
                 task_type=task_type,
-                default_skill_name=action.skill_name,
-                event_prefix="task.bundle_action",
+                default_skill_name=str(task_template.default_skill_name or "").strip() or "",
+                event_prefix=f"task.{task_template.template_id.replace('_', '.')}",
                 allow_payload_skill_name=False,
             )
 

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -2453,7 +2453,7 @@ def build_default_execution_bus(
                         "task_boundary": True,
                     },
                 )
-            return await _execute_skill_backed_task(
+            result = await _execute_skill_backed_task(
                 request,
                 task_id=task_id,
                 task_type=task_type,
@@ -2461,6 +2461,26 @@ def build_default_execution_bus(
                 event_prefix=f"task.{task_template.template_id.replace('_', '.')}",
                 allow_payload_skill_name=False,
             )
+            if isinstance(result.output_payload, dict):
+                result.output_payload["task_template_id"] = task_template.template_id
+                result.output_payload["task_type"] = task_type
+            normalized_events: list[Dict[str, Any]] = []
+            for event in list(result.runtime_events or []):
+                if not isinstance(event, dict):
+                    normalized_events.append(event)
+                    continue
+                detail = event.get("detail_payload")
+                if isinstance(detail, dict):
+                    enriched_detail = dict(detail)
+                    enriched_detail["task_template_id"] = task_template.template_id
+                    enriched_detail["task_type"] = task_type
+                    enriched_event = dict(event)
+                    enriched_event["detail_payload"] = enriched_detail
+                    normalized_events.append(enriched_event)
+                else:
+                    normalized_events.append(event)
+            result.runtime_events = normalized_events
+            return result
 
         if task_type != "tool_task":
             return make_execution_result(

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -445,6 +445,22 @@ def _get_required(payload: Dict[str, Any], key: str) -> Any:
     return payload[key]
 
 
+def _resolve_request_task_template_id(request: ExecutionRequest) -> str | None:
+    """Resolve task template id with a defensive metadata fallback.
+
+    Preferred contract: Portal should always send `input_payload.task_template_id`.
+    `metadata.portal_task_template_id` is only a fallback for older dispatchers
+    or partial UI flows and should not be treated as the primary path.
+    """
+    input_payload = request.input_payload if isinstance(request.input_payload, dict) else {}
+    payload_value = str(input_payload.get("task_template_id") or "").strip().lower()
+    if payload_value:
+        return payload_value
+    metadata = request.metadata if isinstance(request.metadata, dict) else {}
+    metadata_value = str(metadata.get("portal_task_template_id") or "").strip().lower()
+    return metadata_value or None
+
+
 def _coerce_task_tool_result(raw_result: Any) -> Dict[str, Any]:
     """Normalize task tool results from heterogeneous return types."""
     if isinstance(raw_result, ToolResult) or (
@@ -1285,7 +1301,7 @@ def build_default_execution_bus(
                 task_id=task_id,
                 detail_payload={
                     "task_type": task_type,
-                    "task_template_id": str(request.input_payload.get("task_template_id") or "").strip().lower() or None,
+                    "task_template_id": _resolve_request_task_template_id(request),
                     "skill_name": skill_name,
                     "success": skill_success,
                     "capability_id": capability.get("capability_id"),
@@ -1303,7 +1319,7 @@ def build_default_execution_bus(
             status="success" if skill_success else normalized_skill.status,
             output_payload={
                 "task_type": task_type,
-                "task_template_id": str(request.input_payload.get("task_template_id") or "").strip().lower() or None,
+                "task_template_id": _resolve_request_task_template_id(request),
                 "success": skill_success,
                 "bundle_ref": bundle_ref,
                 "updated_files": updated_files,
@@ -2024,6 +2040,7 @@ def build_default_execution_bus(
         if task_type == "github_review_task":
             capability = resolve_task_capability_plan(task_type, request.input_payload)
             involved_capability_ids = list(capability.get("involved_capability_ids") or [])
+            resolved_task_template_id = _resolve_request_task_template_id(request)
             involved_action_ids = list(involved_capability_ids)
             owner = _get_required(request.input_payload, "owner")
             repo = _get_required(request.input_payload, "repo")
@@ -2159,7 +2176,7 @@ def build_default_execution_bus(
                         "owner": owner,
                         "repo": repo,
                         "pull_number": pull_number,
-                        "task_template_id": str(request.input_payload.get("task_template_id") or "").strip().lower() or None,
+                        "task_template_id": resolved_task_template_id,
                         "comment_written": comment_written,
                         "review_written": review_written,
                         "review_event": review_event,
@@ -2185,7 +2202,7 @@ def build_default_execution_bus(
                     "owner": owner,
                     "repo": repo,
                     "pull_number": pull_number,
-                    "task_template_id": str(request.input_payload.get("task_template_id") or "").strip().lower() or None,
+                    "task_template_id": resolved_task_template_id,
                     "review_summary": review_summary,
                     "review_event": review_event,
                     "review_written": review_written,
@@ -2414,8 +2431,16 @@ def build_default_execution_bus(
             )
 
         if task_type == "bundle_action_task":
-            task_template = resolve_task_template_from_payload(request.input_payload)
-            task_template_id = str(request.input_payload.get("task_template_id") or "").strip().lower()
+            # Preferred contract: Portal should send input_payload.task_template_id.
+            # metadata.portal_task_template_id is a defensive fallback only.
+            payload_for_template = dict(request.input_payload or {})
+            task_template = resolve_task_template_from_payload(payload_for_template)
+            if task_template is None:
+                metadata_template_id = str((request.metadata or {}).get("portal_task_template_id") or "").strip().lower()
+                if metadata_template_id:
+                    payload_for_template["task_template_id"] = metadata_template_id
+                    task_template = resolve_task_template_from_payload(payload_for_template)
+            task_template_id = str(payload_for_template.get("task_template_id") or "").strip().lower()
             if task_template is None:
                 return make_execution_result(
                     request_id=request.request_id,
@@ -2440,7 +2465,7 @@ def build_default_execution_bus(
                         "task_boundary": True,
                     },
                 )
-            validation_error = _validate_bundle_action_task_payload(request.input_payload, task_template)
+            validation_error = _validate_bundle_action_task_payload(payload_for_template, task_template)
             if validation_error:
                 return make_execution_result(
                     request_id=request.request_id,
@@ -2453,8 +2478,22 @@ def build_default_execution_bus(
                         "task_boundary": True,
                     },
                 )
+            task_request = request
+            if payload_for_template != (request.input_payload or {}):
+                task_request = make_execution_request(
+                    request_id=request.request_id,
+                    source_type=request.source_type,
+                    source_ref=request.source_ref,
+                    agent_id=request.agent_id,
+                    session_id=request.session_id,
+                    execution_type=request.execution_type,
+                    input_payload=payload_for_template,
+                    context_ref=request.context_ref,
+                    policy_profile_id=request.policy_profile_id,
+                    metadata=request.metadata,
+                )
             result = await _execute_skill_backed_task(
-                request,
+                task_request,
                 task_id=task_id,
                 task_type=task_type,
                 default_skill_name=str(task_template.default_skill_name or "").strip() or "",

--- a/src/runtime/task_capability_contracts.py
+++ b/src/runtime/task_capability_contracts.py
@@ -12,10 +12,10 @@ policy, auditing, and capability metadata remain consistent across call paths.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-from src.runtime.bundle_template_registry import get_bundle_action
 from src.runtime.capability_registry import get_capability_registry
+from src.runtime.task_template_registry import resolve_task_template_from_payload
 
 
 def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -86,7 +86,9 @@ def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) ->
         }
 
     if normalized_task_type == "github_review_task":
-        skill_name = str(normalized_payload.get("skill_name") or "review-pull-request").strip().lower() or "review-pull-request"
+        task_template = resolve_task_template_from_payload(normalized_payload)
+        default_skill_name = task_template.default_skill_name if task_template else "review-pull-request"
+        skill_name = str(normalized_payload.get("skill_name") or default_skill_name).strip().lower() or "review-pull-request"
         primary_capability_id = f"skill:{skill_name}"
         descriptor = registry.get(primary_capability_id)
         involved = _resolve_involved_capability_ids_for_task(normalized_task_type, normalized_payload)
@@ -137,12 +139,17 @@ def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) ->
         }
 
     if normalized_task_type == "bundle_action_task":
-        template_id = str(normalized_payload.get("template_id") or "").strip().lower()
-        action_id = str(normalized_payload.get("action_id") or "").strip().lower()
-        action = get_bundle_action(template_id, action_id)
-        if action is None:
-            return fallback
-        primary_capability_id = f"skill:{action.skill_name}"
+        task_template = resolve_task_template_from_payload(normalized_payload)
+        if task_template is None or task_template.task_type != "bundle_action_task":
+            unresolved = dict(fallback)
+            unresolved["task_template_id"] = str(normalized_payload.get("task_template_id") or "").strip().lower() or None
+            return unresolved
+        skill_name = str(task_template.default_skill_name or "").strip().lower()
+        if not skill_name:
+            unresolved = dict(fallback)
+            unresolved["task_template_id"] = task_template.template_id
+            return unresolved
+        primary_capability_id = f"skill:{skill_name}"
         descriptor = registry.get(primary_capability_id)
         involved = [primary_capability_id]
         if descriptor is None:
@@ -153,6 +160,7 @@ def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) ->
                 "action_id": primary_capability_id,
                 "capability_type": "skill",
                 "involved_capability_ids": involved,
+                "task_template_id": task_template.template_id,
             }
         return {
             **fallback,
@@ -164,58 +172,9 @@ def resolve_task_capability_contract(task_type: str, payload: Dict[str, Any]) ->
             "policy_tags": list(descriptor.policy_tags or []),
             "requires_identity_binding": bool(descriptor.requires_identity_binding),
             "capability_resolution": "resolved",
+            "task_template_id": task_template.template_id,
         }
 
-
-    if normalized_task_type == "requirement_bundle_collect_task":
-        primary_capability_id = "skill:collect_requirements_to_bundle"
-        descriptor = registry.get(primary_capability_id)
-        involved = [primary_capability_id]
-        if descriptor is None:
-            return {
-                **fallback,
-                "primary_capability_id": primary_capability_id,
-                "capability_id": primary_capability_id,
-                "action_id": primary_capability_id,
-                "capability_type": "skill",
-                "involved_capability_ids": involved,
-            }
-        return {
-            **fallback,
-            "primary_capability_id": descriptor.capability_id,
-            "capability_id": descriptor.capability_id,
-            "capability_type": descriptor.type,
-            "action_id": descriptor.capability_id,
-            "involved_capability_ids": involved,
-            "policy_tags": list(descriptor.policy_tags or []),
-            "requires_identity_binding": bool(descriptor.requires_identity_binding),
-            "capability_resolution": "resolved",
-        }
-
-    if normalized_task_type == "requirement_bundle_design_test_cases_task":
-        primary_capability_id = "skill:design_test_cases_from_bundle"
-        descriptor = registry.get(primary_capability_id)
-        involved = [primary_capability_id]
-        if descriptor is None:
-            return {
-                **fallback,
-                "primary_capability_id": primary_capability_id,
-                "capability_id": primary_capability_id,
-                "action_id": primary_capability_id,
-                "capability_type": "skill",
-                "involved_capability_ids": involved,
-            }
-        return {
-            **fallback,
-            "primary_capability_id": descriptor.capability_id,
-            "capability_id": descriptor.capability_id,
-            "capability_type": descriptor.type,
-            "action_id": descriptor.capability_id,
-            "involved_capability_ids": involved,
-            "policy_tags": list(descriptor.policy_tags or []),
-            "requires_identity_binding": bool(descriptor.requires_identity_binding),
-            "capability_resolution": "resolved",
-        }
     if normalized_task_type == "delegation_task":
         skill_name = str(normalized_payload.get("skill_name") or "").strip().lower()
         if not skill_name:
@@ -273,7 +232,9 @@ def _resolve_involved_capability_ids_for_task(task_type: str, payload: Dict[str,
             involved.add("adapter:jira:update_issue")
         return sorted(involved)
     if normalized_task_type == "github_review_task":
-        skill_name = str(payload.get("skill_name") or "review-pull-request").strip().lower() or "review-pull-request"
+        task_template = resolve_task_template_from_payload(payload)
+        default_skill_name = task_template.default_skill_name if task_template else "review-pull-request"
+        skill_name = str(payload.get("skill_name") or default_skill_name).strip().lower() or "review-pull-request"
         writeback_mode = str(payload.get("writeback_mode") or "").strip().lower()
         secondary = "adapter:github:add_comment" if writeback_mode == "issue_comment" else "adapter:github:review_pull_request"
         return [secondary, f"skill:{skill_name}"]

--- a/src/runtime/task_template_registry.py
+++ b/src/runtime/task_template_registry.py
@@ -110,11 +110,15 @@ def require_task_template(template_id: str) -> TaskTemplateDefinition:
 
 def resolve_task_template_from_payload(payload: Dict[str, Any]) -> TaskTemplateDefinition | None:
     normalized_payload = payload if isinstance(payload, dict) else {}
+
+    # Preferred field for runtime task-template routing.
     task_template_id = str(normalized_payload.get("task_template_id") or "").strip().lower()
     if task_template_id:
         return get_task_template(task_template_id)
 
-    # Backward-compatible fallback only when `template_id` clearly points to a task template.
+    # Fallback for legacy callers: only accept `template_id` if it is NOT a known
+    # bundle template id (e.g. requirement.v1). `bundle_template_id` remains the
+    # canonical bundle layout identifier.
     template_id = str(normalized_payload.get("template_id") or "").strip().lower()
     if not template_id:
         return None

--- a/src/runtime/task_template_registry.py
+++ b/src/runtime/task_template_registry.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from src.runtime.bundle_template_registry import get_bundle_template
+
+
+@dataclass(frozen=True)
+class TaskTemplateDefinition:
+    template_id: str
+    label: str
+    task_type: str
+    task_family: str
+    provider: str | None = None
+    default_trigger: str | None = None
+    default_skill_name: str | None = None
+    required_inputs: tuple[str, ...] = ()
+    optional_inputs: tuple[str, ...] = ()
+    output_artifacts: tuple[str, ...] = ()
+    compatible_bundle_templates: tuple[str, ...] = ()
+    requires_bundle: bool = False
+    requires_sources: bool = False
+
+
+_TASK_TEMPLATE_REGISTRY: Dict[str, TaskTemplateDefinition] = {
+    "collect_requirements_to_bundle": TaskTemplateDefinition(
+        template_id="collect_requirements_to_bundle",
+        label="Collect Requirements to Bundle",
+        task_type="bundle_action_task",
+        task_family="bundle",
+        default_skill_name="collect_requirements_to_bundle",
+        compatible_bundle_templates=("requirement.v1",),
+        requires_bundle=True,
+        requires_sources=True,
+        output_artifacts=("requirements",),
+    ),
+    "design_test_cases_from_bundle": TaskTemplateDefinition(
+        template_id="design_test_cases_from_bundle",
+        label="Design Test Cases from Bundle",
+        task_type="bundle_action_task",
+        task_family="bundle",
+        default_skill_name="design_test_cases_from_bundle",
+        compatible_bundle_templates=("requirement.v1",),
+        requires_bundle=True,
+        output_artifacts=("test_cases",),
+    ),
+    "collect_research_notes_to_bundle": TaskTemplateDefinition(
+        template_id="collect_research_notes_to_bundle",
+        label="Collect Research Notes to Bundle",
+        task_type="bundle_action_task",
+        task_family="bundle",
+        default_skill_name="collect_research_notes_to_bundle",
+        compatible_bundle_templates=("research.v1",),
+        requires_bundle=True,
+        requires_sources=True,
+        output_artifacts=("research_notes",),
+    ),
+    "generate_implementation_plan_from_bundle": TaskTemplateDefinition(
+        template_id="generate_implementation_plan_from_bundle",
+        label="Generate Implementation Plan from Bundle",
+        task_type="bundle_action_task",
+        task_family="bundle",
+        default_skill_name="generate_implementation_plan_from_bundle",
+        compatible_bundle_templates=("development.v1",),
+        requires_bundle=True,
+        output_artifacts=("implementation_plan",),
+    ),
+    "generate_runbook_from_bundle": TaskTemplateDefinition(
+        template_id="generate_runbook_from_bundle",
+        label="Generate Runbook from Bundle",
+        task_type="bundle_action_task",
+        task_family="bundle",
+        default_skill_name="generate_runbook_from_bundle",
+        compatible_bundle_templates=("operations.v1",),
+        requires_bundle=True,
+        output_artifacts=("runbook",),
+    ),
+    "github_pr_review": TaskTemplateDefinition(
+        template_id="github_pr_review",
+        label="GitHub PR Review",
+        task_type="github_review_task",
+        task_family="review",
+        provider="github",
+        default_trigger="github_pr_review_requested",
+        default_skill_name="review-pull-request",
+        required_inputs=("owner", "repo", "pull_number"),
+        optional_inputs=("review_event", "head_sha", "writeback_mode", "review_target", "review_target_type"),
+    ),
+}
+
+
+def list_task_templates() -> tuple[TaskTemplateDefinition, ...]:
+    return tuple(_TASK_TEMPLATE_REGISTRY.values())
+
+
+def get_task_template(template_id: str) -> TaskTemplateDefinition | None:
+    normalized = str(template_id or "").strip().lower()
+    if not normalized:
+        return None
+    return _TASK_TEMPLATE_REGISTRY.get(normalized)
+
+
+def require_task_template(template_id: str) -> TaskTemplateDefinition:
+    resolved = get_task_template(template_id)
+    if resolved is None:
+        raise ValueError(f"Unsupported task_template_id: {template_id}")
+    return resolved
+
+
+def resolve_task_template_from_payload(payload: Dict[str, Any]) -> TaskTemplateDefinition | None:
+    normalized_payload = payload if isinstance(payload, dict) else {}
+    task_template_id = str(normalized_payload.get("task_template_id") or "").strip().lower()
+    if task_template_id:
+        return get_task_template(task_template_id)
+
+    # Backward-compatible fallback only when `template_id` clearly points to a task template.
+    template_id = str(normalized_payload.get("template_id") or "").strip().lower()
+    if not template_id:
+        return None
+    if get_bundle_template(template_id) is not None:
+        return None
+    return get_task_template(template_id)

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -8,6 +8,7 @@ from src.runtime.execution_bus import ExecutionBus, build_default_execution_bus
 from src.runtime.events import build_runtime_event
 from src.runtime.governance import GovernanceHooks
 from src.runtime.governance_bus import GovernanceDecision
+from src.runtime.task_template_registry import list_task_templates
 from src.runtime.governance_bus import GovernanceBus
 from src.runtime.capability_registry import CapabilityDescriptor
 
@@ -467,7 +468,7 @@ async def test_execution_bus_logs_blocked_no_handler_and_exception(caplog):
         request_id="req-exception",
         source_type="chat",
         execution_type="chat",
-        input_payload={"task_type": "requirement_bundle_collect_task"},
+        input_payload={"task_type": "bundle_action_task"},
     )
 
     with caplog.at_level("WARNING"):
@@ -3390,82 +3391,6 @@ async def test_run_skill_execution_legacy_direct_opt_in(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_requirement_bundle_collect_task_routes_to_default_skill(monkeypatch):
-    observed = {}
-
-    async def _fake_run_skill_execution(skill_name, **kwargs):
-        observed["skill_name"] = skill_name
-        observed["kwargs"] = kwargs
-        return SkillResult(
-            success=True,
-            output="ok",
-            data={
-                "bundle_ref": kwargs.get("bundle_ref"),
-                "updated_files": ["bundles/a/requirements.yaml"],
-                "commit_sha": "abc123",
-                "summary": "done",
-            },
-        )
-
-    monkeypatch.setattr("src.runtime.execution_bus.run_skill_execution", _fake_run_skill_execution)
-
-    req = make_execution_request(
-        source_type="task",
-        execution_type="task",
-        session_id="s-bundle",
-        input_payload={
-            "task_type": "requirement_bundle_collect_task",
-            "bundle_ref": {"repo": "acme/demo", "path": "bundles/a", "branch": "feat/a"},
-            "sources": {"jira": ["PAY-101"]},
-        },
-    )
-    result = await build_default_execution_bus().execute(req)
-
-    assert observed["skill_name"] == "collect_requirements_to_bundle"
-    assert observed["kwargs"]["bundle_ref"]["path"] == "bundles/a"
-    assert observed["kwargs"]["sources"]["jira"] == ["PAY-101"]
-    assert result.output_payload["task_boundary"] is True
-    assert result.output_payload["success"] is True
-
-
-@pytest.mark.asyncio
-async def test_requirement_bundle_design_test_cases_task_routes_to_default_skill(monkeypatch):
-    observed = {}
-
-    async def _fake_run_skill_execution(skill_name, **kwargs):
-        observed["skill_name"] = skill_name
-        observed["kwargs"] = kwargs
-        return SkillResult(
-            success=True,
-            output="ok",
-            data={
-                "bundle_ref": kwargs.get("bundle_ref"),
-                "updated_files": ["bundles/a/test-cases.yaml"],
-                "commit_sha": "def456",
-                "summary": "done",
-            },
-        )
-
-    monkeypatch.setattr("src.runtime.execution_bus.run_skill_execution", _fake_run_skill_execution)
-
-    req = make_execution_request(
-        source_type="task",
-        execution_type="task",
-        session_id="s-bundle",
-        input_payload={
-            "task_type": "requirement_bundle_design_test_cases_task",
-            "bundle_ref": {"repo": "acme/demo", "path": "bundles/a", "branch": "feat/a"},
-        },
-    )
-    result = await build_default_execution_bus().execute(req)
-
-    assert observed["skill_name"] == "design_test_cases_from_bundle"
-    assert observed["kwargs"]["bundle_ref"]["repo"] == "acme/demo"
-    assert result.output_payload["task_boundary"] is True
-    assert result.output_payload["success"] is True
-
-
-@pytest.mark.asyncio
 async def test_unknown_task_type_still_returns_unsupported_blocked():
     req = make_execution_request(
         source_type="task",
@@ -3479,39 +3404,20 @@ async def test_unknown_task_type_still_returns_unsupported_blocked():
     assert "Unsupported task_type" in result.output_payload["error"]
 
 
-@pytest.mark.asyncio
-async def test_requirement_bundle_collect_task_skill_failure_keeps_task_boundary(monkeypatch):
-    async def _fake_run_skill_execution(_skill_name, **_kwargs):
-        return SkillResult(success=False, error="bad inputs")
-
-    monkeypatch.setattr("src.runtime.execution_bus.run_skill_execution", _fake_run_skill_execution)
-    req = make_execution_request(
-        source_type="task",
-        execution_type="task",
-        input_payload={
-            "task_type": "requirement_bundle_collect_task",
-            "bundle_ref": {"repo": "acme/demo", "path": "bundles/a", "branch": "feat/a"},
-            "sources": {"jira": []},
-        },
-    )
-    result = await build_default_execution_bus().execute(req)
-    assert result.status == "error"
-    assert result.output_payload["task_boundary"] is True
-    assert result.output_payload["success"] is False
+def test_task_template_registry_lists_expected_templates():
+    template_ids = {item.template_id for item in list_task_templates()}
+    assert template_ids == {
+        "collect_requirements_to_bundle",
+        "design_test_cases_from_bundle",
+        "collect_research_notes_to_bundle",
+        "generate_implementation_plan_from_bundle",
+        "generate_runbook_from_bundle",
+        "github_pr_review",
+    }
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("template_id", "action_id", "expected_skill"),
-    [
-        ("requirement.v1", "collect_requirements", "collect_requirements_to_bundle"),
-        ("requirement.v1", "design_test_cases", "design_test_cases_from_bundle"),
-        ("research.v1", "collect_research_notes", "collect_research_notes_to_bundle"),
-        ("development.v1", "generate_implementation_plan", "generate_implementation_plan_from_bundle"),
-        ("operations.v1", "generate_runbook", "generate_runbook_from_bundle"),
-    ],
-)
-async def test_bundle_action_task_routes_to_registry_skill(monkeypatch, template_id, action_id, expected_skill):
+async def test_bundle_action_task_routes_to_task_template_skill(monkeypatch):
     observed = {}
 
     async def _fake_run_skill_execution(skill_name, **kwargs):
@@ -3525,21 +3431,22 @@ async def test_bundle_action_task_routes_to_registry_skill(monkeypatch, template
         execution_type="task",
         input_payload={
             "task_type": "bundle_action_task",
-            "template_id": template_id,
-            "action_id": action_id,
-            "bundle_ref": {"repo": "acme/demo", "path": "bundles/a", "branch": "feat/a"},
+            "task_template_id": "collect_requirements_to_bundle",
+            "bundle_template_id": "requirement.v1",
+            "bundle_ref": {"repo": "org/assets", "path": "bundles/RB-1", "branch": "main"},
+            "manifest_ref": {"repo": "org/assets", "path": "bundles/RB-1/bundle.yaml", "branch": "main"},
+            "sources": {"jira": ["ABC-1"]},
             "skill_name": "should_not_override",
         },
     )
     result = await build_default_execution_bus().execute(req)
-    assert observed["skill_name"] == expected_skill
+    assert observed["skill_name"] == "collect_requirements_to_bundle"
     assert result.status == "success"
-    assert result.output_payload["task_boundary"] is True
-    assert result.output_payload["success"] is True
+    assert result.output_payload["task_template_id"] == "collect_requirements_to_bundle"
 
 
 @pytest.mark.asyncio
-async def test_bundle_action_task_unknown_template_action_blocked(monkeypatch):
+async def test_bundle_action_task_unknown_task_template_blocked(monkeypatch):
     called = {"value": False}
 
     async def _fake_run_skill_execution(_skill_name, **_kwargs):
@@ -3550,12 +3457,128 @@ async def test_bundle_action_task_unknown_template_action_blocked(monkeypatch):
     req = make_execution_request(
         source_type="task",
         execution_type="task",
-        input_payload={"task_type": "bundle_action_task", "template_id": "unknown.v1", "action_id": "x"},
+        input_payload={"task_type": "bundle_action_task", "task_template_id": "unknown_task_template"},
     )
     result = await build_default_execution_bus().execute(req)
     assert result.status == "blocked"
-    assert result.output_payload["task_boundary"] is True
     assert called["value"] is False
+
+
+@pytest.mark.asyncio
+async def test_bundle_action_task_missing_bundle_ref_blocked():
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "bundle_action_task",
+            "task_template_id": "collect_requirements_to_bundle",
+            "bundle_template_id": "requirement.v1",
+            "manifest_ref": {"repo": "org/assets", "path": "bundles/RB-1/bundle.yaml", "branch": "main"},
+            "sources": {"jira": ["ABC-1"]},
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "blocked"
+    assert "bundle_ref" in result.output_payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_bundle_action_task_collect_requirements_empty_sources_blocked():
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "bundle_action_task",
+            "task_template_id": "collect_requirements_to_bundle",
+            "bundle_template_id": "requirement.v1",
+            "bundle_ref": {"repo": "org/assets", "path": "bundles/RB-1", "branch": "main"},
+            "manifest_ref": {"repo": "org/assets", "path": "bundles/RB-1/bundle.yaml", "branch": "main"},
+            "sources": {"jira": []},
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "blocked"
+    assert "sources" in result.output_payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_bundle_action_task_design_test_cases_does_not_require_sources(monkeypatch):
+    observed = {}
+
+    async def _fake_run_skill_execution(skill_name, **kwargs):
+        observed["skill_name"] = skill_name
+        observed["kwargs"] = kwargs
+        return SkillResult(success=True, output="ok", data={"updated_files": []})
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_skill_execution", _fake_run_skill_execution)
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "bundle_action_task",
+            "task_template_id": "design_test_cases_from_bundle",
+            "bundle_template_id": "requirement.v1",
+            "bundle_ref": {"repo": "org/assets", "path": "bundles/RB-1", "branch": "main"},
+            "manifest_ref": {"repo": "org/assets", "path": "bundles/RB-1/bundle.yaml", "branch": "main"},
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "success"
+    assert observed["skill_name"] == "design_test_cases_from_bundle"
+
+
+@pytest.mark.asyncio
+async def test_bundle_action_task_incompatible_bundle_template_id_blocked():
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "bundle_action_task",
+            "task_template_id": "collect_requirements_to_bundle",
+            "bundle_template_id": "research.v1",
+            "bundle_ref": {"repo": "org/assets", "path": "bundles/RB-1", "branch": "main"},
+            "manifest_ref": {"repo": "org/assets", "path": "bundles/RB-1/bundle.yaml", "branch": "main"},
+            "sources": {"jira": ["ABC-1"]},
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "blocked"
+    assert "incompatible" in result.output_payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_with_task_template_id_succeeds(monkeypatch):
+    async def _fake_run_github_review_task(_payload):
+        return {
+            "success": True,
+            "review_summary": "ok",
+            "review_event": "COMMENT",
+            "review_written": True,
+            "comment_written": True,
+            "error": None,
+            "runtime_events": [],
+            "secondary_action_attempted": True,
+            "secondary_action_success": True,
+            "secondary_action_id": "adapter:github:review_pull_request",
+            "result": {},
+        }
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_github_review_task", _fake_run_github_review_task)
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "github_review_task",
+            "task_template_id": "github_pr_review",
+            "owner": "acme",
+            "repo": "demo",
+            "pull_number": 7,
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "success"
+    assert result.output_payload["task_template_id"] == "github_pr_review"
+    assert any(evt.get("detail_payload", {}).get("task_template_id") == "github_pr_review" for evt in result.runtime_events)
 
 
 @pytest.mark.asyncio

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -3443,6 +3443,30 @@ async def test_bundle_action_task_routes_to_task_template_skill(monkeypatch):
     assert observed["skill_name"] == "collect_requirements_to_bundle"
     assert result.status == "success"
     assert result.output_payload["task_template_id"] == "collect_requirements_to_bundle"
+    assert any(
+        evt.get("detail_payload", {}).get("task_template_id") == "collect_requirements_to_bundle"
+        for evt in result.runtime_events
+        if isinstance(evt, dict)
+    )
+
+
+@pytest.mark.asyncio
+async def test_bundle_action_task_template_id_fallback_does_not_accept_bundle_template_id():
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "bundle_action_task",
+            "template_id": "requirement.v1",
+            "bundle_template_id": "requirement.v1",
+            "bundle_ref": {"repo": "org/assets", "path": "bundles/RB-1", "branch": "main"},
+            "manifest_ref": {"repo": "org/assets", "path": "bundles/RB-1/bundle.yaml", "branch": "main"},
+            "sources": {"jira": ["ABC-1"]},
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "blocked"
+    assert "Unsupported task_template_id" in result.output_payload["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -3470,6 +3470,52 @@ async def test_bundle_action_task_template_id_fallback_does_not_accept_bundle_te
 
 
 @pytest.mark.asyncio
+async def test_bundle_action_task_metadata_portal_task_template_id_fallback_succeeds(monkeypatch):
+    observed = {}
+
+    async def _fake_run_skill_execution(skill_name, **kwargs):
+        observed["skill_name"] = skill_name
+        observed["kwargs"] = kwargs
+        return SkillResult(success=True, output="ok", data={"updated_files": []})
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_skill_execution", _fake_run_skill_execution)
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        metadata={"portal_task_template_id": "collect_requirements_to_bundle"},
+        input_payload={
+            "task_type": "bundle_action_task",
+            "bundle_template_id": "requirement.v1",
+            "bundle_ref": {"repo": "org/assets", "path": "bundles/RB-1", "branch": "main"},
+            "manifest_ref": {"repo": "org/assets", "path": "bundles/RB-1/bundle.yaml", "branch": "main"},
+            "sources": {"jira": ["ABC-1"]},
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "success"
+    assert observed["skill_name"] == "collect_requirements_to_bundle"
+    assert result.output_payload["task_template_id"] == "collect_requirements_to_bundle"
+
+
+@pytest.mark.asyncio
+async def test_bundle_action_task_without_task_template_id_and_metadata_is_blocked():
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        input_payload={
+            "task_type": "bundle_action_task",
+            "bundle_template_id": "requirement.v1",
+            "bundle_ref": {"repo": "org/assets", "path": "bundles/RB-1", "branch": "main"},
+            "manifest_ref": {"repo": "org/assets", "path": "bundles/RB-1/bundle.yaml", "branch": "main"},
+            "sources": {"jira": ["ABC-1"]},
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "blocked"
+    assert "Unsupported task_template_id" in result.output_payload["error"]
+
+
+@pytest.mark.asyncio
 async def test_bundle_action_task_unknown_task_template_blocked(monkeypatch):
     called = {"value": False}
 
@@ -3594,6 +3640,41 @@ async def test_github_review_task_with_task_template_id_succeeds(monkeypatch):
         input_payload={
             "task_type": "github_review_task",
             "task_template_id": "github_pr_review",
+            "owner": "acme",
+            "repo": "demo",
+            "pull_number": 7,
+        },
+    )
+    result = await build_default_execution_bus().execute(req)
+    assert result.status == "success"
+    assert result.output_payload["task_template_id"] == "github_pr_review"
+    assert any(evt.get("detail_payload", {}).get("task_template_id") == "github_pr_review" for evt in result.runtime_events)
+
+
+@pytest.mark.asyncio
+async def test_github_review_task_uses_metadata_task_template_id_fallback(monkeypatch):
+    async def _fake_run_github_review_task(_payload):
+        return {
+            "success": True,
+            "review_summary": "ok",
+            "review_event": "COMMENT",
+            "review_written": True,
+            "comment_written": True,
+            "error": None,
+            "runtime_events": [],
+            "secondary_action_attempted": True,
+            "secondary_action_success": True,
+            "secondary_action_id": "adapter:github:review_pull_request",
+            "result": {},
+        }
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_github_review_task", _fake_run_github_review_task)
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        metadata={"portal_task_template_id": "github_pr_review"},
+        input_payload={
+            "task_type": "github_review_task",
             "owner": "acme",
             "repo": "demo",
             "pull_number": 7,

--- a/tests/test_task_capability_contracts.py
+++ b/tests/test_task_capability_contracts.py
@@ -172,34 +172,10 @@ def test_execution_bus_resolve_task_capability_plan_delegates_to_canonical_contr
     assert plan is sentinel
 
 
-def test_resolve_task_capability_contract_requirement_bundle_collect_task():
-    plan = resolve_task_capability_contract(
-        "requirement_bundle_collect_task",
-        {"bundle_ref": {"repo": "acme/demo", "path": "bundles/a", "branch": "feat/a"}},
-    )
-
-    assert plan["primary_capability_id"] == "skill:collect_requirements_to_bundle"
-    assert plan["capability_id"] == "skill:collect_requirements_to_bundle"
-    assert plan["capability_type"] == "skill"
-    assert plan["involved_capability_ids"] == ["skill:collect_requirements_to_bundle"]
-
-
-def test_resolve_task_capability_contract_requirement_bundle_design_test_cases_task():
-    plan = resolve_task_capability_contract(
-        "requirement_bundle_design_test_cases_task",
-        {"bundle_ref": {"repo": "acme/demo", "path": "bundles/a", "branch": "feat/a"}},
-    )
-
-    assert plan["primary_capability_id"] == "skill:design_test_cases_from_bundle"
-    assert plan["capability_id"] == "skill:design_test_cases_from_bundle"
-    assert plan["capability_type"] == "skill"
-    assert plan["involved_capability_ids"] == ["skill:design_test_cases_from_bundle"]
-
-
 def test_resolve_task_capability_contract_bundle_action_task_requirement_collect():
     plan = resolve_task_capability_contract(
         "bundle_action_task",
-        {"template_id": "requirement.v1", "action_id": "collect_requirements"},
+        {"task_template_id": "collect_requirements_to_bundle", "bundle_template_id": "requirement.v1"},
     )
     assert plan["primary_capability_id"] == "skill:collect_requirements_to_bundle"
     assert plan["capability_id"] == "skill:collect_requirements_to_bundle"
@@ -208,7 +184,7 @@ def test_resolve_task_capability_contract_bundle_action_task_requirement_collect
 def test_resolve_task_capability_contract_bundle_action_task_requirement_design():
     plan = resolve_task_capability_contract(
         "bundle_action_task",
-        {"template_id": "requirement.v1", "action_id": "design_test_cases"},
+        {"task_template_id": "design_test_cases_from_bundle", "bundle_template_id": "requirement.v1"},
     )
     assert plan["primary_capability_id"] == "skill:design_test_cases_from_bundle"
     assert plan["capability_id"] == "skill:design_test_cases_from_bundle"
@@ -217,7 +193,7 @@ def test_resolve_task_capability_contract_bundle_action_task_requirement_design(
 def test_resolve_task_capability_contract_bundle_action_task_research_collect():
     plan = resolve_task_capability_contract(
         "bundle_action_task",
-        {"template_id": "research.v1", "action_id": "collect_research_notes"},
+        {"task_template_id": "collect_research_notes_to_bundle", "bundle_template_id": "research.v1"},
     )
     assert plan["primary_capability_id"] == "skill:collect_research_notes_to_bundle"
     assert plan["capability_id"] == "skill:collect_research_notes_to_bundle"
@@ -226,7 +202,7 @@ def test_resolve_task_capability_contract_bundle_action_task_research_collect():
 def test_resolve_task_capability_contract_bundle_action_task_development_generate():
     plan = resolve_task_capability_contract(
         "bundle_action_task",
-        {"template_id": "development.v1", "action_id": "generate_implementation_plan"},
+        {"task_template_id": "generate_implementation_plan_from_bundle", "bundle_template_id": "development.v1"},
     )
     assert plan["primary_capability_id"] == "skill:generate_implementation_plan_from_bundle"
     assert plan["capability_id"] == "skill:generate_implementation_plan_from_bundle"
@@ -235,7 +211,7 @@ def test_resolve_task_capability_contract_bundle_action_task_development_generat
 def test_resolve_task_capability_contract_bundle_action_task_operations_generate():
     plan = resolve_task_capability_contract(
         "bundle_action_task",
-        {"template_id": "operations.v1", "action_id": "generate_runbook"},
+        {"task_template_id": "generate_runbook_from_bundle", "bundle_template_id": "operations.v1"},
     )
     assert plan["primary_capability_id"] == "skill:generate_runbook_from_bundle"
     assert plan["capability_id"] == "skill:generate_runbook_from_bundle"
@@ -244,7 +220,7 @@ def test_resolve_task_capability_contract_bundle_action_task_operations_generate
 def test_resolve_task_capability_contract_bundle_action_task_unknown_is_unresolved():
     plan = resolve_task_capability_contract(
         "bundle_action_task",
-        {"template_id": "unknown.v1", "action_id": "does_not_exist"},
+        {"task_template_id": "unknown_template"},
     )
     assert plan["capability_resolution"] == "unresolved"
 


### PR DESCRIPTION
### Motivation
- Align the runtime with Portal's template-driven model so Tasks are routed by Task Template (task_template_id) instead of Bundle actions (action_id).
- Decouple BundleTemplate (bundle layout) from Task Template (execution contract) so BundleTemplates no longer own actions/skills.
- Enforce task-template validation (bundle refs, bundle template compatibility and non-empty sources) to fail early with clear blocked responses.

### Description
- Add a new `TaskTemplateDefinition` registry in `src/runtime/task_template_registry.py` with 6 built-in Portal-aligned templates and `list/get/require/resolve` helpers that prefer `task_template_id` and avoid confusing bundle `template_id` with task templates.
- Simplify `src/runtime/bundle_template_registry.py` to remove action definitions and only keep bundle layout and `compatible_task_template_ids` plus existing bundle manifest helpers.
- Refactor `src/runtime/execution_bus.py` to resolve `bundle_action_task` via `resolve_task_template_from_payload`, validate required fields (`bundle_ref`, `manifest_ref`, `bundle_template_id`, `sources`) against the task template, disallow payload overrides of `skill_name` by default, and include `task_template_id` in outputs and runtime events; legacy requirement-specific task branches were removed.
- Update `src/runtime/task_capability_contracts.py` to resolve `bundle_action_task` capability via the Task Template Registry (primary capability = `skill:{default_skill_name}`) and remove legacy `requirement_bundle_*` branches.
- Ensure runtime-required skill capabilities are present by extending `src/runtime/capability_registry.py` to register bundle-related skills and `review-pull-request` descriptors when missing while keeping GitHub review identity requirements.
- Tests updated to exercise template-driven routing and validation in `tests/test_execution_bus.py` and to use `task_template_id` in `tests/test_task_capability_contracts.py`.

### Testing
- Ran `pytest tests/test_execution_bus.py tests/test_github_review.py tests/test_task_capability_contracts.py` as the main verification suite.
- All targeted tests passed: full run showed `187 passed` (no failures) when executing the updated test files.
- Updated/added unit tests cover: listing task templates, bundle_action_task routing via `task_template_id`, missing/unknown template blocking, bundle_ref/manifest_ref/sources validation, bundle-template compatibility rejection, and acceptance of `task_template_id` in GitHub review paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04e8ad918832aa5c4a6cae99bddde)