### PR TITLE
Ensure one-shot attachment RAG context is transient (do not persist enhanced prompts)

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -1983,6 +1983,7 @@ You have access to the following tools. When a user asks you to do something tha
         stream_callback: Optional[Callable[[str], None]] = None,
         attached_images: Optional[List[str]] = None,
         attachments: Optional[List[str]] = None,
+        transient_model_message: Optional[str] = None,
         portal_user_id: Optional[str] = None,
         portal_user_name: Optional[str] = None,
         request_id: Optional[str] = None,
@@ -2280,6 +2281,19 @@ You have access to the following tools. When a user asks you to do something tha
         else:
             set_skill_workdir(None)
         # ===== END SKILL MATCHING =====
+
+        # Apply one-shot attachment context only to the current model request.
+        # Do NOT persist this content into session history.
+        if isinstance(transient_model_message, str) and transient_model_message.strip():
+            for idx in range(len(messages) - 1, -1, -1):
+                if messages[idx].get("role") == "user":
+                    replaced = dict(messages[idx])
+                    replaced["content"] = transient_model_message
+                    messages[idx] = replaced
+                    logger.info(
+                        "[Agent] Applied transient model-only message for current request; persisted user history remains original"
+                    )
+                    break
 
         # ===== MESSAGE COMPACTION =====
         model = self.model or config.llm.get("model", DEFAULT_LLM_MODEL)
@@ -4591,6 +4605,7 @@ async def run_chat_execution(
     stream_callback: Optional[Any] = None,
     attached_images: Optional[List[str]] = None,
     attachments: Optional[List[str]] = None,
+    transient_model_message: Optional[str] = None,
     portal_user_id: Optional[str] = None,
     portal_user_name: Optional[str] = None,
     request_id: Optional[str] = None,
@@ -4606,6 +4621,7 @@ async def run_chat_execution(
         "stream_callback": stream_callback,
         "attached_images": attached_images,
         "attachments": attachments,
+        "transient_model_message": transient_model_message,
         "portal_user_id": portal_user_id,
         "portal_user_name": portal_user_name,
         "request_id": request_id,

--- a/src/gateway/webchat.py
+++ b/src/gateway/webchat.py
@@ -471,6 +471,7 @@ async def _run_chat_via_execution_bus(
     portal_user_name: Optional[str],
     attached_images: Optional[List[str]] = None,
     attachments: Optional[List[str]] = None,
+    transient_model_message: Optional[str] = None,
     reasoning_replay: Optional[bool] = None,
     stream_callback: Optional[Any] = None,
     request_path: str = "/api/chat",
@@ -493,6 +494,7 @@ async def _run_chat_via_execution_bus(
             portal_user_name=payload.get("portal_user_name"),
             attached_images=payload.get("attached_images"),
             attachments=payload.get("attachments"),
+            transient_model_message=transient_model_message,
             track_usage=bool(payload.get("track_usage", True)),
             reasoning_replay=payload.get("reasoning_replay"),
             stream_callback=payload.get("stream_callback"),
@@ -838,24 +840,29 @@ async def api_chat(request: web.Request) -> web.Response:
         # Inject file context if user has uploaded files
         original_msg_for_history = message if message.strip() else ("[image]" if attached_images else "")
         logger.info("[api_chat] Message summary: session_id=%s attached_images=%d message_length=%d preview=%s", safe_log_field(session_id, 120), len(attached_images) if attached_images else 0, len(original_msg_for_history), safe_preview(original_msg_for_history, 120))
-        original_message = message
+        history_message = message
+        transient_model_message: Optional[str] = None
         try:
             if attachment_ids:
                 enhanced_message, budget_status, citations = inject_context(
                     session_id=session_id,
-                    message=message,
+                    message=history_message,
                     top_k=5,
                     max_tokens=4000,
                     file_ids=attachment_ids,
                 )
-                if enhanced_message and enhanced_message != message:
-                    logger.info(f"[api_chat] File context injected: status={budget_status}, chunks={len(citations)}")
-                    message = enhanced_message
+                if enhanced_message and enhanced_message != history_message:
+                    logger.info(
+                        "[api_chat] File context prepared transiently: status=%s, chunks=%s",
+                        budget_status,
+                        len(citations),
+                    )
+                    transient_model_message = enhanced_message
                     request['file_citations'] = citations
         except Exception as e:
             logger.warning(f"[api_chat] File context injection failed: {sanitize_exception_message(e)}")
         # Revalidate message is not empty to prevent downstream LLM input from being empty
-        if not message or not message.strip():
+        if not history_message.strip() and not transient_model_message:
             logger.error(f"[api_chat] ERROR: Final message is empty before Copilot API call. Payload: {json.dumps(data, ensure_ascii=False)}")
             return web.json_response({'error': 'Input field missing for Copilot API.'}, status=400)
         
@@ -895,7 +902,7 @@ async def api_chat(request: web.Request) -> web.Response:
                 logger.warning("Best-effort session metadata publish failed for chat.started", exc_info=True)
         result = await _run_chat_via_execution_bus(
                 agent=agent,
-                message=message,
+                message=history_message,
                 session_id=session_id,
                 user_name=effective_user_name,
                 portal_user_id=portal_user_id,
@@ -907,6 +914,7 @@ async def api_chat(request: web.Request) -> web.Response:
                 execution_metadata=execution_metadata,
                 agent_id=runtime_agent_id,
                 request_id=request_id,
+                transient_model_message=transient_model_message,
             )
         execution_result = result.get("_execution_result")
         if runtime_agent_id and execution_result is not None:
@@ -1114,17 +1122,19 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         if not message.strip() and not attached_images and not attachment_ids:
             response = web.json_response({'error': 'Empty message'}, status=400)
             return response
+        history_message = message
+        transient_model_message: Optional[str] = None
         try:
             if attachment_ids:
                 enhanced_message, _budget_status, _citations = inject_context(
                     session_id=session_id,
-                    message=message,
+                    message=history_message,
                     top_k=5,
                     max_tokens=4000,
                     file_ids=attachment_ids,
                 )
-                if enhanced_message:
-                    message = enhanced_message
+                if enhanced_message and enhanced_message != history_message:
+                    transient_model_message = enhanced_message
         except Exception as e:
             logger.warning(f"[api_chat_stream] File context injection failed: {sanitize_exception_message(e)}")
 
@@ -1179,7 +1189,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         run_task = asyncio.create_task(
             _run_chat_via_execution_bus(
                 agent=agent,
-                message=message,
+                message=history_message,
                 session_id=session_id,
                 user_name=effective_user_name,
                 portal_user_id=portal_user_id,
@@ -1191,6 +1201,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
                 execution_metadata=execution_metadata,
                 agent_id=runtime_agent_id,
                 request_id=request_id,
+                transient_model_message=transient_model_message,
             )
         )
 

--- a/tests/test_webchat_one_shot_attachment_history_contract.py
+++ b/tests/test_webchat_one_shot_attachment_history_contract.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_attachment_rag_context_is_transient_not_history_message():
+    webchat = Path("src/gateway/webchat.py").read_text(encoding="utf-8")
+    core = Path("src/agents/core.py").read_text(encoding="utf-8")
+
+    assert "transient_model_message" in webchat
+    assert "transient_model_message" in core
+
+    assert "message=history_message" in webchat
+    assert "transient_model_message=transient_model_message" in webchat
+
+    run_section = webchat.split("execute_chat_orchestration(", 1)[1]
+    input_payload_section = run_section.split("metadata={", 1)[0]
+    assert "transient_model_message" not in input_payload_section
+
+    process_section = core.split("async def process(", 1)[1].split("def emit_early_runtime_event", 1)[0]
+    assert "session_manager.add_message(" in process_section
+    add_call = process_section.split("session_manager.add_message(", 1)[1].split(")", 1)[0]
+    assert "message" in add_call
+    assert "transient_model_message" not in add_call
+
+    assert "Applied transient model-only message" in core
+    assert 'replaced["content"] = transient_model_message' in core or "replaced['content'] = transient_model_message" in core


### PR DESCRIPTION
### Motivation
- Injected RAG/enhanced prompts produced by `inject_context(... file_ids=...)` were being saved into session history and execution-bus payloads, violating the one-shot attachment requirement that file-derived context be visible only to the current LLM request.

### Description
- Add a `transient_model_message` plumbing parameter through the execution path by extending `Agent.process()` and `run_chat_execution()` to accept `transient_model_message` and pass it to `agent.process(...)` without persisting it.
- In `Agent.process()` apply the enhanced prompt only to the in-memory `messages` list by replacing the last user message content locally when `transient_model_message` is present, while keeping `session_manager.add_message(...)` writing the original `message` to persisted history unchanged.
- Update `src/gateway/webchat.py` handlers to use a two-track approach: `history_message` (persisted original or placeholder) and `transient_model_message` (RAG-enhanced prompt only for the current model request), and ensure `_run_chat_via_execution_bus(... input_payload=...)` does NOT include `transient_model_message` so transient content will not be recorded by the execution bus.
- Keep `attachments=None` when invoking the execution path from webchat and do not change other previously completed one-shot attachment behaviors; add a static contract test `tests/test_webchat_one_shot_attachment_history_contract.py` to guard these semantics.

### Testing
- Ran `node --check src/gateway/static/js/webchat.js` and `python -m py_compile src/gateway/webchat.py src/hooks/file_context/injection.py src/hooks/file_context/storage.py src/agents/core.py` and they passed.
- Executed contract tests with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` for: `tests/test_webchat_one_shot_attachment_ui_contract.py`, `tests/test_webchat_file_upload_parse_binding_contract.py`, and the new `tests/test_webchat_one_shot_attachment_history_contract.py`, and all tests passed.
- Performed grep checks to confirm no reintroduction of legacy UI/file-listing code paths and verified `transient_model_message` is not present in execution bus `input_payload`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48e1af738832aa56d457f17b1677c)