### PR TITLE
Add external tools loader and integrate external tool schemas into tool registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 # Create the workspace directory for this container image's default runtime user (root).
 # Note: the canonical runtime workspace model is user-home-based (`~/.efp/workspace`);
 # in this image, `~` resolves to `/root`.
-RUN mkdir -p /app/skills /root/.efp/workspace /root/.efp/skills
+RUN mkdir -p /app/skills /app/tools /root/.efp/workspace /root/.efp/skills
 
 # Expose port
 EXPOSE 8000

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7,8 +7,13 @@ Bash tools with security controls.
 from typing import Any, Dict, List, Optional
 import json
 import logging
+import os
 
 logger = logging.getLogger(__name__)
+
+
+def _external_tools_strict_mode() -> bool:
+    return os.environ.get("EFP_EXTERNAL_TOOLS_STRICT", "false").strip().lower() == "true"
 
 
 class ToolResult:
@@ -80,6 +85,8 @@ def get_all_tools() -> list:
         external_tools = get_external_tool_schemas(runtime_type="native")
         external_disabled_names = get_external_disabled_tool_names(runtime_type="native")
     except Exception:
+        if _external_tools_strict_mode():
+            raise
         logger.warning("Failed to load external tool schemas; falling back to legacy tools", exc_info=True)
         external_tools = []
         external_disabled_names = set()
@@ -207,6 +214,8 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
         if external_known:
             return ToolResult(success=False, error=f"External tool '{name}' did not return a result")
     except Exception as exc:
+        if _external_tools_strict_mode():
+            return ToolResult(success=False, error=f"External tools strict mode failed for '{name}': {exc}")
         try:
             from .runtime.external_tools import has_external_tool
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,6 +6,9 @@ Bash tools with security controls.
 
 from typing import Any, Dict, List, Optional
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ToolResult:
@@ -70,6 +73,22 @@ from . import context_tools
 
 def get_all_tools() -> list:
     """Get all tool schemas."""
+    legacy_tools = _get_legacy_tools()
+    try:
+        from .runtime.external_tools import get_external_disabled_tool_names, get_external_tool_schemas
+
+        external_tools = get_external_tool_schemas(runtime_type="native")
+        external_disabled_names = get_external_disabled_tool_names(runtime_type="native")
+    except Exception:
+        logger.warning("Failed to load external tool schemas; falling back to legacy tools", exc_info=True)
+        external_tools = []
+        external_disabled_names = set()
+    if not external_tools and not external_disabled_names:
+        return legacy_tools
+    return _merge_legacy_and_external_tools(legacy_tools, external_tools, external_disabled_names)
+
+
+def _get_legacy_tools() -> list:
     tools = []
     tools.extend(get_bash_tools())   # Bash/Shell tools: exec only (simplified)
     tools.extend(get_github_tools())
@@ -80,15 +99,48 @@ def get_all_tools() -> list:
     return tools
 
 
+def _extract_tool_schema_name(tool_schema: Dict[str, Any]) -> Optional[str]:
+    function_obj = tool_schema.get("function") if isinstance(tool_schema, dict) else None
+    if isinstance(function_obj, dict) and isinstance(function_obj.get("name"), str):
+        return function_obj["name"].strip()
+    if isinstance(tool_schema, dict) and isinstance(tool_schema.get("name"), str):
+        return tool_schema["name"].strip()
+    return None
+
+
+def _merge_legacy_and_external_tools(
+    legacy_tools: List[Dict[str, Any]],
+    external_tools: List[Dict[str, Any]],
+    external_disabled_names: set[str],
+) -> List[Dict[str, Any]]:
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for schema in legacy_tools:
+        name = _extract_tool_schema_name(schema)
+        if not name or name in external_disabled_names:
+            continue
+        by_name[name] = schema
+    for schema in external_tools:
+        name = _extract_tool_schema_name(schema)
+        if not name:
+            continue
+        by_name[name] = schema
+    return [by_name[name] for name in sorted(by_name.keys())]
+
+
 def get_tool_names() -> List[str]:
     """Get all tool names."""
-    return [t["name"] for t in get_all_tools()]
+    names: List[str] = []
+    for tool in get_all_tools():
+        name = _extract_tool_schema_name(tool)
+        if name:
+            names.append(name)
+    return names
 
 
 def get_tool(name: str) -> Optional[Dict]:
     """Get tool schema by name."""
     for tool in get_all_tools():
-        if tool.get("name") == name:
+        if _extract_tool_schema_name(tool) == name:
             return tool
     return None
 
@@ -103,6 +155,25 @@ def _strip_none_values(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in kwargs.items() if v is not None}
 
 
+def _coerce_external_tool_result(raw: Any) -> ToolResult:
+    if isinstance(raw, ToolResult):
+        return raw
+    if hasattr(raw, "to_dict"):
+        raw = raw.to_dict()
+    if isinstance(raw, dict):
+        success = bool(raw.get("success"))
+        content = raw.get("content")
+        if content is None and raw.get("data") is not None:
+            content = json.dumps(raw.get("data"), ensure_ascii=False, indent=2)
+        if content is None:
+            content = ""
+        error = raw.get("error")
+        return ToolResult(success=success, content=str(content), error=error)
+    if isinstance(raw, str):
+        return ToolResult(success=True, content=raw)
+    return ToolResult(success=True, content=str(raw))
+
+
 async def execute_tool(name: str, **kwargs) -> ToolResult:
     """Execute a tool by name."""
     from . import bash_tools as bash_tools_module
@@ -112,7 +183,38 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
     from . import confluence as confluence_module
     from . import context_tools as context_tools_module
     kwargs = _strip_none_values(kwargs)
-    
+
+    # Backward compatibility: map exec to run_command before external dispatch.
+    if name == "exec":
+        name = "run_command"
+        if "command" in kwargs:
+            kwargs["cmd"] = kwargs.pop("command")
+        if "timeout" in kwargs:
+            kwargs["timeout_ms"] = kwargs.pop("timeout") * 1000
+
+    try:
+        from .runtime.external_tools import execute_external_tool, has_external_tool
+
+        external_known = has_external_tool(name, runtime_type="native", include_disabled=True)
+        external_result = await execute_external_tool(
+            name,
+            kwargs,
+            session_id=kwargs.get("_session_id"),
+            runtime_type="native",
+        )
+        if external_result is not None:
+            return _coerce_external_tool_result(external_result)
+        if external_known:
+            return ToolResult(success=False, error=f"External tool '{name}' did not return a result")
+    except Exception as exc:
+        try:
+            from .runtime.external_tools import has_external_tool
+
+            if has_external_tool(name, runtime_type="native", include_disabled=True):
+                return ToolResult(success=False, error=f"External tool '{name}' execution failed: {exc}")
+        except Exception:
+            pass
+
     # Bash/Shell tools
     if name == "read":
         file_path = kwargs.get("file_path", "")
@@ -138,15 +240,6 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
         path = kwargs.get("path", ".")
         result = bash_tools_module.list_dir(path)
         return ToolResult(success="Error" not in result, content=result)
-    
-    # Backward compatibility: map exec to run_command
-    if name == "exec":
-        name = "run_command"
-        # Map old exec args to new format
-        if "command" in kwargs:
-            kwargs["cmd"] = kwargs.pop("command")
-        if "timeout" in kwargs:
-            kwargs["timeout_ms"] = kwargs.pop("timeout") * 1000
     
     elif name == "run_command":
         cmd = kwargs.get("cmd", "")

--- a/src/runtime/capability_registry.py
+++ b/src/runtime/capability_registry.py
@@ -300,14 +300,24 @@ class _CapabilityBuilder:
                         capability_id=_format_capability_id("tool", tool_name),
                         type="tool",
                         name=tool_name,
-                        input_schema=dict(tool_schema.get("parameters") or {}),
+                        input_schema=dict(
+                            (
+                                (tool_schema.get("function") if isinstance(tool_schema.get("function"), dict) else {}).get("parameters")
+                                or tool_schema.get("parameters")
+                                or {"type": "object"}
+                            )
+                        ),
                         output_schema={"type": "object"},
                         policy_tags=["tool", *(["read"] if _looks_read_only_tool(tool_name) else [])],
                         source_ref="src.__init__.get_tools_schema",
                         metadata={
                             "tool_name": tool_name,
-                            "description": tool_schema.get("description"),
+                            "description": (
+                                (tool_schema.get("function") if isinstance(tool_schema.get("function"), dict) else {}).get("description")
+                                or tool_schema.get("description")
+                            ),
                             "declaration_only": True,
+                            **dict(tool_schema.get("metadata") or {}),
                         },
                     )
                 )

--- a/src/runtime/external_tools.py
+++ b/src/runtime/external_tools.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass, field, is_dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+DEFAULT_TOOLS_DIR = "/app/tools"
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExternalToolsState:
+    tools_dir: Path
+    available: bool
+    error: Optional[str] = None
+    registry: Any = None
+    runner: Any = None
+    validation_errors: list[str] = field(default_factory=list)
+
+
+_cached_state: Optional[ExternalToolsState] = None
+
+
+def resolve_external_tools_dir() -> Path:
+    return Path(os.environ.get("EFP_TOOLS_DIR", DEFAULT_TOOLS_DIR))
+
+
+def external_tools_enabled() -> bool:
+    return os.environ.get("EFP_EXTERNAL_TOOLS_ENABLED", "true").strip().lower() != "false"
+
+
+def clear_external_tools_cache() -> None:
+    global _cached_state
+    _cached_state = None
+    for mod_name in list(sys.modules.keys()):
+        if mod_name == "efp_tools" or mod_name.startswith("efp_tools."):
+            sys.modules.pop(mod_name, None)
+
+
+def _strict_mode() -> bool:
+    return os.environ.get("EFP_EXTERNAL_TOOLS_STRICT", "false").strip().lower() == "true"
+
+
+def _registry_loaded(state: ExternalToolsState) -> bool:
+    return state.registry is not None
+
+
+def _runtime_root_dir() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _workspace_dir() -> str:
+    return os.environ.get("EFP_WORKSPACE_DIR") or str(Path.home() / ".efp" / "workspace")
+
+
+def _context_blob_dir(workspace_dir: str) -> str:
+    return os.environ.get("EFP_CONTEXT_BLOB_DIR") or str(Path(workspace_dir) / "context_blobs")
+
+
+def load_external_tools_state() -> ExternalToolsState:
+    global _cached_state
+    if _cached_state is not None:
+        return _cached_state
+
+    tools_dir = resolve_external_tools_dir()
+    if not external_tools_enabled():
+        _cached_state = ExternalToolsState(tools_dir=tools_dir, available=False, error="external tools disabled")
+        return _cached_state
+
+    python_dir = tools_dir / "python"
+    if not python_dir.exists():
+        _cached_state = ExternalToolsState(tools_dir=tools_dir, available=False, error=f"missing tools python dir: {python_dir}")
+        return _cached_state
+
+    try:
+        importlib.invalidate_caches()
+        python_dir_str = str(python_dir)
+        if python_dir_str not in sys.path:
+            sys.path.insert(0, python_dir_str)
+        registry_mod = importlib.import_module("efp_tools.registry")
+        runner_mod = importlib.import_module("efp_tools.runner")
+        registry = None
+        if hasattr(registry_mod, "load_registry"):
+            registry = registry_mod.load_registry(str(tools_dir))
+        elif hasattr(registry_mod, "ToolRegistry"):
+            registry = registry_mod.ToolRegistry(str(tools_dir))
+        validation_errors: list[str] = []
+        validate = getattr(registry, "validate", None)
+        if callable(validate):
+            raw_errors = validate()
+            validation_errors = list(raw_errors or [])
+        if validation_errors:
+            msg = f"external tools validation failed: {validation_errors}"
+            if _strict_mode():
+                raise RuntimeError(msg)
+            logger.warning(msg)
+            _cached_state = ExternalToolsState(
+                tools_dir=tools_dir,
+                available=False,
+                error=msg,
+                registry=registry,
+                runner=runner_mod,
+                validation_errors=validation_errors,
+            )
+            return _cached_state
+        _cached_state = ExternalToolsState(
+            tools_dir=tools_dir, available=True, registry=registry, runner=runner_mod, validation_errors=validation_errors
+        )
+        return _cached_state
+    except Exception as exc:
+        if _strict_mode():
+            raise
+        logger.warning("Failed to load external tools registry: %s", exc)
+        _cached_state = ExternalToolsState(tools_dir=tools_dir, available=False, error=str(exc))
+        return _cached_state
+
+
+def _descriptor_runtime_compatible(descriptor: Dict[str, Any], runtime_type: str) -> bool:
+    descriptor = _descriptor_to_mapping(descriptor)
+    runtime_compat = descriptor.get("runtime_compat")
+    if runtime_compat is None:
+        return True
+    if isinstance(runtime_compat, list):
+        return runtime_type in runtime_compat
+    return False
+
+
+def _iter_descriptors(state: ExternalToolsState) -> List[Dict[str, Any]]:
+    if not state.registry:
+        return []
+    registry = state.registry
+    if hasattr(registry, "list_all_descriptors"):
+        return [_descriptor_to_mapping(item) for item in (registry.list_all_descriptors() or [])]
+    if hasattr(registry, "list_descriptors"):
+        try:
+            raw = registry.list_descriptors(enabled_only=False, model_facing_only=False)
+        except TypeError:
+            raw = registry.list_descriptors()
+        return [_descriptor_to_mapping(item) for item in (raw or [])]
+    if hasattr(registry, "descriptors"):
+        descriptors = registry.descriptors
+        if isinstance(descriptors, dict):
+            return [_descriptor_to_mapping(item) for item in descriptors.values()]
+        return [_descriptor_to_mapping(item) for item in (descriptors or [])]
+    return []
+
+
+def _descriptor_to_mapping(descriptor: Any) -> Dict[str, Any]:
+    if isinstance(descriptor, dict):
+        return descriptor
+    if is_dataclass(descriptor):
+        return asdict(descriptor)
+    if hasattr(descriptor, "to_dict") and callable(descriptor.to_dict):
+        value = descriptor.to_dict()
+        if isinstance(value, dict):
+            return value
+    result: Dict[str, Any] = {}
+    for key in (
+        "tool_id", "name", "opencode_name", "description", "domain", "type",
+        "runtime_compat", "policy_tags", "requires_identity_binding", "mutation",
+        "risk_level", "python_entrypoint", "input_schema", "output_schema",
+        "metadata", "enabled",
+    ):
+        if hasattr(descriptor, key):
+            result[key] = getattr(descriptor, key)
+    return result
+
+
+def _descriptor_name(descriptor: Dict[str, Any]) -> str:
+    descriptor = _descriptor_to_mapping(descriptor)
+    return str(descriptor.get("name") or "").strip()
+
+
+def _descriptor_to_schema(descriptor: Dict[str, Any]) -> Dict[str, Any]:
+    descriptor = _descriptor_to_mapping(descriptor)
+    if isinstance(descriptor.get("schema"), dict):
+        return descriptor["schema"]
+    name = _descriptor_name(descriptor)
+    parameters = descriptor.get("input_schema") or descriptor.get("parameters") or {"type": "object", "properties": {}}
+    metadata = dict(descriptor.get("metadata") or {})
+    metadata.update({
+        "source": "external_tools_repo",
+        "tool_id": descriptor.get("tool_id"),
+        "domain": descriptor.get("domain"),
+        "policy_tags": descriptor.get("policy_tags") or [],
+        "requires_identity_binding": bool(descriptor.get("requires_identity_binding", False)),
+        "mutation": bool(descriptor.get("mutation", False)),
+        "risk_level": descriptor.get("risk_level"),
+    })
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": descriptor.get("description") or "",
+            "parameters": parameters,
+        },
+        "metadata": metadata,
+    }
+
+
+def get_external_tool_schemas(runtime_type: str = "native") -> List[Dict[str, Any]]:
+    state = load_external_tools_state()
+    if not state.available:
+        return []
+    schemas: List[Dict[str, Any]] = []
+    for descriptor in _iter_descriptors(state):
+        descriptor = _descriptor_to_mapping(descriptor)
+        if not _descriptor_runtime_compatible(descriptor, runtime_type):
+            continue
+        if descriptor.get("enabled", True) is not True:
+            continue
+        metadata = descriptor.get("metadata") or {}
+        if isinstance(metadata, dict) and metadata.get("model_facing") is False:
+            continue
+        schemas.append(_descriptor_to_schema(descriptor))
+    return schemas
+
+
+def get_external_disabled_tool_names(runtime_type: str = "native") -> Set[str]:
+    state = load_external_tools_state()
+    if not _registry_loaded(state):
+        return set()
+    names: Set[str] = set()
+    for descriptor in _iter_descriptors(state):
+        descriptor = _descriptor_to_mapping(descriptor)
+        if not _descriptor_runtime_compatible(descriptor, runtime_type):
+            continue
+        if descriptor.get("enabled", True) is False:
+            name = _descriptor_name(descriptor)
+            if name:
+                names.add(name)
+    return names
+
+
+def has_external_tool(name: str, runtime_type: str = "native", include_disabled: bool = True) -> bool:
+    state = load_external_tools_state()
+    if not _registry_loaded(state):
+        return False
+    for descriptor in _iter_descriptors(state):
+        descriptor = _descriptor_to_mapping(descriptor)
+        if not include_disabled and descriptor.get("enabled", True) is False:
+            continue
+        if _descriptor_name(descriptor) == name and _descriptor_runtime_compatible(descriptor, runtime_type):
+            return True
+    return False
+
+
+async def execute_external_tool(
+    name: str,
+    kwargs: Dict[str, Any],
+    *,
+    session_id: Optional[str] = None,
+    runtime_type: str = "native",
+) -> Any | None:
+    state = load_external_tools_state()
+    if not state.available:
+        if _registry_loaded(state):
+            for item in _iter_descriptors(state):
+                item = _descriptor_to_mapping(item)
+                if _descriptor_name(item) == name and _descriptor_runtime_compatible(item, runtime_type):
+                    if item.get("enabled", True) is False:
+                        return {"success": False, "content": "", "error": f"Tool '{name}' is disabled by external descriptor"}
+                    break
+        return None
+
+    descriptor: Optional[Dict[str, Any]] = None
+    for item in _iter_descriptors(state):
+        item = _descriptor_to_mapping(item)
+        if _descriptor_name(item) == name and _descriptor_runtime_compatible(item, runtime_type):
+            descriptor = item
+            break
+    if descriptor is None:
+        return None
+    if descriptor.get("enabled", True) is False:
+        return {"success": False, "content": "", "error": f"Tool '{name}' is disabled by external descriptor"}
+
+    workspace_dir = _workspace_dir()
+    context = {
+        "runtime_type": runtime_type,
+        "session_id": session_id or kwargs.get("_session_id"),
+        "workspace_dir": workspace_dir,
+        "portal_metadata": {
+            "legacy_runtime_src_dir": str(_runtime_root_dir()),
+            "context_blob_dir": _context_blob_dir(workspace_dir),
+        },
+    }
+    runner_args = {k: v for k, v in kwargs.items() if k not in {"_session_id"}}
+
+    runner = state.runner
+    execute_async = getattr(runner, "execute_tool_async", None)
+    try:
+        if callable(execute_async):
+            result = execute_async(
+                tools_dir=str(state.tools_dir),
+                tool=name,
+                args=runner_args,
+                context=context,
+            )
+        else:
+            execute_fn = getattr(runner, "execute_tool", None)
+            if not callable(execute_fn):
+                return {"success": False, "content": "", "error": "external tools runner missing execute_tool"}
+            try:
+                result = execute_fn(
+                    tools_dir=str(state.tools_dir),
+                    tool=name,
+                    args=runner_args,
+                    context=context,
+                )
+            except TypeError:
+                result = execute_fn(name, kwargs, context=context)
+    except Exception as exc:
+        logger.warning("External tool execution failed for %s: %s", name, exc, exc_info=True)
+        return {"success": False, "content": "", "error": f"External tool '{name}' execution failed: {exc}"}
+    try:
+        if inspect.isawaitable(result):
+            return await result
+        return result
+    except Exception as exc:
+        logger.warning("External tool execution failed for %s: %s", name, exc, exc_info=True)
+        return {"success": False, "content": "", "error": f"External tool '{name}' execution failed: {exc}"}

--- a/src/runtime/external_tools.py
+++ b/src/runtime/external_tools.py
@@ -63,6 +63,12 @@ def _context_blob_dir(workspace_dir: str) -> str:
     return os.environ.get("EFP_CONTEXT_BLOB_DIR") or str(Path(workspace_dir) / "context_blobs")
 
 
+def _unavailable_state_or_raise(tools_dir: Path, error: str) -> ExternalToolsState:
+    if _strict_mode():
+        raise RuntimeError(error)
+    return ExternalToolsState(tools_dir=tools_dir, available=False, error=error)
+
+
 def load_external_tools_state() -> ExternalToolsState:
     global _cached_state
     if _cached_state is not None:
@@ -75,7 +81,10 @@ def load_external_tools_state() -> ExternalToolsState:
 
     python_dir = tools_dir / "python"
     if not python_dir.exists():
-        _cached_state = ExternalToolsState(tools_dir=tools_dir, available=False, error=f"missing tools python dir: {python_dir}")
+        _cached_state = _unavailable_state_or_raise(
+            tools_dir,
+            f"missing tools python dir: {python_dir}",
+        )
         return _cached_state
 
     try:

--- a/src/runtime/external_tools.py
+++ b/src/runtime/external_tools.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Set
 
 DEFAULT_TOOLS_DIR = "/app/tools"
 logger = logging.getLogger(__name__)
+_FRAMEWORK_ARG_KEYS = {"_session_id", "_message_id", "_task_id", "_runtime_type", "_portal_metadata"}
 
 
 @dataclass
@@ -265,7 +266,11 @@ async def execute_external_tool(
                 if _descriptor_name(item) == name and _descriptor_runtime_compatible(item, runtime_type):
                     if item.get("enabled", True) is False:
                         return {"success": False, "content": "", "error": f"Tool '{name}' is disabled by external descriptor"}
-                    break
+                    return {
+                        "success": False,
+                        "content": "",
+                        "error": f"External tools unavailable for '{name}': {state.error or 'unknown error'}",
+                    }
         return None
 
     descriptor: Optional[Dict[str, Any]] = None
@@ -283,13 +288,21 @@ async def execute_external_tool(
     context = {
         "runtime_type": runtime_type,
         "session_id": session_id or kwargs.get("_session_id"),
+        "message_id": kwargs.get("_message_id"),
+        "task_id": kwargs.get("_task_id"),
         "workspace_dir": workspace_dir,
-        "portal_metadata": {
+        "portal_metadata": {},
+    }
+    user_portal_metadata = kwargs.get("_portal_metadata")
+    if isinstance(user_portal_metadata, dict):
+        context["portal_metadata"].update(user_portal_metadata)
+    context["portal_metadata"].update(
+        {
             "legacy_runtime_src_dir": str(_runtime_root_dir()),
             "context_blob_dir": _context_blob_dir(workspace_dir),
-        },
-    }
-    runner_args = {k: v for k, v in kwargs.items() if k not in {"_session_id"}}
+        }
+    )
+    runner_args = {k: v for k, v in kwargs.items() if k not in _FRAMEWORK_ARG_KEYS}
 
     runner = state.runner
     execute_async = getattr(runner, "execute_tool_async", None)
@@ -319,7 +332,9 @@ async def execute_external_tool(
         return {"success": False, "content": "", "error": f"External tool '{name}' execution failed: {exc}"}
     try:
         if inspect.isawaitable(result):
-            return await result
+            result = await result
+        if result is None:
+            return {"success": False, "content": "", "error": f"External tool '{name}' returned no result"}
         return result
     except Exception as exc:
         logger.warning("External tool execution failed for %s: %s", name, exc, exc_info=True)

--- a/src/runtime/external_tools.py
+++ b/src/runtime/external_tools.py
@@ -11,7 +11,15 @@ from typing import Any, Dict, List, Optional, Set
 
 DEFAULT_TOOLS_DIR = "/app/tools"
 logger = logging.getLogger(__name__)
-_FRAMEWORK_ARG_KEYS = {"_session_id", "_message_id", "_task_id", "_runtime_type", "_portal_metadata"}
+_FRAMEWORK_ARG_KEYS = {
+    "_session_id",
+    "_message_id",
+    "_task_id",
+    "_runtime_type",
+    "_workspace_dir",
+    "_portal_metadata",
+    "_opencode_context",
+}
 
 
 @dataclass
@@ -293,7 +301,11 @@ async def execute_external_tool(
     if descriptor.get("enabled", True) is False:
         return {"success": False, "content": "", "error": f"Tool '{name}' is disabled by external descriptor"}
 
-    workspace_dir = _workspace_dir()
+    workspace_override = kwargs.get("_workspace_dir")
+    workspace_dir = workspace_override if isinstance(workspace_override, str) and workspace_override.strip() else _workspace_dir()
+    opencode_context = kwargs.get("_opencode_context")
+    if not isinstance(opencode_context, dict):
+        opencode_context = {}
     context = {
         "runtime_type": runtime_type,
         "session_id": session_id or kwargs.get("_session_id"),
@@ -301,6 +313,7 @@ async def execute_external_tool(
         "task_id": kwargs.get("_task_id"),
         "workspace_dir": workspace_dir,
         "portal_metadata": {},
+        "opencode_context": opencode_context,
     }
     user_portal_metadata = kwargs.get("_portal_metadata")
     if isinstance(user_portal_metadata, dict):

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -1,6 +1,7 @@
 from src.runtime.capability_registry import (
     CapabilityDescriptor,
     DefaultCapabilityRegistry,
+    _CapabilityBuilder,
     build_default_capability_registry,
 )
 from src.config import config
@@ -180,3 +181,23 @@ def test_default_registry_includes_github_add_commit_comment_adapter():
 def test_default_registry_includes_github_add_discussion_comment_adapter():
     registry = build_default_capability_registry()
     assert registry.exists("adapter:github:add_discussion_comment") is True
+
+
+def test_capability_registry_tool_schema_supports_function_nested_parameters(monkeypatch):
+    tool_schema = {
+        "type": "function",
+        "function": {
+            "name": "github_get_pr",
+            "description": "x",
+            "parameters": {"type": "object", "properties": {"owner": {"type": "string"}}},
+        },
+        "metadata": {"tool_id": "efp.tool.github.get_pull_request"},
+    }
+
+    monkeypatch.setattr("src.get_tools_schema", lambda: [tool_schema])
+    builder = _CapabilityBuilder(DefaultCapabilityRegistry())
+    builder._register_tools()
+    descriptor = builder.registry.get("tool:github_get_pr")
+    assert descriptor is not None
+    assert descriptor.input_schema.get("properties", {}).get("owner", {}).get("type") == "string"
+    assert descriptor.metadata.get("tool_id") == "efp.tool.github.get_pull_request"

--- a/tests/test_external_tools_loader.py
+++ b/tests/test_external_tools_loader.py
@@ -132,10 +132,20 @@ async def test_context_payload_and_reserved_arg_filtering(monkeypatch, tmp_path,
             """
             async def execute_tool_async(*, tools_dir, tool, args=None, context=None):
                 assert context['session_id'] == 'sess-1'
+                if tool == 'context_read_ref':
+                    assert context['message_id'] == 'm1'
+                    assert context['task_id'] == 't1'
                 assert context['workspace_dir'].endswith('/workspace')
                 assert context['portal_metadata']['legacy_runtime_src_dir']
                 assert context['portal_metadata']['context_blob_dir'].endswith('/context_blobs')
+                if tool == 'context_read_ref':
+                    assert context['portal_metadata']['x'] == 'y'
+                    assert context['portal_metadata']['context_blob_dir'] != '/bad'
                 assert '_session_id' not in args
+                assert '_message_id' not in args
+                assert '_task_id' not in args
+                assert '_runtime_type' not in args
+                assert '_portal_metadata' not in args
                 return {'success': True, 'content': f"ok:{tool}:{tools_dir}"}
             """
         ),
@@ -146,7 +156,13 @@ async def test_context_payload_and_reserved_arg_filtering(monkeypatch, tmp_path,
     _reload_external_loader()
 
     result = await src_module.execute_tool(
-        "context_read_ref", ref="ctx://context/sess-1/jira/abcdef123456", _session_id="sess-1"
+        "context_read_ref",
+        ref="ctx://context/sess-1/jira/abcdef123456",
+        _session_id="sess-1",
+        _message_id="m1",
+        _task_id="t1",
+        _portal_metadata={"x": "y", "context_blob_dir": "/bad"},
+        _runtime_type="native",
     )
     assert result.success is True
     git_result = await src_module.execute_tool("git_status", workspace=".", _session_id="sess-1")
@@ -242,6 +258,61 @@ async def test_execute_external_tool_direct_returns_error_on_runner_exception(mo
     assert isinstance(result, dict)
     assert result.get("success") is False
     assert "execution failed" in (result.get("error") or "")
+
+
+def test_strict_mode_schema_load_does_not_fallback(monkeypatch, tmp_path, src_module):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo, validate_errors="['bad descriptor']")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    _reload_external_loader()
+    with pytest.raises(RuntimeError):
+        src_module.get_tools_schema()
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_execute_does_not_fallback_to_legacy(monkeypatch, tmp_path, src_module):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo, validate_errors="['bad descriptor']")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    _reload_external_loader()
+    result = await src_module.execute_tool("run_command", cmd="echo hi")
+    assert result.success is False
+    assert "strict mode failed" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_external_tool_known_enabled_unavailable_returns_structured_error(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo, validate_errors="['bad descriptor']")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "false")
+    ext = _reload_external_loader()
+    result = await ext.execute_external_tool(
+        "context_read_ref",
+        {"ref": "ctx://context/sess-1/jira/abcdef123456", "_session_id": "sess-1"},
+        session_id="sess-1",
+        runtime_type="native",
+    )
+    assert result["success"] is False
+    assert "External tools unavailable" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_execute_external_tool_runner_none_returns_structured_error(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo, runner_body="async def execute_tool_async(**kwargs):\n    return None\n")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    ext = _reload_external_loader()
+    result = await ext.execute_external_tool(
+        "context_read_ref",
+        {"ref": "ctx://context/sess-1/jira/abcdef123456", "_session_id": "sess-1"},
+        session_id="sess-1",
+        runtime_type="native",
+    )
+    assert result["success"] is False
+    assert "returned no result" in result["error"]
 
 
 def test_optional_real_tools_repo_fixture(monkeypatch):

--- a/tests/test_external_tools_loader.py
+++ b/tests/test_external_tools_loader.py
@@ -271,6 +271,25 @@ def test_strict_mode_schema_load_does_not_fallback(monkeypatch, tmp_path, src_mo
 
 
 @pytest.mark.asyncio
+async def test_strict_mode_missing_tools_dir_execute_does_not_fallback_to_legacy(monkeypatch, tmp_path, src_module):
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tmp_path / "missing-tools"))
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    _reload_external_loader()
+
+    result = await src_module.execute_tool("run_command", cmd="echo hi")
+    assert result.success is False
+    assert "strict mode failed" in (result.error or "").lower()
+
+
+def test_strict_mode_missing_tools_dir_schema_does_not_fallback(monkeypatch, tmp_path, src_module):
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tmp_path / "missing-tools"))
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    _reload_external_loader()
+    with pytest.raises(RuntimeError):
+        src_module.get_tools_schema()
+
+
+@pytest.mark.asyncio
 async def test_strict_mode_execute_does_not_fallback_to_legacy(monkeypatch, tmp_path, src_module):
     repo = tmp_path / "repo"
     _create_tools_repo(repo, validate_errors="['bad descriptor']")

--- a/tests/test_external_tools_loader.py
+++ b/tests/test_external_tools_loader.py
@@ -62,6 +62,7 @@ DESCRIPTORS = [
     ToolDescriptor('efp.tool.context.context_read_ref','context_read_ref','context_read_ref','Read context ref','context','read',['native'],['read'],False,False,'low','x',{{'type':'object','properties':{{'ref':{{'type':'string'}}}},'required':['ref']}},{{'type':'object'}},{{'model_facing': True}}, True),
     ToolDescriptor('efp.tool.git.git_status','git_status','git_status','Get git status','git','read',['native'],['read'],False,False,'low','x',{{'type':'object','properties':{{'workspace':{{'type':'string'}}}}}},{{'type':'object'}},{{'model_facing': True}}, True),
     ToolDescriptor('efp.tool.bash.run_command','run_command','run_command','Run command','bash','write',['native'],['exec'],False,True,'high','x',{{'type':'object','properties':{{'cmd':{{'type':'string'}}}}}},{{'type':'object'}},{{'model_facing': True}}, False),
+    ToolDescriptor('efp.tool.bash.discover_commands','discover_commands','efp_discover_commands','Discover installed shell commands. Disabled pending bash governance.','bash','adapter_action',['native', 'opencode'],['bash', 'discovery', 'read_only'],False,False,'medium','x',{{'type':'object','properties':{{'prefix':{{'type':'string'}}}}}},{{'type':'object'}},{{'model_facing': True}}, False),
 ]
 
 class Registry:
@@ -118,9 +119,11 @@ def test_t04_dataclass_registry_semantics(monkeypatch, tmp_path):
     assert "context_read_ref" in names
     assert "git_status" in names
     assert "run_command" not in names
-    assert ext.get_external_disabled_tool_names("native") == {"run_command"}
+    assert ext.get_external_disabled_tool_names("native") == {"run_command", "discover_commands"}
     assert ext.has_external_tool("run_command", include_disabled=True) is True
     assert ext.has_external_tool("run_command", include_disabled=False) is False
+    assert ext.has_external_tool("discover_commands", include_disabled=True) is True
+    assert ext.has_external_tool("discover_commands", include_disabled=False) is False
 
 
 @pytest.mark.asyncio
@@ -135,7 +138,9 @@ async def test_context_payload_and_reserved_arg_filtering(monkeypatch, tmp_path,
                 if tool == 'context_read_ref':
                     assert context['message_id'] == 'm1'
                     assert context['task_id'] == 't1'
-                assert context['workspace_dir'].endswith('/workspace')
+                if tool == 'context_read_ref':
+                    assert context['workspace_dir'].endswith('/workspace-override')
+                    assert context['opencode_context'] == {'provider': 'opencode-test'}
                 assert context['portal_metadata']['legacy_runtime_src_dir']
                 assert context['portal_metadata']['context_blob_dir'].endswith('/context_blobs')
                 if tool == 'context_read_ref':
@@ -146,6 +151,8 @@ async def test_context_payload_and_reserved_arg_filtering(monkeypatch, tmp_path,
                 assert '_task_id' not in args
                 assert '_runtime_type' not in args
                 assert '_portal_metadata' not in args
+                assert '_workspace_dir' not in args
+                assert '_opencode_context' not in args
                 return {'success': True, 'content': f"ok:{tool}:{tools_dir}"}
             """
         ),
@@ -163,6 +170,8 @@ async def test_context_payload_and_reserved_arg_filtering(monkeypatch, tmp_path,
         _task_id="t1",
         _portal_metadata={"x": "y", "context_blob_dir": "/bad"},
         _runtime_type="native",
+        _workspace_dir=str(tmp_path / "workspace-override"),
+        _opencode_context={"provider": "opencode-test"},
     )
     assert result.success is True
     git_result = await src_module.execute_tool("git_status", workspace=".", _session_id="sess-1")
@@ -182,6 +191,9 @@ async def test_disabled_descriptor_blocks_legacy_and_exec_alias(monkeypatch, tmp
     alias_result = await src_module.execute_tool("exec", command="ls")
     assert alias_result.success is False
     assert "disabled" in (alias_result.error or "").lower()
+    discovery_result = await src_module.execute_tool("discover_commands")
+    assert discovery_result.success is False
+    assert "disabled" in (discovery_result.error or "").lower()
 
 
 def test_validation_errors_non_strict_disable_external(monkeypatch, tmp_path):
@@ -194,9 +206,11 @@ def test_validation_errors_non_strict_disable_external(monkeypatch, tmp_path):
     state = ext.load_external_tools_state()
     assert state.available is False
     assert state.validation_errors == ["bad descriptor"]
-    assert ext.get_external_disabled_tool_names("native") == {"run_command"}
+    assert ext.get_external_disabled_tool_names("native") == {"run_command", "discover_commands"}
     assert ext.has_external_tool("run_command", include_disabled=True) is True
     assert ext.has_external_tool("run_command", include_disabled=False) is False
+    assert ext.has_external_tool("discover_commands", include_disabled=True) is True
+    assert ext.has_external_tool("discover_commands", include_disabled=False) is False
     assert ext.get_external_tool_schemas("native") == []
 
 
@@ -231,9 +245,13 @@ async def test_invalid_registry_still_blocks_disabled_legacy_tools(monkeypatch, 
 
     names = {(s.get("function", {}) or {}).get("name") or s.get("name") for s in src_module.get_tools_schema()}
     assert "run_command" not in names
+    assert "discover_commands" not in names
     result = await src_module.execute_tool("run_command", cmd="echo hi")
     assert result.success is False
     assert "disabled" in (result.error or "").lower()
+    discovery_result = await src_module.execute_tool("discover_commands")
+    assert discovery_result.success is False
+    assert "disabled" in (discovery_result.error or "").lower()
     alias_result = await src_module.execute_tool("exec", command="ls")
     assert alias_result.success is False
     assert "disabled" in (alias_result.error or "").lower()
@@ -349,11 +367,14 @@ def test_optional_real_tools_repo_fixture(monkeypatch):
     disabled = ext.get_external_disabled_tool_names("native")
     assert "run_command" in disabled
     assert "write" in disabled
+    assert "discover_commands" in disabled
     schema_names = {(s.get("function", {}) or {}).get("name") or s.get("name") for s in ext.get_external_tool_schemas("native")}
     assert "context_read_ref" in schema_names
     assert "git_status" in schema_names
     assert ext.has_external_tool("write", include_disabled=True) is True
     assert ext.has_external_tool("write", include_disabled=False) is False
+    assert ext.has_external_tool("discover_commands", include_disabled=True) is True
+    assert ext.has_external_tool("discover_commands", include_disabled=False) is False
 
 
 def test_strip_none_values_behavior(src_module):

--- a/tests/test_external_tools_loader.py
+++ b/tests/test_external_tools_loader.py
@@ -1,0 +1,274 @@
+import importlib
+import os
+import textwrap
+
+import pytest
+
+
+@pytest.fixture
+def src_module():
+    import src
+
+    return src
+
+
+def _reload_external_loader():
+    import src.runtime.external_tools as ext
+
+    importlib.reload(ext)
+    ext.clear_external_tools_cache()
+    return ext
+
+
+def _create_tools_repo(base_dir, *, validate_errors="[]", runner_body="", dataclass_contract=True):
+    base_dir.mkdir(parents=True, exist_ok=True)
+    (base_dir / "manifest.yaml").write_text("version: 1\n", encoding="utf-8")
+    pkg_dir = base_dir / "python" / "efp_tools"
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    if dataclass_contract:
+        (pkg_dir / "contracts.py").write_text(
+            textwrap.dedent(
+                """
+                from dataclasses import dataclass, field
+
+                @dataclass
+                class ToolDescriptor:
+                    tool_id: str
+                    name: str
+                    opencode_name: str
+                    description: str
+                    domain: str
+                    type: str
+                    runtime_compat: list[str]
+                    policy_tags: list[str]
+                    requires_identity_binding: bool
+                    mutation: bool
+                    risk_level: str
+                    python_entrypoint: str
+                    input_schema: dict
+                    output_schema: dict
+                    metadata: dict = field(default_factory=dict)
+                    enabled: bool = True
+                """
+            ),
+            encoding="utf-8",
+        )
+        (pkg_dir / "registry.py").write_text(
+            f"""
+from efp_tools.contracts import ToolDescriptor
+
+DESCRIPTORS = [
+    ToolDescriptor('efp.tool.context.context_read_ref','context_read_ref','context_read_ref','Read context ref','context','read',['native'],['read'],False,False,'low','x',{{'type':'object','properties':{{'ref':{{'type':'string'}}}},'required':['ref']}},{{'type':'object'}},{{'model_facing': True}}, True),
+    ToolDescriptor('efp.tool.git.git_status','git_status','git_status','Get git status','git','read',['native'],['read'],False,False,'low','x',{{'type':'object','properties':{{'workspace':{{'type':'string'}}}}}},{{'type':'object'}},{{'model_facing': True}}, True),
+    ToolDescriptor('efp.tool.bash.run_command','run_command','run_command','Run command','bash','write',['native'],['exec'],False,True,'high','x',{{'type':'object','properties':{{'cmd':{{'type':'string'}}}}}},{{'type':'object'}},{{'model_facing': True}}, False),
+]
+
+class Registry:
+    def list_descriptors(self, *, runtime_type=None, enabled_only=True, model_facing_only=True):
+        items = list(DESCRIPTORS)
+        if runtime_type:
+            items = [d for d in items if runtime_type in (d.runtime_compat or [])]
+        if enabled_only:
+            items = [d for d in items if d.enabled]
+        if model_facing_only:
+            items = [d for d in items if (d.metadata or {{}}).get('model_facing', True) is not False]
+        return items
+
+    def list_all_descriptors(self):
+        return list(DESCRIPTORS)
+
+    def validate(self):
+        return {validate_errors}
+
+def load_registry(tools_dir):
+    return Registry()
+""",
+            encoding="utf-8",
+        )
+    else:
+        (pkg_dir / "contracts.py").write_text("", encoding="utf-8")
+        (pkg_dir / "registry.py").write_text(
+            "DESCRIPTORS = [{'name': 'run_command', 'enabled': True, 'runtime_compat': ['native'], 'metadata': {}, "
+            "'schema': {'type': 'function', 'function': {'name': 'run_command','description':'external','parameters':{'type':'object'}}}}]\n"
+            "class Registry:\n    def list_descriptors(self, **kwargs):\n        return DESCRIPTORS\n"
+            "def load_registry(tools_dir):\n    return Registry()\n",
+            encoding="utf-8",
+        )
+    if not runner_body:
+        runner_body = "async def execute_tool_async(**kwargs):\n    return {'success': True, 'content': 'ok'}\n"
+    (pkg_dir / "runner.py").write_text(runner_body, encoding="utf-8")
+
+
+def test_missing_tools_dir_falls_back_to_legacy(monkeypatch, tmp_path, src_module):
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tmp_path / "does-not-exist"))
+    ext = _reload_external_loader()
+    assert src_module.get_tools_schema()
+    assert ext.load_external_tools_state().available is False
+
+
+def test_t04_dataclass_registry_semantics(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo)
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    ext = _reload_external_loader()
+
+    schemas = ext.get_external_tool_schemas("native")
+    names = {(s.get("function", {}) or {}).get("name") for s in schemas}
+    assert "context_read_ref" in names
+    assert "git_status" in names
+    assert "run_command" not in names
+    assert ext.get_external_disabled_tool_names("native") == {"run_command"}
+    assert ext.has_external_tool("run_command", include_disabled=True) is True
+    assert ext.has_external_tool("run_command", include_disabled=False) is False
+
+
+@pytest.mark.asyncio
+async def test_context_payload_and_reserved_arg_filtering(monkeypatch, tmp_path, src_module):
+    repo = tmp_path / "repo"
+    _create_tools_repo(
+        repo,
+        runner_body=textwrap.dedent(
+            """
+            async def execute_tool_async(*, tools_dir, tool, args=None, context=None):
+                assert context['session_id'] == 'sess-1'
+                assert context['workspace_dir'].endswith('/workspace')
+                assert context['portal_metadata']['legacy_runtime_src_dir']
+                assert context['portal_metadata']['context_blob_dir'].endswith('/context_blobs')
+                assert '_session_id' not in args
+                return {'success': True, 'content': f"ok:{tool}:{tools_dir}"}
+            """
+        ),
+    )
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    monkeypatch.setenv("EFP_WORKSPACE_DIR", str(tmp_path / "workspace"))
+    monkeypatch.setenv("EFP_CONTEXT_BLOB_DIR", str(tmp_path / "context_blobs"))
+    _reload_external_loader()
+
+    result = await src_module.execute_tool(
+        "context_read_ref", ref="ctx://context/sess-1/jira/abcdef123456", _session_id="sess-1"
+    )
+    assert result.success is True
+    git_result = await src_module.execute_tool("git_status", workspace=".", _session_id="sess-1")
+    assert git_result.success is True
+
+
+@pytest.mark.asyncio
+async def test_disabled_descriptor_blocks_legacy_and_exec_alias(monkeypatch, tmp_path, src_module):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo)
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    _reload_external_loader()
+
+    result = await src_module.execute_tool("run_command", cmd="echo hi")
+    assert result.success is False
+    assert "disabled" in (result.error or "").lower()
+    alias_result = await src_module.execute_tool("exec", command="ls")
+    assert alias_result.success is False
+    assert "disabled" in (alias_result.error or "").lower()
+
+
+def test_validation_errors_non_strict_disable_external(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo, validate_errors="['bad descriptor']")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "false")
+    ext = _reload_external_loader()
+
+    state = ext.load_external_tools_state()
+    assert state.available is False
+    assert state.validation_errors == ["bad descriptor"]
+    assert ext.get_external_disabled_tool_names("native") == {"run_command"}
+    assert ext.has_external_tool("run_command", include_disabled=True) is True
+    assert ext.has_external_tool("run_command", include_disabled=False) is False
+    assert ext.get_external_tool_schemas("native") == []
+
+
+def test_validation_errors_strict_raise(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo, validate_errors="['bad descriptor']")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    ext = _reload_external_loader()
+
+    with pytest.raises(RuntimeError):
+        ext.load_external_tools_state()
+
+
+def test_dict_descriptor_back_compat(monkeypatch, tmp_path, src_module):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo, dataclass_contract=False)
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    _reload_external_loader()
+    schemas = src_module.get_tools_schema()
+    names = {(s.get("function", {}) or {}).get("name") or s.get("name") for s in schemas}
+    assert "run_command" in names
+
+
+@pytest.mark.asyncio
+async def test_invalid_registry_still_blocks_disabled_legacy_tools(monkeypatch, tmp_path, src_module):
+    repo = tmp_path / "repo"
+    _create_tools_repo(repo, validate_errors="['bad descriptor']")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "false")
+    _reload_external_loader()
+
+    names = {(s.get("function", {}) or {}).get("name") or s.get("name") for s in src_module.get_tools_schema()}
+    assert "run_command" not in names
+    result = await src_module.execute_tool("run_command", cmd="echo hi")
+    assert result.success is False
+    assert "disabled" in (result.error or "").lower()
+    alias_result = await src_module.execute_tool("exec", command="ls")
+    assert alias_result.success is False
+    assert "disabled" in (alias_result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_external_tool_direct_returns_error_on_runner_exception(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _create_tools_repo(
+        repo,
+        runner_body="async def execute_tool_async(**kwargs):\n    raise RuntimeError('runner boom')\n",
+    )
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(repo))
+    ext = _reload_external_loader()
+
+    result = await ext.execute_external_tool(
+        "context_read_ref",
+        {"ref": "ctx://context/sess-1/jira/abcdef123456", "_session_id": "sess-1"},
+        session_id="sess-1",
+        runtime_type="native",
+    )
+    assert isinstance(result, dict)
+    assert result.get("success") is False
+    assert "execution failed" in (result.get("error") or "")
+
+
+def test_optional_real_tools_repo_fixture(monkeypatch):
+    fixture = os.environ.get("EFP_TOOLS_REPO_FIXTURE")
+    if not fixture:
+        pytest.skip("EFP_TOOLS_REPO_FIXTURE not set")
+
+    monkeypatch.setenv("EFP_TOOLS_DIR", fixture)
+    ext = _reload_external_loader()
+    state = ext.load_external_tools_state()
+    assert state.available is True
+    descriptors = ext._iter_descriptors(state)
+    assert len(descriptors) >= 50
+    assert len(ext.get_external_tool_schemas("native")) >= 30
+    disabled = ext.get_external_disabled_tool_names("native")
+    assert "run_command" in disabled
+    assert "write" in disabled
+    schema_names = {(s.get("function", {}) or {}).get("name") or s.get("name") for s in ext.get_external_tool_schemas("native")}
+    assert "context_read_ref" in schema_names
+    assert "git_status" in schema_names
+    assert ext.has_external_tool("write", include_disabled=True) is True
+    assert ext.has_external_tool("write", include_disabled=False) is False
+
+
+def test_strip_none_values_behavior(src_module):
+    payload = src_module._strip_none_values({"a": None, "b": False, "c": 0, "d": ""})
+    assert "a" not in payload
+    assert payload["b"] is False
+    assert payload["c"] == 0
+    assert payload["d"] == ""


### PR DESCRIPTION
### Motivation
- Support loading, validating, and executing external tool descriptors from a configurable tools repo so built-in tools can be extended or disabled by external definitions.
- Preserve backward compatibility for legacy tool schemas and the `exec` alias while allowing external tools to override or disable legacy tools.
- Make capability registry consume nested `function.parameters` for function-style tool schemas and surface metadata from nested `function` entries.

### Description
- Added a new `src/runtime/external_tools.py` module that discovers a tools repo at `EFP_TOOLS_DIR`, loads a registry/runner from `python/efp_tools`, validates descriptors, and exposes APIs: `get_external_tool_schemas`, `get_external_disabled_tool_names`, `has_external_tool`, and `execute_external_tool`.
- Integrated external tools into `src/__init__.py` by loading external schemas via `get_external_tool_schemas`, merging them with legacy tool schemas (external wins), and adding robust schema name extraction and result coercion via `_extract_tool_schema_name`, `_merge_legacy_and_external_tools`, and `_coerce_external_tool_result`.
- Updated `execute_tool` to dispatch to external runners first (including mapping the legacy `exec` alias to `run_command`), and to handle external execution errors and disabled-tool semantics gracefully.
- Adjusted `src/runtime/capability_registry.py` to read `parameters` and `description` nested under `function` when registering tool capabilities, and to include tool `metadata` in capability descriptors.
- Updated `Dockerfile` to create `/app/tools` so external tools can be mounted into the container.
- Added new tests in `tests/test_external_tools_loader.py` and extended `tests/test_capability_registry.py` to verify external loader behavior, descriptor formats, disabled-tool blocking, context payloads, and the nested `function.parameters` support.

### Testing
- Ran the test suite with `pytest`, including the new `tests/test_external_tools_loader.py` and updated `tests/test_capability_registry.py` tests, and all tests passed.
- Exercised scenarios for missing tools dir, dataclass-backed registries, dict-backed registries, validation errors (strict and non-strict), disabled-tool behavior, and external runner exceptions via the new tests, all asserting expected success/failure outcomes.
- Verified `execute_tool` backwards compatibility for `exec` alias and that external tools can override or disable legacy tools in the registry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d9bdd9b0832a8ad7621cab2fe06d)