### PR TITLE
[T13] Harden external tools gating, prefer T04 runner, add CI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  native-runtime-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - env:
+          PYTHONPATH: .
+          EFP_EXTERNAL_TOOLS_STRICT: "false"
+        run: |
+          python -m pytest -q \
+            tests/test_external_tools_registry.py \
+            tests/test_external_tools_loader.py \
+            tests/test_agent_llm_tools_surface.py \
+            tests/test_capability_registry.py \
+            tests/test_runtime_capability_contract.py
+
+  native-runtime-docker-smoke:
+    runs-on: ubuntu-latest
+    needs: native-runtime-tests
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -t efp-native-runtime-ci .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
             tests/test_external_tools_loader.py \
             tests/test_agent_llm_tools_surface.py \
             tests/test_capability_registry.py \
-            tests/test_runtime_capability_contract.py
+            tests/test_runtime_capability_contract.py \
+            tests/test_docker_runtime_contract.py
 
   native-runtime-docker-smoke:
     runs-on: ubuntu-latest
@@ -33,3 +34,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: docker build -t efp-native-runtime-ci .
+      - run: |
+          set -euo pipefail
+          trap 'docker logs efp-native-runtime-ci || true; docker rm -f efp-native-runtime-ci || true' EXIT
+          docker run -d \
+            --name efp-native-runtime-ci \
+            -p 8000:8000 \
+            -e EFP_EXTERNAL_TOOLS_STRICT=false \
+            -e PYTHONUNBUFFERED=1 \
+            efp-native-runtime-ci
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:8000/health; then
+              exit 0
+            fi
+            docker logs efp-native-runtime-ci || true
+            sleep 2
+          done
+          docker logs efp-native-runtime-ci || true
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-fastapi
+fastapi>=0.110,<1
+pydantic>=2.7,<3
 uvicorn
 aiohttp
 ruamel.yaml>=0.18.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -75,6 +75,7 @@ from . import git
 from . import bash_tools
 from . import context_tools
 from .tools_external import get_external_tool_registry
+from .tools_external.contracts import is_descriptor_native_compatible
 
 
 def _extract_tool_schema_name(tool_schema: Dict[str, Any]) -> str:
@@ -118,7 +119,9 @@ def is_external_tool_exposed(name: str) -> bool:
     descriptor = registry.get_descriptor(name)
     if descriptor is None or not descriptor.enabled:
         return False
-    if descriptor.metadata.get("model_facing", True) is False:
+    if not is_descriptor_native_compatible(descriptor):
+        return False
+    if not registry.is_model_facing(name):
         return False
     if name in legacy_names:
         return registry.is_override_enabled(name)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -113,7 +113,16 @@ def is_external_tool_exposed(name: str) -> bool:
     """Return True when an external tool is visible in the merged tool surface."""
     registry = get_external_tool_registry()
     legacy_names = _get_legacy_tool_names_set()
-    return registry.has_tool(name) and (name not in legacy_names or registry.is_override_enabled(name))
+    if not registry.has_tool(name, include_disabled=True):
+        return False
+    descriptor = registry.get_descriptor(name)
+    if descriptor is None or not descriptor.enabled:
+        return False
+    if descriptor.metadata.get("model_facing", True) is False:
+        return False
+    if name in legacy_names:
+        return registry.is_override_enabled(name)
+    return True
 
 
 def get_all_tools() -> list:
@@ -172,7 +181,8 @@ def _coerce_external_tool_result(raw: Any) -> ToolResult:
     if hasattr(raw, "to_dict"):
         raw = raw.to_dict()
     if isinstance(raw, dict):
-        success = bool(raw.get("success"))
+        success = raw.get("success")
+        success = bool(success) if success is not None else False
         content = raw.get("content")
         if content is None and raw.get("data") is not None:
             content = json.dumps(raw.get("data"), ensure_ascii=False, indent=2)
@@ -206,7 +216,7 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
     registry = get_external_tool_registry()
     legacy_names = _get_legacy_tool_names_set()
 
-    if registry.has_tool(name) and registry.is_override_enabled(name):
+    if registry.has_tool(name, include_disabled=True) and registry.is_override_enabled(name):
         external_result = await registry.execute_tool(name, **kwargs)
         return ToolResult(
             success=external_result.success,
@@ -793,7 +803,10 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
         result = await confluence_module.confluence_search_by_title(title, space_key)
         return ToolResult(success="Error" not in result, content=result)
     
-    if registry.has_tool(name) and name not in legacy_names:
+    if registry.has_tool(name, include_disabled=True):
+        if not registry.is_tool_enabled(name):
+            return ToolResult(success=False, error=f"Tool '{name}' is disabled by external descriptor")
+    if registry.has_tool(name, include_disabled=True) and name not in legacy_names:
         external_result = await registry.execute_tool(name, **kwargs)
         return ToolResult(
             success=external_result.success,

--- a/src/runtime/capability_registry.py
+++ b/src/runtime/capability_registry.py
@@ -321,6 +321,9 @@ class _CapabilityBuilder:
                         "domain": external_descriptor.domain,
                         "external_type": external_descriptor.type,
                         "runtime_compat": list(external_descriptor.runtime_compat or []),
+                        "opencode_name": external_descriptor.opencode_name,
+                        "mutation": external_descriptor.mutation,
+                        "risk_level": external_descriptor.risk_level,
                         **external_metadata,
                     }
                     source_ref = "src.tools_external"

--- a/src/runtime/capability_registry.py
+++ b/src/runtime/capability_registry.py
@@ -314,18 +314,23 @@ class _CapabilityBuilder:
                         or external_metadata.get("requires_identity_binding", False)
                     )
                     metadata = {
-                        "tool_name": tool_name,
-                        "description": external_descriptor.description or _extract_tool_description(tool_schema),
-                        "declaration_only": True,
+                        **external_metadata,
                         "external_tool": True,
+                        "tool_name": tool_name,
+                        "tool_id": external_descriptor.tool_id,
+                        "description": external_descriptor.description or _extract_tool_description(tool_schema),
                         "domain": external_descriptor.domain,
                         "external_type": external_descriptor.type,
+                        "policy_tags": list(external_descriptor.policy_tags or []),
+                        "requires_identity_binding": requires_identity_binding,
                         "runtime_compat": list(external_descriptor.runtime_compat or []),
                         "opencode_name": external_descriptor.opencode_name,
                         "mutation": external_descriptor.mutation,
                         "risk_level": external_descriptor.risk_level,
-                        **external_metadata,
+                        "declaration_only": True,
                     }
+                    if "source" in external_metadata:
+                        metadata.setdefault("descriptor_source", external_metadata["source"])
                     source_ref = "src.tools_external"
                 else:
                     capability_id = _format_capability_id("tool", tool_name)

--- a/src/tools_external/contracts.py
+++ b/src/tools_external/contracts.py
@@ -66,6 +66,16 @@ def _as_optional_string(value: Any) -> Optional[str]:
     return text or None
 
 
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 def descriptor_from_mapping(data: dict, source_file: str | None = None) -> ToolDescriptor:
     if not isinstance(data, dict):
         raise ValueError("tool descriptor must be a mapping")
@@ -95,9 +105,9 @@ def descriptor_from_mapping(data: dict, source_file: str | None = None) -> ToolD
     if not isinstance(output_schema, dict):
         output_schema = None
 
-    requires_identity_binding = bool(data.get("requires_identity_binding", False))
-    enabled = bool(data.get("enabled", True))
-    mutation = bool(data.get("mutation", False))
+    requires_identity_binding = _as_bool(data.get("requires_identity_binding"), default=False)
+    enabled = _as_bool(data.get("enabled"), default=True)
+    mutation = _as_bool(data.get("mutation"), default=False)
 
     metadata = data.get("metadata")
     if not isinstance(metadata, dict):
@@ -139,6 +149,22 @@ def descriptor_from_mapping(data: dict, source_file: str | None = None) -> ToolD
 
 
 def descriptor_to_tool_schema(descriptor: ToolDescriptor) -> dict:
+    raw_metadata = dict(descriptor.metadata or {})
+    metadata = {
+        **raw_metadata,
+        "source": "external_tools_repo",
+        "tool_id": descriptor.tool_id,
+        "domain": descriptor.domain,
+        "policy_tags": list(descriptor.policy_tags or []),
+        "requires_identity_binding": descriptor.requires_identity_binding,
+        "mutation": descriptor.mutation,
+        "risk_level": descriptor.risk_level,
+        "runtime_compat": list(descriptor.runtime_compat or []),
+        "opencode_name": descriptor.opencode_name,
+        "enabled": descriptor.enabled,
+    }
+    if "source" in raw_metadata and raw_metadata["source"] != "external_tools_repo":
+        metadata["descriptor_source"] = raw_metadata["source"]
     return {
         "type": "function",
         "function": {
@@ -146,18 +172,7 @@ def descriptor_to_tool_schema(descriptor: ToolDescriptor) -> dict:
             "description": descriptor.description,
             "parameters": descriptor.input_schema or dict(DEFAULT_INPUT_SCHEMA),
         },
-        "metadata": {
-            "source": "external_tools_repo",
-            "tool_id": descriptor.tool_id,
-            "domain": descriptor.domain,
-            "policy_tags": list(descriptor.policy_tags or []),
-            "requires_identity_binding": descriptor.requires_identity_binding,
-            "mutation": descriptor.mutation,
-            "risk_level": descriptor.risk_level,
-            "runtime_compat": list(descriptor.runtime_compat or []),
-            "opencode_name": descriptor.opencode_name,
-            **dict(descriptor.metadata or {}),
-        },
+        "metadata": metadata,
     }
 
 

--- a/src/tools_external/contracts.py
+++ b/src/tools_external/contracts.py
@@ -15,6 +15,10 @@ KNOWN_DESCRIPTOR_KEYS = {
     "python_entrypoint",
     "metadata",
     "requires_identity_binding",
+    "opencode_name",
+    "mutation",
+    "risk_level",
+    "enabled",
 }
 
 
@@ -32,6 +36,10 @@ class ToolDescriptor:
     requires_identity_binding: bool = False
     python_entrypoint: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
+    opencode_name: Optional[str] = None
+    mutation: bool = False
+    risk_level: Optional[str] = None
+    enabled: bool = True
 
 
 @dataclass
@@ -88,6 +96,8 @@ def descriptor_from_mapping(data: dict, source_file: str | None = None) -> ToolD
         output_schema = None
 
     requires_identity_binding = bool(data.get("requires_identity_binding", False))
+    enabled = bool(data.get("enabled", True))
+    mutation = bool(data.get("mutation", False))
 
     metadata = data.get("metadata")
     if not isinstance(metadata, dict):
@@ -100,6 +110,8 @@ def descriptor_from_mapping(data: dict, source_file: str | None = None) -> ToolD
             metadata[key] = value
     if "requires_identity_binding" in data:
         metadata.setdefault("requires_identity_binding", requires_identity_binding)
+    if "opencode_name" in data:
+        metadata.setdefault("opencode_name", _as_optional_string(data.get("opencode_name")))
     if source_file:
         metadata["_source_file"] = source_file
 
@@ -119,6 +131,10 @@ def descriptor_from_mapping(data: dict, source_file: str | None = None) -> ToolD
         requires_identity_binding=requires_identity_binding,
         python_entrypoint=_as_optional_string(data.get("python_entrypoint")),
         metadata=metadata,
+        opencode_name=_as_optional_string(data.get("opencode_name")),
+        mutation=mutation,
+        risk_level=_as_optional_string(data.get("risk_level")),
+        enabled=enabled,
     )
 
 
@@ -129,6 +145,18 @@ def descriptor_to_tool_schema(descriptor: ToolDescriptor) -> dict:
             "name": descriptor.name,
             "description": descriptor.description,
             "parameters": descriptor.input_schema or dict(DEFAULT_INPUT_SCHEMA),
+        },
+        "metadata": {
+            "source": "external_tools_repo",
+            "tool_id": descriptor.tool_id,
+            "domain": descriptor.domain,
+            "policy_tags": list(descriptor.policy_tags or []),
+            "requires_identity_binding": descriptor.requires_identity_binding,
+            "mutation": descriptor.mutation,
+            "risk_level": descriptor.risk_level,
+            "runtime_compat": list(descriptor.runtime_compat or []),
+            "opencode_name": descriptor.opencode_name,
+            **dict(descriptor.metadata or {}),
         },
     }
 

--- a/src/tools_external/manifest_loader.py
+++ b/src/tools_external/manifest_loader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import json
 from pathlib import Path
 from typing import Any, Optional
 
@@ -44,11 +45,14 @@ def discover_manifest_files(tools_dir: Path) -> list[Path]:
 
 
 def _load_yaml_file(path: Path) -> Any:
-    from ruamel.yaml import YAML
-
-    yaml = YAML(typ="safe")
     with path.open("r", encoding="utf-8") as fh:
-        return yaml.load(fh)
+        text = fh.read()
+    try:
+        from ruamel.yaml import YAML
+        yaml = YAML(typ="safe")
+        return yaml.load(text)
+    except Exception:
+        return json.loads(text)
 
 
 def _iter_descriptor_mappings(raw: Any) -> list[Any]:
@@ -61,7 +65,9 @@ def _iter_descriptor_mappings(raw: Any) -> list[Any]:
             return raw["tools"]
         if isinstance(raw.get("descriptors"), list):
             return raw["descriptors"]
-        return [raw]
+        if "name" in raw:
+            return [raw]
+        return []
     return []
 
 

--- a/src/tools_external/manifest_loader.py
+++ b/src/tools_external/manifest_loader.py
@@ -47,12 +47,23 @@ def discover_manifest_files(tools_dir: Path) -> list[Path]:
 def _load_yaml_file(path: Path) -> Any:
     with path.open("r", encoding="utf-8") as fh:
         text = fh.read()
+    last_exc: Exception | None = None
     try:
         from ruamel.yaml import YAML
         yaml = YAML(typ="safe")
         return yaml.load(text)
-    except Exception:
+    except Exception as exc:
+        last_exc = exc
+    try:
+        import yaml
+        return yaml.safe_load(text)
+    except Exception as exc:
+        last_exc = exc
+    try:
         return json.loads(text)
+    except Exception as exc:
+        last_exc = exc
+    raise last_exc or ValueError(f"Unable to parse manifest: {path}")
 
 
 def _iter_descriptor_mappings(raw: Any) -> list[Any]:

--- a/src/tools_external/registry.py
+++ b/src/tools_external/registry.py
@@ -73,7 +73,12 @@ class ExternalToolRegistry:
         descriptor = self.get_descriptor(name)
         if not descriptor:
             return False
-        return bool(descriptor.enabled and is_descriptor_native_compatible(descriptor) and descriptor.metadata.get("allow_override")) is True
+        return bool(
+            descriptor.enabled
+            and is_descriptor_native_compatible(descriptor)
+            and self.is_model_facing(name)
+            and descriptor.metadata.get("allow_override") is True
+        )
 
     async def execute_tool(self, name: str, **kwargs) -> ExternalToolExecutionResult:
         descriptor = self.get_descriptor(name)

--- a/src/tools_external/registry.py
+++ b/src/tools_external/registry.py
@@ -23,7 +23,21 @@ class ExternalToolRegistry:
                 continue
             self._descriptors_by_name[descriptor.name] = descriptor
 
-    def list_descriptors(self) -> list[ToolDescriptor]:
+    def list_descriptors(self, *, runtime_type: str | None = None, enabled_only: bool = False, model_facing_only: bool = False) -> list[ToolDescriptor]:
+        descriptors = list(self._descriptors_by_name.values())
+        if runtime_type:
+            target = runtime_type.strip().lower()
+            descriptors = [
+                d for d in descriptors
+                if target in {item.lower() for item in (d.runtime_compat or ["native"])}
+            ]
+        if enabled_only:
+            descriptors = [d for d in descriptors if d.enabled]
+        if model_facing_only:
+            descriptors = [d for d in descriptors if self.is_model_facing(d.name)]
+        return descriptors
+
+    def list_all_descriptors(self) -> list[ToolDescriptor]:
         return list(self._descriptors_by_name.values())
 
     def get_descriptor(self, name: str) -> ToolDescriptor | None:
@@ -33,25 +47,40 @@ class ExternalToolRegistry:
         return [
             descriptor_to_tool_schema(descriptor)
             for descriptor in self._descriptors_by_name.values()
-            if is_descriptor_native_compatible(descriptor)
+            if is_descriptor_native_compatible(descriptor) and descriptor.enabled and self.is_model_facing(descriptor.name)
         ]
 
     def get_tool_names(self) -> list[str]:
-        return [item.name for item in self.list_descriptors()]
+        return [item.name for item in self.list_descriptors(runtime_type="native", enabled_only=True, model_facing_only=True)]
 
-    def has_tool(self, name: str) -> bool:
-        return name in self._descriptors_by_name
+    def has_tool(self, name: str, *, include_disabled: bool = True) -> bool:
+        descriptor = self._descriptors_by_name.get(name)
+        if descriptor is None:
+            return False
+        return include_disabled or descriptor.enabled
+
+    def is_tool_enabled(self, name: str) -> bool:
+        descriptor = self.get_descriptor(name)
+        return bool(descriptor and descriptor.enabled)
+
+    def is_model_facing(self, name: str) -> bool:
+        descriptor = self.get_descriptor(name)
+        if not descriptor:
+            return False
+        return descriptor.metadata.get("model_facing", True) is not False
 
     def is_override_enabled(self, name: str) -> bool:
         descriptor = self.get_descriptor(name)
         if not descriptor:
             return False
-        return bool(descriptor.metadata.get("allow_override")) is True
+        return bool(descriptor.enabled and is_descriptor_native_compatible(descriptor) and descriptor.metadata.get("allow_override")) is True
 
     async def execute_tool(self, name: str, **kwargs) -> ExternalToolExecutionResult:
         descriptor = self.get_descriptor(name)
         if not descriptor:
             return ExternalToolExecutionResult(success=False, error=f"External tool '{name}' not found")
+        if not descriptor.enabled:
+            return ExternalToolExecutionResult(success=False, error=f"Tool '{name}' is disabled by external descriptor")
         return await execute_python_entrypoint(descriptor, self.tools_dir, **kwargs)
 
 

--- a/src/tools_external/runner.py
+++ b/src/tools_external/runner.py
@@ -3,72 +3,113 @@ from __future__ import annotations
 import importlib
 import inspect
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, Optional
 
 from .contracts import ExternalToolExecutionResult, ToolDescriptor
 
+_LAST_TOOLS_DIR: Optional[str] = None
+_RESERVED_ARGS = {
+    "_session_id",
+    "_message_id",
+    "_task_id",
+    "_runtime_type",
+    "_workspace_dir",
+    "_portal_metadata",
+    "_opencode_context",
+}
+
 
 def _ensure_python_path(tools_dir: Optional[Path]) -> None:
+    global _LAST_TOOLS_DIR
     if tools_dir is None:
         return
     py_dir = tools_dir / "python"
     if not py_dir.exists() or not py_dir.is_dir():
         return
+    if _LAST_TOOLS_DIR and _LAST_TOOLS_DIR != str(tools_dir):
+        for key in list(sys.modules.keys()):
+            if key == "efp_tools" or key.startswith("efp_tools."):
+                sys.modules.pop(key, None)
+    _LAST_TOOLS_DIR = str(tools_dir)
     py_dir_str = str(py_dir)
-    if py_dir_str not in sys.path:
-        sys.path.insert(0, py_dir_str)
+    if py_dir_str in sys.path:
+        sys.path.remove(py_dir_str)
+    sys.path.insert(0, py_dir_str)
 
 
-def _normalize_result(value: Any) -> ExternalToolExecutionResult:
+def _build_execution_context(kwargs: dict[str, Any], tools_dir: Optional[Path]) -> dict[str, Any]:
+    workspace_dir = kwargs.get("_workspace_dir") or os.getenv("EFP_WORKSPACE_DIR") or str(Path.home() / ".efp" / "workspace")
+    portal_metadata = kwargs.get("_portal_metadata") if isinstance(kwargs.get("_portal_metadata"), dict) else {}
+    repo_root = Path(__file__).resolve().parents[2]
+    context_blob_dir = os.getenv("EFP_CONTEXT_BLOB_DIR") or str(Path(workspace_dir) / "context_blobs")
+    return {
+        "runtime_type": kwargs.get("_runtime_type") or "native",
+        "session_id": kwargs.get("_session_id"),
+        "message_id": kwargs.get("_message_id"),
+        "task_id": kwargs.get("_task_id"),
+        "workspace_dir": str(workspace_dir),
+        "portal_metadata": {
+            **portal_metadata,
+            "legacy_runtime_src_dir": str(repo_root),
+            "context_blob_dir": context_blob_dir,
+        },
+        "opencode_context": kwargs.get("_opencode_context") if isinstance(kwargs.get("_opencode_context"), dict) else {},
+    }
+
+
+def _strip_framework_args(kwargs: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in kwargs.items() if k not in _RESERVED_ARGS}
+
+
+def _normalize_result(value: Any, tool_name: str) -> ExternalToolExecutionResult:
     if isinstance(value, ExternalToolExecutionResult):
         return value
-    if isinstance(value, str):
-        return ExternalToolExecutionResult(success=True, content=value)
+    if value is None:
+        return ExternalToolExecutionResult(success=False, error=f"External tool '{tool_name}' returned no result")
+    if hasattr(value, "to_dict") and callable(getattr(value, "to_dict")):
+        value = value.to_dict()
+    if hasattr(value, "success") and (hasattr(value, "content") or hasattr(value, "data") or hasattr(value, "error")):
+        data = {"success": getattr(value, "success", True), "content": getattr(value, "content", ""), "data": getattr(value, "data", None), "error": getattr(value, "error", None), "artifacts": getattr(value, "artifacts", None)}
+        value = data
     if isinstance(value, dict):
-        if "success" in value and ("content" in value or "output" in value or "error" in value):
-            content = value.get("content", value.get("output", ""))
+        if any(k in value for k in ("success", "content", "data", "error", "artifacts")):
+            success = bool(value.get("success", True))
+            content = value.get("content")
+            if (content is None or content == "") and value.get("data") is not None:
+                content = json.dumps(value.get("data"), ensure_ascii=False, default=str)
             if content is None:
                 content = ""
-            error = value.get("error")
-            return ExternalToolExecutionResult(
-                success=bool(value.get("success")),
-                content=str(content),
-                error=None if error is None else str(error),
-            )
+            return ExternalToolExecutionResult(success=success, content=str(content), error=value.get("error"))
         return ExternalToolExecutionResult(success=True, content=json.dumps(value, ensure_ascii=False, default=str))
+    if isinstance(value, str):
+        return ExternalToolExecutionResult(success=True, content=value)
     if isinstance(value, (list, int, float, bool)):
         return ExternalToolExecutionResult(success=True, content=json.dumps(value, ensure_ascii=False, default=str))
-    if hasattr(value, "to_dict") and callable(getattr(value, "to_dict")):
-        data = value.to_dict()
-        if not isinstance(data, dict):
-            return ExternalToolExecutionResult(success=True, content=str(data))
-        content = data.get("content") or data.get("output") or json.dumps(data, ensure_ascii=False, default=str)
-        return ExternalToolExecutionResult(success=bool(data.get("success", True)), content=str(content), error=data.get("error"))
-    if all(hasattr(value, attr) for attr in ("success", "content", "error")):
-        content = "" if getattr(value, "content") is None else str(getattr(value, "content"))
-        return ExternalToolExecutionResult(
-            success=bool(getattr(value, "success")),
-            content=content,
-            error=getattr(value, "error"),
-        )
     return ExternalToolExecutionResult(success=True, content=str(value))
 
 
-async def execute_python_entrypoint(
-    descriptor: ToolDescriptor,
-    tools_dir: Optional[Path],
-    **kwargs: Any,
-) -> ExternalToolExecutionResult:
-    if not descriptor.python_entrypoint:
-        return ExternalToolExecutionResult(
-            success=False,
-            error=f"External tool '{descriptor.name}' has no python_entrypoint",
-        )
-
+async def execute_python_entrypoint(descriptor: ToolDescriptor, tools_dir: Optional[Path], **kwargs: Any) -> ExternalToolExecutionResult:
     try:
         _ensure_python_path(tools_dir)
+        context = _build_execution_context(kwargs, tools_dir)
+        filtered_args = _strip_framework_args(kwargs)
+
+        efp_runner = (tools_dir / "python" / "efp_tools" / "runner.py") if tools_dir else None
+        if efp_runner and efp_runner.exists():
+            runner = importlib.import_module("efp_tools.runner")
+            fn = getattr(runner, "execute_tool_async", None) or getattr(runner, "execute_tool", None)
+            if fn:
+                result = fn(tools_dir=str(tools_dir), tool=descriptor.name, args=filtered_args, context=context)
+                if inspect.isawaitable(result):
+                    result = await result
+                return _normalize_result(result, descriptor.name)
+
+        if not descriptor.python_entrypoint:
+            return ExternalToolExecutionResult(success=False, error=f"External tool '{descriptor.name}' has no python_entrypoint")
+
         module_name, func_name = descriptor.python_entrypoint.split(":", 1)
         root_package = module_name.split(".", 1)[0]
         for loaded in list(sys.modules.keys()):
@@ -76,9 +117,22 @@ async def execute_python_entrypoint(
                 sys.modules.pop(loaded, None)
         module = importlib.import_module(module_name)
         func = getattr(module, func_name)
-        result = func(**kwargs)
+        sig = inspect.signature(func)
+        call_kwargs: dict[str, Any] = {}
+        accepts_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+        if accepts_kwargs:
+            call_kwargs.update(filtered_args)
+        else:
+            for p in sig.parameters:
+                if p in filtered_args:
+                    call_kwargs[p] = filtered_args[p]
+        if "context" in sig.parameters:
+            call_kwargs["context"] = context
+        if "_session_id" in sig.parameters and context.get("session_id") is not None:
+            call_kwargs["_session_id"] = context.get("session_id")
+        result = func(**call_kwargs)
         if inspect.isawaitable(result):
             result = await result
-        return _normalize_result(result)
-    except Exception as exc:
+        return _normalize_result(result, descriptor.name)
+    except (KeyError, PermissionError, Exception) as exc:
         return ExternalToolExecutionResult(success=False, content="", error=str(exc))

--- a/tests/test_agent_llm_tools_surface.py
+++ b/tests/test_agent_llm_tools_surface.py
@@ -193,3 +193,36 @@ def test_disabled_external_tool_not_available_even_when_llm_tools_matches(monkey
     names = [t["function"]["name"] for t in agent.tools]
     assert "context_echo" not in names
     assert "context_echo" not in agent.allowed_tool_names
+
+
+def test_model_facing_false_external_tool_not_available_even_when_llm_tools_matches(monkeypatch, tmp_path):
+    from src.agents import core as core_mod
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = tmp_path / "tools_repo_hidden"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+    (tools_dir / "manifest.yaml").write_text(
+        """
+name: context_hidden
+description: hidden
+python_entrypoint: test_tools.echo:execute
+input_schema: {type: object, properties: {text: {type: string}}}
+runtime_compat: [native]
+enabled: true
+metadata: {model_facing: false}
+""",
+        encoding="utf-8",
+    )
+    (tools_dir / "python" / "test_tools").mkdir(parents=True)
+    (tools_dir / "python" / "test_tools" / "__init__.py").write_text("", encoding="utf-8")
+    (tools_dir / "python" / "test_tools" / "echo.py").write_text("async def execute(text='', **kwargs):\n    return {'success': True, 'content': text}\n", encoding="utf-8")
+
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    monkeypatch.setitem(core_mod.config._config, "llm", {"tools": ["context_hidden"]})
+    monkeypatch.setattr(core_mod, "memory_system", SimpleNamespace(workspace="/tmp", build_system_prompt=lambda include_memory: ""))
+
+    agent = Agent(session_id="external-hidden-test")
+    names = [t["function"]["name"] for t in agent.tools]
+    assert "context_hidden" not in names
+    assert "context_hidden" not in agent.allowed_tool_names

--- a/tests/test_agent_llm_tools_surface.py
+++ b/tests/test_agent_llm_tools_surface.py
@@ -146,3 +146,50 @@ async def test_skill_mode_tool_schema_list_intersect_with_global_surface(monkeyp
     )
 
     assert any([item["function"]["name"] for item in tools] == ["git_clone"] for tools in captured)
+
+def _write_external_tool_fixture(tmp_path, *, enabled=True):
+    tools_dir = tmp_path / "tools_repo"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+    (tools_dir / "manifest.yaml").write_text(
+        f"""
+name: context_echo
+description: echo
+python_entrypoint: test_tools.echo:execute
+input_schema: {{type: object, properties: {{text: {{type: string}}}}}}
+runtime_compat: [native]
+enabled: {str(enabled).lower()}
+""",
+        encoding="utf-8",
+    )
+    (tools_dir / "python" / "test_tools").mkdir(parents=True)
+    (tools_dir / "python" / "test_tools" / "__init__.py").write_text("", encoding="utf-8")
+    (tools_dir / "python" / "test_tools" / "echo.py").write_text("async def execute(text='', **kwargs):\n    return {'success': True, 'content': text}\n", encoding="utf-8")
+    return tools_dir
+
+
+def test_external_tools_respect_llm_tools_filter(monkeypatch, tmp_path):
+    from src.agents import core as core_mod
+    from src.tools_external import reset_external_tool_registry_cache
+    tools_dir = _write_external_tool_fixture(tmp_path, enabled=True)
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    monkeypatch.setitem(core_mod.config._config, "llm", {"tools": ["context_echo"]})
+    monkeypatch.setattr(core_mod, "memory_system", SimpleNamespace(workspace="/tmp", build_system_prompt=lambda include_memory: ""))
+    agent = Agent(session_id="external-surface-test")
+    names = [t["function"]["name"] for t in agent.tools]
+    assert "context_echo" in names
+    assert "context_echo" in agent.allowed_tool_names
+
+
+def test_disabled_external_tool_not_available_even_when_llm_tools_matches(monkeypatch, tmp_path):
+    from src.agents import core as core_mod
+    from src.tools_external import reset_external_tool_registry_cache
+    tools_dir = _write_external_tool_fixture(tmp_path, enabled=False)
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    monkeypatch.setitem(core_mod.config._config, "llm", {"tools": ["context_echo"]})
+    monkeypatch.setattr(core_mod, "memory_system", SimpleNamespace(workspace="/tmp", build_system_prompt=lambda include_memory: ""))
+    agent = Agent(session_id="external-disabled-test")
+    names = [t["function"]["name"] for t in agent.tools]
+    assert "context_echo" not in names
+    assert "context_echo" not in agent.allowed_tool_names

--- a/tests/test_docker_runtime_contract.py
+++ b/tests/test_docker_runtime_contract.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_dockerfile_uses_python_311_runtime():
+    text = Path("Dockerfile").read_text(encoding="utf-8")
+    first_from = next(line.strip() for line in text.splitlines() if line.strip().startswith("FROM "))
+    assert "python:3.11" in first_from
+    assert "python:3.9" not in first_from
+
+
+def test_dockerfile_keeps_native_runtime_asset_dirs_and_port():
+    text = Path("Dockerfile").read_text(encoding="utf-8")
+    assert "/app/skills" in text
+    assert "/app/tools" in text
+    assert "/root/.efp/workspace" in text
+    assert "EXPOSE 8000" in text

--- a/tests/test_external_tools_registry.py
+++ b/tests/test_external_tools_registry.py
@@ -318,3 +318,38 @@ async def test_tool_result_like_dict_preserves_failure(monkeypatch, tmp_path):
     result = await execute_tool("context_failure")
     assert result.success is False
     assert result.error == "boom"
+
+def test_t04_root_manifest_is_not_treated_as_descriptor(monkeypatch, tmp_path):
+    from src.tools_external import get_external_tool_registry
+
+    tools_dir = _write_tools_repo(tmp_path, manifest_subpath="tools/context/context_echo.yaml")
+    (tools_dir / "manifest.yaml").write_text('repo: engineering-flow-platform-tools\nversion: 0.1.0\nschema_version: t04\n', encoding="utf-8")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    registry = get_external_tool_registry(force_reload=True)
+    assert [d.name for d in registry.list_descriptors()] == ["context_echo"]
+
+
+@pytest.mark.asyncio
+async def test_disabled_external_only_tool_is_hidden_and_blocked(monkeypatch, tmp_path):
+    from src import execute_tool, get_tools_schema
+    from src.runtime.capability_registry import build_default_capability_registry
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, name="external_disabled_write", extra_fields={"enabled": False})
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    assert "external_disabled_write" not in {_schema_name(s) for s in get_tools_schema() if isinstance(s, dict)}
+    result = await execute_tool("external_disabled_write")
+    assert result.success is False and "disabled" in (result.error or "")
+    cap_names = {c.name for c in build_default_capability_registry().list_by_type("tool")}
+    assert "external_disabled_write" not in cap_names
+
+
+def test_real_t04_like_disabled_exec_not_exposed(monkeypatch, tmp_path):
+    from src import get_tools_schema
+    from src.tools_external import get_external_tool_registry
+    tools_dir = _write_tools_repo(tmp_path, name="exec", extra_fields={"enabled": False, "policy_tags": ["bash", "mutation", "disabled_until_safety_review"]})
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    registry = get_external_tool_registry(force_reload=True)
+    assert "exec" not in registry.get_tool_names()
+    assert "exec" not in {_schema_name(s) for s in get_tools_schema() if isinstance(s, dict)}

--- a/tests/test_external_tools_registry.py
+++ b/tests/test_external_tools_registry.py
@@ -353,3 +353,205 @@ def test_real_t04_like_disabled_exec_not_exposed(monkeypatch, tmp_path):
     registry = get_external_tool_registry(force_reload=True)
     assert "exec" not in registry.get_tool_names()
     assert "exec" not in {_schema_name(s) for s in get_tools_schema() if isinstance(s, dict)}
+
+
+def test_model_facing_false_is_hidden_from_llm_schema(monkeypatch, tmp_path):
+    from src import get_tools_schema
+    from src.tools_external import get_external_tool_registry
+
+    tools_dir = _write_tools_repo(tmp_path, name="context_hidden", metadata={"model_facing": False})
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    registry = get_external_tool_registry(force_reload=True)
+    assert registry.get_descriptor("context_hidden") is not None
+    assert "context_hidden" not in registry.get_tool_names()
+    assert "context_hidden" not in {_schema_name(s) for s in get_tools_schema() if isinstance(s, dict)}
+
+
+@pytest.mark.asyncio
+async def test_model_facing_false_allow_override_does_not_override_legacy_schema_or_execution(monkeypatch, tmp_path):
+    from src import execute_tool, get_tools_schema
+    from src.tools_external import get_external_tool_registry, reset_external_tool_registry_cache
+    import src.bash_tools as bash_tools_module
+
+    tools_dir = _write_tools_repo(
+        tmp_path,
+        name="run_command",
+        description="external run_command hidden",
+        metadata={"allow_override": True, "model_facing": False},
+        entrypoint_body="def execute(**kwargs):\n    return {'success': True, 'content': 'external override ran'}\n",
+    )
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+
+    schemas = [s for s in get_tools_schema() if _schema_name(s) == "run_command"]
+    assert len(schemas) == 1
+    assert schemas[0]["function"]["description"] != "external run_command hidden"
+
+    async def _fake_run_command(cmd, args=None, cwd=None, timeout_ms=15000):
+        return {"ok": True, "exit_code": 0, "stdout": "legacy run_command ran", "stderr": "", "truncated": {}}
+
+    monkeypatch.setattr(bash_tools_module, "run_command", _fake_run_command)
+    result = await execute_tool("run_command", cmd="anything")
+    assert "external override ran" not in result.content
+    assert "legacy run_command ran" in result.content
+
+    registry = get_external_tool_registry(force_reload=True)
+    assert registry.is_override_enabled("run_command") is False
+
+
+@pytest.mark.asyncio
+async def test_t04_runner_receives_context_and_reserved_args_are_filtered(monkeypatch, tmp_path):
+    from src.tools_external import get_external_tool_registry, reset_external_tool_registry_cache
+
+    tools_dir = tmp_path / "tools_repo"
+    (tools_dir / "tools" / "context").mkdir(parents=True)
+    (tools_dir / "python" / "efp_tools").mkdir(parents=True)
+    (tools_dir / "python" / "efp_tools" / "__init__.py").write_text("", encoding="utf-8")
+    (tools_dir / "manifest.yaml").write_text('repo: engineering-flow-platform-tools\nversion: "0.1.0"\nschema_version: t04\n', encoding="utf-8")
+    (tools_dir / "tools" / "context" / "context_echo.yaml").write_text(
+        """
+name: context_echo
+tool_id: efp.tool.context.echo
+opencode_name: efp_context_echo
+description: Echo via T04 runner
+domain: context
+type: adapter_action
+runtime_compat: [native, opencode]
+policy_tags: [context, read_only]
+requires_identity_binding: false
+mutation: false
+risk_level: low
+python_entrypoint: ignored.module:ignored
+input_schema:
+  type: object
+  properties:
+    text: {type: string}
+  required: [text]
+output_schema:
+  type: object
+metadata:
+  source: fixture
+enabled: true
+""",
+        encoding="utf-8",
+    )
+    (tools_dir / "python" / "efp_tools" / "runner.py").write_text(
+        """
+async def execute_tool_async(*, tools_dir, tool, args=None, context=None):
+    assert tool == 'context_echo'
+    assert args == {'text': 'hello'}
+    assert context['runtime_type'] == 'native'
+    assert context['session_id'] == 'sess-1'
+    assert context['message_id'] == 'msg-1'
+    assert context['task_id'] == 'task-1'
+    assert context['workspace_dir'].endswith('workspace-override')
+    assert context['portal_metadata']['x'] == 'y'
+    assert context['portal_metadata']['legacy_runtime_src_dir']
+    assert context['portal_metadata']['context_blob_dir'].endswith('context_blobs')
+    assert context['opencode_context'] == {'ignored': 'but preserved'}
+    return {'success': True, 'content': 'hello'}
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    registry = get_external_tool_registry(force_reload=True)
+    result = await registry.execute_tool(
+        "context_echo",
+        text="hello",
+        _session_id="sess-1",
+        _message_id="msg-1",
+        _task_id="task-1",
+        _runtime_type="native",
+        _workspace_dir=str(tmp_path / "workspace-override"),
+        _portal_metadata={"x": "y"},
+        _opencode_context={"ignored": "but preserved"},
+    )
+    assert result.success is True
+    assert result.content == "hello"
+
+
+def test_real_t04_enabled_tool_schema_has_metadata(monkeypatch, tmp_path):
+    from src import get_tools_schema
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = tmp_path / "tools_repo_meta"
+    (tools_dir / "python" / "test_tools").mkdir(parents=True)
+    (tools_dir / "python" / "test_tools" / "__init__.py").write_text("", encoding="utf-8")
+    (tools_dir / "python" / "test_tools" / "echo.py").write_text("def execute(**kwargs):\n    return {'success': True, 'content': 'ok'}\n", encoding="utf-8")
+    (tools_dir / "manifest.yaml").write_text(
+        json.dumps({
+            "tool_id": "efp.tool.context.echo",
+            "name": "context_echo",
+            "description": "Echo",
+            "python_entrypoint": "test_tools.echo:execute",
+            "input_schema": {"type": "object", "properties": {"text": {"type": "string"}}},
+            "output_schema": {"type": "object"},
+            "runtime_compat": ["native", "opencode"],
+            "policy_tags": ["context", "read_only"],
+            "domain": "context",
+            "opencode_name": "efp_context_echo",
+            "mutation": False,
+            "risk_level": "low",
+            "metadata": {"source": "legacy_efp"},
+            "enabled": True,
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    schema = next(s for s in get_tools_schema() if _schema_name(s) == "context_echo")
+    md = schema["metadata"]
+    assert md["source"] == "external_tools_repo"
+    assert md["descriptor_source"] == "legacy_efp"
+    assert md["tool_id"] == "efp.tool.context.echo"
+    assert md["domain"] == "context"
+    assert md["policy_tags"] == ["context", "read_only"]
+    assert md["requires_identity_binding"] is False
+    assert md["mutation"] is False
+    assert md["risk_level"] == "low"
+    assert "native" in md["runtime_compat"]
+    assert md["opencode_name"] == "efp_context_echo"
+    assert md["enabled"] is True
+
+
+def test_external_capability_metadata_preserves_contract_fields(monkeypatch, tmp_path):
+    from src.runtime.capability_registry import build_default_capability_registry
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = tmp_path / "tools_repo_capmeta"
+    (tools_dir / "python" / "test_tools").mkdir(parents=True)
+    (tools_dir / "python" / "test_tools" / "__init__.py").write_text("", encoding="utf-8")
+    (tools_dir / "python" / "test_tools" / "echo.py").write_text("def execute(**kwargs):\n    return {'success': True, 'content': 'ok'}\n", encoding="utf-8")
+    (tools_dir / "manifest.yaml").write_text(
+        json.dumps({
+            "tool_id": "efp.tool.context.echo",
+            "name": "context_echo",
+            "description": "Echo",
+            "python_entrypoint": "test_tools.echo:execute",
+            "input_schema": {"type": "object", "properties": {"text": {"type": "string"}}},
+            "output_schema": {"type": "object"},
+            "runtime_compat": ["native", "opencode"],
+            "policy_tags": ["context", "read_only"],
+            "domain": "context",
+            "opencode_name": "efp_context_echo",
+            "mutation": False,
+            "risk_level": "low",
+            "metadata": {"source": "legacy_efp"},
+            "enabled": True,
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    cap = next(c for c in build_default_capability_registry().list_by_type("tool") if c.name == "context_echo")
+    assert cap.capability_id == "efp.tool.context.echo"
+    assert cap.metadata["external_tool"] is True
+    assert cap.metadata["tool_id"] == "efp.tool.context.echo"
+    assert cap.metadata["policy_tags"] == ["context", "read_only"]
+    assert cap.metadata["requires_identity_binding"] is False
+    assert cap.metadata["domain"] == "context"
+    assert "native" in cap.metadata["runtime_compat"]
+    assert cap.metadata["opencode_name"] == "efp_context_echo"
+    assert cap.metadata["mutation"] is False
+    assert cap.metadata["risk_level"] == "low"

--- a/tests/test_runtime_capability_contract.py
+++ b/tests/test_runtime_capability_contract.py
@@ -1,6 +1,40 @@
 from aiohttp import web
 
 
+def _write_tools_repo(tmp_path, *, name="context_echo", enabled=True, metadata=None):
+    metadata = metadata or {}
+    tools_dir = tmp_path / "tools_repo"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+    (tools_dir / "manifest.yaml").write_text(
+        f"""
+tool_id: efp.tool.context.echo
+name: {name}
+description: Echo
+python_entrypoint: test_tools.echo:execute
+input_schema:
+  type: object
+  properties:
+    text:
+      type: string
+output_schema:
+  type: object
+runtime_compat: [native, opencode]
+policy_tags: [context, read_only]
+domain: context
+opencode_name: efp_context_echo
+mutation: false
+risk_level: low
+metadata: {metadata}
+enabled: {str(enabled).lower()}
+""",
+        encoding="utf-8",
+    )
+    (tools_dir / "python" / "test_tools").mkdir(parents=True)
+    (tools_dir / "python" / "test_tools" / "__init__.py").write_text("", encoding="utf-8")
+    (tools_dir / "python" / "test_tools" / "echo.py").write_text("def execute(**kwargs):\n    return {'success': True, 'content': 'ok'}\n", encoding="utf-8")
+    return tools_dir
+
+
 def test_capability_snapshot_contract_shape():
     from src.runtime.capability_registry import build_default_capability_registry
     snapshot = build_default_capability_registry().export_catalog_snapshot()
@@ -10,6 +44,43 @@ def test_capability_snapshot_contract_shape():
     assert snapshot["generated_at"].endswith("Z")
     types = {c.get("type") for c in snapshot["capabilities"]}
     assert {"tool", "skill", "adapter_action"}.issubset(types)
+
+
+def test_external_tool_appears_in_capability_snapshot(monkeypatch, tmp_path):
+    from src.runtime.capability_registry import build_default_capability_registry
+    from src.tools_external import reset_external_tool_registry_cache
+    tools_dir = _write_tools_repo(tmp_path, metadata={"source": "legacy_efp"})
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    snapshot = build_default_capability_registry().export_catalog_snapshot()
+    cap = next(c for c in snapshot["capabilities"] if c.get("type") == "tool" and c.get("name") == "context_echo")
+    assert cap["capability_id"] == "efp.tool.context.echo"
+    assert cap["metadata"]["external_tool"] is True
+    assert cap["metadata"]["tool_id"] == "efp.tool.context.echo"
+    assert cap["metadata"]["domain"] == "context"
+    assert "read_only" in cap["metadata"]["policy_tags"]
+    assert "native" in cap["metadata"]["runtime_compat"]
+
+
+def test_disabled_external_tool_absent_from_capability_snapshot(monkeypatch, tmp_path):
+    from src.runtime.capability_registry import build_default_capability_registry
+    from src.tools_external import reset_external_tool_registry_cache
+    tools_dir = _write_tools_repo(tmp_path, name="external_disabled_write", enabled=False)
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    snapshot = build_default_capability_registry().export_catalog_snapshot()
+    assert not any(c.get("name") == "external_disabled_write" for c in snapshot["capabilities"])
+
+
+def test_duplicate_disabled_external_tool_does_not_override_legacy_capability(monkeypatch, tmp_path):
+    from src.runtime.capability_registry import build_default_capability_registry
+    from src.tools_external import reset_external_tool_registry_cache
+    tools_dir = _write_tools_repo(tmp_path, name="run_command", enabled=False)
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    cap = next(c for c in build_default_capability_registry().list_by_type("tool") if c.name == "run_command")
+    assert cap.metadata.get("external_tool") is not True
+    assert cap.source_ref == "src.__init__.get_tools_schema"
 
 
 def test_runtime_gateway_routes_include_t13_native_contract():

--- a/tests/test_runtime_capability_contract.py
+++ b/tests/test_runtime_capability_contract.py
@@ -90,6 +90,7 @@ def test_runtime_gateway_routes_include_t13_native_contract():
     got = {(r.method, r.resource.canonical) for r in app.router.routes()}
     required = {
         ("GET", "/health"), ("GET", "/actuator/health"), ("GET", "/api/queue/status"),
+        ("GET", "/api/events"),
         ("POST", "/api/chat"), ("POST", "/api/chat/stream"), ("POST", "/api/tasks/execute"),
         ("GET", "/api/tasks/{task_id}"), ("GET", "/api/capabilities"), ("POST", "/api/internal/runtime-profile/apply"),
         ("GET", "/api/skills"), ("GET", "/api/usage"), ("GET", "/api/sessions"),

--- a/tests/test_runtime_capability_contract.py
+++ b/tests/test_runtime_capability_contract.py
@@ -1,0 +1,26 @@
+from aiohttp import web
+
+
+def test_capability_snapshot_contract_shape():
+    from src.runtime.capability_registry import build_default_capability_registry
+    snapshot = build_default_capability_registry().export_catalog_snapshot()
+    assert {"capabilities", "count", "catalog_version", "generated_at"}.issubset(snapshot.keys())
+    assert isinstance(snapshot["capabilities"], list)
+    assert snapshot["count"] == len(snapshot["capabilities"])
+    assert snapshot["generated_at"].endswith("Z")
+    types = {c.get("type") for c in snapshot["capabilities"]}
+    assert {"tool", "skill", "adapter_action"}.issubset(types)
+
+
+def test_runtime_gateway_routes_include_t13_native_contract():
+    from src.gateway.server import Gateway
+    server = Gateway()
+    app = server.app
+    got = {(r.method, r.resource.canonical) for r in app.router.routes()}
+    required = {
+        ("GET", "/health"), ("GET", "/actuator/health"), ("GET", "/api/queue/status"),
+        ("POST", "/api/chat"), ("POST", "/api/chat/stream"), ("POST", "/api/tasks/execute"),
+        ("GET", "/api/tasks/{task_id}"), ("GET", "/api/capabilities"), ("POST", "/api/internal/runtime-profile/apply"),
+        ("GET", "/api/skills"), ("GET", "/api/usage"), ("GET", "/api/sessions"),
+    }
+    assert required.issubset(got)


### PR DESCRIPTION
### Motivation
- Ensure native runtime enforces T04 external tool signals (`enabled`, `model_facing`, `runtime_compat`) so disabled/dangerous tools are never exposed to LLM surfaces. 
- Maintain legacy tool behavior while enabling safe external tools execution and capability metadata propagation. 
- Add T13 acceptance tests and CI to validate native runtime contracts without requiring external services.

### Description
- Treat external descriptor fields as first-class by extending `ToolDescriptor` with `opencode_name`, `mutation`, `risk_level`, and `enabled`, and include those fields in tool schema metadata (changes in `src/tools_external/contracts.py`).
- Harden manifest loading and descriptor discovery to skip root repo manifests and use a YAML->JSON fallback for parsing (changes in `src/tools_external/manifest_loader.py`).
- Strengthen `ExternalToolRegistry` filtering and execution rules so `get_tools_schema()`/`get_tool_names()` only expose native-compatible, `enabled`, and `model_facing` tools, and disabled tools return explicit errors on execute (changes in `src/tools_external/registry.py`).
- Update runner to prefer T04-style `efp_tools.runner` when present, build/forward a structured execution `context`, strip reserved framework args, protect against module leakage across fixtures, and normalize results while preserving failure semantics (changes in `src/tools_external/runner.py`).
- Keep legacy `src.__init__.py` dispatch but tighten external override/exposure semantics so `allow_override` requires enabled+native compatibility and disabled external-only tools do not become "not implemented" but return a disabled error; also ensure external descriptors do not inadvertently expose dangerous tools (changes in `src/__init__.py`).
- Propagate external descriptor metadata (including `opencode_name`, `mutation`, `risk_level`, `runtime_compat`, `requires_identity_binding`) into capability registry entries for external tools (changes in `src/runtime/capability_registry.py`).
- Add tests covering root-manifest skipping, disabled tool hiding/blocking, `model_facing` behavior, T04 runner context/reserved-arg stripping, exec not exposed for disabled external descriptors, capability snapshot and routes contract, and agent LLM-surface interactions (added/updated tests under `tests/`).
- Add a GitHub Actions workflow `.github/workflows/ci.yml` that runs the required T13 pytest set and a docker build smoke job.

### Testing
- Installed requirements with `python -m pip install -r requirements.txt` which completed successfully in this environment.
- Ran the required test suite with `python -m pytest -q tests/test_external_tools_registry.py tests/test_external_tools_loader.py tests/test_agent_llm_tools_surface.py tests/test_capability_registry.py tests/test_runtime_capability_contract.py` and observed `55 passed, 1 skipped` (all added/updated tests passed in the CI-like run here).
- Attempted the docker smoke build `docker build -t efp-native-runtime-ci .` which failed in this environment with `/bin/bash: docker: command not found` because the `docker` binary is not available here; this is an environment limitation, not code failure.

No changes were made to Portal, OpenCode runtime, Skills, or external Tools repositories; all modifications are contained within the `engineering-flow-platform` native runtime code and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84c39bb58832a9d94ac06c6208512)