### PR TITLE
Switch Dockerfile to ubuntu:22.04 and install Python 3.11 into /opt/venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,44 @@
-FROM python:3.11-slim
+FROM ubuntu:22.04
 
-ENV PYTHONUNBUFFERED=1
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    VIRTUAL_ENV=/opt/venv
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 WORKDIR /app
 
-# Install system tools required by internal bash/github tooling
+# Install Ubuntu system dependencies and Python 3.11.
+# Keep Python 3.11 for compatibility with the current native runtime and CI.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git curl ca-certificates gnupg tesseract-ocr \
+    && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        ca-certificates \
+        curl \
+        gnupg \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.11 \
+        python3.11-venv \
+        python3.11-dev \
+        build-essential \
+        git \
+        tesseract-ocr \
+    && python3.11 -m venv "$VIRTUAL_ENV" \
+    && "$VIRTUAL_ENV/bin/python" -m pip install --no-cache-dir --upgrade pip setuptools wheel \
     && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+ENV PATH="/opt/venv/bin:$PATH"
 
-# Copy application code
+# Install Python dependencies into the virtual environment.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && apt-get purge -y --auto-remove build-essential python3.11-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy application code.
 COPY . .
 
 # Create the workspace directory for this container image's default runtime user (root).
@@ -21,12 +46,9 @@ COPY . .
 # in this image, `~` resolves to `/root`.
 RUN mkdir -p /app/skills /app/tools /root/.efp/workspace /root/.efp/skills
 
-# Expose port
 EXPOSE 8000
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
-# Run the application
 CMD ["python", "main.py"]

--- a/tests/test_docker_runtime_contract.py
+++ b/tests/test_docker_runtime_contract.py
@@ -1,11 +1,20 @@
 from pathlib import Path
 
 
-def test_dockerfile_uses_python_311_runtime():
+def test_dockerfile_uses_ubuntu_base_and_installs_python_311_runtime():
     text = Path("Dockerfile").read_text(encoding="utf-8")
     first_from = next(line.strip() for line in text.splitlines() if line.strip().startswith("FROM "))
-    assert "python:3.11" in first_from
-    assert "python:3.9" not in first_from
+
+    assert first_from == "FROM ubuntu:22.04"
+    assert "python:" not in first_from
+    assert "python:3.11" not in text
+    assert "python:3.9" not in text
+
+    assert "python3.11" in text
+    assert "python3.11-venv" in text
+    assert "VIRTUAL_ENV=/opt/venv" in text
+    assert "ENV PATH=\"/opt/venv/bin:$PATH\"" in text
+    assert "pip install --no-cache-dir -r requirements.txt" in text
 
 
 def test_dockerfile_keeps_native_runtime_asset_dirs_and_port():
@@ -13,4 +22,6 @@ def test_dockerfile_keeps_native_runtime_asset_dirs_and_port():
     assert "/app/skills" in text
     assert "/app/tools" in text
     assert "/root/.efp/workspace" in text
+    assert "/root/.efp/skills" in text
     assert "EXPOSE 8000" in text
+    assert 'CMD ["python", "main.py"]' in text


### PR DESCRIPTION
### Motivation
- Replace the base image from the Python official image to a reproducible Ubuntu base while preserving Python 3.11 runtime semantics.
- Ensure the `python` and `pip` commands in the image resolve to a controlled virtual environment so existing healthchecks, `CMD`, and docker-compose healthchecks continue to work.
- Keep required system binaries (`git`, `curl`, `ca-certificates`, `gnupg`, `tesseract-ocr`) and runtime directories intact for native runtime behavior.

### Description
- Replace the root `Dockerfile` to `FROM ubuntu:22.04` and install Python 3.11 via the deadsnakes PPA, including `python3.11-venv` and `python3.11-dev` as needed to create a venv.
- Create a virtual environment at `/opt/venv`, set `ENV PATH="/opt/venv/bin:$PATH"`, and install Python requirements into that venv with `pip install --no-cache-dir -r requirements.txt` while preserving layer ordering (`COPY requirements.txt` then `pip install` then `COPY . .`).
- Preserve installation of system tools `git`, `curl`, `ca-certificates`, `gnupg`, and `tesseract-ocr`, creation of `/app/skills`, `/app/tools`, `/root/.efp/workspace`, and `/root/.efp/skills`, `WORKDIR /app`, `EXPOSE 8000`, the Python-based `HEALTHCHECK`, and `CMD ["python", "main.py"]`.
- Update `tests/test_docker_runtime_contract.py` to assert `FROM ubuntu:22.04`, presence of `python3.11`, `python3.11-venv`, `/opt/venv`/PATH, and that `pip install -r requirements.txt` targets the venv, and keep assertions for runtime dirs/port/CMD.

### Testing
- Ran `python -m pytest -q tests/test_docker_runtime_contract.py` and it passed (`2 passed`).
- Ran the CI test subset `python -m pytest -q tests/test_external_tools_registry.py tests/test_external_tools_loader.py tests/test_agent_llm_tools_surface.py tests/test_capability_registry.py tests/test_runtime_capability_contract.py tests/test_docker_runtime_contract.py` and it passed (`66 passed, 1 skipped`).
- Attempted `docker build -t efp-native-runtime-ubuntu-test .` in this environment but the build could not run because Docker is not installed (`docker: command not found`).
- No runtime business logic or forbidden files were modified (e.g., `main.py`, `docker-compose.yml`, `.github/workflows/**`, `requirements.txt`, or `src/**`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f894729e38832a98ce28617f270107)