### PR TITLE
Fix native external tool override/shadow diagnostics and add native smoke test

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -24,17 +24,22 @@ class ToolResult:
         success: bool,
         content: str = "",
         error: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         self.success = success
         self.content = content
         self.error = error
+        self.metadata = metadata or {}
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        result = {
             "success": self.success,
             "content": self.content,
             "error": self.error,
         }
+        if self.metadata:
+            result["metadata"] = self.metadata
+        return result
 
     def __str__(self) -> str:
         if self.success:
@@ -75,7 +80,6 @@ from . import git
 from . import bash_tools
 from . import context_tools
 from .tools_external import get_external_tool_registry
-from .tools_external.contracts import is_descriptor_native_compatible
 
 
 def _extract_tool_schema_name(tool_schema: Dict[str, Any]) -> str:
@@ -110,22 +114,25 @@ def _get_legacy_tool_names_set() -> set[str]:
     }
 
 
-def is_external_tool_exposed(name: str) -> bool:
-    """Return True when an external tool is visible in the merged tool surface."""
+
+
+def get_external_tool_visibility(name: str) -> Dict[str, Any]:
     registry = get_external_tool_registry()
     legacy_names = _get_legacy_tool_names_set()
-    if not registry.has_tool(name, include_disabled=True):
-        return False
-    descriptor = registry.get_descriptor(name)
-    if descriptor is None or not descriptor.enabled:
-        return False
-    if not is_descriptor_native_compatible(descriptor):
-        return False
-    if not registry.is_model_facing(name):
-        return False
-    if name in legacy_names:
-        return registry.is_override_enabled(name)
-    return True
+    return registry.get_visibility(name, legacy_names=legacy_names)
+
+
+def get_external_tools_visibility() -> Dict[str, Dict[str, Any]]:
+    registry = get_external_tool_registry()
+    legacy_names = _get_legacy_tool_names_set()
+    names = set(legacy_names)
+    names.update(d.name for d in registry.list_all_descriptors())
+    return {name: registry.get_visibility(name, legacy_names=legacy_names) for name in sorted(names)}
+
+
+def is_external_tool_exposed(name: str) -> bool:
+    """Return True when an external tool is visible in the merged tool surface."""
+    return bool(get_external_tool_visibility(name).get("exposed"))
 
 
 def get_all_tools() -> list:
@@ -141,11 +148,35 @@ def get_all_tools() -> list:
             continue
         if name in legacy_names:
             if registry.is_override_enabled(name):
+                schema.setdefault("metadata", {})
+                schema["metadata"].update(
+                    {
+                        "source": "external_tools_repo",
+                        "tool_source": "external_tools_repo",
+                        "schema_source": "external_tools_repo",
+                        "execution_source": "external_tools_repo",
+                        "external_tool": True,
+                        "external_override": True,
+                        "external_shadowed_by_legacy": False,
+                    }
+                )
                 result = [item for item in result if _extract_tool_schema_name(item) != name]
                 result.append(schema)
             else:
                 continue
         else:
+            schema.setdefault("metadata", {})
+            schema["metadata"].update(
+                {
+                    "source": "external_tools_repo",
+                    "tool_source": "external_tools_repo",
+                    "schema_source": "external_tools_repo",
+                    "execution_source": "external_tools_repo",
+                    "external_tool": True,
+                    "external_override": False,
+                    "external_shadowed_by_legacy": False,
+                }
+            )
             result.append(schema)
     return result
 
@@ -221,10 +252,22 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
 
     if registry.has_tool(name, include_disabled=True) and registry.is_override_enabled(name):
         external_result = await registry.execute_tool(name, **kwargs)
+        visibility = registry.get_visibility(name, legacy_names=legacy_names)
         return ToolResult(
             success=external_result.success,
             content=external_result.content,
             error=external_result.error,
+            metadata={
+                "tool_source": "external_tools_repo",
+                "schema_source": visibility["schema_source"],
+                "execution_source": "external_tools_repo",
+                "external_tool": True,
+                "external_override": bool(visibility["override_enabled"] and visibility["legacy_name"]),
+                "external_shadowed_by_legacy": False,
+                "allow_override": visibility["allow_override"],
+                "tool_id": visibility["tool_id"],
+                "descriptor_source_file": visibility["descriptor_source_file"],
+            },
         )
 
     # Bash/Shell tools
@@ -811,10 +854,22 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
             return ToolResult(success=False, error=f"Tool '{name}' is disabled by external descriptor")
     if registry.has_tool(name, include_disabled=True) and name not in legacy_names:
         external_result = await registry.execute_tool(name, **kwargs)
+        visibility = registry.get_visibility(name, legacy_names=legacy_names)
         return ToolResult(
             success=external_result.success,
             content=external_result.content,
             error=external_result.error,
+            metadata={
+                "tool_source": "external_tools_repo",
+                "schema_source": visibility["schema_source"],
+                "execution_source": "external_tools_repo",
+                "external_tool": True,
+                "external_override": bool(visibility["override_enabled"] and visibility["legacy_name"]),
+                "external_shadowed_by_legacy": False,
+                "allow_override": visibility["allow_override"],
+                "tool_id": visibility["tool_id"],
+                "descriptor_source_file": visibility["descriptor_source_file"],
+            },
         )
 
     return ToolResult(success=False, error=f"Tool {name} not implemented")
@@ -826,6 +881,8 @@ __all__ = [
     "get_tool",
     "get_tool_map",
     "get_tools_schema",
+    "get_external_tool_visibility",
+    "get_external_tools_visibility",
     "is_external_tool_exposed",
     "execute_tool",
     "get_github_tools",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -249,10 +249,10 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
 
     registry = get_external_tool_registry()
     legacy_names = _get_legacy_tool_names_set()
+    visibility = registry.get_visibility(name, legacy_names=legacy_names)
 
-    if registry.has_tool(name, include_disabled=True) and registry.is_override_enabled(name):
+    if visibility.get("exposed") and visibility.get("legacy_name") and visibility.get("override_enabled"):
         external_result = await registry.execute_tool(name, **kwargs)
-        visibility = registry.get_visibility(name, legacy_names=legacy_names)
         return ToolResult(
             success=external_result.success,
             content=external_result.content,
@@ -850,27 +850,59 @@ async def execute_tool(name: str, **kwargs) -> ToolResult:
         return ToolResult(success="Error" not in result, content=result)
     
     if registry.has_tool(name, include_disabled=True):
-        if not registry.is_tool_enabled(name):
-            return ToolResult(success=False, error=f"Tool '{name}' is disabled by external descriptor")
-    if registry.has_tool(name, include_disabled=True) and name not in legacy_names:
-        external_result = await registry.execute_tool(name, **kwargs)
         visibility = registry.get_visibility(name, legacy_names=legacy_names)
-        return ToolResult(
-            success=external_result.success,
-            content=external_result.content,
-            error=external_result.error,
-            metadata={
-                "tool_source": "external_tools_repo",
-                "schema_source": visibility["schema_source"],
-                "execution_source": "external_tools_repo",
-                "external_tool": True,
-                "external_override": bool(visibility["override_enabled"] and visibility["legacy_name"]),
-                "external_shadowed_by_legacy": False,
-                "allow_override": visibility["allow_override"],
-                "tool_id": visibility["tool_id"],
-                "descriptor_source_file": visibility["descriptor_source_file"],
-            },
-        )
+        if not visibility.get("enabled"):
+            return ToolResult(
+                success=False,
+                error=f"Tool '{name}' is disabled by external descriptor",
+                metadata={
+                    "external_tool": True,
+                    "external_descriptor_present": True,
+                    "tool_source": visibility.get("execution_source"),
+                    "schema_source": visibility.get("schema_source"),
+                    "execution_source": visibility.get("execution_source"),
+                    "external_shadowed_by_legacy": visibility.get("external_shadowed_by_legacy"),
+                    "external_shadow_reason": visibility.get("shadow_reason"),
+                    "tool_id": visibility.get("tool_id"),
+                    "descriptor_source_file": visibility.get("descriptor_source_file"),
+                },
+            )
+        if name not in legacy_names:
+            if not visibility.get("exposed"):
+                reason = visibility.get("shadow_reason") or "not_exposed"
+                return ToolResult(
+                    success=False,
+                    error=f"External tool '{name}' is not exposed for native runtime: {reason}",
+                    metadata={
+                        "external_tool": True,
+                        "external_descriptor_present": True,
+                        "tool_source": visibility.get("execution_source"),
+                        "schema_source": visibility.get("schema_source"),
+                        "execution_source": visibility.get("execution_source"),
+                        "external_shadowed_by_legacy": visibility.get("external_shadowed_by_legacy"),
+                        "external_shadow_reason": reason,
+                        "allow_override": visibility.get("allow_override"),
+                        "tool_id": visibility.get("tool_id"),
+                        "descriptor_source_file": visibility.get("descriptor_source_file"),
+                    },
+                )
+            external_result = await registry.execute_tool(name, **kwargs)
+            return ToolResult(
+                success=external_result.success,
+                content=external_result.content,
+                error=external_result.error,
+                metadata={
+                    "tool_source": "external_tools_repo",
+                    "schema_source": visibility["schema_source"],
+                    "execution_source": "external_tools_repo",
+                    "external_tool": True,
+                    "external_override": bool(visibility["override_enabled"] and visibility["legacy_name"]),
+                    "external_shadowed_by_legacy": False,
+                    "allow_override": visibility["allow_override"],
+                    "tool_id": visibility["tool_id"],
+                    "descriptor_source_file": visibility["descriptor_source_file"],
+                },
+            )
 
     return ToolResult(success=False, error=f"Tool {name} not implemented")
 

--- a/src/runtime/capability_registry.py
+++ b/src/runtime/capability_registry.py
@@ -287,7 +287,7 @@ class _CapabilityBuilder:
 
     def _register_tools(self) -> None:
         try:
-            from src import get_tools_schema, is_external_tool_exposed
+            from src import get_tools_schema, get_external_tool_visibility
             from src.tools_external import get_external_tool_registry
 
             external_registry = get_external_tool_registry()
@@ -299,8 +299,9 @@ class _CapabilityBuilder:
                 if not tool_name:
                     continue
 
+                visibility = get_external_tool_visibility(tool_name)
                 external_descriptor = (
-                    external_registry.get_descriptor(tool_name) if is_external_tool_exposed(tool_name) else None
+                    external_registry.get_descriptor(tool_name) if visibility.get("exposed") else None
                 )
 
                 if external_descriptor:
@@ -316,6 +317,12 @@ class _CapabilityBuilder:
                     metadata = {
                         **external_metadata,
                         "external_tool": True,
+                        "tool_source": "external_tools_repo",
+                        "schema_source": "external_tools_repo",
+                        "execution_source": "external_tools_repo",
+                        "external_override": bool(visibility["override_enabled"] and visibility["legacy_name"]),
+                        "external_shadowed_by_legacy": False,
+                        "allow_override": visibility["allow_override"],
                         "tool_name": tool_name,
                         "tool_id": external_descriptor.tool_id,
                         "description": external_descriptor.description or _extract_tool_description(tool_schema),
@@ -328,6 +335,7 @@ class _CapabilityBuilder:
                         "mutation": external_descriptor.mutation,
                         "risk_level": external_descriptor.risk_level,
                         "declaration_only": True,
+                        "descriptor_source_file": visibility["descriptor_source_file"],
                     }
                     if "source" in external_metadata:
                         metadata.setdefault("descriptor_source", external_metadata["source"])
@@ -341,8 +349,25 @@ class _CapabilityBuilder:
                         "tool_name": tool_name,
                         "description": _extract_tool_description(tool_schema),
                         "declaration_only": True,
+                        "tool_source": "legacy_builtin",
+                        "schema_source": "legacy_builtin",
+                        "execution_source": "legacy_builtin",
+                        "external_tool": False,
                         **dict(tool_schema.get("metadata") or {}),
                     }
+                    if visibility.get("exists"):
+                        metadata.update(
+                            {
+                                "external_descriptor_present": visibility["exists"],
+                                "external_descriptor_enabled": visibility["enabled"],
+                                "external_allow_override": visibility["allow_override"],
+                                "external_native_compatible": visibility["native_compatible"],
+                                "external_model_facing": visibility["model_facing"],
+                                "external_shadowed_by_legacy": visibility["external_shadowed_by_legacy"],
+                                "external_shadow_reason": visibility["shadow_reason"],
+                                "external_descriptor_source_file": visibility["descriptor_source_file"],
+                            }
+                        )
                     source_ref = "src.__init__.get_tools_schema"
                     requires_identity_binding = False
 

--- a/src/tools_external/contracts.py
+++ b/src/tools_external/contracts.py
@@ -19,6 +19,8 @@ KNOWN_DESCRIPTOR_KEYS = {
     "mutation",
     "risk_level",
     "enabled",
+    "allow_override",
+    "model_facing",
 }
 
 
@@ -122,6 +124,11 @@ def descriptor_from_mapping(data: dict, source_file: str | None = None) -> ToolD
         metadata.setdefault("requires_identity_binding", requires_identity_binding)
     if "opencode_name" in data:
         metadata.setdefault("opencode_name", _as_optional_string(data.get("opencode_name")))
+    allow_override = _as_bool(data.get("allow_override", metadata.get("allow_override")), default=False)
+    metadata["allow_override"] = allow_override
+    model_facing_raw = data.get("model_facing", metadata.get("model_facing", None))
+    if model_facing_raw is not None:
+        metadata["model_facing"] = _as_bool(model_facing_raw, default=True)
     if source_file:
         metadata["_source_file"] = source_file
 

--- a/src/tools_external/manifest_loader.py
+++ b/src/tools_external/manifest_loader.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any, Optional
 
-from .contracts import ToolDescriptor, descriptor_from_mapping, is_descriptor_native_compatible
+from .contracts import ToolDescriptor, descriptor_from_mapping
 
 logger = logging.getLogger(__name__)
 
@@ -103,8 +103,6 @@ def load_tool_descriptors(tools_dir: Optional[Path] = None) -> list[ToolDescript
                 descriptor = descriptor_from_mapping(item, source_file=str(manifest))
             except Exception as exc:
                 logger.warning("Invalid descriptor in %s: %s", manifest, exc)
-                continue
-            if not is_descriptor_native_compatible(descriptor):
                 continue
             descriptors.append(descriptor)
 

--- a/src/tools_external/registry.py
+++ b/src/tools_external/registry.py
@@ -132,7 +132,7 @@ class ExternalToolRegistry:
         else:
             schema_source = "legacy_builtin" if legacy_name else "none"
             execution_source = "legacy_builtin" if legacy_name else "none"
-            shadowed = False
+            shadowed = bool(legacy_name and descriptor is not None)
             shadow_reason = None
             if not enabled:
                 shadow_reason = "disabled"
@@ -141,7 +141,6 @@ class ExternalToolRegistry:
             elif not model_facing:
                 shadow_reason = "model_facing_false"
             elif legacy_name and not allow_override:
-                shadowed = True
                 shadow_reason = "allow_override_not_enabled"
 
         base.update(

--- a/src/tools_external/registry.py
+++ b/src/tools_external/registry.py
@@ -10,6 +10,15 @@ from .runner import execute_python_entrypoint
 
 logger = logging.getLogger(__name__)
 
+def _metadata_bool(value, default=False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
 
 class ExternalToolRegistry:
     def __init__(self, tools_dir: Optional[Path] = None, descriptors: Optional[list[ToolDescriptor]] = None):
@@ -67,7 +76,7 @@ class ExternalToolRegistry:
         descriptor = self.get_descriptor(name)
         if not descriptor:
             return False
-        return descriptor.metadata.get("model_facing", True) is not False
+        return _metadata_bool(descriptor.metadata.get("model_facing"), default=True)
 
     def is_override_enabled(self, name: str) -> bool:
         descriptor = self.get_descriptor(name)
@@ -77,8 +86,85 @@ class ExternalToolRegistry:
             descriptor.enabled
             and is_descriptor_native_compatible(descriptor)
             and self.is_model_facing(name)
-            and descriptor.metadata.get("allow_override") is True
+            and _metadata_bool(descriptor.metadata.get("allow_override"), default=False)
         )
+
+    def get_visibility(self, name: str, *, legacy_names: set[str] | None = None) -> dict:
+        legacy_names = legacy_names or set()
+        descriptor = self.get_descriptor(name)
+        legacy_name = name in legacy_names
+        base = {
+            "name": name,
+            "exists": descriptor is not None,
+            "enabled": False,
+            "native_compatible": False,
+            "model_facing": False,
+            "legacy_name": legacy_name,
+            "allow_override": False,
+            "override_enabled": False,
+            "exposed": False,
+            "schema_source": "legacy_builtin" if legacy_name else "none",
+            "execution_source": "legacy_builtin" if legacy_name else "none",
+            "external_shadowed_by_legacy": False,
+            "shadow_reason": None,
+            "descriptor_source_file": None,
+            "tool_id": None,
+            "domain": None,
+            "risk_level": None,
+            "mutation": None,
+            "opencode_name": None,
+        }
+        if descriptor is None:
+            return base
+
+        enabled = bool(descriptor.enabled)
+        native_compatible = is_descriptor_native_compatible(descriptor)
+        model_facing = self.is_model_facing(name)
+        allow_override = _metadata_bool(descriptor.metadata.get("allow_override"), default=False)
+        override_enabled = bool(enabled and native_compatible and model_facing and allow_override)
+        exposed = bool(enabled and native_compatible and model_facing and (not legacy_name or override_enabled))
+
+        if exposed:
+            schema_source = "external_tools_repo"
+            execution_source = "external_tools_repo"
+            shadowed = False
+            shadow_reason = None
+        else:
+            schema_source = "legacy_builtin" if legacy_name else "none"
+            execution_source = "legacy_builtin" if legacy_name else "none"
+            shadowed = False
+            shadow_reason = None
+            if not enabled:
+                shadow_reason = "disabled"
+            elif not native_compatible:
+                shadow_reason = "runtime_incompatible"
+            elif not model_facing:
+                shadow_reason = "model_facing_false"
+            elif legacy_name and not allow_override:
+                shadowed = True
+                shadow_reason = "allow_override_not_enabled"
+
+        base.update(
+            {
+                "enabled": enabled,
+                "native_compatible": native_compatible,
+                "model_facing": model_facing,
+                "allow_override": allow_override,
+                "override_enabled": override_enabled,
+                "exposed": exposed,
+                "schema_source": schema_source,
+                "execution_source": execution_source,
+                "external_shadowed_by_legacy": shadowed,
+                "shadow_reason": shadow_reason,
+                "descriptor_source_file": descriptor.metadata.get("_source_file"),
+                "tool_id": descriptor.tool_id,
+                "domain": descriptor.domain,
+                "risk_level": descriptor.risk_level,
+                "mutation": descriptor.mutation,
+                "opencode_name": descriptor.opencode_name,
+            }
+        )
+        return base
 
     async def execute_tool(self, name: str, **kwargs) -> ExternalToolExecutionResult:
         descriptor = self.get_descriptor(name)

--- a/tests/test_external_tools_registry.py
+++ b/tests/test_external_tools_registry.py
@@ -196,9 +196,55 @@ def test_runtime_compat_without_native_is_skipped(monkeypatch, tmp_path):
     reset_external_tool_registry_cache()
 
     registry = get_external_tool_registry(force_reload=True)
+    assert registry.get_descriptor("context_echo") is not None
+    visibility = registry.get_visibility("context_echo", legacy_names=set())
+    assert visibility["exists"] is True
+    assert visibility["native_compatible"] is False
+    assert visibility["exposed"] is False
+    assert visibility["shadow_reason"] == "runtime_incompatible"
     assert "context_echo" not in registry.get_tool_names()
     names = {_schema_name(item) for item in get_tools_schema() if isinstance(item, dict)}
     assert "context_echo" not in names
+
+
+@pytest.mark.asyncio
+async def test_runtime_incompatible_append_only_is_not_directly_executed(monkeypatch, tmp_path):
+    from src import execute_tool
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, runtime_compat=["opencode"])
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+
+    result = await execute_tool("context_echo", text="hello")
+    assert result.success is False
+    assert "runtime_incompatible" in (result.error or "")
+    assert result.to_dict()["metadata"]["external_shadow_reason"] == "runtime_incompatible"
+
+
+@pytest.mark.asyncio
+async def test_model_facing_false_append_only_is_not_directly_executed(monkeypatch, tmp_path):
+    from src import execute_tool, get_tools_schema
+    from src.tools_external import get_external_tool_registry, reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(
+        tmp_path,
+        name="context_hidden",
+        runtime_compat=["native"],
+        metadata={"model_facing": "false"},
+    )
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+
+    names = {_schema_name(item) for item in get_tools_schema() if isinstance(item, dict)}
+    assert "context_hidden" not in names
+    registry = get_external_tool_registry(force_reload=True)
+    visibility = registry.get_visibility("context_hidden", legacy_names=set())
+    assert visibility["shadow_reason"] == "model_facing_false"
+
+    result = await execute_tool("context_hidden", text="hello")
+    assert result.success is False
+    assert "model_facing_false" in (result.error or "")
 
 
 def test_tools_subdir_yaml_is_loaded(monkeypatch, tmp_path):
@@ -624,3 +670,39 @@ def test_shadowed_legacy_capability_reports_diagnostics(monkeypatch, tmp_path):
     assert cap.metadata["external_shadowed_by_legacy"] is True
     assert cap.metadata["external_shadow_reason"] == "allow_override_not_enabled"
     assert cap.metadata["external_allow_override"] is False
+
+
+def test_runtime_incompatible_legacy_duplicate_capability_diagnostics(monkeypatch, tmp_path):
+    from src.runtime.capability_registry import build_default_capability_registry
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, name="git_status", runtime_compat=["opencode"])
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+
+    cap = next(c for c in build_default_capability_registry().list_by_type("tool") if c.name == "git_status")
+    assert cap.source_ref == "src.__init__.get_tools_schema"
+    assert cap.metadata["tool_source"] == "legacy_builtin"
+    assert cap.metadata["external_descriptor_present"] is True
+    assert cap.metadata["external_native_compatible"] is False
+    assert cap.metadata["external_shadowed_by_legacy"] is True
+    assert cap.metadata["external_shadow_reason"] == "runtime_incompatible"
+
+
+def test_model_facing_false_legacy_duplicate_capability_diagnostics(monkeypatch, tmp_path):
+    from src.runtime.capability_registry import build_default_capability_registry
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(
+        tmp_path,
+        name="git_status",
+        runtime_compat=["native"],
+        metadata={"model_facing": "false", "allow_override": "true"},
+    )
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+
+    cap = next(c for c in build_default_capability_registry().list_by_type("tool") if c.name == "git_status")
+    assert cap.source_ref == "src.__init__.get_tools_schema"
+    assert cap.metadata["external_shadowed_by_legacy"] is True
+    assert cap.metadata["external_shadow_reason"] == "model_facing_false"

--- a/tests/test_external_tools_registry.py
+++ b/tests/test_external_tools_registry.py
@@ -555,3 +555,72 @@ def test_external_capability_metadata_preserves_contract_fields(monkeypatch, tmp
     assert cap.metadata["opencode_name"] == "efp_context_echo"
     assert cap.metadata["mutation"] is False
     assert cap.metadata["risk_level"] == "low"
+
+
+def test_top_level_allow_override_is_normalized(monkeypatch, tmp_path):
+    from src.tools_external import get_external_tool_registry
+
+    tools_dir = _write_tools_repo(tmp_path, name="run_command", extra_fields={"allow_override": True})
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    registry = get_external_tool_registry(force_reload=True)
+    assert registry.is_override_enabled("run_command") is True
+    descriptor = registry.get_descriptor("run_command")
+    assert descriptor.metadata["allow_override"] is True
+
+
+def test_metadata_string_allow_override_is_normalized(monkeypatch, tmp_path):
+    from src.tools_external import get_external_tool_registry
+
+    tools_dir = _write_tools_repo(tmp_path, name="run_command", metadata={"allow_override": "true"})
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    registry = get_external_tool_registry(force_reload=True)
+    assert registry.is_override_enabled("run_command") is True
+
+
+def test_model_facing_string_false_hides_tool(monkeypatch, tmp_path):
+    from src import get_tools_schema
+    from src.tools_external import get_external_tool_registry, reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, name="run_command", metadata={"model_facing": "false", "allow_override": "true"})
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    registry = get_external_tool_registry(force_reload=True)
+    assert registry.is_model_facing("run_command") is False
+    assert registry.is_override_enabled("run_command") is False
+    schema = next(item for item in get_tools_schema() if _schema_name(item) == "run_command")
+    assert schema["function"]["description"] != "Echo input for tests."
+
+
+@pytest.mark.asyncio
+async def test_external_execution_result_metadata_reports_source(monkeypatch, tmp_path):
+    from src import execute_tool
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(
+        tmp_path,
+        name="run_command",
+        metadata={"allow_override": True},
+        entrypoint_body="async def execute(cmd='', **kwargs):\n    return {'override': True, 'cmd': cmd}\n",
+    )
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    result = await execute_tool("run_command", cmd="not-a-real-command")
+    meta = result.to_dict()["metadata"]
+    assert meta["tool_source"] == "external_tools_repo"
+    assert meta["external_override"] is True
+
+
+def test_shadowed_legacy_capability_reports_diagnostics(monkeypatch, tmp_path):
+    from src.runtime.capability_registry import build_default_capability_registry
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, name="git_status")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+
+    registry = build_default_capability_registry()
+    cap = next(item for item in registry.list_by_type("tool") if item.name == "git_status")
+    assert cap.source_ref == "src.__init__.get_tools_schema"
+    assert cap.metadata["external_shadowed_by_legacy"] is True
+    assert cap.metadata["external_shadow_reason"] == "allow_override_not_enabled"
+    assert cap.metadata["external_allow_override"] is False

--- a/tests/test_native_external_tools_smoke.py
+++ b/tests/test_native_external_tools_smoke.py
@@ -1,0 +1,156 @@
+import json
+
+import pytest
+
+
+@pytest.fixture
+def native_external_fixture(tmp_path, monkeypatch):
+    tools_repo = tmp_path / "tools_repo"
+    (tools_repo / "tools" / "context").mkdir(parents=True)
+    (tools_repo / "tools" / "git").mkdir(parents=True)
+    (tools_repo / "python" / "efp_tools").mkdir(parents=True)
+
+    (tools_repo / "manifest.yaml").write_text(
+        'repo: engineering-flow-platform-tools\nversion: "0.1.0"\nschema_version: t04\n',
+        encoding="utf-8",
+    )
+    (tools_repo / "tools" / "context" / "context_echo.yaml").write_text(
+        """
+name: context_echo
+description: External context echo
+python_entrypoint: ignored.module:ignored
+enabled: true
+runtime_compat: [native, opencode]
+metadata:
+  source: fixture
+input_schema:
+  type: object
+  properties:
+    text:
+      type: string
+""",
+        encoding="utf-8",
+    )
+    (tools_repo / "tools" / "context" / "context_read_ref.yaml").write_text(
+        """
+name: context_read_ref
+description: External context read ref override
+python_entrypoint: ignored.module:ignored
+enabled: true
+allow_override: true
+runtime_compat: [native, opencode]
+risk_level: low
+mutation: false
+policy_tags: [context, read_only]
+input_schema:
+  type: object
+  properties:
+    ref:
+      type: string
+""",
+        encoding="utf-8",
+    )
+    (tools_repo / "tools" / "git" / "git_status.yaml").write_text(
+        """
+name: git_status
+description: External git status should be shadowed
+python_entrypoint: ignored.module:ignored
+enabled: true
+runtime_compat: [native, opencode]
+""",
+        encoding="utf-8",
+    )
+    (tools_repo / "python" / "efp_tools" / "__init__.py").write_text("", encoding="utf-8")
+    (tools_repo / "python" / "efp_tools" / "runner.py").write_text(
+        """
+import json
+
+async def execute_tool_async(*, tools_dir, tool, args=None, context=None):
+    return {
+        "success": True,
+        "content": json.dumps({
+            "tool": tool,
+            "args": args or {},
+            "runtime_type": (context or {}).get("runtime_type"),
+            "source": "external_runner",
+        }),
+    }
+""",
+        encoding="utf-8",
+    )
+
+    skills_repo = tmp_path / "skills_repo"
+    (skills_repo / "smoke-skill").mkdir(parents=True)
+    (skills_repo / "smoke-skill" / "skill.md").write_text(
+        """---
+name: smoke-skill
+description: Native smoke skill
+version: 1.0.0
+owner: test
+triggers:
+  - /smoke-skill
+tools:
+  - context_echo
+  - context_read_ref
+---
+Smoke body.
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_repo))
+    monkeypatch.setenv("EFP_SKILLS_DIR", str(skills_repo))
+    from src.tools_external import reset_external_tool_registry_cache
+
+    reset_external_tool_registry_cache()
+    return tmp_path
+
+
+def _schema_name(schema):
+    return (schema.get("function") or {}).get("name")
+
+
+@pytest.mark.asyncio
+async def test_native_external_tools_smoke_schema_execution_and_capability(native_external_fixture):
+    from src import execute_tool, get_tools_schema
+    from src.runtime.capability_registry import build_default_capability_registry
+
+    schemas = get_tools_schema()
+    names = {_schema_name(item) for item in schemas if isinstance(item, dict)}
+    assert "context_echo" in names
+
+    context_read_ref_schema = next(item for item in schemas if _schema_name(item) == "context_read_ref")
+    assert context_read_ref_schema["function"]["description"] == "External context read ref override"
+
+    git_status_schema = next(item for item in schemas if _schema_name(item) == "git_status")
+    assert git_status_schema["function"]["description"] != "External git status should be shadowed"
+
+    echo_result = await execute_tool("context_echo", text="hello")
+    assert echo_result.success is True
+    assert echo_result.to_dict()["metadata"]["tool_source"] == "external_tools_repo"
+
+    read_ref_result = await execute_tool("context_read_ref", ref="ctx://x")
+    assert read_ref_result.success is True
+    payload = json.loads(read_ref_result.content)
+    assert payload["source"] == "external_runner"
+    assert read_ref_result.to_dict()["metadata"]["external_override"] is True
+
+    registry = build_default_capability_registry()
+    caps = {cap.name: cap for cap in registry.list_by_type("tool")}
+    assert caps["context_echo"].metadata["tool_source"] == "external_tools_repo"
+    assert caps["context_echo"].metadata["external_override"] is False
+    assert caps["context_read_ref"].metadata["tool_source"] == "external_tools_repo"
+    assert caps["context_read_ref"].metadata["external_override"] is True
+    assert caps["git_status"].metadata["tool_source"] == "legacy_builtin"
+    assert caps["git_status"].metadata["external_shadowed_by_legacy"] is True
+    assert caps["git_status"].metadata["external_shadow_reason"] == "allow_override_not_enabled"
+
+
+def test_native_external_skills_smoke_loads_from_env_dir(native_external_fixture, tmp_path):
+    from src.skills.registry import SkillRegistry
+
+    registry = SkillRegistry(project_skills_dir=None, user_skills_dir=tmp_path / "user-skills")
+    assert registry.load_skills() == 1
+    skill = registry.get_skill("smoke-skill")
+    assert skill is not None
+    assert skill.tools == ["context_echo", "context_read_ref"]


### PR DESCRIPTION
### Motivation
- Ensure native runtime reliably honors external descriptors' `allow_override` and `model_facing` semantics (top-level or in `metadata`) to avoid silent mis-routing between external runner and legacy implementations. 
- Make external-vs-legacy visibility explicit and machine-readable so Portal/reviewer can decide if an external repo truly took over or was merely shadowed. 
- Add a lightweight native smoke that exercises `/app/tools` + `/app/skills` flow to prove schema exposure, execution routing, and capability metadata.

### Description
- Normalize descriptor booleans and model_facing handling in `src/tools_external/contracts.py` by adding `allow_override`/`model_facing` to `KNOWN_DESCRIPTOR_KEYS` and writing canonical booleans back into `metadata` when present; `model_facing` is only written if present. (file changed: `src/tools_external/contracts.py`)
- Add `_metadata_bool` helper and `get_visibility(name, legacy_names=...)` to `src/tools_external/registry.py`, and switch `is_model_facing` / `is_override_enabled` to use canonical boolean parsing; `get_visibility` emits a serializable diagnostic dict (schema/execution source, override/shadow flags, shadow reason, descriptor source file, tool_id, domain, risk_level, etc.). (file changed: `src/tools_external/registry.py`)
- Extend `ToolResult` in `src/__init__.py` with optional `metadata` (backward compatible: only returned in `to_dict()` when non-empty), add `get_external_tool_visibility` / `get_external_tools_visibility`, make `is_external_tool_exposed` delegate to visibility, annotate merged external schemas with source/override metadata, and attach metadata to `ToolResult` for both external-override and external append-only execution branches so callers can see `tool_source`, `schema_source`, `execution_source`, `external_override`, `allow_override`, `tool_id`, and descriptor source file. (file changed: `src/__init__.py`)
- Update `_register_tools()` in `src/runtime/capability_registry.py` to consume `get_external_tool_visibility()` and populate capability metadata for external capabilities and legacy capabilities with explicit `tool_source`/`schema_source`/`execution_source`, `external_override`, `external_shadowed_by_legacy`, `external_shadow_reason`, `external_allow_override`, and `descriptor_source_file` diagnostics. (file changed: `src/runtime/capability_registry.py`)
- Add a deterministic native smoke test `tests/test_native_external_tools_smoke.py` that builds a T04-like tools repo (manifest, descriptors, python runner) and an external-skills dir, sets `EFP_TOOLS_DIR` / `EFP_SKILLS_DIR`, resets registry cache, and asserts schema exposure, execution routing (external runner), capability metadata for append-only/override/shadow cases, and SkillRegistry loading. (file added: `tests/test_native_external_tools_smoke.py`)
- Augment `tests/test_external_tools_registry.py` with tests that verify top-level `allow_override` normalization, metadata string normalization, `model_facing` string false behavior, external execution result metadata, and shadow diagnostics for legacy duplicates without `allow_override`. (file changed: `tests/test_external_tools_registry.py`)

### Testing
- Installed dependencies: `python -m pip install -r requirements.txt` succeeded. 
- Ran targeted full test command: `python -m pytest -q tests/test_external_tools_registry.py tests/test_runtime_capability_contract.py tests/test_external_tools_loader.py tests/test_skill_registry_external_dir.py tests/test_native_external_tools_smoke.py`. Result: `52 passed, 1 skipped`. 
- All modified/new tests passed; no unrelated test regressions observed. 

Evidence summary: modified files — `src/tools_external/contracts.py`, `src/tools_external/registry.py`, `src/__init__.py`, `src/runtime/capability_registry.py`, `tests/test_external_tools_registry.py` (updated), and `tests/test_native_external_tools_smoke.py` (new); executed the install and pytest commands above and received the green test output reported. 

Proven outcomes: native external override is demonstrably routed to external runner and capability metadata marks `external_override=True`; legacy-duplicate descriptors without `allow_override` remain legacy and produce `external_shadowed_by_legacy=True` with a shadow reason; native smoke covers the `/app/tools` + `/app/skills` flow and validates schema/execution/capability and skill loading.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f965ec83b4832a8c7f89e8c5ef7e3d)