### PR TITLE
Finalize P2: propagate capability_id into tool_metadata and add strict/cancel/governance tests

### DIFF
--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -682,6 +682,14 @@ def _normalize_tool_execution_outcome(
         payload["task_type"] = task_type or "tool_task"
         payload["task_boundary"] = True
     if tool_metadata:
+        if capability.get("capability_id"):
+            tool_metadata.setdefault("capability_id", capability.get("capability_id"))
+        if capability.get("capability_type"):
+            tool_metadata.setdefault("capability_type", capability.get("capability_type"))
+        if not tool_metadata.get("tool_id") and capability.get("capability_id"):
+            tool_metadata["tool_id"] = capability.get("capability_id")
+        if not tool_metadata.get("policy_tags") and capability.get("policy_tags"):
+            tool_metadata["policy_tags"] = capability.get("policy_tags")
         payload["tool_metadata"] = tool_metadata
         payload["tool_source"] = tool_metadata.get("tool_source")
         payload["external_tool"] = tool_metadata.get("external_tool")
@@ -690,7 +698,7 @@ def _normalize_tool_execution_outcome(
         payload["governance_checked"] = tool_metadata.get("governance_checked")
         payload["blocked_by_governance"] = tool_metadata.get("blocked_by_governance")
         artifacts = dict(artifacts)
-        artifacts.setdefault("tool_metadata", tool_metadata)
+        artifacts["tool_metadata"] = tool_metadata
 
     return {
         "success": bool(normalized["success"]),

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -4337,3 +4337,202 @@ async def test_execution_bus_preserves_tool_metadata_and_emits_governance_event(
     ev = next(e for e in result.runtime_events if isinstance(e, dict) and e.get("event_type")=="tool.governance.audit")
     assert ev.get("state") == "blocked"
     assert ev.get("detail_payload", {}).get("capability_id")
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_allowed_external_tool_metadata_emits_allowed_governance_event(monkeypatch):
+    from src import ToolResult
+    from src.runtime.capability_registry import CapabilityDescriptor
+    from src.runtime.contracts import make_execution_request
+    from src.runtime.execution_bus import build_default_execution_bus
+
+    descriptor = CapabilityDescriptor(
+        capability_id="efp.tool.external.write",
+        type="tool",
+        name="external_write",
+        policy_tags=["write"],
+        metadata={
+            "external_tool": True,
+            "tool_source": "external_tools_repo",
+            "tool_name": "external_write",
+            "mutation": True,
+            "risk_level": "high",
+            "tool_id": "efp.tool.external.write",
+        },
+    )
+
+    class _Registry:
+        def get(self, capability_id):
+            if capability_id in {"tool:external_write", "efp.tool.external.write"}:
+                return descriptor
+            return None
+
+        def list_by_type(self, capability_type):
+            if capability_type == "tool":
+                return [descriptor]
+            return []
+
+    monkeypatch.setattr("src.runtime.execution_bus.get_capability_registry", lambda: _Registry())
+    monkeypatch.setattr("src.runtime.governance_bus.get_capability_registry", lambda: _Registry())
+
+    async def _fake_execute(tool_name, **kwargs):
+        return ToolResult(
+            success=True,
+            content="write completed",
+            metadata={
+                "external_tool": True,
+                "mutation": True,
+                "risk_level": "high",
+                "policy_tags": ["write"],
+                "tool_source": "external_tools_repo",
+                "governance_checked": True,
+                "governance_rule": "external_mutation_requires_explicit_allow",
+                "permission_decision": kwargs.get("_permission_decision"),
+                "approval_ref": kwargs.get("_approval_ref"),
+                "tool_id": "efp.tool.external.write",
+            },
+        )
+
+    bus = build_default_execution_bus(execute_tool_func=_fake_execute)
+    request = make_execution_request(
+        request_id="req-allowed",
+        source_type="api",
+        execution_type="tool",
+        input_payload={"tool_name": "external_write", "kwargs": {}},
+        metadata={
+            "governance_allow_mutation": True,
+            "permission_decision": "approved",
+            "approval_ref": "approval-1",
+        },
+    )
+
+    result = await bus.execute(request)
+
+    assert result.status == "success"
+    tool_metadata = result.output_payload.get("tool_metadata") or {}
+    assert tool_metadata["external_tool"] is True
+    assert tool_metadata["governance_checked"] is True
+    assert tool_metadata.get("blocked_by_governance") is not True
+    assert tool_metadata["capability_id"] == "efp.tool.external.write"
+    assert tool_metadata["tool_id"] == "efp.tool.external.write"
+
+    artifacts_metadata = result.artifacts.get("tool_metadata") or {}
+    assert artifacts_metadata["capability_id"] == "efp.tool.external.write"
+
+    event = next(
+        e for e in result.runtime_events
+        if isinstance(e, dict) and e.get("event_type") == "tool.governance.audit"
+    )
+    assert event["state"] == "allowed"
+    detail = event.get("detail_payload") or {}
+    assert detail["tool_name"] == "external_write"
+    assert detail["tool_id"] == "efp.tool.external.write"
+    assert detail["capability_id"] == "efp.tool.external.write"
+    assert detail["permission_decision"] == "approved"
+    assert detail["approval_ref"] == "approval-1"
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_tool_task_preserves_tool_metadata_and_emits_governance_event(monkeypatch):
+    from src import ToolResult
+    from src.runtime.capability_registry import CapabilityDescriptor
+    from src.runtime.contracts import make_execution_request
+    from src.runtime.execution_bus import build_default_execution_bus
+
+    descriptor = CapabilityDescriptor(
+        capability_id="efp.tool.external.write",
+        type="tool",
+        name="external_write",
+        policy_tags=["write"],
+        metadata={
+            "external_tool": True,
+            "tool_source": "external_tools_repo",
+            "tool_name": "external_write",
+            "mutation": True,
+            "risk_level": "high",
+            "tool_id": "efp.tool.external.write",
+        },
+    )
+
+    class _Registry:
+        def get(self, capability_id):
+            if capability_id in {"tool:external_write", "efp.tool.external.write"}:
+                return descriptor
+            return None
+
+        def list_by_type(self, capability_type):
+            if capability_type == "tool":
+                return [descriptor]
+            return []
+
+    monkeypatch.setattr("src.runtime.execution_bus.get_capability_registry", lambda: _Registry())
+    monkeypatch.setattr("src.runtime.governance_bus.get_capability_registry", lambda: _Registry())
+
+    async def _fake_execute(tool_name, **kwargs):
+        return ToolResult(
+            success=True,
+            content="task write completed",
+            metadata={
+                "external_tool": True,
+                "mutation": True,
+                "risk_level": "high",
+                "policy_tags": ["write"],
+                "tool_source": "external_tools_repo",
+                "governance_checked": True,
+                "governance_rule": "external_mutation_requires_explicit_allow",
+                "permission_decision": kwargs.get("_permission_decision"),
+                "approval_ref": kwargs.get("_approval_ref"),
+                "tool_id": "efp.tool.external.write",
+            },
+        )
+
+    bus = build_default_execution_bus(execute_tool_func=_fake_execute)
+    request = make_execution_request(
+        request_id="req-task-tool",
+        source_type="api",
+        execution_type="task",
+        input_payload={
+            "task_type": "tool_task",
+            "tool_name": "external_write",
+            "kwargs": {},
+        },
+        metadata={
+            "task_id": "task-tool-external-write",
+            "governance_allow_mutation": True,
+            "permission_decision": "approved",
+            "approval_ref": "approval-task-1",
+        },
+    )
+
+    result = await bus.execute(request)
+
+    assert result.status == "success"
+    assert result.output_payload["task_boundary"] is True
+    assert result.output_payload["task_type"] == "tool_task"
+
+    tool_metadata = result.output_payload.get("tool_metadata") or {}
+    assert tool_metadata["external_tool"] is True
+    assert tool_metadata["governance_checked"] is True
+    assert tool_metadata["capability_id"] == "efp.tool.external.write"
+    assert tool_metadata["tool_id"] == "efp.tool.external.write"
+
+    artifacts_metadata = result.artifacts.get("tool_metadata") or {}
+    assert artifacts_metadata["capability_id"] == "efp.tool.external.write"
+
+    event = next(
+        e for e in result.runtime_events
+        if isinstance(e, dict) and e.get("event_type") == "tool.governance.audit"
+    )
+    assert event["state"] == "allowed"
+    assert event["task_id"] == "task-tool-external-write"
+    detail = event.get("detail_payload") or {}
+    assert detail["tool_name"] == "external_write"
+    assert detail["tool_id"] == "efp.tool.external.write"
+    assert detail["capability_id"] == "efp.tool.external.write"
+
+    assert any(
+        isinstance(e, dict)
+        and e.get("event_type") == "task.tool.completed"
+        and e.get("task_id") == "task-tool-external-write"
+        for e in result.runtime_events
+    )

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -4300,8 +4300,40 @@ async def test_execution_bus_pre_governance_blocked_external_mutation_emits_tool
     result = await bus.execute(req)
     assert result.status == "blocked"
     assert result.output_payload.get("tool_metadata", {}).get("blocked_by_governance") is True
+    assert result.artifacts.get("tool_metadata", {}).get("blocked_by_governance") is True
     events = [e.get("event_type") for e in result.runtime_events if isinstance(e, dict)]
     assert "governance.audit" in events and "tool.governance.audit" in events
     tool_event = next(e for e in result.runtime_events if isinstance(e, dict) and e.get("event_type") == "tool.governance.audit")
     assert tool_event.get("detail_payload", {}).get("tool_id") == "efp.tool.external.write"
     assert tool_event.get("detail_payload", {}).get("capability_id") == "efp.tool.external.write"
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_passes_governance_metadata_to_tool_kwargs(monkeypatch):
+    captured = {}
+    async def _fake(tool_name, **kwargs):
+        captured.update(kwargs)
+        return {"success": True, "content": "ok"}
+
+    bus = build_default_execution_bus(execute_tool_func=_fake)
+    req = make_execution_request(request_id="r", source_type="api", execution_type="tool", input_payload={"tool_name":"context_echo", "kwargs": {}}, metadata={"governance_allow_mutation": True, "permission_decision": "approved", "approval_ref": "approval-1", "audit_ref": "audit-1", "governance_context": {"source": "test"}})
+    await bus.execute(req)
+    assert captured["_governance_allow_mutation"] is True
+    assert captured["_permission_decision"] == "approved"
+    assert captured["_approval_ref"] == "approval-1"
+    assert captured["_audit_ref"] == "audit-1"
+    assert captured["_governance_context"] == {"source": "test"}
+
+
+@pytest.mark.asyncio
+async def test_execution_bus_preserves_tool_metadata_and_emits_governance_event(monkeypatch):
+    async def _fake(*args, **kwargs):
+        return ToolResult(success=False, error="blocked", metadata={"external_tool": True, "blocked_by_governance": True, "mutation": True, "risk_level": "high", "policy_tags": ["write"], "tool_source": "external_tools_repo", "governance_checked": True, "governance_rule": "external_mutation_requires_explicit_allow", "tool_id": "efp.tool.external.write"})
+    bus = build_default_execution_bus(execute_tool_func=_fake)
+    req = make_execution_request(request_id="r", source_type="api", execution_type="tool", input_payload={"tool_name": "external_write", "kwargs": {}})
+    result = await bus.execute(req)
+    assert result.output_payload.get("tool_metadata", {}).get("capability_id")
+    assert result.artifacts.get("tool_metadata", {}).get("capability_id")
+    ev = next(e for e in result.runtime_events if isinstance(e, dict) and e.get("event_type")=="tool.governance.audit")
+    assert ev.get("state") == "blocked"
+    assert ev.get("detail_payload", {}).get("capability_id")

--- a/tests/test_external_tools_registry.py
+++ b/tests/test_external_tools_registry.py
@@ -19,6 +19,11 @@ def _write_tools_repo(
     description="Echo input for tests.",
     runtime_compat=None,
     metadata=None,
+    tool_id="efp.tool.context.echo",
+    mutation=False,
+    risk_level="low",
+    policy_tags=None,
+    enabled=True,
     domain="context",
     manifest_subpath="manifest.yaml",
     entrypoint_body=None,
@@ -27,6 +32,7 @@ def _write_tools_repo(
     runtime_compat = runtime_compat or ["native", "opencode"]
     metadata = metadata or {}
     extra_fields = extra_fields or {}
+    policy_tags = policy_tags or ["read_only"]
     extra_yaml = "".join(f"{key}: {json.dumps(value)}\n" for key, value in extra_fields.items())
 
     tools_dir = tmp_path / "tools_repo"
@@ -41,7 +47,7 @@ def _write_tools_repo(
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text(
         """
-tool_id: efp.tool.context.echo
+tool_id: {tool_id}
 name: {name}
 description: {description}
 python_entrypoint: test_tools.echo:execute
@@ -54,8 +60,11 @@ input_schema:
 output_schema:
   type: object
 runtime_compat: {runtime_compat}
-policy_tags: [read_only]
+policy_tags: {policy_tags}
 domain: {domain}
+mutation: {mutation}
+risk_level: {risk_level}
+enabled: {enabled}
 metadata: {metadata}
 {extra_yaml}
 """.format(
@@ -64,6 +73,11 @@ metadata: {metadata}
             runtime_compat=json.dumps(runtime_compat),
             domain=domain,
             metadata=json.dumps(metadata),
+            tool_id=tool_id,
+            mutation=json.dumps(mutation),
+            risk_level=risk_level,
+            policy_tags=json.dumps(policy_tags),
+            enabled=json.dumps(enabled),
             extra_yaml=extra_yaml,
         ),
         encoding="utf-8",
@@ -457,7 +471,7 @@ async def test_t04_runner_receives_context_and_reserved_args_are_filtered(monkey
     (tools_dir / "tools" / "context" / "context_echo.yaml").write_text(
         """
 name: context_echo
-tool_id: efp.tool.context.echo
+tool_id: {tool_id}
 opencode_name: efp_context_echo
 description: Echo via T04 runner
 domain: context
@@ -706,3 +720,122 @@ def test_model_facing_false_legacy_duplicate_capability_diagnostics(monkeypatch,
     assert cap.source_ref == "src.__init__.get_tools_schema"
     assert cap.metadata["external_shadowed_by_legacy"] is True
     assert cap.metadata["external_shadow_reason"] == "model_facing_false"
+
+
+def test_external_tool_visibility_includes_policy_and_metadata(monkeypatch, tmp_path):
+    from src.tools_external import get_external_tool_registry
+
+    tools_dir = _write_tools_repo(tmp_path, name="external_write", tool_id="efp.tool.external.write", mutation=True, risk_level="high", policy_tags=["write", "jira"], extra_fields={"requires_identity_binding": True}, metadata={"model_facing": True, "custom_key": "custom_value"})
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    registry = get_external_tool_registry(force_reload=True)
+    visibility = registry.get_visibility("external_write", legacy_names=set())
+    assert "write" in visibility["policy_tags"] and "jira" in visibility["policy_tags"]
+    assert visibility["requires_identity_binding"] is True
+    assert visibility["metadata"]["custom_key"] == "custom_value"
+    assert visibility["mutation"] is True
+    assert visibility["risk_level"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_external_mutation_tool_requires_explicit_governance_allow(monkeypatch, tmp_path):
+    import src
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, name="external_write", tool_id="efp.tool.external.write", mutation=True, risk_level="high", policy_tags=["write"])
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    result = await src.execute_tool("external_write")
+    assert result.success is False
+    assert result.metadata["blocked_by_governance"] is True
+    assert result.metadata["governance_rule"] == "external_mutation_requires_explicit_allow"
+
+
+@pytest.mark.asyncio
+async def test_external_mutation_tool_runs_when_explicitly_allowed_and_metadata_preserved(monkeypatch, tmp_path):
+    import src
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, name="external_write", tool_id="efp.tool.external.write", mutation=True, risk_level="high", policy_tags=["write"])
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    result = await src.execute_tool("external_write", _governance_allow_mutation=True, _permission_decision="approved", _approval_ref="approval-1")
+    assert result.success is True
+    assert result.metadata["governance_checked"] is True
+    assert result.metadata["mutation"] is True
+    assert result.metadata["approval_ref"] == "approval-1"
+    assert result.metadata["permission_decision"] == "approved"
+
+
+def test_strict_mode_hides_legacy_only_tools_from_schema(monkeypatch, tmp_path):
+    import src
+    from src.tools_external import reset_external_tool_registry_cache
+
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tmp_path / "empty_tools"))
+    reset_external_tool_registry_cache()
+    names = set(src.get_tool_names())
+    assert "run_command" not in names
+    assert "git_clone" not in names
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_blocks_legacy_only_execution(monkeypatch, tmp_path):
+    import src
+    from src.tools_external import reset_external_tool_registry_cache
+
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tmp_path / "empty_tools"))
+    reset_external_tool_registry_cache()
+    result = await src.execute_tool("git_status", workspace=str(tmp_path))
+    assert result.success is False
+    assert "strict mode blocks legacy-only tool" in (result.error or "")
+    assert result.metadata["blocked_by_strict_mode"] is True
+    assert result.metadata["tool_source"] == "legacy_builtin"
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_allows_external_append_only_tool(monkeypatch, tmp_path):
+    import src
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, name="context_echo")
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    result = await src.execute_tool("context_echo", text="hello")
+    assert result.success is True
+    assert result.metadata["external_tool"] is True
+    assert result.metadata["tool_source"] == "external_tools_repo"
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_legacy_descriptor_without_allow_override_is_blocked(monkeypatch, tmp_path):
+    import src
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, name="run_command")
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    names = {_schema_name(s) for s in src.get_tools_schema() if isinstance(s, dict)}
+    assert "run_command" not in names
+    result = await src.execute_tool("run_command", cmd="echo hi")
+    assert result.success is False
+    assert result.metadata["blocked_by_strict_mode"] is True
+    assert result.metadata["external_shadow_reason"] == "allow_override_not_enabled"
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_legacy_descriptor_with_allow_override_runs_external(monkeypatch, tmp_path):
+    import src
+    from src.tools_external import reset_external_tool_registry_cache
+
+    tools_dir = _write_tools_repo(tmp_path, name="run_command", metadata={"allow_override": True}, entrypoint_body="def execute(**kwargs):\n    return {'success': True, 'content': 'external override ran'}\n")
+    monkeypatch.setenv("EFP_EXTERNAL_TOOLS_STRICT", "true")
+    monkeypatch.setenv("EFP_TOOLS_DIR", str(tools_dir))
+    reset_external_tool_registry_cache()
+    result = await src.execute_tool("run_command", cmd="not-a-real-command")
+    assert result.success is True
+    assert "external override ran" in result.content
+    assert result.metadata["external_override"] is True
+    assert result.metadata["tool_source"] == "external_tools_repo"

--- a/tests/test_runtime_capability_contract.py
+++ b/tests/test_runtime_capability_contract.py
@@ -92,6 +92,7 @@ def test_runtime_gateway_routes_include_t13_native_contract():
         ("GET", "/health"), ("GET", "/actuator/health"), ("GET", "/api/queue/status"),
         ("GET", "/api/events"),
         ("POST", "/api/chat"), ("POST", "/api/chat/stream"), ("POST", "/api/tasks/execute"),
+        ("POST", "/api/tasks/{task_id}/cancel"),
         ("GET", "/api/tasks/{task_id}"), ("GET", "/api/capabilities"), ("POST", "/api/internal/runtime-profile/apply"),
         ("GET", "/api/skills"), ("GET", "/api/usage"), ("GET", "/api/sessions"),
     }

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -2128,6 +2128,7 @@ def test_routes_include_tasks_execute_and_existing_chat_route():
 
     routes = [r.resource.canonical for r in app.router.routes() if r.resource]
     assert "/api/tasks/execute" in routes
+    assert "/api/tasks/{task_id}/cancel" in routes
     assert "/api/tasks/{task_id}" in routes
     assert "/api/capabilities" in routes
     assert "/api/chat" in routes
@@ -3780,6 +3781,116 @@ async def test_assistant_persist_and_result_payload_share_display_blocks(monkeyp
     assert persisted_extra["display_blocks"] == payload["display_blocks"]
 
 
+
+@pytest.mark.asyncio
+async def test_api_task_cancel_missing_returns_404():
+    import json
+
+    from src.gateway import webchat
+
+    webchat.runtime_task_tracker.reset()
+
+    class _Req:
+        headers = {}
+        match_info = {"task_id": "missing"}
+
+    response = await webchat.api_task_cancel(_Req())
+    assert response.status == 404
+    payload = json.loads(response.body)
+    assert payload["error"] == "Task not found"
+
+
+@pytest.mark.asyncio
+async def test_api_task_cancel_cancels_running_background_task():
+    from src.gateway import webchat
+
+    webchat.runtime_task_tracker.reset()
+    webchat.runtime_task_tracker.create_pending(task_id="t-cancel", request_id="r", task_type="x", source="portal", session_id="s", agent_id="a", trace_id="tr", portal_dispatch_id="pd", portal_task_id="pt")
+    bg = asyncio.create_task(asyncio.sleep(999))
+    webchat.runtime_task_tracker.set_background_task("t-cancel", bg)
+
+    class _Req:
+        headers = {}
+        match_info = {"task_id": "t-cancel"}
+
+    response = await webchat.api_task_cancel(_Req())
+    assert response.status == 200
+    record = webchat.runtime_task_tracker.get("t-cancel")
+    assert record is not None and record.status == "cancelled"
+    assert record.finished_at is not None
+    assert (record.payload or {}).get("status") == "cancelled"
+    assert record.finished_at is not None
+    await asyncio.sleep(0)
+    assert bg.cancelled() or bg.done()
+    if not bg.done():
+        bg.cancel()
+
+
+@pytest.mark.asyncio
+async def test_api_task_cancel_terminal_task_returns_existing_payload():
+    import json
+
+    from src.gateway import webchat
+
+    webchat.runtime_task_tracker.reset()
+    webchat.runtime_task_tracker.create_pending(task_id="t-done", request_id="r", task_type="x", source="portal", session_id="s", agent_id="a", trace_id="tr", portal_dispatch_id="pd", portal_task_id="pt")
+    webchat.runtime_task_tracker.mark_terminal("t-done", status="success", payload={"ok": True, "status": "success"})
+
+    class _Req:
+        headers = {}
+        match_info = {"task_id": "t-done"}
+
+    response = await webchat.api_task_cancel(_Req())
+    assert response.status == 200
+    payload = json.loads(response.body)
+    assert payload["status"] == "success"
+    assert payload["cancel_requested"] is True
+    assert webchat.runtime_task_tracker.get("t-done").status == "success"
+
+
+def test_cancelled_task_is_not_overwritten_by_late_completion():
+    from src.gateway import webchat
+
+    webchat.runtime_task_tracker.reset()
+    webchat.runtime_task_tracker.create_pending(task_id="t-late", request_id="r", task_type="x", source="portal", session_id="s", agent_id="a", trace_id="tr", portal_dispatch_id="pd", portal_task_id="pt")
+    webchat.runtime_task_tracker.cancel("t-late", payload={"ok": False, "status": "cancelled"})
+    webchat.runtime_task_tracker.mark_terminal("t-late", status="success", payload={"ok": True, "status": "success"})
+
+    record = webchat.runtime_task_tracker.get("t-late")
+    assert record is not None and record.status == "cancelled"
+    assert record.finished_at is not None
+    assert (record.payload or {}).get("status") == "cancelled"
+    assert (record.payload or {}).get("status") == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_run_task_execution_background_cancelled_error_marks_cancelled_and_emits_event(monkeypatch):
+    from src.gateway import webchat
+
+    webchat.runtime_task_tracker.reset()
+    webchat.runtime_task_tracker.create_pending(task_id="t-bg-cancel", request_id="r", task_type="x", source="portal", session_id="s", agent_id="a", trace_id="tr", portal_dispatch_id="pd", portal_task_id="pt")
+
+    async def _cancelled(**kwargs):
+        raise asyncio.CancelledError()
+
+    emitted = []
+
+    async def _emit(*args, **kwargs):
+        emitted.append(kwargs.get("event_type") or (args[0] if args else None))
+
+    monkeypatch.setattr(webchat, "execute_runtime_task_request", _cancelled)
+    monkeypatch.setattr(webchat, "_emit_task_lifecycle_event", _emit)
+
+    await webchat._run_task_execution_in_background(task_id="t-bg-cancel", request_id="r", task_type="x", session_id="s", source="portal", runtime_agent_id="a", context_ref=None, merged_input_payload={}, metadata={"portal_task_id":"pt"}, trace_headers={"trace_id":"tr", "portal_dispatch_id":"pd"})
+    record = webchat.runtime_task_tracker.get("t-bg-cancel")
+    assert record is not None and record.status == "cancelled"
+    assert record.finished_at is not None
+    assert (record.payload or {}).get("status") == "cancelled"
+    assert "task.cancelled" in emitted
+    assert "task.failed" not in emitted
+    assert "task.failed" not in emitted
+
+
 @pytest.mark.asyncio
 async def test_run_task_execution_cancelled_during_started_event_marks_cancelled(monkeypatch):
     import src.gateway.webchat as webchat
@@ -3795,4 +3906,6 @@ async def test_run_task_execution_cancelled_during_started_event_marks_cancelled
     await webchat._run_task_execution_in_background(task_id="t-cancel-early", request_id="r", task_type="x", session_id="s", source="portal", runtime_agent_id="a", context_ref=None, merged_input_payload={}, metadata={"portal_task_id":"pt"}, trace_headers={"trace_id":"tr", "portal_dispatch_id":"pd"})
     record = webchat.runtime_task_tracker.get("t-cancel-early")
     assert record is not None and record.status == "cancelled"
+    assert record.finished_at is not None
+    assert (record.payload or {}).get("status") == "cancelled"
     assert "task.failed" not in emitted


### PR DESCRIPTION
### Motivation

- Ensure governance/audit events for external mutation tools always include `capability_id`/`capability_type` so `tool.governance.audit.detail_payload` is complete. 
- Harden strict-mode behavior and route contract coverage so legacy-only tools are hidden/blocked under strict mode while external tools remain usable per the design. 
- Add test coverage for task cancel endpoint and background `CancelledError` handling to prevent cancelled tasks being mis-marked as failures or overwritten by late completion.

### Description

- In `src/runtime/execution_bus.py` `_normalize_tool_execution_outcome()` we backfill `tool_metadata` with capability fields (`capability_id`, `capability_type`) and fallback `tool_id`/`policy_tags` when missing, and ensure `artifacts["tool_metadata"]` mirrors the output payload so audit events read consistent metadata. 
- Added route contract assertions that `POST /api/tasks/{task_id}/cancel` is included in runtime gateway routes and updated webchat route tests to check for the cancel route. 
- Extended `tests/test_external_tools_registry.py` helper `_write_tools_repo` with `tool_id/mutation/risk_level/policy_tags/enabled` parameters and added strict-mode and external-mutation visibility tests covering the blocking/allow behaviors and metadata propagation. 
- Added ExecutionBus tests to verify governance metadata is forwarded to tool kwargs, `ToolResult.metadata` is preserved into `output_payload.tool_metadata` and `artifacts.tool_metadata`, and that `tool.governance.audit` events include `tool_id` and `capability_id`, and added webchat cancel-related tests covering missing, running, terminal, late-completion, and `CancelledError` background paths.

### Testing

- Installed dependencies with `python -m pip install -r requirements.txt` and ran the targeted test suite with `pytest` for the following files: `tests/test_external_tools_loader.py`, `tests/test_external_tools_registry.py`, `tests/test_governance_bus.py`, `tests/test_execution_bus.py`, `tests/test_runtime_capability_contract.py`, `tests/test_docker_runtime_contract.py`, and `tests/test_webchat.py`.
- All targeted tests passed locally: `383 passed` across the run, with no failing tests in the targeted suite. 
- Modified files: `src/runtime/execution_bus.py`, `tests/test_execution_bus.py`, `tests/test_external_tools_registry.py`, `tests/test_runtime_capability_contract.py`, and `tests/test_webchat.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ba84de18832abc21cc7add151403)