### PR TITLE
Fix Responses strict tool schema normalization for combinator branches

### DIFF
--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -255,26 +255,140 @@ def _convert_messages_to_input_items(messages: List[Dict]) -> List[Dict]:
                 items.append({"role": role, "content": str(content)})
     return items
 
-def _convert_tools_schema(tools: List[Dict]) -> List[Dict]:
-    """Convert Chat-style tools to Responses API format."""
+
+def _make_nullable_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Allow null for a schema while preserving metadata."""
     import copy
 
-    def _make_nullable_if_optional(prop_schema: Dict[str, Any]) -> Dict[str, Any]:
-        """Allow null for an optional top-level property while preserving metadata."""
-        schema = copy.deepcopy(prop_schema) if isinstance(prop_schema, dict) else {"type": ["null"]}
-        prop_type = schema.get("type")
-        if isinstance(prop_type, list):
-            if "null" not in prop_type:
-                schema["type"] = [*prop_type, "null"]
-        elif isinstance(prop_type, str):
-            if prop_type != "null":
-                schema["type"] = [prop_type, "null"]
-        if isinstance(schema.get("enum"), list) and None not in schema["enum"]:
-            schema["enum"] = [*schema["enum"], None]
-        if "const" in schema:
-            schema["enum"] = [schema["const"], None]
-            schema.pop("const", None)
-        return schema
+    normalized = copy.deepcopy(schema) if isinstance(schema, dict) else {"type": ["null"]}
+    schema_type = normalized.get("type")
+    if isinstance(schema_type, list):
+        if "null" not in schema_type:
+            normalized["type"] = [*schema_type, "null"]
+    elif isinstance(schema_type, str):
+        if schema_type != "null":
+            normalized["type"] = [schema_type, "null"]
+    if isinstance(normalized.get("enum"), list) and None not in normalized["enum"]:
+        normalized["enum"] = [*normalized["enum"], None]
+    if "const" in normalized:
+        normalized["enum"] = [normalized["const"], None]
+        normalized.pop("const", None)
+    return normalized
+
+
+def _make_non_nullable_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove null allowance from a schema while preserving all other constraints."""
+    import copy
+
+    normalized = copy.deepcopy(schema) if isinstance(schema, dict) else {}
+    schema_type = normalized.get("type")
+    if isinstance(schema_type, list):
+        non_null_types = [value for value in schema_type if value != "null"]
+        if len(non_null_types) == 1:
+            normalized["type"] = non_null_types[0]
+        elif non_null_types:
+            normalized["type"] = non_null_types
+    if isinstance(normalized.get("enum"), list):
+        non_null_enum = [value for value in normalized["enum"] if value is not None]
+        normalized["enum"] = non_null_enum
+        if "const" in normalized:
+            normalized.pop("const", None)
+        if len(non_null_enum) == 1:
+            normalized["const"] = non_null_enum[0]
+    return normalized
+
+
+def _normalize_responses_strict_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively normalize function parameters schema for Responses API strict mode."""
+    import copy
+
+    def _is_object_like(node: Dict[str, Any]) -> bool:
+        return node.get("type") == "object" or isinstance(node.get("properties"), dict)
+
+    def _is_required_only_branch(branch: Dict[str, Any], parent_property_keys: set) -> bool:
+        if not isinstance(branch, dict):
+            return False
+        allowed_keys = {"required", "title", "description"}
+        if set(branch.keys()) - allowed_keys:
+            return False
+        required_fields = branch.get("required")
+        if not isinstance(required_fields, list) or not required_fields:
+            return False
+        return all(isinstance(field, str) and field in parent_property_keys for field in required_fields)
+
+    def _normalize(node: Any) -> Any:
+        if not isinstance(node, dict):
+            return node
+
+        normalized = copy.deepcopy(node)
+
+        if _is_object_like(normalized):
+            original_required = normalized.get("required", [])
+            required_set = set(original_required) if isinstance(original_required, list) else set()
+            properties = normalized.get("properties", {})
+            if not isinstance(properties, dict):
+                properties = {}
+
+            property_keys = list(properties.keys())
+            normalized_properties: Dict[str, Any] = {}
+            for property_name, property_schema in properties.items():
+                child = _normalize(property_schema)
+                if property_name in required_set:
+                    normalized_properties[property_name] = child
+                else:
+                    normalized_properties[property_name] = _make_nullable_schema(child)
+
+            normalized["properties"] = normalized_properties
+            normalized["required"] = property_keys
+            normalized["additionalProperties"] = False
+
+            for combinator in ("anyOf", "oneOf", "allOf"):
+                branches = normalized.get(combinator)
+                if not isinstance(branches, list):
+                    continue
+
+                rewritten_branches: List[Any] = []
+                parent_property_keys = set(property_keys)
+                for branch in branches:
+                    if _is_required_only_branch(branch, parent_property_keys):
+                        branch_required = set(branch.get("required", []))
+                        branch_props = copy.deepcopy(normalized_properties)
+                        for required_name in branch_required:
+                            if required_name in branch_props:
+                                branch_props[required_name] = _make_non_nullable_schema(branch_props[required_name])
+
+                        rewritten_branch = {
+                            "type": "object",
+                            "properties": branch_props,
+                            "required": property_keys,
+                            "additionalProperties": False,
+                        }
+                        if "title" in branch:
+                            rewritten_branch["title"] = branch["title"]
+                        if "description" in branch:
+                            rewritten_branch["description"] = branch["description"]
+                        rewritten_branches.append(rewritten_branch)
+                    else:
+                        rewritten_branches.append(_normalize(branch))
+                normalized[combinator] = rewritten_branches
+
+            return normalized
+
+        if normalized.get("type") == "array" and "items" in normalized:
+            normalized["items"] = _normalize(normalized.get("items"))
+
+        for combinator in ("anyOf", "oneOf", "allOf"):
+            branches = normalized.get(combinator)
+            if isinstance(branches, list):
+                normalized[combinator] = [_normalize(branch) for branch in branches]
+
+        return normalized
+
+    return _normalize(copy.deepcopy(schema))
+
+
+def _convert_tools_schema(tools: List[Dict]) -> List[Dict]:
+    """Convert Chat-style tools to Responses API format."""
 
     converted = []
     for tool in tools:
@@ -283,28 +397,7 @@ def _convert_tools_schema(tools: List[Dict]) -> List[Dict]:
         tool_type = tool.get("type", "")
         if tool_type == "function":
             func = tool.get("function", {})
-            # Deep copy parameters to avoid mutating the original
-            params = copy.deepcopy(func.get("parameters", {}))
-
-            # Capture the original required fields before any strict-mode mutation.
-            original_required = set(params.get("required", []))
-            properties = params.get("properties", {})
-            if isinstance(properties, dict):
-                property_keys = list(properties.keys())
-                normalized_properties = {}
-                for prop_name, prop_schema in properties.items():
-                    if prop_name in original_required:
-                        normalized_properties[prop_name] = prop_schema
-                    else:
-                        normalized_properties[prop_name] = _make_nullable_if_optional(prop_schema)
-                params["properties"] = normalized_properties
-                # Strict mode requires all top-level properties to be required.
-                params["required"] = property_keys
-            elif "required" not in params or not isinstance(params.get("required"), list):
-                params["required"] = []
-
-            # Responses API strict mode requires closed top-level argument objects.
-            params["additionalProperties"] = False
+            params = _normalize_responses_strict_schema(func.get("parameters", {}))
 
             converted.append({
                 "type": "function",

--- a/tests/test_agent_jira_minimal_fixes.py
+++ b/tests/test_agent_jira_minimal_fixes.py
@@ -1,4 +1,5 @@
 import pytest
+import copy
 
 
 def test_convert_tools_schema_preserves_optional_semantics_with_nullable():
@@ -218,6 +219,133 @@ def test_convert_tools_schema_forces_additional_properties_false():
 
     params = _convert_tools_schema(tools)[0]["parameters"]
     assert params["additionalProperties"] is False
+
+
+def test_convert_tools_schema_required_only_anyof_branch_is_rewritten_strict():
+    from src.agents.llm import _convert_tools_schema
+
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "confluence_get_user",
+            "description": "Get user details from Confluence",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "user_id": {"type": "string", "description": "User ID"},
+                    "username": {"type": "string", "description": "Username"},
+                },
+                "anyOf": [
+                    {"required": ["user_id"]},
+                    {"required": ["username"]},
+                ],
+            },
+        },
+    }]
+
+    converted = _convert_tools_schema(tools)[0]
+    params = converted["parameters"]
+
+    assert converted["strict"] is True
+    assert params["additionalProperties"] is False
+    assert params["required"] == ["user_id", "username"]
+    assert params["properties"]["user_id"]["type"] == ["string", "null"]
+    assert params["properties"]["username"]["type"] == ["string", "null"]
+    assert "anyOf" in params
+    assert len(params["anyOf"]) == 2
+
+    branch0 = params["anyOf"][0]
+    assert branch0["type"] == "object"
+    assert branch0["additionalProperties"] is False
+    assert branch0["required"] == ["user_id", "username"]
+    assert branch0["properties"]["user_id"]["type"] == "string"
+    assert branch0["properties"]["username"]["type"] == ["string", "null"]
+
+    branch1 = params["anyOf"][1]
+    assert branch1["type"] == "object"
+    assert branch1["additionalProperties"] is False
+    assert branch1["required"] == ["user_id", "username"]
+    assert branch1["properties"]["username"]["type"] == "string"
+    assert branch1["properties"]["user_id"]["type"] == ["string", "null"]
+
+
+def test_convert_tools_schema_recursively_closes_nested_objects_and_arrays():
+    from src.agents.llm import _convert_tools_schema
+
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "nested_schema_tool",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "filters": {
+                        "type": "object",
+                        "properties": {
+                            "status": {"type": "string"},
+                            "owner": {"type": "string"},
+                        },
+                        "required": ["status"],
+                    },
+                    "entries": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string"},
+                                "score": {"type": "number"},
+                            },
+                            "required": ["id"],
+                        },
+                    },
+                },
+                "required": ["filters"],
+            },
+        },
+    }]
+
+    params = _convert_tools_schema(tools)[0]["parameters"]
+    assert params["additionalProperties"] is False
+    assert params["required"] == ["filters", "entries"]
+    assert params["properties"]["entries"]["type"] == ["array", "null"]
+
+    filters = params["properties"]["filters"]
+    assert filters["additionalProperties"] is False
+    assert filters["required"] == ["status", "owner"]
+    assert filters["properties"]["status"]["type"] == "string"
+    assert filters["properties"]["owner"]["type"] == ["string", "null"]
+
+    entry_items = params["properties"]["entries"]["items"]
+    assert entry_items["additionalProperties"] is False
+    assert entry_items["required"] == ["id", "score"]
+    assert entry_items["properties"]["id"]["type"] == "string"
+    assert entry_items["properties"]["score"]["type"] == ["number", "null"]
+
+
+def test_convert_tools_schema_does_not_mutate_original_input_schema():
+    from src.agents.llm import _convert_tools_schema
+
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "immutability_check",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "user_id": {"type": "string"},
+                    "username": {"type": "string"},
+                },
+                "anyOf": [
+                    {"required": ["user_id"]},
+                    {"required": ["username"]},
+                ],
+            },
+        },
+    }]
+
+    original = copy.deepcopy(tools)
+    _convert_tools_schema(tools)
+    assert tools == original
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- The Responses API returned 400 for tools like `confluence_get_user` because `_convert_tools_schema()` only set `additionalProperties=false` at the top level and did not normalize `anyOf`/`oneOf`/`allOf` branches, leaving required-only combinator branches unsatisfiable.
- The fix must preserve existing top-level semantics where originally required fields remain non-nullable and originally optional fields become nullable while keeping strict mode enabled.

### Description
- Added a recursive normalizer ` _normalize_responses_strict_schema(schema: Dict[str, Any])` plus helpers ` _make_nullable_schema()` and ` _make_non_nullable_schema()` to deep-copy and normalize object/array/combinator nodes so every object-like node has `additionalProperties: False` and top-level properties are marked `required` with optional fields made nullable.
- Implemented rewriting of required-only combinator branches (e.g., `anyOf: [{"required":[...]}]`) into full object branches that include normalized `properties`, `required` set to all parent keys, and `additionalProperties: False`, while removing `null` allowance for branch-required fields and keeping sibling optional fields nullable.
- Replaced the previous ad-hoc top-level logic in ` _convert_tools_schema()` to call the new normalizer and continue to generate Response functions as `{ "type": "function", "name": ..., "parameters": params, "strict": True }` without changing provider endpoints or disabling tools.
- Ensured normalization is non-mutating by deep-copying input schemas and preserved existing optional/enum/const behaviors.

### Testing
- Added tests in `tests/test_agent_jira_minimal_fixes.py` covering required-only `anyOf` rewriting, recursive closure of nested objects and array item objects, and immutability of the input schema.
- Ran `pytest tests/test_agent_jira_minimal_fixes.py -q`, `pytest tests/test_llm_client.py -q`, and `pytest tests/test_external_tools_registry.py -q`, and all test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2451c874832a95bded899402082e)