### PR TITLE
Add copilot-integration-id header for GitHub Copilot provider and centralize token lookup

### DIFF
--- a/src/agents/llm.py
+++ b/src/agents/llm.py
@@ -969,6 +969,9 @@ class OpenAIProvider(BaseProvider):
         ]
 
 
+GITHUB_COPILOT_INTEGRATION_ID = "vscode-chat"
+
+
 class GitHubCopilotProvider(BaseProvider):
     """GitHub Copilot provider."""
     
@@ -980,14 +983,18 @@ class GitHubCopilotProvider(BaseProvider):
         )
         self.default_model = config.llm.get('model', DEFAULT_LLM_MODEL)
     
+    def _get_api_key(self) -> str:
+        return os.environ.get("GITHUB_COPILOT_TOKEN") or config.llm.get("api_key", "")
+
     def _get_headers(self) -> Dict[str, str]:
         """Override to include Copilot-specific headers."""
-        api_key = os.environ.get('GITHUB_COPILOT_TOKEN') or config.llm.get('api_key', '')
+        api_key = self._get_api_key()
         return {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
             "X-GitHub-Api-Version": "2023-06-01",
             "Accept": "application/vnd.github.copilot-chat-preview+json",
+            "copilot-integration-id": GITHUB_COPILOT_INTEGRATION_ID,
         }
     
     async def chat(
@@ -1002,7 +1009,7 @@ class GitHubCopilotProvider(BaseProvider):
     ) -> Dict[str, Any]:
         """Call GitHub Copilot Chat API."""
         # Check if API key is configured
-        api_key = os.environ.get('GITHUB_COPILOT_TOKEN') or config.llm.get('api_key', '')
+        api_key = self._get_api_key()
         if not api_key:
             return {
                 "error": {
@@ -1152,7 +1159,7 @@ class GitHubCopilotProvider(BaseProvider):
             )
         
         # Check if API key is configured
-        api_key = os.environ.get('GITHUB_COPILOT_TOKEN') or config.llm.get('api_key', '')
+        api_key = self._get_api_key()
         if not api_key:
             return {
                 "error": {

--- a/tests/test_github_copilot_provider_headers.py
+++ b/tests/test_github_copilot_provider_headers.py
@@ -1,0 +1,24 @@
+from src.agents.llm import GitHubCopilotProvider
+from src.config import config
+
+
+def test_github_copilot_headers_include_integration_id(monkeypatch):
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN", "gho_TEST")
+
+    provider = GitHubCopilotProvider()
+    headers = provider._get_headers()
+
+    assert headers["Authorization"] == "Bearer gho_TEST"
+    assert headers["copilot-integration-id"] == "vscode-chat"
+    assert headers["Accept"] == "application/vnd.github.copilot-chat-preview+json"
+
+
+def test_github_copilot_api_key_falls_back_to_config(monkeypatch):
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.setitem(config._config, "llm", {"api_key": "CONFIG_TOKEN"})
+
+    provider = GitHubCopilotProvider()
+    headers = provider._get_headers()
+
+    assert headers["Authorization"] == "Bearer CONFIG_TOKEN"
+    assert headers["copilot-integration-id"] == "vscode-chat"


### PR DESCRIPTION
### Motivation
- Ensure every request to GitHub Copilot includes the required integration header `copilot-integration-id: vscode-chat` so the runtime is recognized as the VS Code native client.
- Centralize how the Copilot bearer token is obtained so the runtime consistently uses `GITHUB_COPILOT_TOKEN` or `config.llm["api_key"]` and avoids duplicated lookup code.
- Keep portal-managed and existing webchat auth behavior unchanged by not adding extra OAuth storage or changing `src/gateway/webchat.py` or `src/config.py`.

### Description
- Added `GITHUB_COPILOT_INTEGRATION_ID = "vscode-chat"` near `GitHubCopilotProvider` and ensured the header name is the lowercase `copilot-integration-id`.
- Implemented `GitHubCopilotProvider._get_api_key()` to return `os.environ.get("GITHUB_COPILOT_TOKEN")` or `config.llm.get("api_key", "")`.
- Updated `GitHubCopilotProvider._get_headers()` to use `_get_api_key()` and include `copilot-integration-id: vscode-chat` plus existing Copilot-specific headers.
- Replaced duplicated inline Copilot token lookups in `chat()` and `responses()` with calls to `self._get_api_key()` and left other providers unchanged.

### Testing
- Added `tests/test_github_copilot_provider_headers.py` with assertions for `Authorization`, `copilot-integration-id`, and Copilot `Accept` header.
- Ran `pytest -q tests/test_github_copilot_provider_headers.py tests/test_llm_client.py::TestGitHubCopilotProvider::test_github_copilot_get_headers_includes_copilot_specific` and all collected tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9924e130832a99650aab9229837e)