### PR TITLE
Add regression tests for LLM tools / response-flow and annotate PORTAL_MANAGED_FIELD_TREE

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -108,6 +108,10 @@ class Config:
         "debug",
     }
     PORTAL_MANAGED_FIELD_TREE = {
+        # Keep hidden/deprecated Portal LLM fields in this field tree.
+        # Portal may stop rendering temperature/tools/response_flow controls, but
+        # set_managed_overlay() must still prune older Portal-managed values from
+        # config.yaml when a newer sparse overlay omits them.
         "llm": {
             "provider": True,
             "model": True,

--- a/tests/test_config_managed_overlay.py
+++ b/tests/test_config_managed_overlay.py
@@ -1,0 +1,49 @@
+from ruamel.yaml import YAML
+
+from src.config import Config
+
+
+yaml = YAML()
+
+
+def test_set_managed_overlay_prunes_stale_llm_temperature_and_response_flow(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "llm:\n"
+        "  provider: openai\n"
+        "  model: gpt-4\n"
+        "  temperature: 0.2\n"
+        "  tools: []\n"
+        "  response_flow:\n"
+        "    plan_policy: always\n"
+        "  tool_loop:\n"
+        "    one_tool_per_turn: true\n"
+        "proxy:\n"
+        "  enabled: false\n"
+        "session:\n"
+        "  timeout_minutes: 30\n",
+        encoding="utf-8",
+    )
+
+    cfg = Config(str(config_path))
+    cfg.set_managed_overlay(
+        runtime_profile_id="rp-1",
+        revision=2,
+        overlay_config={
+            "llm": {
+                "provider": "github_copilot",
+                "model": "gpt-5.4-mini",
+                "tools": ["*"],
+            }
+        },
+    )
+
+    with config_path.open("r", encoding="utf-8") as handle:
+        written = yaml.load(handle)
+
+    assert written["llm"]["provider"] == "github_copilot"
+    assert written["llm"]["model"] == "gpt-5.4-mini"
+    assert written["llm"]["tools"] == ["*"]
+    assert "temperature" not in written["llm"]
+    assert "response_flow" not in written["llm"]
+    assert written["session"]["timeout_minutes"] == 30

--- a/tests/test_llm_tools_filtering.py
+++ b/tests/test_llm_tools_filtering.py
@@ -36,6 +36,39 @@ def test_normalize_explicit_empty_is_none(tools_value):
     assert spec.configured is True
     assert spec.mode == "none"
 
+def test_missing_llm_tools_defaults_to_all():
+    spec = normalize_llm_tools_spec({})
+    assert spec.configured is False
+    assert spec.mode == "all"
+
+
+def test_explicit_wildcard_tools_means_all():
+    spec = normalize_llm_tools_spec({"tools": ["*"]})
+    assert spec.configured is True
+    assert spec.mode == "all"
+
+
+def test_explicit_empty_tools_means_none():
+    spec = normalize_llm_tools_spec({"tools": []})
+    assert spec.configured is True
+    assert spec.mode == "none"
+
+
+def test_filter_tools_defaults_and_explicit_modes_with_regular_tools_only():
+    regular_tools = [
+        {"type": "function", "function": {"name": "git_clone", "description": "clone"}},
+        {"type": "function", "function": {"name": "jira_get_issue", "description": "jira"}},
+    ]
+
+    missing_result = filter_tool_schemas_for_llm(regular_tools, {})
+    wildcard_result = filter_tool_schemas_for_llm(regular_tools, {"tools": ["*"]})
+    none_result = filter_tool_schemas_for_llm(regular_tools, {"tools": []})
+
+    assert _names(missing_result) == ["git_clone", "jira_get_issue"]
+    assert _names(wildcard_result) == ["git_clone", "jira_get_issue"]
+    assert _names(none_result) == []
+
+
 
 @pytest.mark.parametrize("tools_value", ["*", ["*"]])
 def test_normalize_wildcard_all(tools_value):

--- a/tests/test_response_flow_policy.py
+++ b/tests/test_response_flow_policy.py
@@ -77,3 +77,52 @@ def test_resolve_skill_behavior_defaults_skill_omission_uses_config_defaults():
     assert execution_style == "stepwise"
     assert ask_policy == "permissive"
     assert conflict_policy == "always_ask"
+
+from src.runtime.response_flow_policy import DEFAULT_RESPONSE_FLOW_CONFIG, resolve_response_flow_config
+
+
+def test_resolve_response_flow_config_none_returns_default_copy():
+    resolved = resolve_response_flow_config(None)
+    assert resolved == DEFAULT_RESPONSE_FLOW_CONFIG
+    assert resolved is not DEFAULT_RESPONSE_FLOW_CONFIG
+
+
+def test_resolve_response_flow_config_empty_returns_default_copy():
+    resolved = resolve_response_flow_config({})
+    assert resolved == DEFAULT_RESPONSE_FLOW_CONFIG
+    assert resolved is not DEFAULT_RESPONSE_FLOW_CONFIG
+
+
+def test_resolve_response_flow_config_mutation_does_not_change_defaults():
+    resolved = resolve_response_flow_config(None)
+    resolved["plan_policy"] = "always"
+    assert DEFAULT_RESPONSE_FLOW_CONFIG["plan_policy"] == "explicit_or_complex"
+
+
+def test_resolve_response_flow_config_partial_overlay_only_overrides_target_field():
+    resolved = resolve_response_flow_config({"plan_policy": "always"})
+    assert resolved["plan_policy"] == "always"
+    assert resolved["staging_policy"] == DEFAULT_RESPONSE_FLOW_CONFIG["staging_policy"]
+    assert (
+        resolved["default_skill_execution_style"]
+        == DEFAULT_RESPONSE_FLOW_CONFIG["default_skill_execution_style"]
+    )
+    assert resolved["ask_user_policy"] == DEFAULT_RESPONSE_FLOW_CONFIG["ask_user_policy"]
+    assert (
+        resolved["active_skill_conflict_policy"]
+        == DEFAULT_RESPONSE_FLOW_CONFIG["active_skill_conflict_policy"]
+    )
+
+
+def test_resolve_response_flow_config_invalid_complexity_values_fall_back_to_defaults():
+    resolved = resolve_response_flow_config(
+        {"complexity_prompt_budget_ratio": "not-a-number", "complexity_min_request_tokens": "bad"}
+    )
+    assert (
+        resolved["complexity_prompt_budget_ratio"]
+        == DEFAULT_RESPONSE_FLOW_CONFIG["complexity_prompt_budget_ratio"]
+    )
+    assert (
+        resolved["complexity_min_request_tokens"]
+        == DEFAULT_RESPONSE_FLOW_CONFIG["complexity_min_request_tokens"]
+    )


### PR DESCRIPTION
### Motivation
- Lock down existing runtime semantics for `llm.tools` so missing vs explicit values keep the current semantics (missing -> all, `"*"` -> all, `[]`/`null` -> none) to avoid regressions when Portal UI changes. 
- Ensure `resolve_response_flow_config` continues to fall back to `DEFAULT_RESPONSE_FLOW_CONFIG` and returns a copy so runtime defaults are preserved even if Portal hides UI controls. 
- Preserve and document why hidden/deprecated Portal-managed LLM keys remain in `PORTAL_MANAGED_FIELD_TREE` so `set_managed_overlay()` can prune old managed fields from on-disk `config.yaml`.

### Description
- Added unit tests to `tests/test_llm_tools_filtering.py` that assert `normalize_llm_tools_spec` behavior for missing, wildcard, and empty `llm.tools`, and added a `filter_tool_schemas_for_llm` regression verifying `{}`, `{"tools": ["*"]}`, and `{"tools": []}` behaviors against regular tool schemas. 
- Extended `tests/test_response_flow_policy.py` with tests that `resolve_response_flow_config(None)` and `resolve_response_flow_config({})` return a copy of `DEFAULT_RESPONSE_FLOW_CONFIG`, that mutations to the returned dict do not change defaults, that partial overlays only override targeted fields, and that invalid complexity values fall back to defaults. 
- Added `tests/test_config_managed_overlay.py` to verify `Config.set_managed_overlay()` prunes stale `llm.temperature` and `llm.response_flow` from an existing `config.yaml` when applying a newer sparse overlay that sets only `provider/model/tools`, and that unrelated fields are preserved. 
- Inserted a maintenance comment above `Config.PORTAL_MANAGED_FIELD_TREE["llm"]` in `src/config.py` explaining why `temperature`, `tools`, and `response_flow` must remain in the managed field tree; no managed-tree keys were removed or relocated. 
- No runtime behavior or logic in `src/runtime/tool_filtering.py`, `src/runtime/response_flow_policy.py`, or `Config.set_managed_overlay()` was changed.

### Testing
- Ran focused pytest for the modified areas with `python -m pytest -q tests/test_llm_tools_filtering.py tests/test_response_flow_policy.py tests/test_config_managed_overlay.py` and all tests passed. 
- End-to-end local run of the selected test set resulted in `37 passed, 1 warning`.
- Tests specifically added or updated: `tests/test_llm_tools_filtering.py` (added cases), `tests/test_response_flow_policy.py` (added cases), and new `tests/test_config_managed_overlay.py` (new file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff24c0b204832a9543fa7f08408bf1)