### PR TITLE
Add Runtime v2 Phase37 context management

### DIFF
--- a/docs/runtime-v2-design.md
+++ b/docs/runtime-v2-design.md
@@ -240,6 +240,10 @@ The loader maps the following opencode-style and snake_case keys into
 - `commandDirectories` / `command_directories`.
 - `toolDirectories` / `tool_directories`.
 - `runtime.mode` or `runtime_mode`.
+- `compaction.prune`, `compaction.toolOutputMaxChars` /
+  `compaction.tool_output_max_chars`, `compaction.pruneMinChars` /
+  `compaction.prune_min_chars`, and `compaction.pruneProtectChars` /
+  `compaction.prune_protect_chars`.
 
 Configured path fields are resolved as workspace-local `Path` objects without
 requiring those files or directories to already exist. With
@@ -1307,3 +1311,16 @@ request-local compaction remains a safety net for provider-only context
 overflow. The overflow retry is single-shot to avoid infinite loops, and the
 retried request records `overflow_retry` metadata on the request and compaction
 metadata while the loop publishes a `provider.context_overflow_retry` event.
+
+`AgentRuntime.prune_session_tool_outputs(session_id, ...)` is a separate
+persistent maintenance step for old tool result content. It runs after outputs
+have already been normalized and possibly truncated at execution time. Instead
+of changing a single provider request, it rewrites stored history with bounded
+previews for older completed tool results, marks both the `ToolResult` and
+`MessagePart` metadata with `compaction_pruned`, and publishes a
+`session_tool_outputs_pruned` event when it persists changes. The latest two
+user turns are always preserved before pruning is considered, protected tools
+such as `skill` are skipped, and already-pruned results are ignored.
+`RuntimeConfig.compaction_prune`, `compaction_tool_output_max_chars`,
+`compaction_prune_min_chars`, and `compaction_prune_protect_chars` provide the
+default maintenance settings.

--- a/docs/runtime-v2-design.md
+++ b/docs/runtime-v2-design.md
@@ -1241,6 +1241,24 @@ retained, pending tool calls and the latest non-system block are protected, and
 provider request metadata records the configured budget plus compacted/kept
 part, message, pair, and character counts.
 
+Request-local budget compaction still exists: it only rewrites the provider
+request for the current turn and does not mutate stored session history.
+Runtime v2 also exposes opencode-style compaction policy fields on
+`RuntimeConfig`: `compaction_auto`, `compaction_prune`,
+`compaction_tail_turns`, `compaction_preserve_recent_chars`,
+`compaction_reserved_chars`, and `compaction_tool_output_max_chars`. Workspace
+config can load these from a nested `compaction` object or matching top-level
+snake_case keys.
+
+The tail-turn selection policy keeps a recent suffix of user turns. By default
+it considers the latest two user turns, bounds them with a recent-context
+character budget, can split an older recent turn by keeping only the suffix that
+fits, and still preserves protected system context plus pending tool calls.
+Generated compaction parts set `tail_start_message_id` to the first retained
+tail message so later compaction-aware flows can identify where verbatim recent
+history begins. This branch only adds the policy fields and selector; automatic
+persistent compaction is intentionally left for a later integration.
+
 `AgentRuntime.compact_session(...)` provides manual persistent compaction for
 stored session history. Unlike request-local budget compaction, which only
 changes the provider request for a single turn, manual compaction replaces older

--- a/docs/runtime-v2-design.md
+++ b/docs/runtime-v2-design.md
@@ -1256,8 +1256,28 @@ character budget, can split an older recent turn by keeping only the suffix that
 fits, and still preserves protected system context plus pending tool calls.
 Generated compaction parts set `tail_start_message_id` to the first retained
 tail message so later compaction-aware flows can identify where verbatim recent
-history begins. This branch only adds the policy fields and selector; automatic
-persistent compaction is intentionally left for a later integration.
+history begins.
+
+Automatic session compaction runs inside the Runtime v2 loop before each
+provider request when `RuntimeConfig.compaction_auto` is true and a context
+budget is configured with `max_context_parts` or `max_context_chars`. The loop
+compacts only persisted session history, writes the compacted history back
+through the session store, and then builds the provider request from the
+provider-only context messages plus the newly stored session history. System
+prompt, instruction, and skill context messages remain provider-only; automatic
+session compaction never writes those messages into the stored session. Set
+`compaction_auto=False` to disable this automatic persistent compaction while
+leaving request-local rendering safeguards available.
+
+Automatic compaction uses tail-turn retention for stored session history, with
+`compaction_tail_turns` controlling how many recent user turns stay intact and
+`compaction_preserve_recent_chars` optionally preserving a recent character
+suffix. `compaction_reserved_chars`, when set, overrides
+`context_reserve_chars` for loop context budgets. If
+`enable_compaction_summarizer` is enabled and a summarizer is configured, the
+same `CompactionController` path used by manual compaction supplies the
+persisted summary; otherwise deterministic compaction creates the stored
+summary.
 
 `AgentRuntime.compact_session(...)` provides manual persistent compaction for
 stored session history. Unlike request-local budget compaction, which only
@@ -1277,9 +1297,13 @@ empty note.
 
 If provider invocation raises `ProviderContextOverflowError` and
 `RuntimeConfig.enable_context_overflow_retry` is enabled, the same loop
-iteration is rendered once more with a stricter budget and retried. Existing
-part-aware compaction rules still protect pending tool calls and the latest
-non-system block. The overflow retry is single-shot to avoid infinite loops, and
-the retried request records `overflow_retry` metadata on the request and
-compaction metadata while the loop publishes a
-`provider.context_overflow_retry` event.
+iteration is rendered once more with a stricter budget and retried. When
+automatic compaction is enabled, the loop first persists that stricter overflow
+compaction to stored session history with `overflow_retry=true`,
+`overflow=true`, and `trigger="provider_context_overflow"` metadata. The retry
+request is then rebuilt from provider-only context messages plus the compacted
+stored history, keeping the latest user request visible. Existing part-aware
+request-local compaction remains a safety net for provider-only context
+overflow. The overflow retry is single-shot to avoid infinite loops, and the
+retried request records `overflow_retry` metadata on the request and compaction
+metadata while the loop publishes a `provider.context_overflow_retry` event.

--- a/src/efp_runtime/agents/task_runner.py
+++ b/src/efp_runtime/agents/task_runner.py
@@ -367,6 +367,28 @@ def _child_config(
         context_reserve_chars=(
             base_config.context_reserve_chars if base_config is not None else 0
         ),
+        compaction_auto=(
+            True if base_config is None else base_config.compaction_auto
+        ),
+        compaction_prune=(
+            True if base_config is None else base_config.compaction_prune
+        ),
+        compaction_tail_turns=(
+            2 if base_config is None else base_config.compaction_tail_turns
+        ),
+        compaction_preserve_recent_chars=(
+            None
+            if base_config is None
+            else base_config.compaction_preserve_recent_chars
+        ),
+        compaction_reserved_chars=(
+            None if base_config is None else base_config.compaction_reserved_chars
+        ),
+        compaction_tool_output_max_chars=(
+            2000
+            if base_config is None
+            else base_config.compaction_tool_output_max_chars
+        ),
         enable_compaction_summarizer=(
             False
             if base_config is None

--- a/src/efp_runtime/compaction/__init__.py
+++ b/src/efp_runtime/compaction/__init__.py
@@ -20,6 +20,7 @@ from .strategy import (
     CompactionResult,
     ContextBudget,
     PartAwareCompactionStrategy,
+    TailTurnCompactionStrategy,
 )
 
 __all__ = [
@@ -34,6 +35,7 @@ __all__ = [
     "ContextBudget",
     "DeterministicCompactionSummarizer",
     "PartAwareCompactionStrategy",
+    "TailTurnCompactionStrategy",
     "build_compaction_prompt",
     "latest_compaction_summary",
     "maybe_summarize_compaction",

--- a/src/efp_runtime/compaction/__init__.py
+++ b/src/efp_runtime/compaction/__init__.py
@@ -22,6 +22,7 @@ from .strategy import (
     PartAwareCompactionStrategy,
     TailTurnCompactionStrategy,
 )
+from .prune import ToolOutputPruneResult, prune_old_tool_outputs
 
 __all__ = [
     "BudgetCompactionStrategy",
@@ -36,8 +37,10 @@ __all__ = [
     "DeterministicCompactionSummarizer",
     "PartAwareCompactionStrategy",
     "TailTurnCompactionStrategy",
+    "ToolOutputPruneResult",
     "build_compaction_prompt",
     "latest_compaction_summary",
     "maybe_summarize_compaction",
+    "prune_old_tool_outputs",
     "render_anchored_compaction_summary",
 ]

--- a/src/efp_runtime/compaction/prune.py
+++ b/src/efp_runtime/compaction/prune.py
@@ -1,0 +1,238 @@
+"""Post-hoc pruning of old persisted tool result output."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+from ..session.models import Message, MessagePart, MessagePartType, MessageRole
+from ..types import ToolResult, utc_now_iso
+
+
+DEFAULT_PROTECTED_TOOLS = frozenset({"skill"})
+PRUNE_MARKER_TEMPLATE = (
+    "[Old tool result content cleared for context compaction: omitted {chars} chars]"
+)
+
+
+@dataclass(frozen=True)
+class ToolOutputPruneResult:
+    """Result of clearing old tool result content from copied messages."""
+
+    messages: list[Message]
+    pruned_result_count: int = 0
+    pruned_chars: int = 0
+    protected_chars: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _PruneCandidate:
+    part: MessagePart
+    result: ToolResult
+    original_chars: int
+
+
+def prune_old_tool_outputs(
+    messages: Iterable[Message],
+    *,
+    protect_recent_chars: int = 40000,
+    min_pruned_chars: int = 20000,
+    output_max_chars: int = 2000,
+    protected_tools: frozenset[str] = DEFAULT_PROTECTED_TOOLS,
+) -> ToolOutputPruneResult:
+    """Prune old completed tool result content from copied session history.
+
+    The latest two user turns are always protected. Older completed tool
+    results are walked from newest to oldest; the newest eligible output up to
+    ``protect_recent_chars`` is kept, and only older eligible output is pruned.
+    """
+
+    protect_recent_chars = _non_negative_int(
+        protect_recent_chars,
+        "protect_recent_chars",
+    )
+    min_pruned_chars = _non_negative_int(min_pruned_chars, "min_pruned_chars")
+    output_max_chars = _non_negative_int(output_max_chars, "output_max_chars")
+    protected_tool_names = frozenset(str(tool) for tool in protected_tools)
+
+    copied_messages = deepcopy(list(messages))
+    candidates: list[_PruneCandidate] = []
+    protected_chars = 0
+    total_counted_chars = 0
+    skipped_protected_tools = 0
+    skipped_already_pruned = 0
+    user_turns_seen = 0
+
+    for message in reversed(copied_messages):
+        if message.role is MessageRole.USER:
+            user_turns_seen += 1
+        if user_turns_seen < 2:
+            continue
+
+        for part in reversed(message.parts):
+            if part.type is not MessagePartType.TOOL_RESULT:
+                continue
+            result = part.tool_result
+            if result is None or not _is_completed_tool_result(result):
+                continue
+            if result.tool_name in protected_tool_names:
+                skipped_protected_tools += 1
+                continue
+            if _is_compaction_pruned(part.metadata) or _is_compaction_pruned(
+                result.metadata
+            ):
+                skipped_already_pruned += 1
+                continue
+
+            original_chars = len(result.content or "")
+            if original_chars <= 0:
+                continue
+
+            total_counted_chars += original_chars
+            if total_counted_chars <= protect_recent_chars:
+                protected_chars += original_chars
+                continue
+
+            candidates.append(
+                _PruneCandidate(
+                    part=part,
+                    result=result,
+                    original_chars=original_chars,
+                )
+            )
+
+    candidate_chars = sum(candidate.original_chars for candidate in candidates)
+    if candidate_chars <= min_pruned_chars:
+        return ToolOutputPruneResult(
+            messages=copied_messages,
+            protected_chars=protected_chars,
+            metadata=_result_metadata(
+                pruned_result_count=0,
+                pruned_chars=0,
+                protected_chars=protected_chars,
+                candidate_chars=candidate_chars,
+                protect_recent_chars=protect_recent_chars,
+                min_pruned_chars=min_pruned_chars,
+                output_max_chars=output_max_chars,
+                protected_tools=protected_tool_names,
+                skipped_protected_tools=skipped_protected_tools,
+                skipped_already_pruned=skipped_already_pruned,
+            ),
+        )
+
+    pruned_chars = 0
+    pruned_at = utc_now_iso()
+    for candidate in candidates:
+        pruned_chars += _prune_candidate(
+            candidate,
+            output_max_chars=output_max_chars,
+            pruned_at=pruned_at,
+        )
+
+    return ToolOutputPruneResult(
+        messages=copied_messages,
+        pruned_result_count=len(candidates),
+        pruned_chars=pruned_chars,
+        protected_chars=protected_chars,
+        metadata=_result_metadata(
+            pruned_result_count=len(candidates),
+            pruned_chars=pruned_chars,
+            protected_chars=protected_chars,
+            candidate_chars=candidate_chars,
+            protect_recent_chars=protect_recent_chars,
+            min_pruned_chars=min_pruned_chars,
+            output_max_chars=output_max_chars,
+            protected_tools=protected_tool_names,
+            skipped_protected_tools=skipped_protected_tools,
+            skipped_already_pruned=skipped_already_pruned,
+            compaction_pruned_at=pruned_at,
+        ),
+    )
+
+
+def _prune_candidate(
+    candidate: _PruneCandidate,
+    *,
+    output_max_chars: int,
+    pruned_at: str,
+) -> int:
+    result = candidate.result
+    preview = (result.content or "")[:output_max_chars]
+    omitted_chars = max(0, candidate.original_chars - len(preview))
+    marker = PRUNE_MARKER_TEMPLATE.format(chars=omitted_chars)
+    compacted_content = f"{preview}\n\n{marker}" if preview else marker
+
+    result.content = compacted_content
+    if isinstance(result.output, str):
+        result.output = compacted_content
+    result.truncated = True
+
+    marker_metadata = {
+        "compaction_pruned": True,
+        "compaction_pruned_at": pruned_at,
+        "original_chars": candidate.original_chars,
+        "omitted_chars": omitted_chars,
+        "output_max_chars": output_max_chars,
+    }
+    result.metadata.update(marker_metadata)
+    candidate.part.metadata.update(marker_metadata)
+    return omitted_chars
+
+
+def _result_metadata(
+    *,
+    pruned_result_count: int,
+    pruned_chars: int,
+    protected_chars: int,
+    candidate_chars: int,
+    protect_recent_chars: int,
+    min_pruned_chars: int,
+    output_max_chars: int,
+    protected_tools: frozenset[str],
+    skipped_protected_tools: int,
+    skipped_already_pruned: int,
+    compaction_pruned_at: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "compaction_pruned": pruned_result_count > 0,
+        "pruned_result_count": pruned_result_count,
+        "pruned_chars": pruned_chars,
+        "candidate_chars": candidate_chars,
+        "protected_chars": protected_chars,
+        "protect_recent_chars": protect_recent_chars,
+        "min_pruned_chars": min_pruned_chars,
+        "output_max_chars": output_max_chars,
+        "protected_tools": sorted(protected_tools),
+        "skipped_protected_tool_count": skipped_protected_tools,
+        "skipped_already_pruned_count": skipped_already_pruned,
+    }
+    if compaction_pruned_at is not None:
+        metadata["compaction_pruned_at"] = compaction_pruned_at
+    return metadata
+
+
+def _is_completed_tool_result(result: ToolResult) -> bool:
+    return result.success and result.status in {"success", "complete", "completed"}
+
+
+def _is_compaction_pruned(metadata: Mapping[str, Any]) -> bool:
+    return any(
+        metadata.get(key) is True
+        for key in (
+            "compaction_pruned",
+            "compaction_compacted",
+            "compacted",
+            "pruned",
+        )
+    )
+
+
+def _non_negative_int(value: int, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+__all__ = ["ToolOutputPruneResult", "prune_old_tool_outputs"]

--- a/src/efp_runtime/compaction/strategy.py
+++ b/src/efp_runtime/compaction/strategy.py
@@ -82,6 +82,13 @@ class _Block:
         return sum(_part_chars(ref.part) for ref in self.refs)
 
 
+@dataclass(frozen=True)
+class _Turn:
+    start_index: int
+    end_index: int
+    message_id: str
+
+
 class BudgetCompactionStrategy:
     """Keep protected and recent part blocks inside an approximate budget."""
 
@@ -208,6 +215,146 @@ class PartAwareCompactionStrategy(BudgetCompactionStrategy):
         super().__init__(budget=ContextBudget(max_parts=max_parts))
 
 
+class TailTurnCompactionStrategy(BudgetCompactionStrategy):
+    """Keep a recent suffix of user turns and summarize older history."""
+
+    def __init__(
+        self,
+        *,
+        budget: ContextBudget,
+        tail_turns: int = 2,
+        preserve_recent_chars: int | None = None,
+    ):
+        _validate_non_negative_int(tail_turns, "tail_turns")
+        if preserve_recent_chars is not None:
+            _validate_non_negative_int(
+                preserve_recent_chars,
+                "preserve_recent_chars",
+            )
+        super().__init__(budget=budget)
+        self.tail_turns = tail_turns
+        self.preserve_recent_chars = preserve_recent_chars
+
+    def compact(self, messages: list[Message]) -> CompactionResult:
+        refs = _flatten_messages(messages)
+        total_chars = _messages_chars(messages)
+        if not self._over_budget(part_count=len(refs), char_count=total_chars):
+            return CompactionResult(
+                messages=list(messages),
+                source_messages=list(messages),
+                kept_messages=list(messages),
+                kept_chars=total_chars,
+            )
+
+        blocks = _group_part_blocks(refs)
+        pending_call_ids = _pending_tool_call_ids(refs)
+        protected_indices = {
+            index
+            for index, block in enumerate(blocks)
+            if _is_protected_block(block, pending_call_ids=pending_call_ids)
+        }
+        recent_budget = self._recent_tail_budget()
+        tail_start_index = self._tail_start_index(messages, recent_budget)
+        tail_indices = (
+            _block_indices_from_message_index(blocks, tail_start_index)
+            if tail_start_index is not None
+            else set()
+        )
+        kept_indices = protected_indices | tail_indices
+        compacted_blocks = [
+            block for index, block in enumerate(blocks) if index not in kept_indices
+        ]
+        if not compacted_blocks:
+            return CompactionResult(
+                messages=list(messages),
+                source_messages=list(messages),
+                kept_messages=list(messages),
+                kept_chars=total_chars,
+            )
+
+        kept_keys = {ref.key for index in kept_indices for ref in blocks[index].refs}
+        compacted_keys = {ref.key for block in compacted_blocks for ref in block.refs}
+        tail_start_message_id = _tail_start_message_id(
+            messages,
+            blocks=blocks,
+            tail_indices=tail_indices,
+            tail_start_index=tail_start_index,
+        )
+        compaction_message = _build_compaction_message(
+            compacted_blocks,
+            previous_summary=latest_compaction_summary(messages),
+            tail_start_message_id=tail_start_message_id,
+            metadata={
+                "strategy": "tail_turn",
+                "tail_turns": self.tail_turns,
+                "preserve_recent_chars": recent_budget,
+                "tail_start_message_id": tail_start_message_id,
+            },
+        )
+        remaining_items = _rebuild_message_items(messages, kept_keys)
+        final_messages = _insert_compaction_message(
+            compaction_message,
+            remaining_items,
+            compacted_blocks,
+        )
+        return CompactionResult(
+            messages=final_messages,
+            source_messages=list(messages),
+            compacted_messages=_rebuild_messages(messages, compacted_keys),
+            kept_messages=_rebuild_messages(messages, kept_keys),
+            compacted_part_count=sum(block.part_count for block in compacted_blocks),
+            compacted_message_count=len(
+                {ref.message_index for block in compacted_blocks for ref in block.refs}
+            ),
+            compacted_tool_pair_count=sum(1 for block in compacted_blocks if block.is_tool_pair),
+            compacted_chars=sum(block.char_count for block in compacted_blocks),
+            kept_chars=_messages_chars(final_messages),
+        )
+
+    def _recent_tail_budget(self) -> int:
+        if self.preserve_recent_chars is not None:
+            return self.preserve_recent_chars
+        effective_max_chars = self.budget.effective_max_chars
+        if effective_max_chars is None:
+            return 8000
+        return max(2000, min(8000, effective_max_chars // 4))
+
+    def _tail_start_index(
+        self,
+        messages: list[Message],
+        recent_budget: int,
+    ) -> int | None:
+        if self.tail_turns <= 0:
+            return None
+        turns = _user_turns(messages)
+        if not turns:
+            return None
+
+        recent_turns = turns[-self.tail_turns :]
+        turn_sizes = [
+            _messages_chars(messages[turn.start_index : turn.end_index])
+            for turn in recent_turns
+        ]
+        total = 0
+        keep_start: int | None = None
+        for index in reversed(range(len(recent_turns))):
+            turn = recent_turns[index]
+            turn_size = turn_sizes[index]
+            if total + turn_size <= recent_budget:
+                total += turn_size
+                keep_start = turn.start_index
+                continue
+            split_start = _split_turn_start(
+                messages,
+                turn=turn,
+                budget=recent_budget - total,
+            )
+            if split_start is not None:
+                keep_start = split_start
+            break
+        return keep_start
+
+
 def _flatten_messages(messages: list[Message]) -> list[_PartRef]:
     refs: list[_PartRef] = []
     for message_index, message in enumerate(messages):
@@ -274,6 +421,81 @@ def _pending_tool_call_ids(refs: list[_PartRef]) -> set[str]:
     return call_ids - result_ids
 
 
+def _user_turns(messages: list[Message]) -> list[_Turn]:
+    turns: list[_Turn] = []
+    for index, message in enumerate(messages):
+        if message.role is not MessageRole.USER:
+            continue
+        if _message_has_compaction_part(message):
+            continue
+        turns.append(
+            _Turn(
+                start_index=index,
+                end_index=len(messages),
+                message_id=message.message_id,
+            )
+        )
+
+    for index in range(len(turns) - 1):
+        turns[index] = _Turn(
+            start_index=turns[index].start_index,
+            end_index=turns[index + 1].start_index,
+            message_id=turns[index].message_id,
+        )
+    return turns
+
+
+def _message_has_compaction_part(message: Message) -> bool:
+    return any(part.type is MessagePartType.COMPACTION for part in message.parts)
+
+
+def _split_turn_start(
+    messages: list[Message],
+    *,
+    turn: _Turn,
+    budget: int,
+) -> int | None:
+    if budget <= 0:
+        return None
+    if turn.end_index - turn.start_index <= 1:
+        return None
+    for start_index in range(turn.start_index + 1, turn.end_index):
+        if _messages_chars(messages[start_index : turn.end_index]) <= budget:
+            return start_index
+    return None
+
+
+def _block_indices_from_message_index(
+    blocks: list[_Block],
+    message_index: int,
+) -> set[int]:
+    return {
+        index
+        for index, block in enumerate(blocks)
+        if any(ref.message_index >= message_index for ref in block.refs)
+    }
+
+
+def _tail_start_message_id(
+    messages: list[Message],
+    *,
+    blocks: list[_Block],
+    tail_indices: set[int],
+    tail_start_index: int | None,
+) -> str | None:
+    if tail_start_index is None:
+        return None
+    message_indices = [
+        ref.message_index
+        for index in tail_indices
+        for ref in blocks[index].refs
+        if ref.message_index >= tail_start_index
+    ]
+    if not message_indices:
+        return None
+    return messages[min(message_indices)].message_id
+
+
 def _is_protected_block(block: _Block, *, pending_call_ids: set[str]) -> bool:
     for ref in block.refs:
         if (
@@ -314,7 +536,13 @@ def _selection_usage(blocks: list[_Block], kept_indices: set[int]) -> tuple[int,
     return part_count, char_count
 
 
-def _build_compaction_message(compacted_blocks: list[_Block]) -> Message:
+def _build_compaction_message(
+    compacted_blocks: list[_Block],
+    *,
+    previous_summary: str | None = None,
+    tail_start_message_id: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> Message:
     part_count = sum(block.part_count for block in compacted_blocks)
     message_refs = {ref.message_index: ref.message for block in compacted_blocks for ref in block.refs}
     message_count = len(message_refs)
@@ -325,21 +553,26 @@ def _build_compaction_message(compacted_blocks: list[_Block]) -> Message:
     summary = render_anchored_compaction_summary(
         session_id=session_id,
         compacted_messages=source_messages,
-        previous_summary=latest_compaction_summary(source_messages),
+        previous_summary=previous_summary or latest_compaction_summary(source_messages),
         metadata={
             "compacted_part_count": part_count,
             "compacted_message_count": message_count,
             "compacted_tool_pair_count": tool_pair_count,
         },
     )
+    compaction_metadata = {
+        "approx_compacted_chars": sum(block.char_count for block in compacted_blocks)
+    }
+    compaction_metadata.update(dict(metadata or {}))
     compaction = CompactionPart(
         summary=summary,
         source_message_ids=source_message_ids,
         auto=True,
+        tail_start_message_id=tail_start_message_id,
         original_part_count=part_count,
         original_message_count=message_count,
         tool_pair_count=tool_pair_count,
-        metadata={"approx_compacted_chars": sum(block.char_count for block in compacted_blocks)},
+        metadata=compaction_metadata,
     )
     return Message(
         role="system",
@@ -464,3 +697,8 @@ def _json_chars(value: Mapping[str, Any]) -> int:
 
 def _copy_mapping(mapping: Mapping[str, Any]) -> dict[str, Any]:
     return dict(mapping)
+
+
+def _validate_non_negative_int(value: Any, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be greater than or equal to 0")

--- a/src/efp_runtime/compaction/strategy.py
+++ b/src/efp_runtime/compaction/strategy.py
@@ -221,7 +221,10 @@ class TailTurnCompactionStrategy(BudgetCompactionStrategy):
     def __init__(
         self,
         *,
-        budget: ContextBudget,
+        budget: ContextBudget | None = None,
+        max_parts: int | None = None,
+        max_chars: int | None = None,
+        reserve_chars: int = 0,
         tail_turns: int = 2,
         preserve_recent_chars: int | None = None,
     ):
@@ -231,7 +234,12 @@ class TailTurnCompactionStrategy(BudgetCompactionStrategy):
                 preserve_recent_chars,
                 "preserve_recent_chars",
             )
-        super().__init__(budget=budget)
+        super().__init__(
+            budget=budget,
+            max_parts=max_parts,
+            max_chars=max_chars,
+            reserve_chars=reserve_chars,
+        )
         self.tail_turns = tail_turns
         self.preserve_recent_chars = preserve_recent_chars
 
@@ -521,6 +529,49 @@ def _latest_unprotected_block_index(
         if index not in protected_indices:
             return index
     return None
+
+
+def _tail_turn_block_indices(blocks: list[_Block], *, tail_turns: int) -> set[int]:
+    if tail_turns <= 0:
+        return set()
+
+    user_message_indices = sorted(
+        {
+            ref.message_index
+            for block in blocks
+            for ref in block.refs
+            if ref.message.role is MessageRole.USER
+        }
+    )
+    if not user_message_indices:
+        return set()
+
+    tail_start_index = user_message_indices[
+        max(0, len(user_message_indices) - tail_turns)
+    ]
+    return {
+        index
+        for index, block in enumerate(blocks)
+        if any(ref.message_index >= tail_start_index for ref in block.refs)
+    }
+
+
+def _recent_char_block_indices(
+    blocks: list[_Block],
+    *,
+    preserve_recent_chars: int | None,
+) -> set[int]:
+    if preserve_recent_chars is None or preserve_recent_chars <= 0:
+        return set()
+
+    selected: set[int] = set()
+    chars = 0
+    for index in reversed(range(len(blocks))):
+        selected.add(index)
+        chars += blocks[index].char_count
+        if chars >= preserve_recent_chars:
+            break
+    return selected
 
 
 def _selection_usage(blocks: list[_Block], kept_indices: set[int]) -> tuple[int, int]:

--- a/src/efp_runtime/config_loader.py
+++ b/src/efp_runtime/config_loader.py
@@ -72,6 +72,13 @@ _RUNTIME_CONFIG_KEYS = {
     "enabled_tools",
     "modelAwareToolSelection",
     "model_aware_tool_selection",
+    "compaction",
+    "compaction_auto",
+    "compaction_prune",
+    "compaction_tail_turns",
+    "compaction_preserve_recent_chars",
+    "compaction_reserved_chars",
+    "compaction_tool_output_max_chars",
     "instructions",
     "systemPrompt",
     "system_prompt",
@@ -478,6 +485,8 @@ def _runtime_config_from_raw(
     if model_aware_tool_selection is not None:
         kwargs["model_aware_tool_selection"] = model_aware_tool_selection
 
+    kwargs.update(_compaction_policy_fields(raw))
+
     instruction_paths, instruction_texts = _instruction_sources(
         raw.get("instructions"),
         workspace_root=workspace_root,
@@ -698,6 +707,55 @@ def _model_aware_tool_selection(raw: Mapping[str, Any]) -> Any:
     return selection
 
 
+_COMPACTION_NESTED_ALIASES = {
+    "auto": "compaction_auto",
+    "prune": "compaction_prune",
+    "tail_turns": "compaction_tail_turns",
+    "tailTurns": "compaction_tail_turns",
+    "preserve_recent_chars": "compaction_preserve_recent_chars",
+    "preserveRecentChars": "compaction_preserve_recent_chars",
+    "reserved": "compaction_reserved_chars",
+    "tool_output_max_chars": "compaction_tool_output_max_chars",
+    "toolOutputMaxChars": "compaction_tool_output_max_chars",
+}
+
+_COMPACTION_TOP_LEVEL_FIELDS = {
+    "compaction_auto",
+    "compaction_prune",
+    "compaction_tail_turns",
+    "compaction_preserve_recent_chars",
+    "compaction_reserved_chars",
+    "compaction_tool_output_max_chars",
+}
+
+
+def _compaction_policy_fields(raw: Mapping[str, Any]) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for key, value in raw.items():
+        key_text = str(key)
+        if key_text == "compaction":
+            if not isinstance(value, Mapping):
+                raise ValueError("compaction must be an object")
+            for nested_key, nested_value in value.items():
+                field_name = _COMPACTION_NESTED_ALIASES.get(str(nested_key))
+                if field_name is not None:
+                    fields[field_name] = nested_value
+            continue
+        if key_text in _COMPACTION_TOP_LEVEL_FIELDS:
+            fields[key_text] = value
+    return fields
+
+
+def _unconsumed_compaction_config(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("compaction must be an object")
+    return {
+        str(compaction_key): deepcopy(compaction_value)
+        for compaction_key, compaction_value in value.items()
+        if str(compaction_key) not in _COMPACTION_NESTED_ALIASES
+    }
+
+
 def _command_directories(
     raw: Mapping[str, Any],
     *,
@@ -805,6 +863,11 @@ def _unconsumed_config(raw: Mapping[str, Any]) -> dict[str, Any]:
                     unconsumed[key_text] = runtime_extra
             else:
                 unconsumed[key_text] = deepcopy(value)
+            continue
+        if key_text == "compaction":
+            compaction_extra = _unconsumed_compaction_config(value)
+            if compaction_extra:
+                unconsumed[key_text] = compaction_extra
             continue
         if key_text == "skills":
             skills_extra = _unconsumed_skills_config(value)

--- a/src/efp_runtime/config_loader.py
+++ b/src/efp_runtime/config_loader.py
@@ -79,6 +79,8 @@ _RUNTIME_CONFIG_KEYS = {
     "compaction_preserve_recent_chars",
     "compaction_reserved_chars",
     "compaction_tool_output_max_chars",
+    "compaction_prune_min_chars",
+    "compaction_prune_protect_chars",
     "instructions",
     "systemPrompt",
     "system_prompt",
@@ -717,6 +719,10 @@ _COMPACTION_NESTED_ALIASES = {
     "reserved": "compaction_reserved_chars",
     "tool_output_max_chars": "compaction_tool_output_max_chars",
     "toolOutputMaxChars": "compaction_tool_output_max_chars",
+    "prune_min_chars": "compaction_prune_min_chars",
+    "pruneMinChars": "compaction_prune_min_chars",
+    "prune_protect_chars": "compaction_prune_protect_chars",
+    "pruneProtectChars": "compaction_prune_protect_chars",
 }
 
 _COMPACTION_TOP_LEVEL_FIELDS = {
@@ -726,6 +732,8 @@ _COMPACTION_TOP_LEVEL_FIELDS = {
     "compaction_preserve_recent_chars",
     "compaction_reserved_chars",
     "compaction_tool_output_max_chars",
+    "compaction_prune_min_chars",
+    "compaction_prune_protect_chars",
 }
 
 

--- a/src/efp_runtime/loop/runner.py
+++ b/src/efp_runtime/loop/runner.py
@@ -11,7 +11,12 @@ import json
 from typing import Any, Callable, List, Optional, Union
 
 from ..compaction.controller import CompactionController, CompactionSummarizer
-from ..compaction.strategy import ContextBudget
+from ..compaction.strategy import (
+    BudgetCompactionStrategy,
+    CompactionResult,
+    ContextBudget,
+    TailTurnCompactionStrategy,
+)
 from ..context.render import prepare_history_for_request
 from ..event_bus import RuntimeEventBus
 from ..events import RuntimeEvent
@@ -117,6 +122,10 @@ class RuntimeLoopRunner:
         is_cancelled: Optional[CancelCallback] = None,
         tool_selection: Optional[ToolSelection] = None,
         compaction_summarizer: Optional[CompactionSummarizer] = None,
+        compaction_auto: bool = True,
+        compaction_tail_turns: int = 2,
+        compaction_preserve_recent_chars: int | None = None,
+        compaction_reserved_chars: int | None = None,
         provider_max_retries: int = 2,
         provider_retry_backoff_seconds: float = 0.0,
         provider_retry_backoff_multiplier: float = 2.0,
@@ -135,6 +144,18 @@ class RuntimeLoopRunner:
             raise ValueError("max_context_chars must be at least 1")
         if context_reserve_chars < 0:
             raise ValueError("context_reserve_chars must be at least 0")
+        _validate_non_negative_int(
+            compaction_tail_turns,
+            field_name="compaction_tail_turns",
+        )
+        _validate_optional_non_negative_int(
+            compaction_preserve_recent_chars,
+            field_name="compaction_preserve_recent_chars",
+        )
+        _validate_optional_non_negative_int(
+            compaction_reserved_chars,
+            field_name="compaction_reserved_chars",
+        )
         if provider_max_retries < 0:
             raise ValueError("provider_max_retries must be greater than or equal to 0")
         if provider_retry_backoff_seconds < 0:
@@ -158,6 +179,10 @@ class RuntimeLoopRunner:
         self.is_cancelled = is_cancelled
         self.tool_selection = _copy_tool_selection(tool_selection)
         self.compaction_summarizer = compaction_summarizer
+        self.compaction_auto = bool(compaction_auto)
+        self.compaction_tail_turns = compaction_tail_turns
+        self.compaction_preserve_recent_chars = compaction_preserve_recent_chars
+        self.compaction_reserved_chars = compaction_reserved_chars
         self.provider_max_retries = provider_max_retries
         self.provider_retry_backoff_seconds = provider_retry_backoff_seconds
         self.provider_retry_backoff_multiplier = provider_retry_backoff_multiplier
@@ -344,6 +369,16 @@ class RuntimeLoopRunner:
 
             iteration = iterations + 1
             history = self.store.read_history(resolved_session_id)
+            history = await self._maybe_compact_stored_session_history(
+                session_id=resolved_session_id,
+                history=history,
+                runtime_events=runtime_events,
+                run_id=run_id,
+                iteration=iteration,
+                trigger="context_budget",
+                overflow=False,
+                budget=self._context_budget(),
+            )
             request_history = [*(context_messages or []), *history]
             request_metadata = _request_metadata(
                 run_metadata,
@@ -624,7 +659,7 @@ class RuntimeLoopRunner:
         return ContextBudget(
             max_parts=self.max_context_parts,
             max_chars=self.max_context_chars,
-            reserve_chars=self.context_reserve_chars,
+            reserve_chars=self._context_budget_reserve_chars(),
         )
 
     def _context_budget_enabled(self, budget: Optional[ContextBudget] = None) -> bool:
@@ -643,7 +678,126 @@ class RuntimeLoopRunner:
         return ContextBudget(
             max_parts=max_parts,
             max_chars=max_chars,
-            reserve_chars=self.context_reserve_chars,
+            reserve_chars=self._context_budget_reserve_chars(),
+        )
+
+    def _context_budget_reserve_chars(self) -> int:
+        if self.compaction_reserved_chars is not None:
+            return self.compaction_reserved_chars
+        return self.context_reserve_chars
+
+    async def _maybe_compact_stored_session_history(
+        self,
+        *,
+        session_id: str,
+        history: list[Message],
+        runtime_events: List[RuntimeEvent],
+        run_id: str,
+        iteration: int,
+        trigger: str,
+        overflow: bool,
+        budget: ContextBudget,
+        overflow_retry: bool = False,
+    ) -> list[Message]:
+        if not self.compaction_auto:
+            return history
+        if not self._context_budget_enabled(budget):
+            return history
+        if not history:
+            return history
+
+        strategy = self._stored_session_compaction_strategy(budget)
+        tail_start_message_id = _tail_start_message_id(
+            history,
+            tail_turns=self.compaction_tail_turns,
+        )
+        operation_metadata = _auto_compaction_operation_metadata(
+            budget=budget,
+            trigger=trigger,
+            overflow=overflow,
+            overflow_retry=overflow_retry,
+            tail_turns=self.compaction_tail_turns,
+            preserve_recent_chars=self.compaction_preserve_recent_chars,
+            tail_start_message_id=tail_start_message_id,
+        )
+        summary: str | None = None
+        if self.compaction_summarizer is not None:
+            preparation = await CompactionController(self.compaction_summarizer).prepare(
+                history,
+                session_id=session_id,
+                metadata=operation_metadata,
+                compaction_strategy=strategy,
+            )
+            result = preparation.result
+            summary = preparation.summary
+            compaction_metadata = dict(preparation.compaction_metadata)
+        else:
+            result = strategy.compact(history)
+            compaction_metadata = (
+                _compaction_result_metadata(budget, result)
+                if result.compacted
+                else {}
+            )
+
+        if not result.compacted:
+            return history
+
+        compaction_metadata.update(operation_metadata)
+        compacted_messages = _apply_auto_compaction_metadata(
+            result.messages,
+            source_messages=history,
+            summary=summary,
+            metadata=compaction_metadata,
+            overflow=overflow,
+            tail_start_message_id=tail_start_message_id,
+        )
+        message_id, part_id = _first_new_compaction_identifiers(
+            compacted_messages,
+            source_messages=history,
+        )
+        event_payload = {
+            "run_id": run_id,
+            "iteration": iteration,
+            **compaction_metadata,
+        }
+        runtime_events.append(
+            RuntimeEvent(
+                type="session_compaction_started",
+                message="Automatic session compaction started.",
+                session_id=session_id,
+                message_id=message_id,
+                part_id=part_id,
+                payload=dict(event_payload),
+            )
+        )
+        updated_session = self.store.replace_history(session_id, compacted_messages)
+        updated_history = list(updated_session.messages)
+        runtime_events.append(
+            RuntimeEvent(
+                type="session_compacted",
+                message="Session history compacted.",
+                session_id=session_id,
+                message_id=message_id,
+                part_id=part_id,
+                payload={
+                    **event_payload,
+                    "stored_message_count": len(updated_history),
+                },
+            )
+        )
+        return updated_history
+
+    def _stored_session_compaction_strategy(
+        self,
+        budget: ContextBudget,
+    ) -> BudgetCompactionStrategy:
+        strategy_cls = globals().get("TailTurnCompactionStrategy")
+        if strategy_cls is None:
+            return BudgetCompactionStrategy(budget=budget)
+        return strategy_cls(
+            budget=budget,
+            tail_turns=self.compaction_tail_turns,
+            preserve_recent_chars=self.compaction_preserve_recent_chars,
         )
 
     async def _prepare_runtime_request(
@@ -783,10 +937,30 @@ class RuntimeLoopRunner:
                     attempt=overflow_retry_count,
                     budget=overflow_budget,
                 )
+                provider_context_messages = request_history[
+                    : max(0, len(request_history) - len(history))
+                ]
+                retry_history = history
+                if self.compaction_auto:
+                    retry_history = await self._maybe_compact_stored_session_history(
+                        session_id=current_request.session_id,
+                        history=self.store.read_history(current_request.session_id),
+                        runtime_events=runtime_events,
+                        run_id=run_id,
+                        iteration=iteration,
+                        trigger="provider_context_overflow",
+                        overflow=True,
+                        overflow_retry=True,
+                        budget=overflow_budget,
+                    )
+                retry_request_history = [
+                    *provider_context_messages,
+                    *retry_history,
+                ]
                 overflow_request = await self._prepare_runtime_request(
                     session_id=current_request.session_id,
-                    history=history,
-                    request_history=request_history,
+                    history=retry_history,
+                    request_history=retry_request_history,
                     iteration=iteration,
                     max_iterations=max_iterations,
                     metadata=overflow_metadata,
@@ -1326,6 +1500,10 @@ async def run_runtime_loop(
     structured_output_required: bool = False,
     structured_output_tool_id: str = "StructuredOutput",
     compaction_summarizer: Optional[CompactionSummarizer] = None,
+    compaction_auto: bool = True,
+    compaction_tail_turns: int = 2,
+    compaction_preserve_recent_chars: int | None = None,
+    compaction_reserved_chars: int | None = None,
     provider_max_retries: int = 2,
     provider_retry_backoff_seconds: float = 0.0,
     provider_retry_backoff_multiplier: float = 2.0,
@@ -1348,6 +1526,10 @@ async def run_runtime_loop(
         is_cancelled=is_cancelled,
         tool_selection=tool_selection,
         compaction_summarizer=compaction_summarizer,
+        compaction_auto=compaction_auto,
+        compaction_tail_turns=compaction_tail_turns,
+        compaction_preserve_recent_chars=compaction_preserve_recent_chars,
+        compaction_reserved_chars=compaction_reserved_chars,
         provider_max_retries=provider_max_retries,
         provider_retry_backoff_seconds=provider_retry_backoff_seconds,
         provider_retry_backoff_multiplier=provider_retry_backoff_multiplier,
@@ -1444,6 +1626,17 @@ def _copy_tool_selection(selection: Optional[ToolSelection]) -> ToolSelection:
         disabled=set(selection.disabled),
         forced_disabled=set(selection.forced_disabled),
     )
+
+
+def _validate_non_negative_int(value: Any, *, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer")
+
+
+def _validate_optional_non_negative_int(value: Any, *, field_name: str) -> None:
+    if value is None:
+        return
+    _validate_non_negative_int(value, field_name=field_name)
 
 
 def _disabled_tool_ids(
@@ -1796,6 +1989,120 @@ def _request_metadata(
     return request_metadata
 
 
+def _auto_compaction_operation_metadata(
+    *,
+    budget: ContextBudget,
+    trigger: str,
+    overflow: bool,
+    overflow_retry: bool,
+    tail_turns: int,
+    preserve_recent_chars: int | None,
+    tail_start_message_id: str | None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "trigger": trigger,
+        "compaction_trigger": trigger,
+        "auto": True,
+        "overflow": overflow,
+        "overflow_retry": overflow_retry,
+        "max_parts": budget.max_parts,
+        "max_chars": budget.max_chars,
+        "reserve_chars": budget.reserve_chars,
+        "tail_turns": tail_turns,
+    }
+    if preserve_recent_chars is not None:
+        metadata["preserve_recent_chars"] = preserve_recent_chars
+    if tail_start_message_id is not None:
+        metadata["tail_start_message_id"] = tail_start_message_id
+    return metadata
+
+
+def _compaction_result_metadata(
+    budget: ContextBudget,
+    result: CompactionResult,
+) -> dict[str, Any]:
+    return {
+        "max_parts": budget.max_parts,
+        "max_chars": budget.max_chars,
+        "reserve_chars": budget.reserve_chars,
+        "compacted_part_count": result.compacted_part_count,
+        "compacted_message_count": result.compacted_message_count,
+        "compacted_tool_pair_count": result.compacted_tool_pair_count,
+        "compacted_chars": result.compacted_chars,
+        "kept_chars": result.kept_chars,
+    }
+
+
+def _apply_auto_compaction_metadata(
+    messages: Iterable[Message],
+    *,
+    source_messages: Iterable[Message],
+    summary: str | None,
+    metadata: Mapping[str, Any],
+    overflow: bool,
+    tail_start_message_id: str | None,
+) -> list[Message]:
+    source_message_ids = {message.message_id for message in source_messages}
+    marker = {
+        "auto": True,
+        "compaction_trigger": metadata.get("trigger", "context_budget"),
+        "overflow": overflow,
+    }
+    updated_messages: list[Message] = []
+    for message in messages:
+        updated_message = deepcopy(message)
+        if updated_message.message_id in source_message_ids:
+            updated_messages.append(updated_message)
+            continue
+
+        updated_message.metadata.update(marker)
+        for part in updated_message.parts:
+            if part.type is not MessagePartType.COMPACTION or part.compaction is None:
+                continue
+            part.metadata.update(marker)
+            if summary is not None:
+                part.compaction.summary = summary
+                part.text = summary
+            part.compaction.auto = True
+            part.compaction.overflow = overflow
+            part.compaction.tail_start_message_id = tail_start_message_id
+            part.compaction.metadata.update(dict(metadata))
+        updated_messages.append(updated_message)
+    return updated_messages
+
+
+def _first_new_compaction_identifiers(
+    messages: Iterable[Message],
+    *,
+    source_messages: Iterable[Message],
+) -> tuple[str | None, str | None]:
+    source_message_ids = {message.message_id for message in source_messages}
+    for message in messages:
+        if message.message_id in source_message_ids:
+            continue
+        for part in message.parts:
+            if part.type is MessagePartType.COMPACTION:
+                return message.message_id, part.part_id
+    return None, None
+
+
+def _tail_start_message_id(
+    messages: Iterable[Message],
+    *,
+    tail_turns: int,
+) -> str | None:
+    if tail_turns <= 0:
+        return None
+    user_messages = [
+        message
+        for message in messages
+        if message.role is MessageRole.USER
+    ]
+    if not user_messages:
+        return None
+    return user_messages[max(0, len(user_messages) - tail_turns)].message_id
+
+
 def _provider_retry_event(
     *,
     session_id: str,
@@ -1935,6 +2242,9 @@ def _overflow_retry_info(
 ) -> dict[str, Any]:
     return {
         "overflow_retry": True,
+        "overflow": True,
+        "trigger": "provider_context_overflow",
+        "compaction_trigger": "provider_context_overflow",
         "overflow_attempt": attempt,
         "max_parts": budget.max_parts,
         "max_chars": budget.max_chars,

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -2224,6 +2224,12 @@ def _resolve_config(
             if context_reserve_chars is not None
             else config.context_reserve_chars
         ),
+        compaction_auto=config.compaction_auto,
+        compaction_prune=config.compaction_prune,
+        compaction_tail_turns=config.compaction_tail_turns,
+        compaction_preserve_recent_chars=config.compaction_preserve_recent_chars,
+        compaction_reserved_chars=config.compaction_reserved_chars,
+        compaction_tool_output_max_chars=config.compaction_tool_output_max_chars,
         enable_compaction_summarizer=config.enable_compaction_summarizer,
         provider_max_retries=config.provider_max_retries,
         provider_retry_backoff_seconds=config.provider_retry_backoff_seconds,

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
 from ..compaction.controller import CompactionController, CompactionSummarizer
+from ..compaction.prune import prune_old_tool_outputs
 from ..compaction.strategy import (
     BudgetCompactionStrategy,
     CompactionResult,
@@ -857,6 +858,35 @@ class AgentRuntime:
                 message_id=message_id,
                 part_id=part_id,
                 payload=dict(compaction_metadata),
+            )
+        )
+        return updated_session
+
+    def prune_session_tool_outputs(self, session_id: str, **options: Any) -> Session:
+        """Persistently clear old completed tool result content from a session."""
+
+        current_session = self.store.get_session(session_id)
+        if not self.config.compaction_prune:
+            return current_session
+
+        history = self.store.read_history(session_id)
+        prune_options = {
+            "protect_recent_chars": self.config.compaction_prune_protect_chars,
+            "min_pruned_chars": self.config.compaction_prune_min_chars,
+            "output_max_chars": self.config.compaction_tool_output_max_chars,
+        }
+        prune_options.update(options)
+        result = prune_old_tool_outputs(history, **prune_options)
+        if result.pruned_result_count == 0:
+            return current_session
+
+        updated_session = self._replace_history(session_id, result.messages)
+        self.event_bus.publish(
+            RuntimeEvent(
+                type="session_tool_outputs_pruned",
+                message="Old tool result content pruned.",
+                session_id=session_id,
+                payload=dict(result.metadata),
             )
         )
         return updated_session
@@ -2275,6 +2305,8 @@ def _resolve_config(
             else config.compaction_reserved_chars
         ),
         compaction_tool_output_max_chars=config.compaction_tool_output_max_chars,
+        compaction_prune_min_chars=config.compaction_prune_min_chars,
+        compaction_prune_protect_chars=config.compaction_prune_protect_chars,
         provider_max_retries=config.provider_max_retries,
         provider_retry_backoff_seconds=config.provider_retry_backoff_seconds,
         provider_retry_backoff_multiplier=config.provider_retry_backoff_multiplier,

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -144,6 +144,10 @@ class AgentRuntime:
         max_context_parts: int | None = None,
         max_context_chars: int | None = None,
         context_reserve_chars: int | None = None,
+        compaction_auto: bool | None = None,
+        compaction_tail_turns: int | None = None,
+        compaction_preserve_recent_chars: int | None = None,
+        compaction_reserved_chars: int | None = None,
         metadata: Mapping[str, Any] | None = None,
         store: SessionStore | None = None,
         tool_registry: ToolRegistry | None = None,
@@ -172,6 +176,10 @@ class AgentRuntime:
             max_context_parts=max_context_parts,
             max_context_chars=max_context_chars,
             context_reserve_chars=context_reserve_chars,
+            compaction_auto=compaction_auto,
+            compaction_tail_turns=compaction_tail_turns,
+            compaction_preserve_recent_chars=compaction_preserve_recent_chars,
+            compaction_reserved_chars=compaction_reserved_chars,
             metadata=metadata,
         )
         self.provider = provider
@@ -554,6 +562,12 @@ class AgentRuntime:
                     if self.config.enable_compaction_summarizer
                     else None
                 ),
+                compaction_auto=self.config.compaction_auto,
+                compaction_tail_turns=self.config.compaction_tail_turns,
+                compaction_preserve_recent_chars=(
+                    self.config.compaction_preserve_recent_chars
+                ),
+                compaction_reserved_chars=self.config.compaction_reserved_chars,
             )
             result = await runner.run(
                 user_text=user_text_for_request,
@@ -747,6 +761,12 @@ class AgentRuntime:
                     if self.config.enable_compaction_summarizer
                     else None
                 ),
+                compaction_auto=self.config.compaction_auto,
+                compaction_tail_turns=self.config.compaction_tail_turns,
+                compaction_preserve_recent_chars=(
+                    self.config.compaction_preserve_recent_chars
+                ),
+                compaction_reserved_chars=self.config.compaction_reserved_chars,
             )
             result = await runner.run(
                 user_text="",
@@ -2193,6 +2213,10 @@ def _resolve_config(
     max_context_chars: int | None,
     context_reserve_chars: int | None,
     metadata: Mapping[str, Any] | None,
+    compaction_auto: bool | None = None,
+    compaction_tail_turns: int | None = None,
+    compaction_preserve_recent_chars: int | None = None,
+    compaction_reserved_chars: int | None = None,
 ) -> RuntimeConfig:
     if config is None:
         return RuntimeConfig(
@@ -2204,6 +2228,12 @@ def _resolve_config(
             context_reserve_chars=(
                 context_reserve_chars if context_reserve_chars is not None else 0
             ),
+            compaction_auto=True if compaction_auto is None else compaction_auto,
+            compaction_tail_turns=(
+                2 if compaction_tail_turns is None else compaction_tail_turns
+            ),
+            compaction_preserve_recent_chars=compaction_preserve_recent_chars,
+            compaction_reserved_chars=compaction_reserved_chars,
             metadata=dict(metadata or {}),
         )
 
@@ -2224,13 +2254,27 @@ def _resolve_config(
             if context_reserve_chars is not None
             else config.context_reserve_chars
         ),
-        compaction_auto=config.compaction_auto,
-        compaction_prune=config.compaction_prune,
-        compaction_tail_turns=config.compaction_tail_turns,
-        compaction_preserve_recent_chars=config.compaction_preserve_recent_chars,
-        compaction_reserved_chars=config.compaction_reserved_chars,
-        compaction_tool_output_max_chars=config.compaction_tool_output_max_chars,
         enable_compaction_summarizer=config.enable_compaction_summarizer,
+        compaction_auto=(
+            compaction_auto if compaction_auto is not None else config.compaction_auto
+        ),
+        compaction_prune=config.compaction_prune,
+        compaction_tail_turns=(
+            compaction_tail_turns
+            if compaction_tail_turns is not None
+            else config.compaction_tail_turns
+        ),
+        compaction_preserve_recent_chars=(
+            compaction_preserve_recent_chars
+            if compaction_preserve_recent_chars is not None
+            else config.compaction_preserve_recent_chars
+        ),
+        compaction_reserved_chars=(
+            compaction_reserved_chars
+            if compaction_reserved_chars is not None
+            else config.compaction_reserved_chars
+        ),
+        compaction_tool_output_max_chars=config.compaction_tool_output_max_chars,
         provider_max_retries=config.provider_max_retries,
         provider_retry_backoff_seconds=config.provider_retry_backoff_seconds,
         provider_retry_backoff_multiplier=config.provider_retry_backoff_multiplier,

--- a/src/efp_runtime/runtime/config.py
+++ b/src/efp_runtime/runtime/config.py
@@ -22,6 +22,12 @@ class RuntimeConfig:
     max_context_parts: int | None = None
     max_context_chars: int | None = None
     context_reserve_chars: int = 0
+    compaction_auto: bool = True
+    compaction_prune: bool = True
+    compaction_tail_turns: int = 2
+    compaction_preserve_recent_chars: int | None = None
+    compaction_reserved_chars: int | None = None
+    compaction_tool_output_max_chars: int = 2000
     enable_compaction_summarizer: bool = False
     provider_max_retries: int = 2
     provider_retry_backoff_seconds: float = 0.0
@@ -83,6 +89,22 @@ class RuntimeConfig:
             raise ValueError("max_context_chars must be at least 1")
         if self.context_reserve_chars < 0:
             raise ValueError("context_reserve_chars must be at least 0")
+        _validate_non_negative_int(
+            self.compaction_tail_turns,
+            "compaction_tail_turns",
+        )
+        _validate_optional_non_negative_int(
+            self.compaction_preserve_recent_chars,
+            "compaction_preserve_recent_chars",
+        )
+        _validate_optional_non_negative_int(
+            self.compaction_reserved_chars,
+            "compaction_reserved_chars",
+        )
+        _validate_non_negative_int(
+            self.compaction_tool_output_max_chars,
+            "compaction_tool_output_max_chars",
+        )
         if self.provider_max_retries < 0:
             raise ValueError("provider_max_retries must be greater than or equal to 0")
         if self.provider_retry_backoff_seconds < 0:
@@ -120,6 +142,8 @@ class RuntimeConfig:
         self.enabled_tools = (
             None if self.enabled_tools is None else list(self.enabled_tools)
         )
+        self.compaction_auto = bool(self.compaction_auto)
+        self.compaction_prune = bool(self.compaction_prune)
         self.enable_compaction_summarizer = bool(self.enable_compaction_summarizer)
         self.enable_context_overflow_retry = bool(self.enable_context_overflow_retry)
         self.emit_llm_stream_events = bool(self.emit_llm_stream_events)
@@ -169,6 +193,17 @@ class RuntimeConfig:
         self.enable_command_expansion = bool(self.enable_command_expansion)
         self.local_tool_directories = list(self.local_tool_directories)
         self.archive_truncated_tool_outputs = bool(self.archive_truncated_tool_outputs)
+
+
+def _validate_non_negative_int(value: Any, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be greater than or equal to 0")
+
+
+def _validate_optional_non_negative_int(value: Any, field_name: str) -> None:
+    if value is None:
+        return
+    _validate_non_negative_int(value, field_name)
 
 
 __all__ = ["RuntimeConfig"]

--- a/src/efp_runtime/runtime/config.py
+++ b/src/efp_runtime/runtime/config.py
@@ -28,6 +28,8 @@ class RuntimeConfig:
     compaction_preserve_recent_chars: int | None = None
     compaction_reserved_chars: int | None = None
     compaction_tool_output_max_chars: int = 2000
+    compaction_prune_min_chars: int = 20000
+    compaction_prune_protect_chars: int = 40000
     enable_compaction_summarizer: bool = False
     provider_max_retries: int = 2
     provider_retry_backoff_seconds: float = 0.0
@@ -89,21 +91,29 @@ class RuntimeConfig:
             raise ValueError("max_context_chars must be at least 1")
         if self.context_reserve_chars < 0:
             raise ValueError("context_reserve_chars must be at least 0")
-        _validate_non_negative_int(
+        self.compaction_tail_turns = _validate_non_negative_int(
             self.compaction_tail_turns,
             "compaction_tail_turns",
         )
-        _validate_optional_non_negative_int(
+        self.compaction_preserve_recent_chars = _validate_optional_non_negative_int(
             self.compaction_preserve_recent_chars,
             "compaction_preserve_recent_chars",
         )
-        _validate_optional_non_negative_int(
+        self.compaction_reserved_chars = _validate_optional_non_negative_int(
             self.compaction_reserved_chars,
             "compaction_reserved_chars",
         )
-        _validate_non_negative_int(
+        self.compaction_tool_output_max_chars = _validate_non_negative_int(
             self.compaction_tool_output_max_chars,
             "compaction_tool_output_max_chars",
+        )
+        self.compaction_prune_min_chars = _validate_non_negative_int(
+            self.compaction_prune_min_chars,
+            "compaction_prune_min_chars",
+        )
+        self.compaction_prune_protect_chars = _validate_non_negative_int(
+            self.compaction_prune_protect_chars,
+            "compaction_prune_protect_chars",
         )
         if self.provider_max_retries < 0:
             raise ValueError("provider_max_retries must be greater than or equal to 0")
@@ -195,15 +205,16 @@ class RuntimeConfig:
         self.archive_truncated_tool_outputs = bool(self.archive_truncated_tool_outputs)
 
 
-def _validate_non_negative_int(value: Any, field_name: str) -> None:
+def _validate_non_negative_int(value: Any, field_name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise ValueError(f"{field_name} must be greater than or equal to 0")
+        raise ValueError(f"{field_name} must be a non-negative integer")
+    return int(value)
 
 
-def _validate_optional_non_negative_int(value: Any, field_name: str) -> None:
+def _validate_optional_non_negative_int(value: Any, field_name: str) -> int | None:
     if value is None:
-        return
-    _validate_non_negative_int(value, field_name)
+        return None
+    return _validate_non_negative_int(value, field_name)
 
 
 __all__ = ["RuntimeConfig"]

--- a/tests/runtime_v2/test_auto_session_compaction.py
+++ b/tests/runtime_v2/test_auto_session_compaction.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from efp_runtime.event_bus import RuntimeEventBus
+from efp_runtime.llm.errors import ProviderContextOverflowError
+from efp_runtime.loop import (
+    LoopStatus,
+    RuntimeLoopRunner,
+    RuntimeRequest,
+    ScriptedLLMProvider,
+)
+from efp_runtime.models import Message, MessagePart, MessagePartType, MessageRole
+from efp_runtime.runtime import AgentRuntime, RuntimeConfig
+from efp_runtime.session.store import InMemorySessionStore
+from efp_runtime.tools.registry import ToolRegistry
+from efp_runtime.tools.runtime import ToolRuntime
+
+
+class SequenceProvider:
+    def __init__(self, steps):
+        self.steps = list(steps)
+        self.requests: list[RuntimeRequest] = []
+        self.metadata_snapshots: list[dict] = []
+
+    async def invoke(self, request: RuntimeRequest):
+        self.requests.append(request)
+        self.metadata_snapshots.append(deepcopy(request.provider_request.metadata))
+        if not self.steps:
+            raise AssertionError("SequenceProvider has no step left")
+        step = self.steps.pop(0)
+        if isinstance(step, BaseException):
+            raise step
+        return step
+
+
+def _runner(store, provider, **kwargs) -> RuntimeLoopRunner:
+    return RuntimeLoopRunner(
+        store=store,
+        provider=provider,
+        tool_runtime=ToolRuntime(ToolRegistry()),
+        **kwargs,
+    )
+
+
+def _seed_history(store, session_id: str, *, latest: str | None = None) -> None:
+    store.create_session(session_id=session_id)
+    for index, (role, text) in enumerate(
+        [
+            (MessageRole.USER, "old request one"),
+            (MessageRole.ASSISTANT, "old answer one"),
+            (MessageRole.USER, "old request two"),
+            (MessageRole.ASSISTANT, "old answer two"),
+        ]
+    ):
+        store.append_message(
+            session_id,
+            role=role,
+            parts=[MessagePart.text_part(text)],
+            message_id=f"msg-old-{index}",
+            status="complete",
+        )
+    if latest is not None:
+        store.append_message(
+            session_id,
+            role=MessageRole.USER,
+            parts=[MessagePart.text_part(latest)],
+            message_id="msg-latest-user",
+            status="complete",
+        )
+
+
+def _compaction_parts(messages):
+    return [
+        part
+        for message in messages
+        for part in message.parts
+        if part.type is MessagePartType.COMPACTION
+    ]
+
+
+def _events(result, event_type: str):
+    return [event for event in result.runtime_events if event.type == event_type]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"compaction_tail_turns": -1},
+        {"compaction_preserve_recent_chars": -1},
+        {"compaction_reserved_chars": -1},
+    ],
+)
+def test_runtime_config_validates_auto_compaction_integers(kwargs):
+    with pytest.raises(ValueError):
+        RuntimeConfig(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_auto_compaction_persists_before_provider_and_request_includes_latest():
+    store = InMemorySessionStore()
+    _seed_history(store, "session-auto")
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    bus = RuntimeEventBus()
+    runner = _runner(
+        store,
+        provider,
+        max_context_parts=3,
+        compaction_tail_turns=1,
+        event_bus=bus,
+    )
+
+    result = await runner.run(
+        session_id="session-auto",
+        user_text="latest request",
+        metadata={"run_id": "run-auto"},
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    request = provider.requests[0]
+    request_compactions = _compaction_parts(request.messages)
+    assert len(request_compactions) == 1
+    assert request_compactions[0].compaction is not None
+    assert request_compactions[0].compaction.auto is True
+    assert request_compactions[0].compaction.overflow is False
+    assert request_compactions[0].compaction.metadata["trigger"] == "context_budget"
+    assert request.provider_request.messages[0].context[0].type == "compaction_summary"
+    assert request.provider_request.messages[-1].role == "user"
+    assert request.provider_request.messages[-1].text == "latest request"
+
+    stored_compactions = _compaction_parts(store.read_history("session-auto"))
+    assert len(stored_compactions) == 1
+    assert stored_compactions[0].compaction.metadata["auto"] is True
+
+    started = _events(result, "session_compaction_started")
+    compacted = _events(result, "session_compacted")
+    assert len(started) == 1
+    assert len(compacted) == 1
+    for event in [started[0], compacted[0]]:
+        assert event.payload["run_id"] == "run-auto"
+        assert event.payload["iteration"] == 1
+        assert event.payload["trigger"] == "context_budget"
+        assert event.payload["auto"] is True
+        assert event.payload["overflow"] is False
+        assert event.payload["max_parts"] == 3
+        assert event.payload["max_chars"] is None
+        assert event.payload["reserve_chars"] == 0
+        assert event.payload["compacted_part_count"] > 0
+        assert event.payload["compacted_message_count"] > 0
+    assert [event.type for event in bus.history("session-auto")[:2]] == [
+        "run_start",
+        "session_compaction_started",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_compaction_auto_false_leaves_stored_session_unchanged():
+    store = InMemorySessionStore()
+    _seed_history(store, "session-disabled")
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runner = _runner(
+        store,
+        provider,
+        max_context_parts=3,
+        compaction_auto=False,
+    )
+
+    result = await runner.run(
+        session_id="session-disabled",
+        user_text="latest request",
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    stored = store.read_history("session-disabled")
+    assert [message.message_id for message in stored[:4]] == [
+        "msg-old-0",
+        "msg-old-1",
+        "msg-old-2",
+        "msg-old-3",
+    ]
+    assert stored[4].parts[0].text == "latest request"
+    assert _compaction_parts(stored) == []
+    assert _events(result, "session_compaction_started") == []
+
+
+@pytest.mark.asyncio
+async def test_provider_only_context_messages_are_not_persisted():
+    store = InMemorySessionStore()
+    _seed_history(store, "session-provider-only")
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runner = _runner(
+        store,
+        provider,
+        max_context_parts=3,
+        compaction_tail_turns=1,
+    )
+    provider_only = Message.from_text(
+        "system",
+        "provider-only instruction",
+        message_id="msg-provider-only",
+    )
+
+    result = await runner.run(
+        session_id="session-provider-only",
+        user_text="latest request",
+        context_messages=[provider_only],
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    assert provider.requests[0].provider_request.messages[0].text == (
+        "provider-only instruction"
+    )
+    stored = store.read_history("session-provider-only")
+    assert all(message.message_id != "msg-provider-only" for message in stored)
+    assert all(
+        part.text != "provider-only instruction"
+        for message in stored
+        for part in message.parts
+    )
+
+
+@pytest.mark.asyncio
+async def test_overflow_retry_persists_overflow_compaction_and_retries_once():
+    store = InMemorySessionStore()
+    _seed_history(store, "session-overflow")
+    provider = SequenceProvider(
+        [
+            ProviderContextOverflowError("context too long"),
+            {"content": "Recovered."},
+        ]
+    )
+    runner = _runner(
+        store,
+        provider,
+        max_context_parts=10,
+        compaction_tail_turns=1,
+    )
+
+    result = await runner.run(
+        session_id="session-overflow",
+        user_text="latest request",
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    assert len(provider.requests) == 2
+    retry_metadata = provider.metadata_snapshots[1]
+    assert retry_metadata["overflow_retry"] is True
+    assert retry_metadata["compaction"]["overflow"] is True
+    assert retry_metadata["compaction"]["trigger"] == "provider_context_overflow"
+    assert retry_metadata["compaction"]["overflow_retry"] is True
+    assert provider.requests[1].provider_request.messages[-1].text == "latest request"
+
+    stored_compactions = _compaction_parts(store.read_history("session-overflow"))
+    assert len(stored_compactions) == 1
+    compaction = stored_compactions[0].compaction
+    assert compaction is not None
+    assert compaction.overflow is True
+    assert compaction.metadata["overflow_retry"] is True
+    assert compaction.metadata["trigger"] == "provider_context_overflow"
+    assert len(_events(result, "provider.context_overflow_retry")) == 1
+    assert len(_events(result, "session_compaction_started")) == 1
+    assert len(_events(result, "session_compacted")) == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_path_uses_auto_session_compaction():
+    store = InMemorySessionStore()
+    _seed_history(store, "session-resume", latest="resume latest request")
+    provider = ScriptedLLMProvider([{"content": "Resumed."}])
+    runtime = AgentRuntime(
+        provider=provider,
+        store=store,
+        config=RuntimeConfig(
+            max_iterations=1,
+            max_context_parts=3,
+            compaction_tail_turns=1,
+            include_default_system_prompt=False,
+            include_runtime_reminders=False,
+        ),
+    )
+
+    result = await runtime.resume("session-resume", metadata={"run_id": "run-resume"})
+
+    assert result.status == LoopStatus.COMPLETED
+    request = provider.requests[0]
+    assert _compaction_parts(request.messages)
+    assert request.provider_request.messages[-1].role == "user"
+    assert request.provider_request.messages[-1].text == "resume latest request"
+    stored_compactions = _compaction_parts(store.read_history("session-resume"))
+    assert len(stored_compactions) == 1
+    assert stored_compactions[0].compaction.metadata["trigger"] == "context_budget"

--- a/tests/runtime_v2/test_context_compaction_policy.py
+++ b/tests/runtime_v2/test_context_compaction_policy.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from efp_runtime.compaction import ContextBudget, TailTurnCompactionStrategy
+from efp_runtime.config_loader import load_runtime_config
+from efp_runtime.models import CompactionPart, Message, MessagePart, ToolCall
+from efp_runtime.runtime import RuntimeConfig
+
+
+def test_runtime_config_validates_compaction_policy_defaults():
+    config = RuntimeConfig(
+        compaction_auto=False,
+        compaction_prune=False,
+        compaction_tail_turns=3,
+        compaction_preserve_recent_chars=1200,
+        compaction_reserved_chars=4000,
+        compaction_tool_output_max_chars=1500,
+    )
+
+    assert config.compaction_auto is False
+    assert config.compaction_prune is False
+    assert config.compaction_tail_turns == 3
+    assert config.compaction_preserve_recent_chars == 1200
+    assert config.compaction_reserved_chars == 4000
+    assert config.compaction_tool_output_max_chars == 1500
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "compaction_tail_turns",
+        "compaction_preserve_recent_chars",
+        "compaction_reserved_chars",
+        "compaction_tool_output_max_chars",
+    ],
+)
+def test_runtime_config_rejects_negative_compaction_policy_ints(field: str):
+    with pytest.raises(ValueError, match=field):
+        RuntimeConfig(**{field: -1})
+
+
+@pytest.mark.parametrize(
+    (
+        "payload",
+        "expected_tail_turns",
+        "expected_preserve",
+        "expected_reserved",
+        "expected_tool_max",
+    ),
+    [
+        (
+            {
+                "compaction": {
+                    "auto": False,
+                    "prune": False,
+                    "tail_turns": 3,
+                    "preserve_recent_chars": 1400,
+                    "reserved": 6000,
+                    "tool_output_max_chars": 1750,
+                }
+            },
+            3,
+            1400,
+            6000,
+            1750,
+        ),
+        (
+            {
+                "compaction": {
+                    "auto": False,
+                    "prune": False,
+                    "tailTurns": 4,
+                    "preserveRecentChars": 1500,
+                    "reserved": 7000,
+                    "toolOutputMaxChars": 1800,
+                }
+            },
+            4,
+            1500,
+            7000,
+            1800,
+        ),
+    ],
+)
+def test_config_loader_maps_nested_compaction_policy(
+    tmp_path: Path,
+    payload: dict[str, object],
+    expected_tail_turns: int,
+    expected_preserve: int,
+    expected_reserved: int,
+    expected_tool_max: int,
+):
+    _write_json(tmp_path / "policy.json", payload)
+
+    result = load_runtime_config(
+        tmp_path,
+        paths=["policy.json"],
+        include_defaults=False,
+    )
+
+    assert result.config.compaction_auto is False
+    assert result.config.compaction_prune is False
+    assert result.config.compaction_tail_turns == expected_tail_turns
+    assert result.config.compaction_preserve_recent_chars == expected_preserve
+    assert result.config.compaction_reserved_chars == expected_reserved
+    assert result.config.compaction_tool_output_max_chars == expected_tool_max
+    assert result.metadata["unconsumed_config"] == {}
+
+
+def test_config_loader_maps_top_level_compaction_policy_fields(tmp_path: Path):
+    _write_json(
+        tmp_path / "policy.json",
+        {
+            "compaction_auto": False,
+            "compaction_prune": False,
+            "compaction_tail_turns": 5,
+            "compaction_preserve_recent_chars": 1600,
+            "compaction_reserved_chars": 8000,
+            "compaction_tool_output_max_chars": 1900,
+        },
+    )
+
+    result = load_runtime_config(
+        tmp_path,
+        paths=["policy.json"],
+        include_defaults=False,
+    )
+
+    assert result.config.compaction_auto is False
+    assert result.config.compaction_prune is False
+    assert result.config.compaction_tail_turns == 5
+    assert result.config.compaction_preserve_recent_chars == 1600
+    assert result.config.compaction_reserved_chars == 8000
+    assert result.config.compaction_tool_output_max_chars == 1900
+    assert result.metadata["unconsumed_config"] == {}
+
+
+def test_tail_turn_strategy_keeps_last_two_user_turns_and_marks_tail_start():
+    messages = [
+        _text("user", "old user " + "u" * 300, "msg-u1"),
+        _text("assistant", "old answer " + "a" * 300, "msg-a1"),
+        _text("user", "second request", "msg-u2"),
+        _text("assistant", "second answer", "msg-a2"),
+        _text("user", "third request", "msg-u3"),
+        _text("assistant", "third answer", "msg-a3"),
+    ]
+
+    result = TailTurnCompactionStrategy(
+        budget=ContextBudget(max_chars=200),
+        preserve_recent_chars=200,
+    ).compact(messages)
+
+    assert result.compacted is True
+    assert _visible_message_ids(result.messages) == [
+        "msg-u2",
+        "msg-a2",
+        "msg-u3",
+        "msg-a3",
+    ]
+    compaction = _tail_turn_compaction(result.messages)
+    assert compaction.tail_start_message_id == "msg-u2"
+    assert compaction.metadata["strategy"] == "tail_turn"
+    assert compaction.metadata["tail_turns"] == 2
+    assert compaction.metadata["preserve_recent_chars"] == 200
+    assert compaction.metadata["tail_start_message_id"] == "msg-u2"
+
+
+def test_tail_turn_strategy_splits_oversized_older_recent_turn():
+    messages = [
+        _text("user", "old user " + "u" * 300, "msg-u1"),
+        _text("assistant", "old answer", "msg-a1"),
+        _text("user", "oversized older recent request " + "x" * 100, "msg-u2"),
+        _text("assistant", "suffix", "msg-a2"),
+        _text("user", "now", "msg-u3"),
+        _text("assistant", "done", "msg-a3"),
+    ]
+
+    result = TailTurnCompactionStrategy(
+        budget=ContextBudget(max_chars=120),
+        preserve_recent_chars=len("suffix") + len("now") + len("done"),
+    ).compact(messages)
+
+    assert result.compacted is True
+    assert _visible_message_ids(result.messages) == ["msg-a2", "msg-u3", "msg-a3"]
+    assert _tail_turn_compaction(result.messages).tail_start_message_id == "msg-a2"
+
+
+def test_tail_turn_strategy_keeps_pending_tool_calls_visible():
+    pending_call = ToolCall(
+        call_id="call-pending",
+        tool_name="write_file",
+        arguments={"path": "created.txt", "content": "pending"},
+    )
+    messages = [
+        _text("user", "old user " + "u" * 300, "msg-u1"),
+        Message(
+            role="assistant",
+            message_id="msg-pending",
+            parts=[MessagePart.tool_call_part(pending_call)],
+        ),
+        _text("user", "latest", "msg-u2"),
+    ]
+
+    result = TailTurnCompactionStrategy(
+        budget=ContextBudget(max_chars=100),
+        preserve_recent_chars=len("latest"),
+    ).compact(messages)
+
+    assert result.compacted is True
+    calls = [
+        part.tool_call.call_id
+        for message in result.messages
+        for part in message.parts
+        if part.tool_call is not None
+    ]
+    assert calls == ["call-pending"]
+
+
+def test_tail_turn_strategy_carries_previous_summary_from_whole_history():
+    previous_summary = "Prior summary context marker."
+    messages = [
+        _text("user", "old user " + "u" * 300, "msg-u1"),
+        _text("assistant", "old answer", "msg-a1"),
+        _text("user", "latest request", "msg-u2"),
+        _compaction_message(previous_summary, "msg-prev-summary"),
+        _text("assistant", "latest answer", "msg-a2"),
+    ]
+
+    result = TailTurnCompactionStrategy(
+        budget=ContextBudget(max_chars=120),
+        tail_turns=1,
+        preserve_recent_chars=5000,
+    ).compact(messages)
+
+    compaction = _tail_turn_compaction(result.messages)
+    assert "msg-prev-summary" not in compaction.source_message_ids
+    assert previous_summary in compaction.summary
+
+
+def _text(role: str, text: str, message_id: str) -> Message:
+    return Message.from_text(role, text, message_id=message_id)
+
+
+def _compaction_message(summary: str, message_id: str) -> Message:
+    compaction = CompactionPart(
+        summary=summary,
+        source_message_ids=["msg-prior"],
+        auto=True,
+    )
+    return Message(
+        role="system",
+        message_id=message_id,
+        parts=[MessagePart.compaction_part(compaction)],
+    )
+
+
+def _visible_message_ids(messages: list[Message]) -> list[str]:
+    return [
+        message.message_id
+        for message in messages
+        if not any(part.type == "compaction" for part in message.parts)
+    ]
+
+
+def _tail_turn_compaction(messages: list[Message]) -> CompactionPart:
+    for message in messages:
+        for part in message.parts:
+            if (
+                part.compaction is not None
+                and part.compaction.metadata.get("strategy") == "tail_turn"
+            ):
+                return part.compaction
+    raise AssertionError("tail-turn compaction part not found")
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")

--- a/tests/runtime_v2/test_tool_output_prune.py
+++ b/tests/runtime_v2/test_tool_output_prune.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from efp_runtime import InMemorySessionStore, Message, MessagePart, MessageRole
+from efp_runtime.compaction import prune_old_tool_outputs
+from efp_runtime.config_loader import load_runtime_config
+from efp_runtime.loop import ScriptedLLMProvider
+from efp_runtime.runtime import AgentRuntime, RuntimeConfig
+from efp_runtime.types import ToolCall, ToolResult
+
+
+def test_prunes_old_completed_tool_result_content_and_marks_metadata():
+    messages = _messages_with_tool_results(
+        [
+            ("old", "search", "A" * 50),
+            ("kept", "search", "B" * 10),
+            ("mid", "search", "D" * 30),
+            ("recent", "search", "C" * 30),
+        ]
+    )
+
+    result = prune_old_tool_outputs(
+        messages,
+        protect_recent_chars=12,
+        min_pruned_chars=20,
+        output_max_chars=8,
+    )
+
+    old_result = _tool_result(result.messages, "call-old")
+    old_part = _tool_result_part(result.messages, "call-old")
+    kept_result = _tool_result(result.messages, "call-kept")
+    mid_result = _tool_result(result.messages, "call-mid")
+    recent_result = _tool_result(result.messages, "call-recent")
+
+    assert result.pruned_result_count == 1
+    assert result.pruned_chars == 42
+    assert result.protected_chars == 10
+    assert old_result.content.startswith("A" * 8)
+    assert "Old tool result content cleared for context compaction" in old_result.content
+    assert "omitted 42 chars" in old_result.content
+    assert old_result.output == old_result.content
+    assert old_result.truncated is True
+    assert old_result.metadata["compaction_pruned"] is True
+    assert old_result.metadata["original_chars"] == 50
+    assert old_result.metadata["omitted_chars"] == 42
+    assert old_result.metadata["output_max_chars"] == 8
+    assert "compaction_pruned_at" in old_result.metadata
+    assert old_part.metadata["compaction_pruned"] is True
+    assert old_part.metadata["omitted_chars"] == 42
+    assert kept_result.content == "B" * 10
+    assert mid_result.content == "D" * 30
+    assert recent_result.content == "C" * 30
+
+
+def test_protects_latest_two_user_turns():
+    messages = _messages_with_tool_results(
+        [
+            ("old", "search", "A" * 30),
+            ("second_latest", "search", "B" * 30),
+            ("latest", "search", "C" * 30),
+        ]
+    )
+
+    result = prune_old_tool_outputs(
+        messages,
+        protect_recent_chars=0,
+        min_pruned_chars=0,
+        output_max_chars=5,
+    )
+
+    assert result.pruned_result_count == 1
+    assert _tool_result(result.messages, "call-old").metadata["compaction_pruned"] is True
+    assert _tool_result(result.messages, "call-second_latest").content == "B" * 30
+    assert _tool_result(result.messages, "call-latest").content == "C" * 30
+
+
+def test_skips_skill_tool_results():
+    messages = _messages_with_tool_results(
+        [
+            ("skill", "skill", "S" * 30),
+            ("old", "search", "A" * 30),
+            ("second_latest", "search", "B" * 30),
+            ("latest", "search", "C" * 30),
+        ]
+    )
+
+    result = prune_old_tool_outputs(
+        messages,
+        protect_recent_chars=0,
+        min_pruned_chars=0,
+        output_max_chars=5,
+    )
+
+    assert result.pruned_result_count == 1
+    assert _tool_result(result.messages, "call-skill").content == "S" * 30
+    assert "compaction_pruned" not in _tool_result(
+        result.messages,
+        "call-skill",
+    ).metadata
+    assert _tool_result(result.messages, "call-old").metadata["compaction_pruned"] is True
+    assert result.metadata["skipped_protected_tool_count"] == 1
+
+
+def test_noop_when_prunable_chars_do_not_pass_threshold():
+    messages = _messages_with_tool_results(
+        [
+            ("old", "search", "A" * 10),
+            ("second_latest", "search", "B" * 30),
+            ("latest", "search", "C" * 30),
+        ]
+    )
+
+    result = prune_old_tool_outputs(
+        messages,
+        protect_recent_chars=0,
+        min_pruned_chars=10,
+        output_max_chars=5,
+    )
+
+    assert result.pruned_result_count == 0
+    assert result.pruned_chars == 0
+    assert result.metadata["candidate_chars"] == 10
+    assert _tool_result(result.messages, "call-old").content == "A" * 10
+
+
+def test_does_not_mutate_input_messages():
+    messages = _messages_with_tool_results(
+        [
+            ("old", "search", "A" * 30),
+            ("second_latest", "search", "B" * 30),
+            ("latest", "search", "C" * 30),
+        ]
+    )
+    original_result = _tool_result(messages, "call-old")
+
+    result = prune_old_tool_outputs(
+        messages,
+        protect_recent_chars=0,
+        min_pruned_chars=0,
+        output_max_chars=5,
+    )
+
+    assert original_result.content == "A" * 30
+    assert original_result.output == "A" * 30
+    assert original_result.metadata == {}
+    assert result.messages is not messages
+    assert _tool_result(result.messages, "call-old") is not original_result
+    assert _tool_result(result.messages, "call-old").metadata["compaction_pruned"] is True
+
+
+def test_agent_runtime_prune_session_tool_outputs_persists_changes_and_publishes_event():
+    store = InMemorySessionStore()
+    store.create_session(session_id="session-prune")
+    _append_tool_turn(store, "session-prune", "old", "search", "A" * 30)
+    _append_tool_turn(store, "session-prune", "second_latest", "search", "B" * 30)
+    _append_tool_turn(store, "session-prune", "latest", "search", "C" * 30)
+    runtime = AgentRuntime(
+        provider=ScriptedLLMProvider([]),
+        store=store,
+        config=RuntimeConfig(
+            compaction_prune=True,
+            compaction_prune_protect_chars=0,
+            compaction_prune_min_chars=0,
+            compaction_tool_output_max_chars=5,
+        ),
+    )
+
+    session = runtime.prune_session_tool_outputs("session-prune")
+
+    persisted = store.read_history("session-prune")
+    old_result = _tool_result(persisted, "call-old")
+    assert session.messages[2].parts[0].tool_result.content == old_result.content
+    assert old_result.metadata["compaction_pruned"] is True
+    assert old_result.content.startswith("A" * 5)
+    assert _tool_result(persisted, "call-second_latest").content == "B" * 30
+    events = runtime.event_bus.history("session-prune")
+    assert events[-1].type == "session_tool_outputs_pruned"
+    assert events[-1].payload["pruned_result_count"] == 1
+    assert events[-1].payload["pruned_chars"] == 25
+
+
+def test_config_loader_maps_nested_prune_settings(tmp_path: Path):
+    _write_json(
+        tmp_path / "camel.json",
+        {
+            "compaction": {
+                "prune": False,
+                "toolOutputMaxChars": 123,
+                "pruneMinChars": 456,
+                "pruneProtectChars": 789,
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "snake.json",
+        {
+            "compaction": {
+                "tool_output_max_chars": 321,
+                "prune_min_chars": 654,
+                "prune_protect_chars": 987,
+            }
+        },
+    )
+
+    camel = load_runtime_config(
+        tmp_path,
+        paths=["camel.json"],
+        include_defaults=False,
+    )
+    snake = load_runtime_config(
+        tmp_path,
+        paths=["snake.json"],
+        include_defaults=False,
+    )
+
+    assert camel.config.compaction_prune is False
+    assert camel.config.compaction_tool_output_max_chars == 123
+    assert camel.config.compaction_prune_min_chars == 456
+    assert camel.config.compaction_prune_protect_chars == 789
+    assert camel.metadata["unconsumed_config"] == {}
+    assert snake.config.compaction_tool_output_max_chars == 321
+    assert snake.config.compaction_prune_min_chars == 654
+    assert snake.config.compaction_prune_protect_chars == 987
+    assert snake.metadata["unconsumed_config"] == {}
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"compaction_tool_output_max_chars": -1},
+        {"compaction_prune_min_chars": -1},
+        {"compaction_prune_protect_chars": -1},
+        {"compaction_tool_output_max_chars": True},
+    ],
+)
+def test_runtime_config_validates_compaction_prune_integer_settings(kwargs):
+    with pytest.raises(ValueError, match="non-negative integer"):
+        RuntimeConfig(**kwargs)
+
+
+def _messages_with_tool_results(
+    specs: list[tuple[str, str, str]],
+) -> list[Message]:
+    messages: list[Message] = []
+    for label, tool_name, content in specs:
+        messages.extend(_tool_turn_messages(label, tool_name, content))
+    return messages
+
+
+def _tool_turn_messages(label: str, tool_name: str, content: str) -> list[Message]:
+    call = ToolCall(
+        call_id=f"call-{label}",
+        tool_name=tool_name,
+        arguments={"label": label},
+    )
+    result = ToolResult(
+        call_id=call.call_id,
+        tool_name=tool_name,
+        output=content,
+        content=content,
+        status="success",
+        success=True,
+    )
+    return [
+        Message(
+            role=MessageRole.USER,
+            message_id=f"msg-user-{label}",
+            parts=[MessagePart.text_part(f"turn {label}")],
+            status="complete",
+        ),
+        Message(
+            role=MessageRole.ASSISTANT,
+            message_id=f"msg-assistant-{label}",
+            parts=[MessagePart.tool_call_part(call)],
+            status="complete",
+        ),
+        Message(
+            role=MessageRole.TOOL,
+            message_id=f"msg-tool-{label}",
+            parts=[MessagePart.tool_result_part(result)],
+            status="complete",
+        ),
+    ]
+
+
+def _append_tool_turn(
+    store: InMemorySessionStore,
+    session_id: str,
+    label: str,
+    tool_name: str,
+    content: str,
+) -> None:
+    for message in _tool_turn_messages(label, tool_name, content):
+        store.append_message(
+            session_id,
+            role=message.role,
+            parts=message.parts,
+            message_id=message.message_id,
+            status=message.status,
+        )
+
+
+def _tool_result(messages: list[Message], call_id: str) -> ToolResult:
+    return _tool_result_part(messages, call_id).tool_result
+
+
+def _tool_result_part(messages: list[Message], call_id: str) -> MessagePart:
+    for message in messages:
+        for part in message.parts:
+            if part.tool_result is not None and part.tool_result.call_id == call_id:
+                return part
+    raise AssertionError(f"tool result not found: {call_id}")
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")


### PR DESCRIPTION
## Summary

Stacked on Phase36 PR #516. This phase adds Runtime v2 content/context management aligned with the current opencode core behavior, without adding any MCP surface.

- adds explicit compaction policy config for automatic session compaction, tail-turn retention, reserve budget overrides, and old tool-output pruning
- adds a tail-turn compaction strategy that preserves recent user turns, supports recent-character preservation, records tail_start_message_id, and keeps protected/system/pending tool blocks intact
- persists automatic stored-history compaction before provider requests and on the single context-overflow retry, while keeping provider-only system/instruction/skill context out of session storage
- adds manual old tool result pruning for stored sessions with latest-turn protection, protected tool skip rules, bounded previews, metadata markers, and a session_tool_outputs_pruned event
- updates Runtime v2 design docs and focused tests for policy, auto session compaction, overflow compaction, config loading, and tool output pruning

## Validation

- `PYTHONPATH=src python -m pytest tests/runtime_v2/test_context_compaction_policy.py tests/runtime_v2/test_auto_session_compaction.py tests/runtime_v2/test_tool_output_prune.py tests/runtime_v2/test_compaction_strategy.py tests/runtime_v2/test_context_budget_compaction.py tests/runtime_v2/test_compaction_summarizer_controller.py tests/runtime_v2/test_manual_compaction.py tests/runtime_v2/test_provider_retry_overflow.py tests/runtime_v2/test_config_loader.py tests/runtime_v2/test_runtime_facade.py tests/runtime_v2/test_tool_output_truncation.py tests/runtime_v2/test_tool_runtime.py -q` -> 156 passed
- `PYTHONPATH=src python -m pytest tests/runtime_v2 -q` -> 741 passed
- `PYTHONPATH=src python -m compileall -q src tests/runtime_v2`
- `git diff --check origin/efp-runtime-v2-phase36-integrated-20260529..HEAD`
- `rg -n "MCP|mcp" src/efp_runtime docs/runtime-v2-design.md tests/runtime_v2 || true` -> no matches
