### PR TITLE
Add Runtime v2 Phase39 opencode state and context alignment

### DIFF
--- a/docs/runtime-v2-design.md
+++ b/docs/runtime-v2-design.md
@@ -587,6 +587,16 @@ allow rule for the matching retry, while `always=True` creates a persistent
 allow rule for the same tool/category. Deny follows the same rule scope model
 and is appended as a final tool result on resume.
 
+For `bash` and legacy `shell_exec`, the permission request includes lightweight
+opencode-style shell metadata derived before execution from the submitted args.
+Runtime v2 records the command preview, command name list, workdir, recognized
+path arguments, dynamic/glob/path-escape flags, and permission patterns. The
+scanner is deterministic and conservative: it tokenizes simple command segments
+with the Python standard library, recognizes common file-oriented commands, and
+falls back to the command preview when it cannot safely identify paths. This
+gives UIs and policy layers enough structure for command- or path-granular
+allow/ask/deny decisions without running a full shell parser.
+
 `RuntimeConfig.tool_permissions` adds an opencode-style execution permission
 layer on top of the static permission metadata carried by each tool definition.
 Keys can be exact tool ids such as `bash`, `shell_exec`, `read`, `read_file`,

--- a/docs/runtime-v2-design.md
+++ b/docs/runtime-v2-design.md
@@ -77,8 +77,8 @@ Each loop iteration builds a `RuntimeRequest` for the provider. It keeps the raw
 `ProviderRequest`, the `PreparedProviderRequest` with compaction metadata, and
 the sorted `ToolDef` list used to render provider-neutral tool schemas.
 `AgentRuntime` prepends provider-only context before persisted history in this
-order: system prompt and runtime reminders, workspace instructions, active
-skills, then session history.
+order: system prompt stack, workspace instructions, active skills, then session
+history.
 
 `STEP_FINISH` updates the active assistant message. Tool result events append a
 separate tool message and do not make that tool message the active assistant
@@ -243,6 +243,8 @@ The loader maps the following opencode-style and snake_case keys into
   `context_reserve_tokens` for Copilot context budgeting.
 - `toolSurface` / `tool_surface`, either `opencode` or `legacy`.
 - `includeLegacyToolAliases` / `include_legacy_tool_aliases`.
+- `includeEnvironmentContext` / `include_environment_context` to toggle the
+  transient environment system context.
 - `instructions`, as string paths or `{"path": ...}` / `{"text": ...}` entries,
   to `instruction_paths` and `instruction_texts`.
 - `systemPrompt` / `system_prompt`, as a string or list, to
@@ -1230,26 +1232,32 @@ as provider-only system context.
 ## System Prompt Stack
 
 Runtime v2 has a small configurable system prompt stack. By default,
-`AgentRuntime` adds a stable base code-agent prompt, then optional explicit
+`AgentRuntime` adds a stable base code-agent prompt, then a transient
+environment context message, then optional explicit
 `RuntimeConfig.system_prompt_texts` and UTF-8 workspace-local
 `RuntimeConfig.system_prompt_paths`. It can also add runtime reminders for the
 current iteration limit, the optional `question` tool, plan mode, and saved
 truncated tool output referenced by `output_path`.
 
-The default prompt is provider-only coding-agent context. Runtime reminders are
-separate transient system messages driven by request metadata, so per-run loop
-guidance can be added or omitted without changing configured prompts. System
-prompt and reminder messages are not appended to the session store, are not
-copied into user messages, and are rebuilt for each `run()` or `resume()`
+The default prompt is provider-only coding-agent context. The environment
+context is provider-only and request-local: it exposes the selected model,
+working directory, workspace root, local git repository detection, platform, and
+local date so model-visible runtime facts match opencode-style environment
+visibility. `RuntimeConfig.include_environment_context=False` disables this
+message without changing configured prompts. Runtime reminders are separate
+transient system messages driven by request metadata, so per-run loop guidance
+can be added or omitted without changing configured prompts. System prompt,
+environment, and reminder messages are not appended to the session store, are
+not copied into user messages, and are rebuilt for each `run()` or `resume()`
 request.
 Plan mode does not persist extra system prompt text either; only ordinary
 user, assistant, and tool history is stored.
 
 The full provider request context order is:
 
-1. System prompt and runtime reminder messages.
+1. System prompt stack messages.
 2. Workspace instruction messages.
-3. Active skill messages.
+3. Available-skill and active-skill messages.
 4. Persisted session history.
 
 ## Instructions

--- a/docs/runtime-v2-design.md
+++ b/docs/runtime-v2-design.md
@@ -124,6 +124,11 @@ The facade also exposes direct session management helpers:
 `session_children(...)`, and `session_messages(...)`. These methods proxy the
 configured session store. `session_children(parent_session_id)` filters listed
 sessions whose metadata records that parent, preserving the store list order.
+The facade also exposes opencode-style session todo helpers:
+`get_todos(session_id=None)`, `set_todos(session_id, todos)`, and
+`clear_todos(session_id=None)`. Todo state is process-local Runtime v2 session
+state; it is not injected into provider-visible history apart from normal tool
+outputs and runtime events.
 
 `switch_agent(session_id, agent)` and `switch_model(session_id, model)` persist
 future defaults in `Session.metadata`. The selected agent is stored as
@@ -737,15 +742,21 @@ identifies one, common entrypoints, and git branch/head metadata when available.
 Large dependency directories such as `.git`, `node_modules`, `.venv`, `dist`,
 `build`, and language build caches are skipped from the visible structure.
 
-The default `todowrite` id stores one session-local in-memory todo list. When
-legacy aliases are enabled, `todo_write` is registered against the same store.
-Todo items normalize to `content`, `status`, and `priority`; `status` accepts
-`pending`, `in_progress`, `completed`, and `cancelled`, while `priority` accepts
-`high`, `medium`, and `low` and defaults to `medium` when callers omit it.
-Successful writes return the normalized todos in output and metadata, include
-active/completed/cancelled count metadata, and attach a `todo.updated` runtime
-event with the current session id, tool id, tool call id, normalized todos, and
-the same count fields.
+The default `todowrite` id writes opencode-style session todo state through a
+Runtime v2 `SessionTodoStore`. State is keyed by `session_id` with the historical
+`session_id or "default"` fallback, so repeated runs in one `AgentRuntime` see
+the same todo list for the same session while child sessions with different ids
+start with their own list. When legacy aliases are enabled, `todo_write` is only
+a compatibility alias registered against the same store. Todo items normalize to
+`content`, `status`, and `priority`; `status` accepts `pending`, `in_progress`,
+`completed`, and `cancelled`, while `priority` accepts `high`, `medium`, and
+`low` and defaults to `medium` when callers omit it. Successful writes return
+the normalized todos in output and metadata, include active/completed/cancelled
+count metadata, and attach a `todo.updated` runtime event with the current
+session id, tool id, tool call id, normalized todos, and the same count fields.
+Callers that need direct access use `AgentRuntime.get_todos(...)`,
+`set_todos(...)`, and `clear_todos(...)`; no database or provider tool surface is
+added for this state.
 
 The legacy `read_file` id keeps its original raw text output. The `read` alias
 keeps raw selected text in `ToolResult.output["content"]` for callers, while its

--- a/src/efp_runtime/agents/task_runner.py
+++ b/src/efp_runtime/agents/task_runner.py
@@ -506,6 +506,11 @@ def _child_config(
             if base_config is None
             else base_config.include_default_system_prompt
         ),
+        include_environment_context=(
+            True
+            if base_config is None
+            else base_config.include_environment_context
+        ),
         system_prompt_texts=(
             [] if base_config is None else list(base_config.system_prompt_texts)
         ),

--- a/src/efp_runtime/config_loader.py
+++ b/src/efp_runtime/config_loader.py
@@ -97,6 +97,8 @@ _RUNTIME_CONFIG_KEYS = {
     "compaction_prune_min_chars",
     "compaction_prune_protect_chars",
     "instructions",
+    "includeEnvironmentContext",
+    "include_environment_context",
     "systemPrompt",
     "system_prompt",
     "skills",
@@ -526,6 +528,13 @@ def _runtime_config_from_raw(
     system_prompt_texts = _merged_alias_strings(raw, ("systemPrompt", "system_prompt"))
     if system_prompt_texts is not None:
         kwargs["system_prompt_texts"] = system_prompt_texts
+
+    include_environment_context = _first_alias_value(
+        raw,
+        ("includeEnvironmentContext", "include_environment_context"),
+    )
+    if include_environment_context is not None:
+        kwargs["include_environment_context"] = include_environment_context
 
     default_skill_dirs = default_skill_directories(
         workspace_root,

--- a/src/efp_runtime/permissions.py
+++ b/src/efp_runtime/permissions.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 from typing import Any, Protocol
 
+from .shell_permissions import shell_permission_metadata, shell_permission_patterns
 from .types import utc_now_iso
 
 
@@ -365,7 +366,12 @@ class PermissionRequest:
         request_patterns = (
             _normalize_patterns(patterns)
             if patterns is not None
-            else _request_patterns(args=args, metadata=metadata, context=context)
+            else _request_patterns(
+                tool_id=tool_id,
+                args=args,
+                metadata=metadata,
+                context=context,
+            )
         )
         request_metadata = dict(metadata.data)
         request_metadata.update(_args_request_metadata(tool_id, args, metadata))
@@ -1171,6 +1177,7 @@ def _make_request_id(
 
 def _request_patterns(
     *,
+    tool_id: str,
     args: Mapping[str, Any],
     metadata: PermissionMetadata,
     context: Any,
@@ -1196,10 +1203,8 @@ def _request_patterns(
         subject = _permission_subject(args, metadata)
         if subject:
             patterns = [subject]
-    if not patterns and metadata.category == "shell":
-        command = _string_arg(args, "command")
-        if command:
-            patterns = [command[:500]]
+    if not patterns and _is_shell_permission(tool_id, metadata):
+        patterns = shell_permission_patterns(args)
     return patterns
 
 
@@ -1211,21 +1216,20 @@ def _args_request_metadata(
     if _is_fetch_permission(tool_id, metadata):
         return _fetch_request_metadata(args)
 
-    if tool_id != "shell_exec" and metadata.category != "shell":
+    if not _is_shell_permission(tool_id, metadata):
         return {}
 
-    request_metadata: dict[str, Any] = {}
-    command = _string_arg(args, "command")
-    if command:
-        request_metadata["command_preview"] = _preview_text(command)
-
-    description = _string_arg(args, "description")
-    if description is not None:
-        request_metadata["description"] = description
-
-    workdir = _string_arg(args, "workdir") or _string_arg(args, "cwd") or "."
-    request_metadata["workdir"] = workdir
+    request_metadata = shell_permission_metadata(args)
+    explicit_patterns = _normalize_patterns(metadata.data.get("patterns"))
+    if not explicit_patterns:
+        explicit_patterns = _normalize_patterns(metadata.data.get("pattern"))
+    if explicit_patterns:
+        request_metadata["permission_patterns"] = explicit_patterns
     return request_metadata
+
+
+def _is_shell_permission(tool_id: str, metadata: PermissionMetadata) -> bool:
+    return tool_id in {"bash", "shell_exec"} or metadata.category == "shell"
 
 
 def _is_fetch_permission(tool_id: str, metadata: PermissionMetadata) -> bool:

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -537,7 +537,10 @@ class AgentRuntime:
             if profile is None:
                 self.active_skills = active_skills
 
-            run_metadata["system_prompt_context_count"] = len(system_prompt_messages)
+            self._annotate_system_prompt_context_metadata(
+                run_metadata,
+                system_prompt_messages,
+            )
             run_metadata["agent_prompt_context_count"] = len(agent_profile_messages)
             run_metadata["structured_output_context_count"] = len(
                 structured_output_messages
@@ -744,7 +747,10 @@ class AgentRuntime:
                 *available_skill_context_messages,
                 *skill_context_messages,
             ]
-            run_metadata["system_prompt_context_count"] = len(system_prompt_messages)
+            self._annotate_system_prompt_context_metadata(
+                run_metadata,
+                system_prompt_messages,
+            )
             run_metadata["agent_prompt_context_count"] = len(agent_profile_messages)
             run_metadata["structured_output_context_count"] = len(
                 structured_output_messages
@@ -1086,6 +1092,26 @@ class AgentRuntime:
     def _build_system_prompt_messages(self, metadata: Mapping[str, Any]):
         return self.system_prompt_builder.build_messages(metadata=metadata)
 
+    def _annotate_system_prompt_context_metadata(
+        self,
+        run_metadata: dict[str, Any],
+        messages: list[Message],
+    ) -> None:
+        environment_messages = [
+            message
+            for message in messages
+            if message.metadata.get("kind") == "environment_context"
+            or message.metadata.get("source") == "environment_context"
+        ]
+        run_metadata["system_prompt_context_count"] = len(messages)
+        run_metadata["environment_context_count"] = len(environment_messages)
+        if environment_messages:
+            model_id = environment_messages[0].metadata.get("model_id")
+            if model_id is not None:
+                run_metadata["environment_context_model"] = model_id
+        else:
+            run_metadata.pop("environment_context_model", None)
+
     def _build_agent_profile_messages(self, profile: Any | None) -> list[Message]:
         if profile is None:
             return []
@@ -1409,6 +1435,8 @@ class AgentRuntime:
         run_metadata["runtime_mode"] = self.config.runtime_mode
         run_metadata["plan_mode_read_only"] = self.config.plan_mode_read_only
         run_metadata["enable_question_tool"] = self.config.enable_question_tool
+        run_metadata["default_provider_id"] = self.config.default_provider_id
+        run_metadata["default_model"] = self.config.default_model
         run_metadata["model_aware_tool_selection_enabled"] = (
             self.config.model_aware_tool_selection
         )
@@ -2420,6 +2448,7 @@ def _resolve_config(
         ),
         metadata=resolved_metadata,
         include_default_system_prompt=config.include_default_system_prompt,
+        include_environment_context=config.include_environment_context,
         system_prompt_texts=list(config.system_prompt_texts),
         system_prompt_paths=list(config.system_prompt_paths),
         max_system_prompt_chars=config.max_system_prompt_chars,
@@ -2704,6 +2733,7 @@ def _resolve_system_prompt_builder(
     return SystemPromptBuilder(
         workspace_root=config.workspace_root,
         include_default_system_prompt=config.include_default_system_prompt,
+        include_environment_context=config.include_environment_context,
         system_prompt_texts=config.system_prompt_texts,
         system_prompt_paths=config.system_prompt_paths,
         max_system_prompt_chars=config.max_system_prompt_chars,

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from html import escape
@@ -55,6 +55,7 @@ from ..session.query import (
     session_context_messages as _session_context_messages,
 )
 from ..session.store import InMemorySessionStore
+from ..session.todo import SessionTodoStore
 from ..skills.commands import (
     SkillCommandResult,
     parse_skill_commands,
@@ -214,6 +215,9 @@ class AgentRuntime:
             skill_discovery=self.skill_discovery,
             question_broker=self.question_broker,
             lsp_client=lsp_client,
+        )
+        self._todo_store = (
+            _find_session_todo_store(self.tool_runtime.registry) or SessionTodoStore()
         )
         self.skill_context_builder = _resolve_skill_context_builder(
             config=self.config,
@@ -393,6 +397,19 @@ class AgentRuntime:
 
     def session_context(self, session_id: str) -> list[Message]:
         return _session_context_messages(self.session_messages(session_id))
+
+    def get_todos(self, session_id: str | None = None) -> list[dict[str, str]]:
+        return self._session_todo_store().get(session_id)
+
+    def set_todos(
+        self,
+        session_id: str | None,
+        todos: Iterable[Mapping[str, Any]],
+    ) -> list[dict[str, str]]:
+        return self._session_todo_store().set(session_id, todos)
+
+    def clear_todos(self, session_id: str | None = None) -> None:
+        self._session_todo_store().clear(session_id)
 
     async def run(
         self,
@@ -1577,6 +1594,29 @@ class AgentRuntime:
         if not callable(method):
             raise TypeError("session store does not support history replacement")
         return method(session_id, messages)
+
+    def _session_todo_store(self) -> SessionTodoStore:
+        registry_store = _find_session_todo_store(self.tool_runtime.registry)
+        if registry_store is not None:
+            self._todo_store = registry_store
+        return self._todo_store
+
+
+def _find_session_todo_store(registry: ToolRegistry) -> SessionTodoStore | None:
+    for tool_id in ("todowrite", "todo_write"):
+        tool = registry.get(tool_id)
+        if tool is None:
+            continue
+        store = tool.runtime_metadata.get("todo_store")
+        if isinstance(store, SessionTodoStore):
+            return store
+        todos_by_session = tool.runtime_metadata.get("todos_by_session")
+        if isinstance(todos_by_session, MutableMapping):
+            store = SessionTodoStore(todos_by_session)
+            tool.runtime_metadata["todo_store"] = store
+            tool.runtime_metadata["todos_by_session"] = store.todos_by_session
+            return store
+    return None
 
 
 def _manual_compaction_budget(

--- a/src/efp_runtime/runtime/config.py
+++ b/src/efp_runtime/runtime/config.py
@@ -60,6 +60,7 @@ class RuntimeConfig:
     structured_output_schema: dict[str, Any] | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     include_default_system_prompt: bool = True
+    include_environment_context: bool = True
     system_prompt_texts: list[str] = field(default_factory=list)
     system_prompt_paths: list[str | Path] = field(default_factory=list)
     max_system_prompt_chars: int = 20000
@@ -218,6 +219,7 @@ class RuntimeConfig:
         self.tool_permissions = normalize_tool_permissions(self.tool_permissions)
         self.metadata = dict(self.metadata)
         self.include_default_system_prompt = bool(self.include_default_system_prompt)
+        self.include_environment_context = bool(self.include_environment_context)
         self.system_prompt_texts = list(self.system_prompt_texts)
         self.system_prompt_paths = list(self.system_prompt_paths)
         self.include_runtime_reminders = bool(self.include_runtime_reminders)

--- a/src/efp_runtime/session/__init__.py
+++ b/src/efp_runtime/session/__init__.py
@@ -16,6 +16,7 @@ from .protocol import SessionStore
 from .query import query_messages, query_sessions, session_context_messages
 from .status import RuntimeStatus
 from .store import InMemorySessionStore
+from .todo import SessionTodoStore
 
 __all__ = [
     "CompactionPart",
@@ -31,6 +32,7 @@ __all__ = [
     "SessionCheckpoint",
     "SessionProcessor",
     "SessionStore",
+    "SessionTodoStore",
     "TaskPart",
     "query_messages",
     "query_sessions",

--- a/src/efp_runtime/session/todo.py
+++ b/src/efp_runtime/session/todo.py
@@ -1,0 +1,65 @@
+"""Session-level todo state for Runtime v2."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, MutableMapping
+from threading import RLock
+from typing import Any, cast
+
+
+TodoItem = dict[str, str]
+TodosBySession = MutableMapping[str, list[TodoItem]]
+
+
+class SessionTodoStore:
+    """In-memory todo state keyed by Runtime v2 session id."""
+
+    def __init__(self, todos_by_session: TodosBySession | None = None) -> None:
+        self.todos_by_session: TodosBySession = (
+            todos_by_session if todos_by_session is not None else {}
+        )
+        self._lock = RLock()
+
+    def get(self, session_id: str | None) -> list[TodoItem]:
+        with self._lock:
+            return _copy_todos(self.todos_by_session.get(_session_key(session_id), []))
+
+    def set(
+        self,
+        session_id: str | None,
+        todos: Iterable[Mapping[str, Any]],
+    ) -> list[TodoItem]:
+        stored = [_copy_todo(todo) for todo in todos]
+        with self._lock:
+            self.todos_by_session[_session_key(session_id)] = stored
+            return _copy_todos(stored)
+
+    def clear(self, session_id: str | None) -> None:
+        with self._lock:
+            self.todos_by_session.pop(_session_key(session_id), None)
+
+    def snapshot(self) -> dict[str, list[TodoItem]]:
+        with self._lock:
+            return {
+                session_id: _copy_todos(todos)
+                for session_id, todos in self.todos_by_session.items()
+            }
+
+
+def _session_key(session_id: str | None) -> str:
+    return session_id or "default"
+
+
+def _copy_todos(todos: Iterable[Mapping[str, Any]]) -> list[TodoItem]:
+    return [_copy_todo(todo) for todo in todos]
+
+
+def _copy_todo(todo: Mapping[str, Any]) -> TodoItem:
+    return {
+        "content": cast(str, todo["content"]),
+        "status": cast(str, todo["status"]),
+        "priority": cast(str, todo.get("priority", "medium")),
+    }
+
+
+__all__ = ["SessionTodoStore", "TodoItem", "TodosBySession"]

--- a/src/efp_runtime/shell_permissions.py
+++ b/src/efp_runtime/shell_permissions.py
@@ -1,0 +1,597 @@
+"""Lightweight shell command scanning for permission requests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import posixpath
+import re
+import shlex
+from typing import Any
+
+
+_DYNAMIC_PATH_RE = re.compile(
+    r"(\$\(|\$\{|`|\$[A-Za-z_][A-Za-z0-9_]*|^~(?:/|[^/]*))"
+)
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
+_REDIRECT_RE = re.compile(r"^(?:\d+)?(?:>>?|<<?|<>|>&|<&)(?:&?\d+|-|.+)?$")
+_GLOB_CHARS = frozenset("*?[")
+_SHELL_TOOL_FALLBACK_PATTERN_CHARS = 500
+
+
+@dataclass(frozen=True)
+class ShellPermissionSummary:
+    """Structured shell permission scan result."""
+
+    metadata: dict[str, Any]
+    patterns: list[str]
+
+
+def shell_permission_summary(args: Mapping[str, Any]) -> ShellPermissionSummary:
+    """Return conservative permission metadata and patterns for a shell call."""
+
+    command = _string_arg(args, "command") or ""
+    description = _string_arg(args, "description")
+    workdir = _workdir(args)
+    command_preview = _preview_text(command)
+    metadata: dict[str, Any] = {
+        "command_preview": command_preview,
+        "description": description if description is not None else "",
+        "workdir": workdir,
+        "command_names": [],
+        "path_args": [],
+        "permission_patterns": [],
+        "dynamic_paths": False,
+        "workspace_escape": False,
+    }
+
+    if not command:
+        return ShellPermissionSummary(metadata=metadata, patterns=[])
+
+    try:
+        _scan_command(command, workdir=workdir, metadata=metadata)
+    except ValueError as exc:
+        metadata["shell_parse_error"] = str(exc)
+        patterns = [_fallback_pattern(command)]
+        metadata["permission_patterns"] = list(patterns)
+        return ShellPermissionSummary(metadata=metadata, patterns=patterns)
+
+    patterns = _patterns_from_path_args(metadata["path_args"])
+    if not patterns:
+        patterns = [_fallback_pattern(command)]
+    metadata["permission_patterns"] = list(patterns)
+
+    command_names = metadata["command_names"]
+    if command_names:
+        metadata["command_name"] = command_names[0]
+
+    return ShellPermissionSummary(metadata=metadata, patterns=patterns)
+
+
+def shell_permission_metadata(args: Mapping[str, Any]) -> dict[str, Any]:
+    """Return shell permission request metadata for a shell call."""
+
+    return shell_permission_summary(args).metadata
+
+
+def shell_permission_patterns(args: Mapping[str, Any]) -> list[str]:
+    """Return shell permission request patterns for a shell call."""
+
+    return shell_permission_summary(args).patterns
+
+
+def _scan_command(
+    command: str,
+    *,
+    workdir: str,
+    metadata: dict[str, Any],
+) -> None:
+    current_workdir = _normalize_workdir(workdir)
+    for segment in _split_simple_commands(command):
+        if not segment:
+            continue
+        tokens = shlex.split(segment, posix=True)
+        if not tokens:
+            continue
+
+        command_name, arg_index = _command_token(tokens)
+        if not command_name:
+            continue
+        metadata["command_names"].append(command_name)
+
+        path_specs = _path_specs(command_name, tokens[arg_index:])
+        if command_name in {"cd", "pushd"} and path_specs:
+            metadata["cwd_affecting"] = True
+
+        added_entries: list[dict[str, Any]] = []
+        for raw, kind in path_specs:
+            entry = _path_entry(
+                raw=raw,
+                command=command_name,
+                workdir=current_workdir,
+                kind=kind,
+            )
+            if entry is None:
+                continue
+            added_entries.append(entry)
+            metadata["path_args"].append(entry)
+            if entry.get("dynamic"):
+                metadata["dynamic_paths"] = True
+            if entry.get("workspace_escape"):
+                metadata["workspace_escape"] = True
+
+        if command_name in {"cd", "pushd"} and added_entries:
+            target = added_entries[0]
+            if not target.get("dynamic"):
+                current_workdir = str(target["path"])
+
+
+def _split_simple_commands(command: str) -> list[str]:
+    segments: list[str] = []
+    start = 0
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            index += 1
+            continue
+        if quote is not None:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if command.startswith("&&", index) or command.startswith("||", index):
+            segments.append(command[start:index].strip())
+            index += 2
+            start = index
+            continue
+        if char in {";", "|", "\n"}:
+            segments.append(command[start:index].strip())
+            index += 1
+            start = index
+            continue
+        index += 1
+    segments.append(command[start:].strip())
+    return segments
+
+
+def _command_token(tokens: list[str]) -> tuple[str | None, int]:
+    index = 0
+    while index < len(tokens) and _is_assignment(tokens[index]):
+        index += 1
+
+    if index < len(tokens) and tokens[index] == "env":
+        index += 1
+        while index < len(tokens):
+            token = tokens[index]
+            if _is_assignment(token):
+                index += 1
+                continue
+            if token == "--":
+                index += 1
+                break
+            if token.startswith("-"):
+                index += 2 if token in {"-u", "--unset", "-C", "--chdir"} else 1
+                continue
+            break
+
+    if index >= len(tokens):
+        return None, index
+    return _basename_command(tokens[index]), index + 1
+
+
+def _path_specs(command: str, args: list[str]) -> list[tuple[str, str]]:
+    if command in {"cd", "pushd"}:
+        operands = _non_flag_operands(args, command=command, keep_dash=True)
+        return [(operands[0], "cwd")] if operands else []
+    if command in {"cat", "ls", "head", "tail", "touch", "mkdir", "rm"}:
+        return [(operand, "argument") for operand in _non_flag_operands(args, command=command)]
+    if command in {"cp", "mv"}:
+        return _copy_move_specs(_non_flag_operands(args, command=command))
+    if command in {"chmod", "chown"}:
+        operands = _non_flag_operands(args, command=command)
+        return [(operand, "argument") for operand in operands[1:]]
+    if command == "find":
+        return [(operand, "argument") for operand in _find_operands(args)]
+    if command == "sed":
+        return _sed_specs(args)
+    if command in {"grep", "rg"}:
+        return [(operand, "argument") for operand in _grep_operands(args, command=command)]
+    return []
+
+
+def _copy_move_specs(operands: list[str]) -> list[tuple[str, str]]:
+    if not operands:
+        return []
+    if len(operands) == 1:
+        return [(operands[0], "source")]
+    return [
+        *((operand, "source") for operand in operands[:-1]),
+        (operands[-1], "destination"),
+    ]
+
+
+def _non_flag_operands(
+    args: list[str],
+    *,
+    command: str,
+    keep_dash: bool = False,
+) -> list[str]:
+    operands: list[str] = []
+    index = 0
+    options_done = False
+    while index < len(args):
+        token = args[index]
+        if not options_done and token == "--":
+            options_done = True
+            index += 1
+            continue
+        if not options_done and _is_redirection(token):
+            index += 2 if _is_redirection_operator(token) else 1
+            continue
+        if not options_done and _looks_like_flag(token):
+            index += 1 + _flag_value_count(command, token)
+            continue
+        if token == "-" and not keep_dash:
+            index += 1
+            continue
+        operands.append(token)
+        index += 1
+    return operands
+
+
+def _find_operands(args: list[str]) -> list[str]:
+    operands: list[str] = []
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            index += 1
+            continue
+        if token in {"-H", "-L", "-P"} or re.match(r"^-O\d+$", token):
+            index += 1
+            continue
+        if token in {"!", "(", ")"} or token.startswith("-"):
+            break
+        if _is_redirection(token):
+            index += 2 if _is_redirection_operator(token) else 1
+            continue
+        operands.append(token)
+        index += 1
+    return operands or ["."]
+
+
+def _sed_specs(args: list[str]) -> list[tuple[str, str]]:
+    specs: list[tuple[str, str]] = []
+    script_seen = False
+    index = 0
+    options_done = False
+    while index < len(args):
+        token = args[index]
+        if not options_done and token == "--":
+            options_done = True
+            index += 1
+            continue
+        if not options_done and _is_redirection(token):
+            index += 2 if _is_redirection_operator(token) else 1
+            continue
+        if not options_done and _looks_like_flag(token):
+            flag, inline_value = _split_long_flag_value(token)
+            if flag in {"-e", "--expression"}:
+                script_seen = True
+                index += 1 if inline_value is not None or token.startswith("-e") and len(token) > 2 else 2
+                continue
+            if flag in {"-f", "--file"}:
+                script_seen = True
+                value = inline_value
+                if value is None and token.startswith("-f") and len(token) > 2:
+                    value = token[2:]
+                if value is None and index + 1 < len(args):
+                    value = args[index + 1]
+                    index += 2
+                else:
+                    index += 1
+                if value:
+                    specs.append((value, "script"))
+                continue
+            index += 1 + _flag_value_count("sed", token)
+            continue
+        if not script_seen:
+            script_seen = True
+            index += 1
+            continue
+        if token != "-":
+            specs.append((token, "argument"))
+        index += 1
+    return specs
+
+
+def _grep_operands(args: list[str], *, command: str) -> list[str]:
+    operands: list[str] = []
+    pattern_seen = False
+    index = 0
+    options_done = False
+    while index < len(args):
+        token = args[index]
+        if not options_done and token == "--":
+            options_done = True
+            index += 1
+            continue
+        if not options_done and _is_redirection(token):
+            index += 2 if _is_redirection_operator(token) else 1
+            continue
+        if not options_done and _looks_like_flag(token):
+            flag, inline_value = _split_long_flag_value(token)
+            if flag in _grep_pattern_flags(command):
+                pattern_seen = True
+                if inline_value is not None or _short_flag_has_inline_value(token, flag):
+                    index += 1
+                else:
+                    index += 2
+                continue
+            index += 1 + _flag_value_count(command, token)
+            continue
+        if not pattern_seen:
+            pattern_seen = True
+            index += 1
+            continue
+        if token != "-":
+            operands.append(token)
+        index += 1
+    return operands
+
+
+def _flag_value_count(command: str, token: str) -> int:
+    flag, inline_value = _split_long_flag_value(token)
+    if inline_value is not None:
+        return 0
+    return 1 if flag in _flags_with_separate_values(command) else 0
+
+
+def _flags_with_separate_values(command: str) -> set[str]:
+    common = {"--color", "--exclude", "--exclude-dir", "--include"}
+    if command in {"grep", "rg"}:
+        return common | {
+            "-A",
+            "-B",
+            "-C",
+            "-D",
+            "-e",
+            "-f",
+            "-g",
+            "-m",
+            "--after-context",
+            "--before-context",
+            "--binary-files",
+            "--context",
+            "--context-separator",
+            "--directories",
+            "--engine",
+            "--file",
+            "--glob",
+            "--glob-case-insensitive",
+            "--iglob",
+            "--label",
+            "--max-count",
+            "--max-depth",
+            "--max-filesize",
+            "--mmap",
+            "--pager",
+            "--path-separator",
+            "--pre",
+            "--regexp",
+            "--replace",
+            "--sort",
+            "--sortr",
+            "--type",
+            "--type-add",
+            "--type-clear",
+        }
+    if command == "sed":
+        return {"-e", "-f", "--expression", "--file"}
+    if command in {"cp", "mv"}:
+        return {"-S", "-t", "--backup", "--suffix", "--target-directory"}
+    if command in {"head", "tail"}:
+        return {"-c", "-n", "--bytes", "--lines"}
+    if command == "ls":
+        return {"-I", "--block-size", "--color", "--format", "--ignore", "--sort", "--time"}
+    if command == "mkdir":
+        return {"-m", "--mode"}
+    if command == "touch":
+        return {"-d", "-r", "-t", "--date", "--reference", "--time"}
+    if command == "chmod":
+        return {"--reference"}
+    if command == "chown":
+        return {"--from", "--reference"}
+    return common
+
+
+def _grep_pattern_flags(command: str) -> set[str]:
+    if command == "rg":
+        return {"-e", "-f", "--regexp", "--file"}
+    return {"-e", "-f", "--regexp", "--file"}
+
+
+def _split_long_flag_value(token: str) -> tuple[str, str | None]:
+    if token.startswith("--") and "=" in token:
+        flag, value = token.split("=", 1)
+        return flag, value
+    if token.startswith("-") and not token.startswith("--") and len(token) > 2:
+        short = token[:2]
+        if short in {
+            "-A",
+            "-B",
+            "-C",
+            "-D",
+            "-I",
+            "-c",
+            "-d",
+            "-e",
+            "-f",
+            "-g",
+            "-m",
+            "-n",
+            "-r",
+            "-S",
+            "-t",
+        }:
+            return short, token[2:]
+    return token, None
+
+
+def _short_flag_has_inline_value(token: str, flag: str) -> bool:
+    return token.startswith(flag) and token != flag and not token.startswith("--")
+
+
+def _path_entry(
+    *,
+    raw: str,
+    command: str,
+    workdir: str,
+    kind: str,
+) -> dict[str, Any] | None:
+    if raw == "":
+        return None
+    dynamic = _is_dynamic_path(raw)
+    glob = _is_glob_path(raw)
+    path = _normalize_path(raw, workdir=workdir, dynamic=dynamic)
+    if path == "":
+        return None
+    workspace_escape = _workspace_escape(path)
+    entry: dict[str, Any] = {
+        "raw": raw,
+        "path": path,
+        "command": command,
+        "kind": kind,
+    }
+    if dynamic:
+        entry["dynamic"] = True
+    if glob:
+        entry["glob"] = True
+    if workspace_escape:
+        entry["workspace_escape"] = True
+    return entry
+
+
+def _normalize_path(raw: str, *, workdir: str, dynamic: bool) -> str:
+    if dynamic and _dynamic_starts_path(raw):
+        return _normalize_dynamic_path(raw)
+    if _is_absolute_or_home(raw):
+        return _normalize_dynamic_path(raw) if dynamic else posixpath.normpath(raw)
+    base = _normalize_workdir(workdir)
+    if base in {"", "."}:
+        return _normalize_dynamic_path(raw) if dynamic else posixpath.normpath(raw)
+    joined = posixpath.join(base, raw)
+    return _normalize_dynamic_path(joined) if dynamic else posixpath.normpath(joined)
+
+
+def _normalize_dynamic_path(path: str) -> str:
+    while "//" in path:
+        path = path.replace("//", "/")
+    if path.endswith("/.") and len(path) > 2:
+        path = path[:-2]
+    return path
+
+
+def _normalize_workdir(workdir: str) -> str:
+    if workdir in {"", "."}:
+        return "."
+    return posixpath.normpath(workdir)
+
+
+def _patterns_from_path_args(path_args: list[dict[str, Any]]) -> list[str]:
+    patterns: list[str] = []
+    seen: set[str] = set()
+    for entry in path_args:
+        pattern = str(entry.get("path") or "")
+        if not pattern or pattern in seen:
+            continue
+        seen.add(pattern)
+        patterns.append(pattern)
+    return patterns
+
+
+def _workdir(args: Mapping[str, Any]) -> str:
+    workdir = _string_arg(args, "workdir")
+    if workdir:
+        return workdir
+    cwd = _string_arg(args, "cwd")
+    return cwd or "."
+
+
+def _fallback_pattern(command: str) -> str:
+    return command[:_SHELL_TOOL_FALLBACK_PATTERN_CHARS]
+
+
+def _preview_text(value: str, *, max_chars: int = 240) -> str:
+    text = " ".join(value.split())
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 3:
+        return text[:max_chars]
+    return f"{text[: max_chars - 3]}..."
+
+
+def _string_arg(args: Mapping[str, Any], key: str) -> str | None:
+    value = args.get(key)
+    if value is None:
+        return None
+    return str(value)
+
+
+def _basename_command(token: str) -> str:
+    if "/" not in token:
+        return token
+    return posixpath.basename(token.rstrip("/")) or token
+
+
+def _is_assignment(token: str) -> bool:
+    return bool(_ASSIGNMENT_RE.match(token))
+
+
+def _looks_like_flag(token: str) -> bool:
+    return token.startswith("-") and token not in {"-", "--"}
+
+
+def _is_redirection(token: str) -> bool:
+    return bool(_REDIRECT_RE.match(token))
+
+
+def _is_redirection_operator(token: str) -> bool:
+    return token in {">", ">>", "<", "<<", "<>", ">|", "2>", "2>>", "&>", "&>>"}
+
+
+def _is_dynamic_path(path: str) -> bool:
+    return bool(_DYNAMIC_PATH_RE.search(path))
+
+
+def _dynamic_starts_path(path: str) -> bool:
+    return (
+        path.startswith("$")
+        or path.startswith("`")
+        or path.startswith("~")
+        or path.startswith("$(")
+    )
+
+
+def _is_glob_path(path: str) -> bool:
+    return any(char in path for char in _GLOB_CHARS)
+
+
+def _is_absolute_or_home(path: str) -> bool:
+    return path.startswith("/") or path.startswith("~")
+
+
+def _workspace_escape(path: str) -> bool:
+    return path.startswith("/") or path == ".." or path.startswith("../")

--- a/src/efp_runtime/system_prompt.py
+++ b/src/efp_runtime/system_prompt.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from datetime import date
 from pathlib import Path
+import subprocess
+import sys
 from typing import Any
 
 from .session.models import Message, MessagePart, MessageRole
@@ -49,6 +52,7 @@ class SystemPromptBuilder:
         *,
         workspace_root: str | Path | None,
         include_default_system_prompt: bool = True,
+        include_environment_context: bool = True,
         system_prompt_texts: Iterable[str] = (),
         system_prompt_paths: Iterable[str | Path] = (),
         max_system_prompt_chars: int = 20000,
@@ -58,6 +62,7 @@ class SystemPromptBuilder:
             raise ValueError("max_system_prompt_chars must be greater than or equal to 0")
         self.workspace_root = _coerce_workspace_root(workspace_root)
         self.include_default_system_prompt = bool(include_default_system_prompt)
+        self.include_environment_context = bool(include_environment_context)
         self.system_prompt_texts = list(system_prompt_texts)
         self.system_prompt_paths = list(system_prompt_paths)
         self.max_system_prompt_chars = max_system_prompt_chars
@@ -74,6 +79,11 @@ class SystemPromptBuilder:
                     source="default_system_prompt",
                 )
             )
+
+        if self.include_environment_context:
+            environment = self._environment_context_message(runtime_metadata)
+            if environment is not None:
+                messages.append(environment)
 
         for index, text in enumerate(self.system_prompt_texts):
             content = str(text)
@@ -131,6 +141,52 @@ class SystemPromptBuilder:
             path=str(path) if path is not None else None,
             content=rendered_content,
             truncated=truncated,
+            original_chars=len(content),
+            metadata=source_metadata,
+        )
+        return _system_text_message(source)
+
+    def _environment_context_message(
+        self,
+        metadata: Mapping[str, Any],
+    ) -> Message | None:
+        workspace_root = _environment_workspace_root(metadata, self.workspace_root)
+        working_directory = _environment_working_directory(metadata, workspace_root)
+        model_id = _environment_model_id(metadata)
+        git_repository = _is_git_repository(workspace_root)
+        platform_id = sys.platform
+        current_date = _current_local_date_iso()
+
+        fields: list[tuple[str, str]] = [("model", model_id)]
+        if working_directory is not None:
+            fields.append(("working directory", str(working_directory)))
+        if workspace_root is not None:
+            fields.append(("workspace root", str(workspace_root)))
+        fields.extend(
+            [
+                ("git repository", str(git_repository).lower()),
+                ("platform", platform_id),
+                ("date", current_date),
+            ]
+        )
+        if not fields:
+            return None
+
+        content = "Environment:\n" + "\n".join(
+            f"- {label}: {value}" for label, value in fields
+        )
+        source_metadata: dict[str, Any] = {
+            "source": "environment_context",
+            "kind": "environment_context",
+            "model_id": model_id,
+            "git_repository": git_repository,
+        }
+        if workspace_root is not None:
+            source_metadata["workspace_root"] = str(workspace_root)
+        source = SystemPromptSource(
+            path=None,
+            content=content,
+            truncated=False,
             original_chars=len(content),
             metadata=source_metadata,
         )
@@ -270,6 +326,90 @@ def _metadata_value(metadata: Mapping[str, Any], key: str) -> Any:
     if isinstance(runtime_config, Mapping):
         return runtime_config.get(key)
     return None
+
+
+def _environment_workspace_root(
+    metadata: Mapping[str, Any],
+    builder_workspace_root: Path | None,
+) -> Path | None:
+    metadata_workspace_root = _coerce_metadata_path(
+        _metadata_value(metadata, "workspace_root")
+    )
+    return metadata_workspace_root or builder_workspace_root
+
+
+def _environment_working_directory(
+    metadata: Mapping[str, Any],
+    workspace_root: Path | None,
+) -> Path | None:
+    for key in ("cwd", "working_directory"):
+        path = _coerce_metadata_path(_metadata_value(metadata, key))
+        if path is not None:
+            return path
+    return workspace_root
+
+
+def _environment_model_id(metadata: Mapping[str, Any]) -> str:
+    provider_id = (
+        _metadata_string(metadata, "default_provider_id") or "github-copilot"
+    )
+    requested_model = _metadata_string(metadata, "requested_model")
+    if requested_model is not None:
+        return _qualified_model_id(requested_model, provider_id)
+    default_model = _metadata_string(metadata, "default_model") or "gpt-5-mini"
+    return _qualified_model_id(default_model, provider_id)
+
+
+def _qualified_model_id(model_id: str, provider_id: str | None) -> str:
+    model = str(model_id).strip()
+    if not model:
+        return "github-copilot/gpt-5-mini"
+    if "/" in model:
+        return model
+    provider = str(provider_id or "").strip().strip("/")
+    if not provider:
+        provider = "github-copilot"
+    return f"{provider}/{model}"
+
+
+def _metadata_string(metadata: Mapping[str, Any], key: str) -> str | None:
+    value = _metadata_value(metadata, key)
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _coerce_metadata_path(value: Any) -> Path | None:
+    if not isinstance(value, (str, Path)):
+        return None
+    return _coerce_workspace_root(value)
+
+
+def _is_git_repository(workspace_root: Path | None) -> bool:
+    if workspace_root is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(workspace_root), "rev-parse", "--is-inside-work-tree"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip().lower() == "true"
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    try:
+        return (workspace_root / ".git").exists()
+    except OSError:
+        return False
+
+
+def _current_local_date_iso() -> str:
+    return date.today().isoformat()
 
 
 def _metadata_bool(metadata: Mapping[str, Any], *keys: str) -> bool:

--- a/src/efp_runtime/tools/builtin/registry.py
+++ b/src/efp_runtime/tools/builtin/registry.py
@@ -10,6 +10,7 @@ from ...instructions import ReadInstructionResolver
 from ...lsp import LSPClient
 from ...permissions import ALLOW, PermissionMetadata
 from ...questions import QuestionBroker
+from ...session.todo import SessionTodoStore
 from ...skills.discovery import SkillDiscovery
 from ...skills.tool import build_skill_list_tool, build_skill_tool
 from ..registry import ToolRegistry
@@ -43,7 +44,7 @@ from .task import (
     create_task_status_tool,
     create_task_tool,
 )
-from .todo import TodoStore, create_todo_write_tool, create_todowrite_tool
+from .todo import create_todo_write_tool, create_todowrite_tool
 
 if TYPE_CHECKING:
     from ...agents.background_tasks import BackgroundTaskManager
@@ -175,10 +176,10 @@ def create_core_tool_registry(
             registry.register(create_task_cancel_tool(task_manager))
     if include_question_tool:
         registry.register(create_question_tool(question_broker))
-    todo_store: TodoStore = {}
+    todo_store = SessionTodoStore()
     if expose_legacy_aliases:
-        registry.register(create_todo_write_tool(todos_by_session=todo_store))
-    registry.register(create_todowrite_tool(todos_by_session=todo_store))
+        registry.register(create_todo_write_tool(todo_store=todo_store))
+    registry.register(create_todowrite_tool(todo_store=todo_store))
     if include_plan_tool:
         registry.register(create_plan_exit_tool())
     if resolved_skill_discovery is not None:

--- a/src/efp_runtime/tools/builtin/todo.py
+++ b/src/efp_runtime/tools/builtin/todo.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ...events import RuntimeEvent
 from ...permissions import ALLOW, PermissionMetadata
+from ...session.todo import SessionTodoStore
 from ...types import ToolResult
 from ..definition import ToolContext, ToolDef
 
@@ -18,20 +19,24 @@ TodoStore = dict[str, list[dict[str, str]]]
 
 def create_todo_write_tool(
     *,
+    todo_store: SessionTodoStore | None = None,
     todos_by_session: TodoStore | None = None,
 ) -> ToolDef:
     return _create_todo_tool(
         tool_id="todo_write",
+        todo_store=todo_store,
         todos_by_session=todos_by_session,
     )
 
 
 def create_todowrite_tool(
     *,
+    todo_store: SessionTodoStore | None = None,
     todos_by_session: TodoStore | None = None,
 ) -> ToolDef:
     return _create_todo_tool(
         tool_id="todowrite",
+        todo_store=todo_store,
         todos_by_session=todos_by_session,
     )
 
@@ -39,9 +44,13 @@ def create_todowrite_tool(
 def _create_todo_tool(
     *,
     tool_id: str,
+    todo_store: SessionTodoStore | None,
     todos_by_session: TodoStore | None,
 ) -> ToolDef:
-    store = todos_by_session if todos_by_session is not None else {}
+    store = _resolve_todo_store(
+        todo_store=todo_store,
+        todos_by_session=todos_by_session,
+    )
 
     async def execute(args: dict[str, Any], context: ToolContext) -> ToolResult:
         normalized = [
@@ -52,15 +61,14 @@ def _create_todo_tool(
             }
             for todo in args["todos"]
         ]
-        session_key = context.session_id or "default"
-        store[session_key] = normalized
-        counts = _todo_counts(normalized)
+        todos = store.set(context.session_id, normalized)
+        counts = _todo_counts(todos)
         output = {
-            "todos": normalized,
+            "todos": todos,
             **counts,
         }
         metadata = {
-            "todos": normalized,
+            "todos": todos,
             **counts,
         }
         return ToolResult(
@@ -78,7 +86,7 @@ def _create_todo_tool(
                     payload={
                         "tool_id": tool_id,
                         "tool_call_id": context.tool_call_id,
-                        "todos": normalized,
+                        "todos": todos,
                         **counts,
                     },
                 )
@@ -118,8 +126,21 @@ def _create_todo_tool(
             resource="session",
             risk="low",
         ),
-        runtime_metadata={"todos_by_session": store},
+        runtime_metadata={
+            "todo_store": store,
+            "todos_by_session": store.todos_by_session,
+        },
     )
+
+
+def _resolve_todo_store(
+    *,
+    todo_store: SessionTodoStore | None,
+    todos_by_session: TodoStore | None,
+) -> SessionTodoStore:
+    if todo_store is not None:
+        return todo_store
+    return SessionTodoStore(todos_by_session)
 
 
 def _todo_counts(todos: list[dict[str, str]]) -> dict[str, int]:

--- a/tests/runtime_v2/test_active_skills.py
+++ b/tests/runtime_v2/test_active_skills.py
@@ -29,6 +29,7 @@ async def test_config_active_skills_are_injected_before_user_history(tmp_path: P
             active_skills=["review-pr"],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -61,6 +62,7 @@ async def test_injected_skill_context_builder_is_used_without_config_directories
             active_skills=["review-pr"],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         skill_context_builder=SkillContextBuilder(SkillDiscovery([tmp_path])),
@@ -83,6 +85,7 @@ async def test_skill_command_adds_active_skill_and_cleans_user_text(tmp_path: Pa
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -113,6 +116,7 @@ async def test_skill_command_only_still_sends_context(tmp_path: Path):
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -141,6 +145,7 @@ async def test_skill_clear_removes_active_skills_and_stops_injection(tmp_path: P
             active_skills=["review-pr"],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )

--- a/tests/runtime_v2/test_agent_profiles_subagent_runner.py
+++ b/tests/runtime_v2/test_agent_profiles_subagent_runner.py
@@ -662,6 +662,7 @@ async def test_profile_active_skills_enter_child_context_without_base_pollution(
         active_skills=["base-skill"],
         max_iterations=1,
         include_default_system_prompt=False,
+        include_environment_context=False,
         include_runtime_reminders=False,
     )
     runner = create_subagent_task_runner(

--- a/tests/runtime_v2/test_agent_runtime_profiles.py
+++ b/tests/runtime_v2/test_agent_runtime_profiles.py
@@ -52,6 +52,7 @@ async def test_named_agent_injects_profile_prompt_into_provider_system_context()
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
             system_prompt_texts=["Base system prompt."],
             instruction_texts=["Workspace instructions."],
@@ -92,6 +93,7 @@ async def test_builtin_read_only_agent_records_metadata_and_applies_prompt():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         agent_registry=registry,
@@ -136,6 +138,7 @@ async def test_profile_prompt_is_not_written_to_session_history():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -163,6 +166,7 @@ async def test_default_agent_is_used_when_run_omits_agent():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         agent_registry=registry,
@@ -194,6 +198,7 @@ async def test_switch_agent_persists_event_and_run_resume_use_session_profile():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         agent_registry=registry,
@@ -259,6 +264,7 @@ async def test_caller_command_and_mention_agents_override_session_agent():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=command_registry,
@@ -309,6 +315,7 @@ async def test_agent_mention_selects_profile_and_strips_token():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         agent_registry=registry,
@@ -338,6 +345,7 @@ async def test_agent_mention_alone_selects_profile_and_sends_clean_prompt():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         agent_registry=registry,
@@ -369,6 +377,7 @@ async def test_caller_agent_wins_over_agent_mention_without_stripping():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         agent_registry=registry,
@@ -412,6 +421,7 @@ async def test_command_agent_wins_over_agent_mention_without_stripping():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=command_registry,
@@ -443,6 +453,7 @@ async def test_unknown_agent_mention_is_left_as_prompt_text():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         agent_registry=registry,
@@ -472,6 +483,7 @@ async def test_file_reference_at_first_token_is_not_consumed_as_agent_mention(
             workspace_root=tmp_path,
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         agent_registry=registry,
@@ -496,6 +508,7 @@ async def test_direct_agent_profile_does_not_require_registry():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -531,6 +544,7 @@ async def test_profile_active_skills_are_base_and_skill_commands_are_temporary(
             active_skills=["runtime-skill"],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -579,6 +593,7 @@ async def test_profile_active_skills_do_not_leak_to_next_plain_run(tmp_path: Pat
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -626,6 +641,7 @@ async def test_profile_active_skills_apply_when_profile_selected_by_command(
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=command_registry,

--- a/tests/runtime_v2/test_config_loader.py
+++ b/tests/runtime_v2/test_config_loader.py
@@ -459,6 +459,26 @@ def test_runtime_config_field_mapping(tmp_path: Path):
     assert config.runtime_mode == "plan"
 
 
+@pytest.mark.parametrize(
+    "alias",
+    ["includeEnvironmentContext", "include_environment_context"],
+)
+def test_config_loader_maps_environment_context_aliases(
+    tmp_path: Path,
+    alias: str,
+):
+    _write_json(tmp_path / "custom.json", {alias: False})
+
+    result = load_runtime_config(
+        tmp_path,
+        paths=["custom.json"],
+        include_defaults=False,
+    )
+
+    assert result.config.include_environment_context is False
+    assert alias not in result.metadata["unconsumed_config"]
+
+
 def test_tool_surface_config_aliases(tmp_path: Path):
     _write_json(
         tmp_path / "camel.json",

--- a/tests/runtime_v2/test_custom_commands.py
+++ b/tests/runtime_v2/test_custom_commands.py
@@ -456,6 +456,7 @@ async def test_slash_command_expands_into_provider_user_message(tmp_path: Path):
             command_directories=[command_dir],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -492,6 +493,7 @@ async def test_skill_backed_slash_command_expands_into_provider_user_message(
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -533,6 +535,7 @@ async def test_run_command_matches_slash_invocation_prompt_and_metadata(
         command_directories=[command_dir],
         max_iterations=1,
         include_default_system_prompt=False,
+        include_environment_context=False,
         include_runtime_reminders=False,
     )
     slash_provider = ScriptedLLMProvider([{"content": "Done."}])
@@ -584,6 +587,7 @@ async def test_run_command_accepts_leading_slash_in_command_name(tmp_path: Path)
             command_directories=[command_dir],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -643,6 +647,7 @@ async def test_run_command_invokes_skill_backed_command(tmp_path: Path):
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -685,6 +690,7 @@ async def test_run_command_emits_command_executed_event_once(tmp_path: Path):
             command_directories=[command_dir],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         event_bus=bus,
@@ -727,6 +733,7 @@ async def test_slash_command_emits_command_executed_event(tmp_path: Path):
             command_directories=[command_dir],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         event_bus=bus,
@@ -799,6 +806,7 @@ async def test_command_executed_event_emits_on_pause_and_not_resume(tmp_path: Pa
             max_iterations=3,
             include_legacy_tool_aliases=True,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         event_bus=bus,
@@ -872,6 +880,7 @@ async def test_builtin_init_available_without_config_or_command_directory(
             workspace_root=tmp_path,
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -900,6 +909,7 @@ async def test_builtin_review_available_without_config_or_command_directory(
             workspace_root=tmp_path,
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -996,6 +1006,7 @@ async def test_injected_command_registry_expands_without_config_directories():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1054,6 +1065,7 @@ async def test_command_subtask_true_executes_task_tool_before_parent_provider():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1176,6 +1188,7 @@ async def test_command_agent_subagent_profile_executes_task_when_subtask_omitted
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1226,6 +1239,7 @@ async def test_command_subtask_false_overrides_subagent_profile_mode():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1273,6 +1287,7 @@ async def test_command_subtask_respects_disabled_task_tool():
             max_iterations=1,
             disabled_tools=["task"],
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1317,6 +1332,7 @@ async def test_command_subtask_respects_per_run_task_disable():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1370,6 +1386,7 @@ async def test_command_subtask_error_falls_back_to_ordinary_command_prompt():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1462,6 +1479,7 @@ async def test_command_agent_selects_profile_when_caller_omits_agent():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1504,6 +1522,7 @@ async def test_caller_agent_wins_over_command_agent():
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1574,6 +1593,7 @@ async def test_command_model_records_requested_model_without_provider_model_swit
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1626,6 +1646,7 @@ async def test_command_model_sets_openai_payload_model_without_provider_model_sw
         config=RuntimeConfig(
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1752,6 +1773,7 @@ async def test_slash_command_preserves_remaining_body(tmp_path: Path):
             command_directories=[command_dir],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -1778,6 +1800,7 @@ async def test_unknown_slash_command_is_left_as_user_text(tmp_path: Path):
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         event_bus=bus,
@@ -1810,6 +1833,7 @@ async def test_skill_slash_fallback_activates_discovered_skill_when_unhandled(
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1848,6 +1872,7 @@ async def test_skill_slash_fallback_handles_multiline_form(tmp_path: Path):
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -1877,6 +1902,7 @@ async def test_custom_command_wins_over_same_named_skill(tmp_path: Path):
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -1906,6 +1932,7 @@ async def test_skill_command_does_not_trigger_custom_command(tmp_path: Path):
             skill_directories=[tmp_path],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         event_bus=bus,
@@ -1944,6 +1971,7 @@ async def test_command_content_is_truncated_by_configured_limit(tmp_path: Path):
             max_command_chars=3,
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -1986,6 +2014,7 @@ async def test_command_shell_interpolation_renders_tool_results(tmp_path: Path):
             include_legacy_tool_aliases=True,
             tool_permissions={"shell_exec": "allow"},
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -2035,6 +2064,7 @@ async def test_command_shell_interpolation_permission_denial_is_visible(
             include_legacy_tool_aliases=True,
             tool_permissions={"shell_exec": "deny"},
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -2071,6 +2101,7 @@ async def test_command_arguments_and_body_shell_syntax_are_not_interpolated(
             max_iterations=1,
             tool_permissions={"shell_exec": "allow"},
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,
@@ -2110,6 +2141,7 @@ async def test_command_file_references_are_resolved_after_expansion(tmp_path: Pa
             workspace_root=tmp_path,
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         command_registry=registry,

--- a/tests/runtime_v2/test_instruction_context.py
+++ b/tests/runtime_v2/test_instruction_context.py
@@ -137,6 +137,7 @@ async def test_agent_runtime_run_injects_instruction_context_without_persisting_
             workspace_root=tmp_path,
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -188,6 +189,7 @@ async def test_resume_injects_instruction_context_without_empty_user_message(
             workspace_root=tmp_path,
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
         store=store,
@@ -227,6 +229,7 @@ async def test_instruction_context_precedes_active_skill_context(tmp_path: Path)
             active_skills=["review-pr"],
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )

--- a/tests/runtime_v2/test_opencode_remaining_tool_aliases.py
+++ b/tests/runtime_v2/test_opencode_remaining_tool_aliases.py
@@ -181,8 +181,12 @@ async def test_todo_write_and_todowrite_share_registry_store(tmp_path: Path):
     runtime = ToolRuntime(registry)
     todo_store = registry.require("todo_write").runtime_metadata["todos_by_session"]
     alias_store = registry.require("todowrite").runtime_metadata["todos_by_session"]
+    session_store = registry.require("todo_write").runtime_metadata["todo_store"]
+    alias_session_store = registry.require("todowrite").runtime_metadata["todo_store"]
 
     assert alias_store is todo_store
+    assert alias_session_store is session_store
+    assert session_store.todos_by_session is todo_store
 
     await runtime.execute(
         ToolCall(

--- a/tests/runtime_v2/test_permission_config.py
+++ b/tests/runtime_v2/test_permission_config.py
@@ -15,9 +15,11 @@ from efp_runtime.loop import LoopStatus, ScriptedLLMProvider
 from efp_runtime.models import ToolCall
 from efp_runtime.permissions import (
     ALLOW,
+    ASK,
     ConfiguredPermissionBroker,
     PermissionConfig,
     PermissionMetadata,
+    PermissionRequest,
     normalize_agent_permission_overlay,
     normalize_tool_permissions,
 )
@@ -123,6 +125,23 @@ async def test_bash_allow_config_executes_shell_without_pending(tmp_path: Path):
     tool_result = history[2].parts[0].tool_result
     assert tool_result.status == "success"
     assert tool_result.output["stdout"] == "ok"
+
+
+def test_shell_permission_request_respects_static_patterns():
+    request = PermissionRequest.create(
+        tool_id="bash",
+        args={"command": "cat src/app.py"},
+        metadata=PermissionMetadata(
+            action=ASK,
+            category="shell",
+            data={"patterns": ["configured-shell-pattern"]},
+        ),
+    )
+
+    assert request.patterns == ["configured-shell-pattern"]
+    assert request.metadata["patterns"] == ["configured-shell-pattern"]
+    assert request.metadata["permission_patterns"] == ["configured-shell-pattern"]
+    assert request.metadata["path_args"][0]["path"] == "src/app.py"
 
 
 @pytest.mark.asyncio

--- a/tests/runtime_v2/test_runtime_facade.py
+++ b/tests/runtime_v2/test_runtime_facade.py
@@ -75,7 +75,8 @@ async def test_agent_runtime_defaults_to_builtin_tools_for_workspace(tmp_path: P
     ]
     assert request.metadata["suite"] == "facade"
     assert request.metadata["request_id"] == "run-1"
-    assert request.metadata["system_prompt_context_count"] == 2
+    assert request.metadata["system_prompt_context_count"] == 3
+    assert request.metadata["environment_context_count"] == 1
     assert request.metadata["instruction_context_count"] == 0
     assert request.metadata["skill_context_count"] == 0
     assert request.metadata["loop"]["iteration"] == 1

--- a/tests/runtime_v2/test_session_todos.py
+++ b/tests/runtime_v2/test_session_todos.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from efp_runtime.loop import LoopStatus, ScriptedLLMProvider
+from efp_runtime.models import ToolCall
+from efp_runtime.runtime import AgentRuntime, RuntimeConfig
+from efp_runtime.session.todo import SessionTodoStore
+from efp_runtime.tools.builtin import create_core_tool_registry
+from efp_runtime.tools.definition import ToolContext
+from efp_runtime.tools.registry import ToolRegistry
+from efp_runtime.tools.runtime import ToolRuntime
+
+
+@pytest.mark.asyncio
+async def test_todowrite_updates_runtime_session_todo_state(tmp_path: Path):
+    provider = ScriptedLLMProvider(
+        [
+            {
+                "tool_calls": [
+                    _provider_tool_call(
+                        "call-todo",
+                        "todowrite",
+                        {
+                            "todos": [
+                                {
+                                    "content": "Inspect runtime state",
+                                    "status": "completed",
+                                },
+                                {
+                                    "content": "Run focused tests",
+                                    "status": "in_progress",
+                                    "priority": "high",
+                                },
+                            ]
+                        },
+                    )
+                ]
+            },
+            {"content": "Done."},
+            {"content": "Still done."},
+        ]
+    )
+    runtime = AgentRuntime(
+        provider=provider,
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=3),
+    )
+
+    result = await runtime.run("Write todos.", session_id="session-todos")
+
+    assert result.status == LoopStatus.COMPLETED
+    assert runtime.get_todos("session-todos") == [
+        {
+            "content": "Inspect runtime state",
+            "status": "completed",
+            "priority": "medium",
+        },
+        {
+            "content": "Run focused tests",
+            "status": "in_progress",
+            "priority": "high",
+        },
+    ]
+
+    second_result = await runtime.run("Read todos.", session_id="session-todos")
+
+    assert second_result.status == LoopStatus.COMPLETED
+    assert runtime.get_todos("session-todos") == [
+        {
+            "content": "Inspect runtime state",
+            "status": "completed",
+            "priority": "medium",
+        },
+        {
+            "content": "Run focused tests",
+            "status": "in_progress",
+            "priority": "high",
+        },
+    ]
+
+
+def test_runtime_todo_facade_returns_copies(tmp_path: Path):
+    runtime = AgentRuntime(
+        provider=ScriptedLLMProvider([]),
+        config=RuntimeConfig(workspace_root=tmp_path),
+    )
+    input_todos = [
+        {"content": "Draft plan", "status": "pending", "priority": "medium"}
+    ]
+
+    returned = runtime.set_todos("session-copy", input_todos)
+    input_todos[0]["content"] = "mutated input"
+    returned[0]["content"] = "mutated return"
+
+    stored = runtime.get_todos("session-copy")
+    assert stored == [
+        {"content": "Draft plan", "status": "pending", "priority": "medium"}
+    ]
+
+    stored[0]["status"] = "completed"
+    assert runtime.get_todos("session-copy") == [
+        {"content": "Draft plan", "status": "pending", "priority": "medium"}
+    ]
+
+    runtime.clear_todos("session-copy")
+    assert runtime.get_todos("session-copy") == []
+
+
+def test_runtime_todos_are_isolated_by_session_id(tmp_path: Path):
+    runtime = AgentRuntime(
+        provider=ScriptedLLMProvider([]),
+        config=RuntimeConfig(workspace_root=tmp_path),
+    )
+
+    runtime.set_todos(
+        "parent-session",
+        [{"content": "Parent work", "status": "pending", "priority": "high"}],
+    )
+    runtime.set_todos(
+        "child-session",
+        [{"content": "Child work", "status": "completed", "priority": "low"}],
+    )
+
+    assert runtime.get_todos("parent-session") == [
+        {"content": "Parent work", "status": "pending", "priority": "high"}
+    ]
+    assert runtime.get_todos("child-session") == [
+        {"content": "Child work", "status": "completed", "priority": "low"}
+    ]
+
+    runtime.clear_todos("parent-session")
+    assert runtime.get_todos("parent-session") == []
+    assert runtime.get_todos("child-session") == [
+        {"content": "Child work", "status": "completed", "priority": "low"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_legacy_todo_write_and_todowrite_share_session_store(tmp_path: Path):
+    registry = create_core_tool_registry(tmp_path, include_legacy_aliases=True)
+    runtime = ToolRuntime(registry)
+    legacy_store = registry.require("todo_write").runtime_metadata["todo_store"]
+    opencode_store = registry.require("todowrite").runtime_metadata["todo_store"]
+
+    assert isinstance(legacy_store, SessionTodoStore)
+    assert opencode_store is legacy_store
+    assert (
+        registry.require("todo_write").runtime_metadata["todos_by_session"]
+        is registry.require("todowrite").runtime_metadata["todos_by_session"]
+    )
+
+    await runtime.execute(
+        ToolCall(
+            id="call-legacy",
+            tool_id="todo_write",
+            args={"todos": [{"content": "From legacy", "status": "pending"}]},
+        ),
+        context=ToolContext(session_id="session-shared"),
+    )
+    assert legacy_store.get("session-shared") == [
+        {"content": "From legacy", "status": "pending", "priority": "medium"}
+    ]
+
+    await runtime.execute(
+        ToolCall(
+            id="call-opencode",
+            tool_id="todowrite",
+            args={
+                "todos": [
+                    {
+                        "content": "From opencode",
+                        "status": "completed",
+                        "priority": "high",
+                    }
+                ]
+            },
+        ),
+        context=ToolContext(session_id="session-shared"),
+    )
+    assert legacy_store.get("session-shared") == [
+        {"content": "From opencode", "status": "completed", "priority": "high"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_todowrite_event_payload_shape_is_unchanged(tmp_path: Path):
+    runtime = ToolRuntime(create_core_tool_registry(tmp_path))
+
+    result = await runtime.execute(
+        ToolCall(
+            id="call-event",
+            tool_id="todowrite",
+            args={
+                "todos": [
+                    {"content": "Done", "status": "completed"},
+                    {"content": "Cancelled", "status": "cancelled"},
+                    {"content": "Active", "status": "in_progress"},
+                ]
+            },
+        ),
+        context=ToolContext(session_id="session-events"),
+    )
+
+    todos = [
+        {"content": "Done", "status": "completed", "priority": "medium"},
+        {"content": "Cancelled", "status": "cancelled", "priority": "medium"},
+        {"content": "Active", "status": "in_progress", "priority": "medium"},
+    ]
+    expected_counts = {
+        "todo_count": 3,
+        "active_todo_count": 1,
+        "completed_todo_count": 1,
+        "cancelled_todo_count": 1,
+    }
+    assert result.output == {"todos": todos, **expected_counts}
+    todo_event = next(event for event in result.events if event.type == "todo.updated")
+    assert todo_event.session_id == "session-events"
+    assert todo_event.payload == {
+        "tool_id": "todowrite",
+        "tool_call_id": "call-event",
+        "todos": todos,
+        **expected_counts,
+    }
+
+
+def test_custom_runtime_without_todo_tool_returns_empty_todos():
+    runtime = AgentRuntime(
+        provider=ScriptedLLMProvider([]),
+        tool_runtime=ToolRuntime(ToolRegistry()),
+    )
+
+    assert runtime.get_todos("session-missing") == []
+    runtime.clear_todos("session-missing")
+    assert runtime.get_todos("session-missing") == []
+
+
+def _provider_tool_call(
+    call_id: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": tool_name,
+            "arguments": arguments,
+        },
+    }

--- a/tests/runtime_v2/test_shell_permission_scan.py
+++ b/tests/runtime_v2/test_shell_permission_scan.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from efp_runtime.models import ToolCall
+from efp_runtime.shell_permissions import (
+    shell_permission_metadata,
+    shell_permission_patterns,
+)
+from efp_runtime.tools.builtin import create_core_tool_registry
+from efp_runtime.tools.definition import ToolContext
+from efp_runtime.tools.runtime import ToolRuntime
+
+
+@pytest.mark.asyncio
+async def test_bash_permission_request_extracts_cat_path(tmp_path: Path):
+    runtime = ToolRuntime(create_core_tool_registry(tmp_path))
+
+    result = await runtime.execute(
+        ToolCall(
+            id="call-bash-cat",
+            tool_id="bash",
+            args={"command": "cat src/app.py"},
+        ),
+        context=ToolContext(session_id="session-bash-cat"),
+    )
+
+    request = result.metadata["permission_request"]
+    metadata = request["metadata"]
+    assert result.status == "permission_requested"
+    assert metadata["command_name"] == "cat"
+    assert metadata["path_args"][0]["path"] == "src/app.py"
+    assert "src/app.py" in request["patterns"]
+    assert "src/app.py" in metadata["permission_patterns"]
+
+
+@pytest.mark.asyncio
+async def test_bash_permission_request_applies_workdir_to_paths(tmp_path: Path):
+    runtime = ToolRuntime(create_core_tool_registry(tmp_path))
+
+    result = await runtime.execute(
+        ToolCall(
+            id="call-bash-workdir",
+            tool_id="bash",
+            args={"command": "cat app.py", "workdir": "src"},
+        ),
+        context=ToolContext(session_id="session-bash-workdir"),
+    )
+
+    request = result.metadata["permission_request"]
+    metadata = request["metadata"]
+    assert result.status == "permission_requested"
+    assert metadata["workdir"] == "src"
+    assert metadata["path_args"][0]["path"] == "src/app.py"
+    assert request["patterns"] == ["src/app.py"]
+
+
+def test_shell_permission_scan_marks_rm_globs():
+    metadata = shell_permission_metadata({"command": "rm -rf build dist/*.tmp"})
+
+    assert metadata["command_name"] == "rm"
+    assert metadata["permission_patterns"] == ["build", "dist/*.tmp"]
+    assert metadata["path_args"][1]["path"] == "dist/*.tmp"
+    assert metadata["path_args"][1]["glob"] is True
+
+
+def test_shell_permission_scan_keeps_copy_and_move_sources_destinations():
+    cp_metadata = shell_permission_metadata({"command": "cp src/a.py dst/a.py"})
+    mv_metadata = shell_permission_metadata({"command": "mv old new"})
+
+    assert [(entry["path"], entry["kind"]) for entry in cp_metadata["path_args"]] == [
+        ("src/a.py", "source"),
+        ("dst/a.py", "destination"),
+    ]
+    assert [(entry["path"], entry["kind"]) for entry in mv_metadata["path_args"]] == [
+        ("old", "source"),
+        ("new", "destination"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'rm "$TARGET"',
+        "cat $(pwd)/file",
+    ],
+)
+def test_shell_permission_scan_marks_dynamic_paths(command: str):
+    metadata = shell_permission_metadata({"command": command})
+
+    assert metadata["dynamic_paths"] is True
+    assert metadata["path_args"][0]["dynamic"] is True
+    assert metadata["permission_patterns"]
+
+
+def test_shell_permission_scan_marks_cd_workspace_escape():
+    metadata = shell_permission_metadata({"command": "cd .."})
+
+    assert metadata["command_name"] == "cd"
+    assert metadata["cwd_affecting"] is True
+    assert metadata["workspace_escape"] is True
+    assert metadata["permission_patterns"] == [".."]
+
+
+def test_shell_permission_scan_parse_failure_falls_back_to_command_pattern():
+    patterns = shell_permission_patterns({"command": "cat 'unterminated"})
+    metadata = shell_permission_metadata({"command": "cat 'unterminated"})
+
+    assert patterns == ["cat 'unterminated"]
+    assert metadata["permission_patterns"] == ["cat 'unterminated"]
+    assert metadata["path_args"] == []
+    assert "shell_parse_error" in metadata
+
+
+@pytest.mark.asyncio
+async def test_legacy_shell_exec_permission_request_uses_same_scan(tmp_path: Path):
+    runtime = ToolRuntime(
+        create_core_tool_registry(tmp_path, include_legacy_aliases=True)
+    )
+
+    result = await runtime.execute(
+        ToolCall(
+            id="call-shell-exec-cat",
+            tool_id="shell_exec",
+            args={"command": "cat legacy.py"},
+        ),
+        context=ToolContext(session_id="session-shell-exec-cat"),
+    )
+
+    request = result.metadata["permission_request"]
+    metadata = request["metadata"]
+    assert result.status == "permission_requested"
+    assert metadata["command_name"] == "cat"
+    assert metadata["path_args"][0]["path"] == "legacy.py"
+    assert request["patterns"] == ["legacy.py"]

--- a/tests/runtime_v2/test_shell_tool_parity.py
+++ b/tests/runtime_v2/test_shell_tool_parity.py
@@ -248,6 +248,9 @@ async def test_shell_permission_request_includes_usable_metadata(tmp_path: Path)
     assert request["risk"] == "high"
     assert request["reason"] == "Shell execution requires approval."
     assert request["metadata"]["command_preview"] == "printf ok"
+    assert request["metadata"]["command_name"] == "printf"
+    assert request["metadata"]["command_names"] == ["printf"]
+    assert request["metadata"]["path_args"] == []
     assert request["metadata"]["description"] == "Print ok"
     assert request["metadata"]["workdir"] == "src"
     assert request["patterns"] == ["printf ok"]

--- a/tests/runtime_v2/test_skill_tool.py
+++ b/tests/runtime_v2/test_skill_tool.py
@@ -552,6 +552,7 @@ async def test_active_skill_and_skill_tool_coexist_without_active_skill_pollutio
             active_skills=["active-skill"],
             max_iterations=2,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )
@@ -623,6 +624,7 @@ async def test_agent_runtime_filters_denied_active_skill_context(tmp_path):
             tool_permissions={"skill": {"*": "allow", "internal-*": "deny"}},
             max_iterations=1,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
         ),
     )

--- a/tests/runtime_v2/test_system_prompt_stack.py
+++ b/tests/runtime_v2/test_system_prompt_stack.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -55,16 +56,37 @@ async def test_default_runtime_prepends_system_prompt_before_instructions_and_sk
     assert messages[0].role == "system"
     assert "EFP Runtime v2" in messages[0].text
 
+    environment_index = _message_index(messages, "Environment:")
     instruction_index = _message_index(messages, "Instructions from:")
     available_skill_index = _message_index(messages, "<available_skills>")
     skill_index = _message_index(messages, '<skill_content name="review-pr">')
     user_index = _message_index(messages, "Inspect this.")
-    assert 0 < instruction_index < available_skill_index < skill_index < user_index
-    assert request.metadata["system_prompt_context_count"] == 2
+    assert 0 < environment_index < instruction_index
+    assert instruction_index < available_skill_index < skill_index < user_index
+    environment_message = messages[environment_index]
+    assert environment_message.metadata["message_metadata"]["source"] == (
+        "environment_context"
+    )
+    assert environment_message.metadata["message_metadata"]["kind"] == (
+        "environment_context"
+    )
+    assert "- model: github-copilot/gpt-5-mini" in environment_message.text
+    assert f"- working directory: {tmp_path.resolve()}" in environment_message.text
+    assert f"- workspace root: {tmp_path.resolve()}" in environment_message.text
+    assert "- git repository: false" in environment_message.text
+    assert f"- platform: {sys.platform}" in environment_message.text
+    assert re.search(r"- date: \d{4}-\d{2}-\d{2}", environment_message.text)
+    assert request.metadata["system_prompt_context_count"] == 3
+    assert request.metadata["environment_context_count"] == 1
+    assert request.metadata["environment_context_model"] == "github-copilot/gpt-5-mini"
     assert request.metadata["instruction_context_count"] == 1
     assert request.metadata["available_skill_context_count"] == 1
     assert request.metadata["skill_context_count"] == 1
-    assert request.provider_request.metadata["system_prompt_context_count"] == 2
+    assert request.provider_request.metadata["system_prompt_context_count"] == 3
+    assert request.provider_request.metadata["environment_context_count"] == 1
+    assert request.provider_request.metadata["environment_context_model"] == (
+        "github-copilot/gpt-5-mini"
+    )
     assert request.provider_request.metadata["instruction_context_count"] == 1
     assert request.provider_request.metadata["available_skill_context_count"] == 1
     assert request.provider_request.metadata["skill_context_count"] == 1
@@ -203,6 +225,7 @@ async def test_default_system_prompt_can_be_disabled_but_explicit_texts_remain(
         config=RuntimeConfig(
             workspace_root=tmp_path,
             include_default_system_prompt=False,
+            include_environment_context=False,
             include_runtime_reminders=False,
             system_prompt_texts=["Custom system layer."],
             max_iterations=1,
@@ -229,6 +252,7 @@ def test_system_prompt_paths_load_workspace_files_with_truncation_metadata(
     messages = SystemPromptBuilder(
         workspace_root=tmp_path,
         include_default_system_prompt=False,
+        include_environment_context=False,
         include_runtime_reminders=False,
         system_prompt_paths=["prompts/base.txt"],
         max_system_prompt_chars=3,
@@ -247,7 +271,7 @@ def test_system_prompt_paths_load_workspace_files_with_truncation_metadata(
     assert "truncated to 3 of 6 chars" in message.parts[0].text
 
 
-def test_inline_and_file_prompts_appear_between_default_and_runtime_reminders(
+def test_environment_inline_and_file_prompts_appear_before_runtime_reminders(
     tmp_path: Path,
 ):
     prompt_dir = tmp_path / "prompts"
@@ -266,17 +290,20 @@ def test_inline_and_file_prompts_appear_between_default_and_runtime_reminders(
         MessageRole.SYSTEM,
         MessageRole.SYSTEM,
         MessageRole.SYSTEM,
+        MessageRole.SYSTEM,
     ]
     assert [message.metadata["source"] for message in messages] == [
         "default_system_prompt",
+        "environment_context",
         "inline",
         "file",
         "runtime_reminders",
     ]
     assert "EFP Runtime v2" in messages[0].parts[0].text
-    assert messages[1].parts[0].text == "Inline prompt."
-    assert messages[2].parts[0].text == "Team file prompt."
-    assert "max_iterations=2" in messages[3].parts[0].text
+    assert "Environment:" in messages[1].parts[0].text
+    assert messages[2].parts[0].text == "Inline prompt."
+    assert messages[3].parts[0].text == "Team file prompt."
+    assert "max_iterations=2" in messages[4].parts[0].text
 
 
 def test_system_prompt_paths_reject_path_traversal_and_outside_files(tmp_path: Path):
@@ -286,6 +313,7 @@ def test_system_prompt_paths_reject_path_traversal_and_outside_files(tmp_path: P
     messages = SystemPromptBuilder(
         workspace_root=tmp_path,
         include_default_system_prompt=False,
+        include_environment_context=False,
         include_runtime_reminders=False,
         system_prompt_paths=["../outside-system.txt", outside],
     ).build_messages()
@@ -297,6 +325,7 @@ def test_runtime_reminders_can_be_enabled_and_disabled():
     enabled = SystemPromptBuilder(
         workspace_root=None,
         include_default_system_prompt=False,
+        include_environment_context=False,
         include_runtime_reminders=True,
     ).build_messages(
         metadata={
@@ -319,6 +348,7 @@ def test_runtime_reminders_can_be_enabled_and_disabled():
     disabled = SystemPromptBuilder(
         workspace_root=None,
         include_default_system_prompt=False,
+        include_environment_context=False,
         include_runtime_reminders=False,
     ).build_messages(metadata={"max_iterations": 3, "enable_question_tool": True})
     assert disabled == []
@@ -328,6 +358,7 @@ def test_plan_mode_reminder_is_read_only_and_finishes_with_plan_exit():
     messages = SystemPromptBuilder(
         workspace_root=None,
         include_default_system_prompt=False,
+        include_environment_context=False,
     ).build_messages(metadata={"runtime_mode": "plan"})
 
     assert len(messages) == 1
@@ -374,18 +405,127 @@ async def test_system_prompt_context_is_not_persisted_or_duplicated_between_runs
     default_prompt_count = sum(
         1 for message in second_messages if "EFP Runtime v2" in message.text
     )
+    environment_count = sum(
+        1 for message in second_messages if "Environment:" in message.text
+    )
     assert default_prompt_count == 1
+    assert environment_count == 1
     assert [message.role for message in provider.requests[1].messages] == [
         MessageRole.USER,
         MessageRole.ASSISTANT,
         MessageRole.USER,
     ]
+    assert all(
+        "Environment:" not in part.text
+        for message in history
+        for part in message.parts
+        if part.text is not None
+    )
+
+
+def test_environment_context_builder_contains_runtime_environment(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    cwd = tmp_path / "src"
+
+    messages = SystemPromptBuilder(
+        workspace_root=tmp_path,
+        include_default_system_prompt=False,
+        include_runtime_reminders=False,
+    ).build_messages(
+        metadata={
+            "requested_model": "github-copilot/gpt-5",
+            "cwd": cwd,
+        }
+    )
+
+    assert len(messages) == 1
+    message = messages[0]
+    assert message.metadata["source"] == "environment_context"
+    assert message.metadata["kind"] == "environment_context"
+    assert message.metadata["model_id"] == "github-copilot/gpt-5"
+    assert message.metadata["workspace_root"] == str(tmp_path.resolve())
+    assert message.metadata["git_repository"] is True
+    assert message.parts[0].metadata == message.metadata
+    text = message.parts[0].text
+    assert text.startswith("Environment:\n")
+    assert "- model: github-copilot/gpt-5" in text
+    assert f"- working directory: {cwd.resolve()}" in text
+    assert f"- workspace root: {tmp_path.resolve()}" in text
+    assert "- git repository: true" in text
+    assert f"- platform: {sys.platform}" in text
+    assert re.search(r"- date: \d{4}-\d{2}-\d{2}", text)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested_model", "expected_model"),
+    [
+        ("github-copilot/gpt-5", "github-copilot/gpt-5"),
+        ("gpt-5", "github-copilot/gpt-5"),
+    ],
+)
+async def test_environment_context_uses_requested_model(
+    tmp_path: Path,
+    requested_model: str,
+    expected_model: str,
+):
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runtime = AgentRuntime(
+        provider=provider,
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            include_default_system_prompt=False,
+            include_runtime_reminders=False,
+            max_iterations=1,
+        ),
+    )
+
+    await runtime.run(
+        "Use requested model.",
+        session_id=f"session-env-{requested_model.replace('/', '-')}",
+        metadata={"requested_model": requested_model},
+    )
+
+    request = provider.requests[0]
+    environment_message = request.provider_request.messages[0]
+    assert environment_message.metadata["message_metadata"]["kind"] == (
+        "environment_context"
+    )
+    assert f"- model: {expected_model}" in environment_message.text
+    assert request.metadata["environment_context_count"] == 1
+    assert request.metadata["environment_context_model"] == expected_model
+
+
+@pytest.mark.asyncio
+async def test_environment_context_can_be_disabled(tmp_path: Path):
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runtime = AgentRuntime(
+        provider=provider,
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            include_environment_context=False,
+            include_runtime_reminders=False,
+            max_iterations=1,
+        ),
+    )
+
+    await runtime.run("No environment.", session_id="session-no-env")
+
+    request = provider.requests[0]
+    assert all(
+        "Environment:" not in message.text
+        for message in request.provider_request.messages
+    )
+    assert request.metadata["environment_context_count"] == 0
+    assert "environment_context_model" not in request.metadata
+    assert request.provider_request.metadata["environment_context_count"] == 0
 
 
 def test_child_config_preserves_system_prompt_settings(tmp_path: Path):
     base_config = RuntimeConfig(
         workspace_root=tmp_path,
         include_default_system_prompt=False,
+        include_environment_context=False,
         system_prompt_texts=["Child system prompt."],
         system_prompt_paths=["prompts/child.md"],
         max_system_prompt_chars=17,
@@ -400,6 +540,7 @@ def test_child_config_preserves_system_prompt_settings(tmp_path: Path):
     )
 
     assert child.include_default_system_prompt is False
+    assert child.include_environment_context is False
     assert child.system_prompt_texts == ["Child system prompt."]
     assert child.system_prompt_paths == ["prompts/child.md"]
     assert child.max_system_prompt_chars == 17


### PR DESCRIPTION
## Summary
- add lightweight opencode-style shell permission scanning for bash and legacy shell_exec
- add session-level todo state shared by todowrite/todo_write and AgentRuntime facade methods
- add transient environment system context with Copilot-oriented model metadata, workspace/cwd/git/platform/date facts

## Validation
- PYTHONPATH=src python -m pytest tests/runtime_v2/test_shell_permission_scan.py tests/runtime_v2/test_session_todos.py tests/runtime_v2/test_system_prompt_stack.py tests/runtime_v2/test_permission_config.py tests/runtime_v2/test_shell_tool_parity.py tests/runtime_v2/test_opencode_bash_tool_alias.py tests/runtime_v2/test_core_tool_parity.py tests/runtime_v2/test_opencode_remaining_tool_aliases.py tests/runtime_v2/test_runtime_facade.py tests/runtime_v2/test_config_loader.py tests/runtime_v2/test_agent_profiles_subagent_runner.py -q
- PYTHONPATH=src python -m pytest tests/runtime_v2 -q
- PYTHONPATH=src python -m compileall -q src tests/runtime_v2
- git diff --check origin/efp-runtime-v2-phase38-integrated-20260529..HEAD
- rg -n "MCP|mcp" src/efp_runtime docs/runtime-v2-design.md tests/runtime_v2 || true
