### PR TITLE
[codex] Remove opencode parity manifest from runtime package

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ engineering-flow-platform/
 
 Business skill assets are maintained in **engineering-flow-platform-skills**. Portal/K8s typically checks out/mounts that skills repository at `/app/skills` (or another path via `EFP_SKILLS_DIR`) for runtime discovery.
 
-EFP native runtime exposes only opencode-style built-in LLM tools
+EFP native runtime exposes only EFP-owned built-in LLM tools
 (`bash`, `read`, `write`, `edit`, `grep`, `glob`, `webfetch`, `todowrite`,
 `apply_patch`, plus other EFP runtime built-ins). Legacy Python tool packages,
 including `src/bash_tools`, are not part of the production LLM tool surface.
@@ -240,7 +240,7 @@ For complete control-plane contract details, see `docs/control_plane_contract.md
 Additional runtime contracts:
 - `docs/runtime_contract.md`
 - `docs/runtime-design.md`
-- `docs/opencode-parity.md`
+- `docs/runtime-tool-surface.md`
 - `docs/observability_contract.md`
 
 ### Portal Control-Plane Integration (Operator Minimum)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,5 @@ See main `README.md` for project overview and architecture.
 - `control_plane_contract.md` — Phase 5 control-plane trust contract for Portal ↔ Runtime APIs.
 - `runtime-design.md` — Current EFP runtime design, removed legacy surfaces, and session/tool boundaries.
 - `runtime_contract.md` — Native runtime HTTP surface, asset directory, capability snapshot, and fixture contract.
-- `opencode-parity.md` — Audited parity checklist and intentional gaps.
+- `runtime-tool-surface.md` — EFP-owned runtime capability and tool contract.
 - `observability_contract.md` — Runtime log context, binding points, redaction, and reviewer checks.

--- a/docs/runtime-design.md
+++ b/docs/runtime-design.md
@@ -38,7 +38,7 @@ Tests may reference these names only to assert that they remain absent.
 
 ## Tool Surface
 
-Model-facing tools come from the opencode-style built-in registry under
+Model-facing tools come from the EFP-owned built-in registry under
 `efp_runtime.tools.builtin`.
 
 Default core tool ids are:
@@ -169,5 +169,5 @@ The runtime intentionally does not implement:
 - Provider fallback to OpenAI, Anthropic, or Ollama.
 - Cross-process background task persistence or shell job restoration.
 
-The current parity checklist is tracked in `docs/opencode-parity.md` and the
-data manifest in `src/efp_runtime/opencode_parity.py`.
+The current tool and capability contract is tracked in
+`docs/runtime-tool-surface.md` and guarded by runtime tests.

--- a/docs/runtime-tool-surface.md
+++ b/docs/runtime-tool-surface.md
@@ -1,8 +1,9 @@
-# Opencode Parity Checklist
+# EFP Runtime Tool Surface Contract
 
-This checklist records the current EFP runtime state against the audited
-opencode baseline. It is intentionally conservative: items are marked complete
-only when covered by implementation and tests.
+The initial rebuild used opencode as an engineering reference, but this
+document records the EFP-owned runtime capability and tool contract. It is not a
+continuing upstream compatibility promise. Items are marked implemented only
+when covered by EFP runtime implementation and tests.
 
 | Area | State | Notes |
 | --- | --- | --- |
@@ -19,7 +20,7 @@ only when covered by implementation and tests.
 | GitHub Copilot provider/model path | Implemented | Production chat supports Copilot only, with token/base URL environment overrides and no OpenAI/Anthropic/Ollama fallback. |
 | Embedded runtime frontend | Removed | Gateway has no root HTML route and no static/template frontend assets. Portal owns UI. |
 | Old Python tool loaders | Removed | `src.context_tools`, `src.bash_tools`, `efp_runtime.tools.local`, and `efp_runtime.tools.external` are absent. |
-| MCP | Excluded | MCP servers and external protocol tool surfaces are out of scope for this runtime replacement branch. |
+| MCP | Excluded | MCP servers and external protocol tool surfaces are out of scope for this runtime branch. |
 
 ## Intentional Remaining Gaps
 
@@ -30,4 +31,4 @@ only when covered by implementation and tests.
 - `websearch` has no bundled provider. Callers must inject a runner so network
   search policy remains explicit.
 - Internal runtime tests live under `tests/runtime` and form the current
-  runtime test boundary.
+  EFP runtime test boundary.

--- a/docs/runtime_contract.md
+++ b/docs/runtime_contract.md
@@ -34,7 +34,7 @@ Native runtime must support:
 
 - EFP native runtime uses EFP runtime (`efp_runtime.runtime.AgentRuntime`) for `/api/chat`, `/api/chat/stream`, and Jira chat handling.
 - EFP runtime native mode supports GitHub Copilot only. Configure `llm.provider: github_copilot` plus `llm.api_key` or `EFP_GITHUB_COPILOT_TOKEN`.
-- Runtime tool surface comes from the opencode-style EFP runtime built-in registry only (`src.__init__.get_tools_schema()`).
+- Runtime tool surface comes from the EFP-owned runtime built-in registry only (`src.__init__.get_tools_schema()`).
 - Model-visible tool ids include `bash`, `read`, `write`, `edit`, `grep`, `glob`, `webfetch`, `todowrite`, and `apply_patch`.
 - Legacy Python tool packages such as `src.bash_tools` are not present, and Jira/GitHub/Confluence/Git Python tools are not exposed as LLM tools.
 - The runtime image may include prebuilt `engineering-flow-platform-tools` CLI binaries on `PATH` in `/usr/local/bin`. Current binaries include `jira`, `confluence`, and `browser`; future binaries are discovered from `cmd/<tool>` in that repo.

--- a/src/README.md
+++ b/src/README.md
@@ -73,4 +73,4 @@ src/
 - EFP runtime (execution plane) receives dispatched tasks via `/api/tasks/execute`.
 - `github_review_task` remains a runtime execution path.
 - Do **not** add new runtime-side automation polling in EFP.
-- For native runtime HTTP surface, design, parity, capability snapshot shape, and observability fields, see `../docs/runtime_contract.md`, `../docs/runtime-design.md`, `../docs/opencode-parity.md`, and `../docs/observability_contract.md`.
+- For native runtime HTTP surface, design, capability snapshot shape, tool surface, and observability fields, see `../docs/runtime_contract.md`, `../docs/runtime-design.md`, `../docs/runtime-tool-surface.md`, and `../docs/observability_contract.md`.

--- a/tests/_runtime_tool_surface_contract.py
+++ b/tests/_runtime_tool_surface_contract.py
@@ -1,41 +1,30 @@
-"""EFP runtime parity manifest for the audited opencode dev head.
-
-This module is intentionally data-only. Tests compare it with the live runtime
-tool registry so default and conditional surfaces drift visibly.
-"""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Literal
 
-ParityStatus = Literal["done", "conditional", "excluded", "remaining"]
+ContractStatus = Literal["implemented", "conditional", "excluded", "remaining"]
 
 
 @dataclass(frozen=True)
-class SurfaceEntry:
-    """One tool-surface parity entry."""
+class SurfaceContractEntry:
+    """One EFP runtime tool-surface contract entry."""
 
-    status: ParityStatus
+    status: ContractStatus
     reason: str
     next_action: str | None = None
 
 
 @dataclass(frozen=True)
-class CapabilityEntry:
-    """One capability-group parity entry."""
+class CapabilityContractEntry:
+    """One EFP runtime capability contract entry."""
 
-    status: ParityStatus
+    status: ContractStatus
     summary: str
     next_action: str | None = None
 
 
-OPENCODE_UPSTREAM_REPO = "https://github.com/anomalyco/opencode"
-OPENCODE_DEV_HEAD = "16cae9a32329b65116869d2fd3c1fac27c4adcb6"
-OPENCODE_DEV_TREE = "754a57c6f0e0413c1541b320a482f85708cffb88"
-OPENCODE_AUDITED_AT = "2026-05-29T15:52:46Z"
-
-DEFAULT_CORE_TOOL_IDS = (
+EXPECTED_DEFAULT_CORE_TOOL_IDS = (
     "apply_patch",
     "bash",
     "edit",
@@ -50,79 +39,93 @@ DEFAULT_CORE_TOOL_IDS = (
     "write",
 )
 
-OPTIONAL_CONDITIONAL_TOOL_IDS: dict[str, SurfaceEntry] = {
-    "lsp": SurfaceEntry(
+REMOVED_LEGACY_TOOL_IDS = {
+    "fetch",
+    "list_dir",
+    "read_file",
+    "shell_exec",
+    "shell_kill",
+    "shell_status",
+    "skill_list",
+    "task_cancel",
+    "task_status",
+    "todo_write",
+    "write_file",
+}
+
+CONDITIONAL_TOOL_IDS: dict[str, SurfaceContractEntry] = {
+    "lsp": SurfaceContractEntry(
         status="conditional",
         reason="Enabled by RuntimeConfig.enable_lsp_tool, include_lsp_tool, or an injected LSP client.",
     ),
-    "plan_exit": SurfaceEntry(
+    "plan_exit": SurfaceContractEntry(
         status="conditional",
         reason="Enabled for EFP runtime plan mode or include_plan_tool.",
     ),
-    "question": SurfaceEntry(
+    "question": SurfaceContractEntry(
         status="conditional",
         reason="Enabled by RuntimeConfig.enable_question_tool or include_question_tool.",
     ),
-    "repo_clone": SurfaceEntry(
+    "repo_clone": SurfaceContractEntry(
         status="conditional",
         reason="Disabled by default; registered only when repository scout tools are explicitly requested.",
     ),
-    "repo_overview": SurfaceEntry(
+    "repo_overview": SurfaceContractEntry(
         status="conditional",
         reason="Disabled by default; registered only when repository scout tools are explicitly requested.",
     ),
-    "websearch": SurfaceEntry(
+    "websearch": SurfaceContractEntry(
         status="conditional",
         reason="Registered only when callers inject a provider-neutral websearch runner; default core registry leaves it disabled.",
     ),
 }
 
-EXCLUDED_TOOL_IDS: dict[str, SurfaceEntry] = {
-    "external_protocol_tools": SurfaceEntry(
+EXCLUDED_RUNTIME_SURFACES: dict[str, SurfaceContractEntry] = {
+    "external_protocol_tools": SurfaceContractEntry(
         status="excluded",
-        reason="External protocol tool surfaces are outside the EFP runtime parity scope.",
+        reason="External protocol tool surfaces are outside the EFP runtime scope.",
     ),
-    "mcp": SurfaceEntry(
+    "mcp": SurfaceContractEntry(
         status="excluded",
-        reason="MCP servers and MCP-hosted tools are explicitly outside this replacement runtime scope.",
+        reason="MCP servers and MCP-hosted tools are explicitly outside the EFP runtime scope.",
     ),
 }
 
-CAPABILITY_GROUPS: dict[str, CapabilityEntry] = {
-    "loop": CapabilityEntry(
-        status="done",
+CAPABILITY_GROUPS: dict[str, CapabilityContractEntry] = {
+    "loop": CapabilityContractEntry(
+        status="implemented",
         summary="AgentRuntime, RuntimeLoopRunner, terminal tools, resume, and pause statuses are covered by EFP runtime tests.",
     ),
-    "permissions": CapabilityEntry(
-        status="done",
+    "permissions": CapabilityContractEntry(
+        status="implemented",
         summary="Tool permission metadata, broker decisions, deny/ask/allow flow, and resume after approval are implemented.",
     ),
-    "tool lifecycle": CapabilityEntry(
-        status="done",
+    "tool lifecycle": CapabilityContractEntry(
+        status="implemented",
         summary="Validation, execution, output normalization, truncation, terminal results, and runtime events share one tool path.",
     ),
-    "skills": CapabilityEntry(
+    "skills": CapabilityContractEntry(
         status="conditional",
         summary="Skill discovery, active skill context, the skill tool, and slash activation are enabled when skills are configured.",
     ),
-    "commands": CapabilityEntry(
-        status="done",
+    "commands": CapabilityContractEntry(
+        status="implemented",
         summary="Built-in, configured, file-backed, and skill-backed slash commands expand through the EFP runtime command registry.",
     ),
-    "context/compaction": CapabilityEntry(
-        status="done",
+    "context/compaction": CapabilityContractEntry(
+        status="implemented",
         summary="System context, instructions, skill context, budget compaction, automatic session compaction, and pruning are implemented.",
     ),
-    "Copilot provider": CapabilityEntry(
-        status="done",
+    "Copilot provider": CapabilityContractEntry(
+        status="implemented",
         summary="EFP runtime defaults to the Copilot provider family and uses Copilot model profiles for context budgets.",
     ),
-    "session state": CapabilityEntry(
-        status="done",
+    "session state": CapabilityContractEntry(
+        status="implemented",
         summary="In-memory and file-backed sessions, todos, checkpoints, summary diffs, revert/unrevert, retry state, and query helpers are implemented.",
     ),
-    "legacy boundary": CapabilityEntry(
-        status="done",
+    "legacy boundary": CapabilityContractEntry(
+        status="implemented",
         summary=(
             "EFP runtime is independent from legacy core imports, default tool "
             "surfaces exclude legacy Python tool aliases, and repository-level "
@@ -131,17 +134,3 @@ CAPABILITY_GROUPS: dict[str, CapabilityEntry] = {
         ),
     ),
 }
-
-__all__ = [
-    "CAPABILITY_GROUPS",
-    "DEFAULT_CORE_TOOL_IDS",
-    "EXCLUDED_TOOL_IDS",
-    "OPENCODE_AUDITED_AT",
-    "OPENCODE_DEV_HEAD",
-    "OPENCODE_DEV_TREE",
-    "OPENCODE_UPSTREAM_REPO",
-    "OPTIONAL_CONDITIONAL_TOOL_IDS",
-    "CapabilityEntry",
-    "ParityStatus",
-    "SurfaceEntry",
-]

--- a/tests/runtime/test_core_tool_parity.py
+++ b/tests/runtime/test_core_tool_parity.py
@@ -10,10 +10,10 @@ import pytest
 
 from efp_runtime.models import ToolCall
 from efp_runtime.permissions import ALLOW, PermissionDecision, PermissionMetadata
-from efp_runtime.opencode_parity import DEFAULT_CORE_TOOL_IDS
 from efp_runtime.tools.builtin import create_core_tool_registry
 from efp_runtime.tools.definition import ToolContext
 from efp_runtime.tools.runtime import ToolRuntime
+from tests._runtime_tool_surface_contract import EXPECTED_DEFAULT_CORE_TOOL_IDS
 
 
 class AllowEvaluator:
@@ -342,7 +342,7 @@ async def test_todo_write_normalizes_metadata_events_and_validates_input(
 @pytest.mark.asyncio
 async def test_new_core_tool_permission_defaults(tmp_path: Path):
     registry = create_core_tool_registry(tmp_path)
-    assert registry.ids() == list(DEFAULT_CORE_TOOL_IDS)
+    assert registry.ids() == list(EXPECTED_DEFAULT_CORE_TOOL_IDS)
     assert registry.require("glob").permission.action == ALLOW
     assert registry.require("webfetch").permission.action == ALLOW
     assert registry.require("webfetch").permission.category == "network"

--- a/tests/runtime/test_opencode_tool_surface.py
+++ b/tests/runtime/test_opencode_tool_surface.py
@@ -7,9 +7,9 @@ import pytest
 from efp_runtime.agents import AgentProfile
 from efp_runtime.agents.task_runner import _child_config
 from efp_runtime.loop import LoopStatus, ScriptedLLMProvider
-from efp_runtime.opencode_parity import DEFAULT_CORE_TOOL_IDS
 from efp_runtime.runtime import AgentRuntime, RuntimeConfig
 from efp_runtime.tools.builtin import create_core_tool_registry
+from tests._runtime_tool_surface_contract import EXPECTED_DEFAULT_CORE_TOOL_IDS
 
 
 REMOVED_TOOL_IDS = {
@@ -27,15 +27,15 @@ REMOVED_TOOL_IDS = {
 }
 
 
-def test_default_core_registry_uses_opencode_tool_surface(tmp_path: Path):
+def test_default_core_registry_uses_efp_tool_surface(tmp_path: Path):
     registry = create_core_tool_registry(tmp_path)
 
-    assert registry.ids() == list(DEFAULT_CORE_TOOL_IDS)
+    assert registry.ids() == list(EXPECTED_DEFAULT_CORE_TOOL_IDS)
     assert REMOVED_TOOL_IDS.isdisjoint(registry.ids())
 
 
 @pytest.mark.asyncio
-async def test_agent_runtime_default_request_uses_opencode_core_tools(tmp_path: Path):
+async def test_agent_runtime_default_request_uses_efp_core_tools(tmp_path: Path):
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
@@ -47,7 +47,9 @@ async def test_agent_runtime_default_request_uses_opencode_core_tools(tmp_path: 
 
     assert result.status == LoopStatus.COMPLETED
     expected_model_tools = [
-        tool_id for tool_id in DEFAULT_CORE_TOOL_IDS if tool_id not in {"edit", "write"}
+        tool_id
+        for tool_id in EXPECTED_DEFAULT_CORE_TOOL_IDS
+        if tool_id not in {"edit", "write"}
     ]
     assert schema_ids == expected_model_tools
     assert REMOVED_TOOL_IDS.isdisjoint(schema_ids)
@@ -77,7 +79,7 @@ async def test_model_aware_selection_uses_only_registered_file_tools_by_default(
 
 
 
-def test_opencode_core_tool_schemas_expose_only_source_level_parameters(tmp_path: Path):
+def test_efp_core_tool_schemas_expose_only_source_level_parameters(tmp_path: Path):
     registry = create_core_tool_registry(tmp_path)
 
     expected = {
@@ -126,7 +128,7 @@ def test_opencode_core_tool_schemas_expose_only_source_level_parameters(tmp_path
     assert todo_item_schema["required"] == ["content", "status", "priority"]
 
 
-def test_child_config_inherits_only_opencode_tool_fields(tmp_path: Path):
+def test_child_config_inherits_only_efp_tool_fields(tmp_path: Path):
     base = RuntimeConfig(workspace_root=tmp_path, disabled_tools=["write"])
 
     child = _child_config(

--- a/tests/runtime/test_plan_mode.py
+++ b/tests/runtime/test_plan_mode.py
@@ -17,11 +17,11 @@ from efp_runtime.runtime import AgentRuntime, RuntimeConfig
 from efp_runtime.tools.builtin import create_core_tool_registry
 from efp_runtime.tools.definition import ToolDef
 from efp_runtime.tools.registry import ToolRegistry
-from efp_runtime.opencode_parity import DEFAULT_CORE_TOOL_IDS
+from tests._runtime_tool_surface_contract import EXPECTED_DEFAULT_CORE_TOOL_IDS
 
 
 ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_TOOL_IDS = list(DEFAULT_CORE_TOOL_IDS)
+DEFAULT_TOOL_IDS = list(EXPECTED_DEFAULT_CORE_TOOL_IDS)
 MODEL_FILTERED_DEFAULT_TOOL_IDS = [
     tool_id for tool_id in DEFAULT_TOOL_IDS if tool_id not in {"edit", "write"}
 ]

--- a/tests/runtime/test_runtime_tool_surface_contract.py
+++ b/tests/runtime/test_runtime_tool_surface_contract.py
@@ -3,22 +3,19 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from efp_runtime.opencode_parity import (
-    CAPABILITY_GROUPS,
-    DEFAULT_CORE_TOOL_IDS,
-    EXCLUDED_TOOL_IDS,
-    OPENCODE_AUDITED_AT,
-    OPENCODE_DEV_HEAD,
-    OPENCODE_DEV_TREE,
-    OPENCODE_UPSTREAM_REPO,
-    OPTIONAL_CONDITIONAL_TOOL_IDS,
-)
 from efp_runtime.skills.discovery import SkillDiscovery
 from efp_runtime.tools.builtin import WebSearchRequest, create_core_tool_registry
 from efp_runtime.tools.builtin.task import TaskToolRequest
+from tests._runtime_tool_surface_contract import (
+    CAPABILITY_GROUPS,
+    CONDITIONAL_TOOL_IDS,
+    EXCLUDED_RUNTIME_SURFACES,
+    EXPECTED_DEFAULT_CORE_TOOL_IDS,
+    REMOVED_LEGACY_TOOL_IDS,
+)
 
 
-ALLOWED_STATUSES = {"done", "conditional", "excluded", "remaining"}
+ALLOWED_STATUSES = {"implemented", "conditional", "excluded", "remaining"}
 
 
 async def _task_runner(request: TaskToolRequest) -> str:
@@ -29,13 +26,17 @@ def _websearch_runner(request: WebSearchRequest) -> str:
     return f"results for {request.query}"
 
 
-def test_default_registry_matches_manifest_default_core_ids(tmp_path: Path):
+def test_default_registry_matches_efp_expected_default_core_ids(tmp_path: Path):
     registry = create_core_tool_registry(tmp_path)
 
-    assert tuple(registry.ids()) == DEFAULT_CORE_TOOL_IDS
+    assert tuple(registry.ids()) == EXPECTED_DEFAULT_CORE_TOOL_IDS
+    assert REMOVED_LEGACY_TOOL_IDS.isdisjoint(registry.ids())
+    assert set(CONDITIONAL_TOOL_IDS).isdisjoint(registry.ids())
 
 
-def test_conditional_manifest_tool_ids_are_registrable(tmp_path: Path):
+def test_conditional_contract_tool_ids_are_registrable_under_conditions(
+    tmp_path: Path,
+):
     registry = create_core_tool_registry(
         tmp_path,
         task_runner=_task_runner,
@@ -48,8 +49,9 @@ def test_conditional_manifest_tool_ids_are_registrable(tmp_path: Path):
         websearch_runner=_websearch_runner,
     )
 
-    assert "websearch" in OPTIONAL_CONDITIONAL_TOOL_IDS
-    assert set(OPTIONAL_CONDITIONAL_TOOL_IDS).issubset(registry.ids())
+    assert "websearch" in CONDITIONAL_TOOL_IDS
+    assert set(CONDITIONAL_TOOL_IDS).issubset(registry.ids())
+    assert "mcp" not in registry.ids()
 
 
 def test_capability_group_statuses_are_explicit_and_known():
@@ -72,21 +74,14 @@ def test_capability_group_statuses_are_explicit_and_known():
         assert entry.summary.strip()
 
 
-def test_opencode_upstream_baseline_is_exact():
-    assert OPENCODE_UPSTREAM_REPO == "https://github.com/anomalyco/opencode"
-    assert OPENCODE_DEV_HEAD == "16cae9a32329b65116869d2fd3c1fac27c4adcb6"
-    assert OPENCODE_DEV_TREE == "754a57c6f0e0413c1541b320a482f85708cffb88"
-    assert OPENCODE_AUDITED_AT == "2026-05-29T15:52:46Z"
-
-
-def test_session_state_manifest_mentions_summary_and_revert():
+def test_session_state_contract_mentions_summary_and_revert():
     summary = CAPABILITY_GROUPS["session state"].summary
 
     assert "summary diffs" in summary
     assert "revert/unrevert" in summary
 
 
-def test_legacy_boundary_manifest_separates_import_independence_from_tree_removal():
+def test_legacy_boundary_contract_separates_import_independence_from_tree_removal():
     summary = CAPABILITY_GROUPS["legacy boundary"].summary
 
     assert "independent from legacy core imports" in summary
@@ -94,17 +89,18 @@ def test_legacy_boundary_manifest_separates_import_independence_from_tree_remova
     assert "separate migration item" in summary
 
 
-def test_manifest_explicitly_excludes_mcp():
-    entry = EXCLUDED_TOOL_IDS["mcp"]
+def test_contract_explicitly_excludes_mcp(tmp_path: Path):
+    entry = EXCLUDED_RUNTIME_SURFACES["mcp"]
 
     assert entry.status == "excluded"
     assert "MCP" in entry.reason
+    assert "mcp" not in create_core_tool_registry(tmp_path).ids()
 
 
-def test_remaining_manifest_items_have_concrete_next_actions():
+def test_remaining_contract_items_have_concrete_next_actions():
     vague_actions = {"", "todo", "tbd", "follow up", "investigate", "later"}
 
-    for name, entry in _manifest_entries():
+    for name, entry in _contract_entries():
         if entry.status != "remaining":
             continue
         action = (entry.next_action or "").strip()
@@ -112,15 +108,15 @@ def test_remaining_manifest_items_have_concrete_next_actions():
         assert len(action.split()) >= 8, name
 
 
-def test_manifest_has_no_remaining_items():
+def test_contract_has_no_remaining_items():
     assert [
-        name for name, entry in _manifest_entries() if entry.status == "remaining"
+        name for name, entry in _contract_entries() if entry.status == "remaining"
     ] == []
 
 
-def _manifest_entries() -> list[tuple[str, Any]]:
+def _contract_entries() -> list[tuple[str, Any]]:
     entries: list[tuple[str, Any]] = []
     entries.extend(CAPABILITY_GROUPS.items())
-    entries.extend(OPTIONAL_CONDITIONAL_TOOL_IDS.items())
-    entries.extend(EXCLUDED_TOOL_IDS.items())
+    entries.extend(CONDITIONAL_TOOL_IDS.items())
+    entries.extend(EXCLUDED_RUNTIME_SURFACES.items())
     return entries

--- a/tests/test_p3_docs_contract.py
+++ b/tests/test_p3_docs_contract.py
@@ -4,17 +4,17 @@ from pathlib import Path
 def test_p3_contract_docs_exist_and_are_indexed():
     assert Path("docs/runtime_contract.md").exists()
     assert Path("docs/runtime-design.md").exists()
-    assert Path("docs/opencode-parity.md").exists()
+    assert Path("docs/runtime-tool-surface.md").exists()
     assert Path("docs/observability_contract.md").exists()
     docs_index = Path("docs/README.md").read_text(encoding="utf-8")
     assert "runtime_contract.md" in docs_index
     assert "runtime-design.md" in docs_index
-    assert "opencode-parity.md" in docs_index
+    assert "runtime-tool-surface.md" in docs_index
     assert "observability_contract.md" in docs_index
     root_readme = Path("README.md").read_text(encoding="utf-8")
     assert "docs/runtime_contract.md" in root_readme
     assert "docs/runtime-design.md" in root_readme
-    assert "docs/opencode-parity.md" in root_readme
+    assert "docs/runtime-tool-surface.md" in root_readme
     assert "docs/observability_contract.md" in root_readme
 
 
@@ -32,7 +32,7 @@ def test_runtime_contract_doc_mentions_current_native_contract_surfaces():
         "EFP_SKILLS_DIR",
         "/app/skills",
         "EFP runtime native mode supports GitHub Copilot only",
-        "opencode-style EFP runtime built-in registry",
+        "EFP-owned runtime built-in registry",
         "prebuilt `engineering-flow-platform-tools` CLI binaries",
         "`jira`, `confluence`, and `browser`",
         "<tool> commands --json",
@@ -71,8 +71,8 @@ def test_runtime_design_doc_matches_removed_tool_and_portal_boundaries():
         assert stale not in text
 
 
-def test_opencode_parity_doc_records_current_gaps():
-    text = Path("docs/opencode-parity.md").read_text(encoding="utf-8")
+def test_runtime_tool_surface_doc_records_current_gaps():
+    text = Path("docs/runtime-tool-surface.md").read_text(encoding="utf-8")
 
     for needle in [
         "Core loop/history/provider request",


### PR DESCRIPTION
## Summary

- Remove the production `efp_runtime.opencode_parity` module from the runtime package.
- Move the useful runtime tool/capability regression data into test-only contract fixtures.
- Rename the parity document to an EFP-owned runtime tool surface contract and update README/docs references.

## Why

EFP used opencode as an engineering reference, but the Python runtime should not keep a long-lived upstream parity manifest in production source. Runtime behavior should be owned by EFP contracts and tests instead.

## Validation

- `python -m pytest -q tests/runtime/test_runtime_tool_surface_contract.py tests/runtime/test_opencode_tool_surface.py tests/runtime/test_core_tool_parity.py tests/runtime/test_plan_mode.py tests/test_p3_docs_contract.py tests/runtime/test_import_boundary.py`
- `git diff --check`
- `rg -n "opencode_parity|opencode-parity|Opencode Parity|opencode parity manifest|OPENCODE_DEV_HEAD|OPENCODE_DEV_TREE|OPENCODE_AUDITED_AT" src tests docs README.md`
- `rg -n "efp_runtime\\.opencode_parity|from efp_runtime.opencode_parity|import efp_runtime.opencode_parity" .`
- `PYTHONPATH=src python -c "import importlib.util; print(importlib.util.find_spec(\"efp_runtime.opencode_parity\"))"`
