### PR TITLE
[codex] Add native runtime realtime events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements.txt
+      - name: Prepare workspace directories
+        run: |
+          sudo mkdir -p /workspace/uploads /workspace/file_context/sessions
+          sudo chown -R "$USER":"$USER" /workspace
       - env:
           PYTHONPATH: .
           EFP_EXTERNAL_TOOLS_STRICT: "false"

--- a/src/efp_runtime/llm/adapter.py
+++ b/src/efp_runtime/llm/adapter.py
@@ -704,11 +704,12 @@ def _response_tool_draft(
 ) -> _ToolCallDraft:
     draft = drafts.get(call_id)
     source = item if item is not None else raw
+    tool_name = _response_tool_name(source, raw=raw, draft=draft)
     if draft is None:
         draft = _ToolCallDraft(
             index=len(drafts),
             id=str(source.get("call_id") or source.get("id") or call_id),
-            name=str(source.get("name") or source.get("tool_name") or ""),
+            name=tool_name,
             raw=dict(raw),
         )
         drafts[call_id] = draft
@@ -716,11 +717,61 @@ def _response_tool_draft(
         draft.raw.update(dict(raw))
         if source.get("call_id") or source.get("id"):
             draft.id = str(source.get("call_id") or source.get("id"))
-        if source.get("name") or source.get("tool_name"):
-            draft.name = str(source.get("name") or source.get("tool_name"))
+        if tool_name:
+            draft.name = tool_name
     if item is not None:
         draft.raw["item"] = dict(item)
     return draft
+
+
+def _response_tool_name(
+    source: Mapping[str, Any],
+    *,
+    raw: Mapping[str, Any] | None = None,
+    draft: _ToolCallDraft | None = None,
+) -> str:
+    for candidate in _response_tool_name_candidates(source, raw=raw):
+        name = _tool_name_from_mapping(candidate)
+        if name:
+            return name
+
+    if draft is not None:
+        if draft.name:
+            return draft.name
+        for candidate in _response_tool_name_candidates(draft.raw):
+            name = _tool_name_from_mapping(candidate)
+            if name:
+                return name
+    return ""
+
+
+def _response_tool_name_candidates(
+    source: Mapping[str, Any],
+    *,
+    raw: Mapping[str, Any] | None = None,
+) -> List[Mapping[str, Any]]:
+    candidates = [source]
+    if raw is not None and raw is not source:
+        candidates.append(raw)
+    for mapping in list(candidates):
+        item = mapping.get("item")
+        if isinstance(item, Mapping):
+            candidates.append(item)
+    return candidates
+
+
+def _tool_name_from_mapping(source: Mapping[str, Any]) -> str:
+    for key in ("name", "tool_name"):
+        value = source.get(key)
+        if value not in (None, ""):
+            return str(value)
+
+    function = source.get("function")
+    if isinstance(function, Mapping):
+        name = function.get("name")
+        if name not in (None, ""):
+            return str(name)
+    return ""
 
 
 def _response_item_draft_key(
@@ -769,6 +820,29 @@ def _complete_response_tool_draft(draft: _ToolCallDraft) -> List[LLMEvent]:
     events = _ensure_response_tool_started(draft)
     events.extend(_end_response_tool_input(draft))
     draft.completed = True
+    if not draft.name:
+        item_id = _response_draft_item_id(draft)
+        location = f"call_id={draft.id}"
+        if item_id and item_id != draft.id:
+            location = f"{location}, item_id={item_id}"
+        message = (
+            "Provider emitted incomplete function call without tool name "
+            f"({location})."
+        )
+        events.append(
+            LLMEvent(
+                LLMEventType.ERROR,
+                tool_call_id=draft.id,
+                error=message,
+                raw={
+                    "call_id": draft.id,
+                    "item_id": item_id,
+                    "type": draft.raw.get("type"),
+                },
+                metadata={"index": draft.index},
+            )
+        )
+        return events
     tool_call = _make_tool_call(
         {
             "id": draft.id,
@@ -790,6 +864,20 @@ def _complete_response_tool_draft(draft: _ToolCallDraft) -> List[LLMEvent]:
         )
     )
     return events
+
+
+def _response_draft_item_id(draft: _ToolCallDraft) -> Optional[str]:
+    for key in ("item_id", "id"):
+        value = draft.raw.get(key)
+        if value not in (None, ""):
+            return str(value)
+    item = draft.raw.get("item")
+    if isinstance(item, Mapping):
+        for key in ("id", "call_id"):
+            value = item.get(key)
+            if value not in (None, ""):
+                return str(value)
+    return None
 
 
 def _is_responses_function_call_item(item: Mapping[str, Any]) -> bool:

--- a/src/efp_runtime/llm/adapter.py
+++ b/src/efp_runtime/llm/adapter.py
@@ -17,6 +17,7 @@ class _ToolCallDraft:
     id: str
     name: str = ""
     arguments_chunks: List[str] = field(default_factory=list)
+    final_arguments_text: Optional[str] = None
     raw: Dict[str, Any] = field(default_factory=dict)
     started: bool = False
     input_ended: bool = False
@@ -24,7 +25,15 @@ class _ToolCallDraft:
 
     @property
     def arguments_text(self) -> str:
-        return "".join(self.arguments_chunks)
+        return self.final_arguments_text if self.final_arguments_text is not None else "".join(self.arguments_chunks)
+
+
+@dataclass
+class _ReasoningDraft:
+    item_id: str
+    encrypted_content: Optional[str] = None
+    active_part_ids: set[str] = field(default_factory=set)
+    raw: Dict[str, Any] = field(default_factory=dict)
 
 
 class LLMEventAdapter(Protocol):
@@ -48,11 +57,12 @@ class DefaultLLMEventAdapter:
 
         if "error" in raw and raw.get("error"):
             yield LLMEvent(
-                LLMEventType.ERROR,
+                LLMEventType.PROVIDER_ERROR,
                 error=_format_error(raw.get("error")),
                 raw=raw,
+                metadata={"provider": "openai"},
+                provider_metadata={"openai": {"error": raw.get("error")}},
             )
-            yield LLMEvent(LLMEventType.STEP_FINISH, usage=usage, raw=raw)
             return
 
         yield LLMEvent(LLMEventType.MESSAGE_START, raw=raw)
@@ -131,8 +141,11 @@ class DefaultLLMEventAdapter:
         text_part_id = _stable_part_id("text", 0)
         tool_drafts: Dict[int, _ToolCallDraft] = {}
         response_tool_drafts: Dict[str, _ToolCallDraft] = {}
+        response_reasoning_drafts: Dict[str, _ReasoningDraft] = {}
         usage: Dict[str, Any] = {}
         finish_reason: Optional[str] = None
+        finish_emitted = False
+        provider_error_emitted = False
 
         async for chunk in _aiter_chunks(chunks):
             if isinstance(chunk, LLMEvent):
@@ -154,7 +167,16 @@ class DefaultLLMEventAdapter:
             response_events, consumed_response_chunk = self._normalize_responses_stream_chunk(
                 raw,
                 response_tool_drafts,
+                response_reasoning_drafts,
             )
+            response_type = str(raw.get("type") or "")
+            if consumed_response_chunk and response_type in {
+                "response.completed",
+                "response.incomplete",
+            }:
+                if text_started:
+                    yield LLMEvent(LLMEventType.TEXT_END, part_id=text_part_id, raw=raw)
+                    text_started = False
             for event in response_events:
                 if event.type == LLMEventType.TEXT_DELTA and not text_started:
                     yield LLMEvent(LLMEventType.TEXT_START, part_id=text_part_id, raw=raw)
@@ -162,6 +184,21 @@ class DefaultLLMEventAdapter:
                 if event.type in (LLMEventType.TEXT_DELTA, LLMEventType.TEXT_END):
                     event.part_id = event.part_id or text_part_id
                 yield event
+                if event.type == LLMEventType.STEP_FINISH:
+                    finish_emitted = True
+                    finish_reason = (
+                        event.metadata.get("finish_reason")
+                        or event.metadata.get("reason")
+                        or finish_reason
+                    )
+                    if event.usage:
+                        usage = dict(event.usage)
+                elif event.type == LLMEventType.FINISH:
+                    finish_emitted = True
+                    if event.usage:
+                        usage = dict(event.usage)
+                elif event.type == LLMEventType.PROVIDER_ERROR:
+                    provider_error_emitted = True
             if consumed_response_chunk:
                 finish_reason = finish_reason or _extract_finish_reason(raw)
                 continue
@@ -246,46 +283,39 @@ class DefaultLLMEventAdapter:
         if started and text_started:
             yield LLMEvent(LLMEventType.TEXT_END, part_id=text_part_id)
 
-        for draft in sorted(tool_drafts.values(), key=lambda item: item.index):
-            if draft.started:
-                yield LLMEvent(
-                    LLMEventType.TOOL_INPUT_END,
-                    tool_call_id=draft.id,
-                    tool_name=draft.name,
-                    text=draft.arguments_text,
-                    raw=draft.raw,
-                )
-                tool_call = _make_tool_call(
-                    {
-                        "id": draft.id,
-                        "type": "function",
-                        "function": {
-                            "name": draft.name,
-                            "arguments": draft.arguments_text,
+        if not provider_error_emitted:
+            for draft in sorted(tool_drafts.values(), key=lambda item: item.index):
+                if draft.started:
+                    yield LLMEvent(
+                        LLMEventType.TOOL_INPUT_END,
+                        tool_call_id=draft.id,
+                        tool_name=draft.name,
+                        text=draft.arguments_text,
+                        raw=draft.raw,
+                    )
+                    tool_call = _make_tool_call(
+                        {
+                            "id": draft.id,
+                            "type": "function",
+                            "function": {
+                                "name": draft.name,
+                                "arguments": draft.arguments_text,
+                            },
                         },
-                    },
-                    draft.index,
-                )
-                yield LLMEvent(
-                    LLMEventType.TOOL_CALL_COMPLETE,
-                    tool_call_id=tool_call.call_id,
-                    tool_name=tool_call.tool_name,
-                    tool_call=tool_call,
-                    raw=draft.raw,
-                )
+                        draft.index,
+                    )
+                    yield LLMEvent(
+                        LLMEventType.TOOL_CALL_COMPLETE,
+                        tool_call_id=tool_call.call_id,
+                        tool_name=tool_call.tool_name,
+                        tool_call=tool_call,
+                        raw=draft.raw,
+                    )
 
-        seen_response_drafts: set[int] = set()
-        for draft in sorted(response_tool_drafts.values(), key=lambda item: item.index):
-            draft_identity = id(draft)
-            if draft_identity in seen_response_drafts:
-                continue
-            seen_response_drafts.add(draft_identity)
-            if not draft.name:
-                continue
-            for event in _complete_response_tool_draft(draft):
+            for event in _complete_all_response_tool_drafts(response_tool_drafts):
                 yield event
 
-        if started:
+        if started and not finish_emitted and not provider_error_emitted:
             metadata = {"finish_reason": finish_reason} if finish_reason else {}
             yield LLMEvent(LLMEventType.STEP_FINISH, usage=usage, metadata=metadata)
 
@@ -293,9 +323,14 @@ class DefaultLLMEventAdapter:
         self,
         raw: Mapping[str, Any],
         response_tool_drafts: Dict[str, _ToolCallDraft],
+        response_reasoning_drafts: Dict[str, _ReasoningDraft],
     ) -> tuple[List[LLMEvent], bool]:
         response_type = raw.get("type")
-        if not isinstance(response_type, str) or not response_type.startswith("response."):
+        if not isinstance(response_type, str):
+            return [], False
+        if response_type == "error":
+            return [_provider_error_event(raw, fallback="OpenAI Responses stream error")], True
+        if not response_type.startswith("response."):
             return [], False
 
         if response_type in {"response.output_text.delta"}:
@@ -303,11 +338,57 @@ class DefaultLLMEventAdapter:
             return [LLMEvent(LLMEventType.TEXT_DELTA, delta=delta, text=delta, raw=dict(raw))], True
 
         if response_type in {
+            "response.reasoning_summary.delta",
             "response.reasoning_summary_text.delta",
             "response.reasoning_text.delta",
         }:
             delta = str(raw.get("delta") or "")
-            return [LLMEvent(LLMEventType.REASONING_DELTA, delta=delta, text=delta, raw=dict(raw))], True
+            if not delta:
+                return [], True
+            part_id = _response_reasoning_part_id(raw, response_reasoning_drafts)
+            events = _ensure_response_reasoning_started(
+                response_reasoning_drafts,
+                raw,
+                part_id,
+            )
+            events.append(
+                LLMEvent(
+                    LLMEventType.REASONING_DELTA,
+                    part_id=part_id,
+                    delta=delta,
+                    text=delta,
+                    raw=dict(raw),
+                    metadata=_response_reasoning_metadata(raw, response_reasoning_drafts),
+                    provider_metadata=_response_reasoning_provider_metadata(
+                        raw,
+                        response_reasoning_drafts,
+                    ),
+                )
+            )
+            return events, True
+
+        if response_type in {
+            "response.reasoning_summary.done",
+            "response.reasoning_summary_text.done",
+            "response.reasoning_text.done",
+        }:
+            return [], True
+
+        if response_type == "response.reasoning_summary_part.added":
+            part_id = _response_reasoning_part_id(raw, response_reasoning_drafts)
+            return _ensure_response_reasoning_started(
+                response_reasoning_drafts,
+                raw,
+                part_id,
+            ), True
+
+        if response_type == "response.reasoning_summary_part.done":
+            part_id = _response_reasoning_part_id(raw, response_reasoning_drafts)
+            return _end_response_reasoning_part(
+                response_reasoning_drafts,
+                raw,
+                part_id,
+            ), True
 
         if response_type == "response.function_call_arguments.delta":
             draft = _response_existing_tool_draft(response_tool_drafts, raw)
@@ -332,7 +413,27 @@ class DefaultLLMEventAdapter:
 
         if response_type in {"response.output_item.added", "response.output_item.done"}:
             item = raw.get("item")
-            if not isinstance(item, Mapping) or not _is_responses_function_call_item(item):
+            if not isinstance(item, Mapping):
+                return [], True
+            if _is_responses_reasoning_item(item):
+                if response_type == "response.output_item.added":
+                    part_id = _response_reasoning_part_id(raw, response_reasoning_drafts)
+                    return _ensure_response_reasoning_started(
+                        response_reasoning_drafts,
+                        raw,
+                        part_id,
+                        item=item,
+                    ), True
+                return _end_all_response_reasoning_parts(
+                    response_reasoning_drafts,
+                    raw,
+                    item=item,
+                ), True
+            if _is_responses_hosted_tool_item(item):
+                # Provider-hosted tools are not local EFP tool calls. This phase
+                # keeps them observable in raw metadata but does not execute them.
+                return [], True
+            if not _is_responses_function_call_item(item):
                 return [], True
             draft_key = _response_output_key(raw, item)
             if draft_key is None:
@@ -342,7 +443,10 @@ class DefaultLLMEventAdapter:
                 return [], True
             events = _ensure_response_tool_started(draft)
             arguments = _response_tool_arguments(item)
-            if arguments not in (None, "") and not draft.arguments_text:
+            if response_type == "response.output_item.done" and arguments not in (None, ""):
+                draft.final_arguments_text = _copilot_stream_value_text(arguments)
+                draft.raw.update(dict(raw))
+            if arguments not in (None, "") and not draft.arguments_chunks:
                 arguments_text = _copilot_stream_value_text(arguments)
                 if arguments_text and draft.name:
                     draft.arguments_chunks.append(arguments_text)
@@ -365,12 +469,48 @@ class DefaultLLMEventAdapter:
             if draft is None or not draft.name:
                 return [], True
             arguments = raw.get("arguments")
-            if arguments not in (None, "") and not draft.arguments_text:
-                draft.arguments_chunks.append(_copilot_stream_value_text(arguments))
+            if arguments not in (None, ""):
+                if not draft.arguments_chunks:
+                    draft.arguments_chunks.append(_copilot_stream_value_text(arguments))
+                draft.final_arguments_text = _copilot_stream_value_text(arguments)
                 draft.raw.update(dict(raw))
             events = _ensure_response_tool_started(draft)
             events.extend(_end_response_tool_input(draft))
             return events, True
+
+        if response_type in {"response.completed", "response.incomplete"}:
+            events: List[LLMEvent] = []
+            events.extend(_complete_all_response_tool_drafts(response_tool_drafts))
+            events.extend(_end_all_response_reasoning_parts(response_reasoning_drafts, raw))
+            finish_reason = _response_finish_reason(raw, has_function_call=_has_completed_tool_call(response_tool_drafts))
+            usage = _response_usage(raw)
+            metadata = {
+                "finish_reason": finish_reason,
+                **_response_finish_metadata(raw),
+            }
+            provider_metadata = _response_provider_metadata(raw)
+            events.append(
+                LLMEvent(
+                    LLMEventType.STEP_FINISH,
+                    usage=usage,
+                    metadata=metadata,
+                    provider_metadata=provider_metadata,
+                    raw=dict(raw),
+                )
+            )
+            events.append(
+                LLMEvent(
+                    LLMEventType.FINISH,
+                    usage=usage,
+                    metadata=metadata,
+                    provider_metadata=provider_metadata,
+                    raw=dict(raw),
+                )
+            )
+            return events, True
+
+        if response_type == "response.failed":
+            return [_provider_error_event(raw, fallback="OpenAI Responses response failed")], True
 
         return [], True
 
@@ -387,6 +527,8 @@ class DefaultLLMEventAdapter:
                     delta=str(raw.get("delta") or ""),
                     text=str(raw.get("text") or ""),
                     raw=dict(raw),
+                    metadata=_dict_or_empty(raw.get("metadata")),
+                    provider_metadata=_dict_or_empty(raw.get("provider_metadata")),
                 )
             ]
 
@@ -395,6 +537,7 @@ class DefaultLLMEventAdapter:
             delta = str(raw.get("delta") or "")
             return [LLMEvent(LLMEventType.TEXT_DELTA, delta=delta, text=delta, raw=dict(raw))]
         if response_type in {
+            "response.reasoning_summary.delta",
             "response.reasoning_summary_text.delta",
             "response.reasoning_text.delta",
             "reasoning_delta",
@@ -699,10 +842,16 @@ def _response_output_key(
     output_index = raw.get("output_index")
     if output_index not in (None, ""):
         return f"output_index:{output_index}"
+    item_id = raw.get("item_id")
+    if item_id not in (None, "") and item is None:
+        return f"item_id:{item_id}"
     if item is not None and _is_responses_function_call_item(item):
         call_id = item.get("call_id")
         if call_id not in (None, ""):
             return f"call_id:{call_id}"
+        item_id = item.get("id") or raw.get("item_id")
+        if item_id not in (None, ""):
+            return f"item_id:{item_id}"
     return None
 
 
@@ -713,6 +862,12 @@ def _response_existing_tool_draft(
     output_key = _response_output_key(raw)
     if output_key is not None and output_key in drafts:
         return drafts[output_key]
+
+    item_id = raw.get("item_id")
+    if item_id not in (None, ""):
+        draft = drafts.get(f"item_id:{item_id}")
+        if draft is not None:
+            return draft
 
     for key in ("call_id", "tool_call_id"):
         value = raw.get(key)
@@ -758,19 +913,45 @@ def _response_tool_draft(
     tool_name = _response_tool_name(item, draft=draft)
     if draft is None:
         draft = _ToolCallDraft(
-            index=len(drafts),
+            index=_unique_response_draft_count(drafts),
             id=draft_id,
             name=tool_name,
             raw=dict(raw),
         )
-        drafts[draft_key] = draft
     else:
         draft.raw.update(dict(raw))
         draft.id = draft_id
         if tool_name:
             draft.name = tool_name
     draft.raw["item"] = dict(item)
+    _response_register_tool_aliases(drafts, draft_key, raw, item, draft)
     return draft
+
+
+def _unique_response_draft_count(drafts: Mapping[str, _ToolCallDraft]) -> int:
+    return len({id(draft) for draft in drafts.values()})
+
+
+def _response_register_tool_aliases(
+    drafts: Dict[str, _ToolCallDraft],
+    draft_key: str,
+    raw: Mapping[str, Any],
+    item: Mapping[str, Any],
+    draft: _ToolCallDraft,
+) -> None:
+    drafts[draft_key] = draft
+    output_index = raw.get("output_index")
+    if output_index not in (None, ""):
+        drafts[f"output_index:{output_index}"] = draft
+    call_id = item.get("call_id") or item.get("tool_call_id")
+    if call_id not in (None, ""):
+        drafts[f"call_id:{call_id}"] = draft
+    item_id = item.get("id")
+    if item_id not in (None, ""):
+        drafts[f"item_id:{item_id}"] = draft
+    raw_item_id = raw.get("item_id")
+    if raw_item_id not in (None, "") and raw_item_id == item_id:
+        drafts[f"item_id:{raw_item_id}"] = draft
 
 
 def _response_tool_call_id(item: Mapping[str, Any]) -> str:
@@ -841,6 +1022,291 @@ def _response_tool_arguments(item: Mapping[str, Any]) -> Any:
     return None
 
 
+def _response_reasoning_part_id(
+    raw: Mapping[str, Any],
+    drafts: Mapping[str, _ReasoningDraft],
+) -> str:
+    item_id = _response_reasoning_item_id(raw)
+    if not item_id:
+        for draft in drafts.values():
+            if draft.active_part_ids:
+                return sorted(draft.active_part_ids)[-1]
+        return _stable_part_id("reasoning", 0)
+    summary_index = raw.get("summary_index")
+    if summary_index in (None, ""):
+        summary_index = 0
+    return f"{item_id}:{summary_index}"
+
+
+def _response_reasoning_item_id(raw: Mapping[str, Any]) -> str:
+    item = raw.get("item")
+    if isinstance(item, Mapping) and item.get("id") not in (None, ""):
+        return str(item.get("id"))
+    if raw.get("item_id") not in (None, ""):
+        return str(raw.get("item_id"))
+    return ""
+
+
+def _response_reasoning_draft(
+    drafts: Dict[str, _ReasoningDraft],
+    raw: Mapping[str, Any],
+    *,
+    item: Mapping[str, Any] | None = None,
+) -> _ReasoningDraft:
+    item_id = (
+        str(item.get("id"))
+        if item is not None and item.get("id") not in (None, "")
+        else _response_reasoning_item_id(raw)
+    )
+    if not item_id:
+        item_id = "reasoning_0"
+    draft = drafts.get(item_id)
+    if draft is None:
+        draft = _ReasoningDraft(item_id=item_id, raw=dict(raw))
+        drafts[item_id] = draft
+    else:
+        draft.raw.update(dict(raw))
+    if item is not None:
+        draft.raw["item"] = dict(item)
+        if "encrypted_content" in item:
+            encrypted = item.get("encrypted_content")
+            draft.encrypted_content = str(encrypted) if encrypted is not None else None
+    return draft
+
+
+def _ensure_response_reasoning_started(
+    drafts: Dict[str, _ReasoningDraft],
+    raw: Mapping[str, Any],
+    part_id: str,
+    *,
+    item: Mapping[str, Any] | None = None,
+) -> List[LLMEvent]:
+    draft = _response_reasoning_draft(drafts, raw, item=item)
+    if part_id in draft.active_part_ids:
+        return []
+    draft.active_part_ids.add(part_id)
+    metadata = _response_reasoning_metadata(raw, drafts, item=item)
+    provider_metadata = _response_reasoning_provider_metadata(raw, drafts, item=item)
+    return [
+        LLMEvent(
+            LLMEventType.REASONING_START,
+            part_id=part_id,
+            raw=dict(raw),
+            metadata=metadata,
+            provider_metadata=provider_metadata,
+        )
+    ]
+
+
+def _end_response_reasoning_part(
+    drafts: Dict[str, _ReasoningDraft],
+    raw: Mapping[str, Any],
+    part_id: str,
+    *,
+    item: Mapping[str, Any] | None = None,
+) -> List[LLMEvent]:
+    draft = _response_reasoning_draft(drafts, raw, item=item)
+    if part_id not in draft.active_part_ids:
+        return []
+    draft.active_part_ids.remove(part_id)
+    return [
+        LLMEvent(
+            LLMEventType.REASONING_END,
+            part_id=part_id,
+            raw=dict(raw),
+            metadata=_response_reasoning_metadata(raw, drafts, item=item),
+            provider_metadata=_response_reasoning_provider_metadata(raw, drafts, item=item),
+        )
+    ]
+
+
+def _end_all_response_reasoning_parts(
+    drafts: Dict[str, _ReasoningDraft],
+    raw: Mapping[str, Any],
+    *,
+    item: Mapping[str, Any] | None = None,
+) -> List[LLMEvent]:
+    if item is not None:
+        draft = _response_reasoning_draft(drafts, raw, item=item)
+        item_ids = [draft.item_id]
+    else:
+        item_ids = list(drafts)
+    events: List[LLMEvent] = []
+    for item_id in item_ids:
+        draft = drafts.get(item_id)
+        if draft is None:
+            continue
+        if not draft.active_part_ids and item is not None:
+            part_id = _response_reasoning_part_id(raw, drafts)
+            events.extend(_ensure_response_reasoning_started(drafts, raw, part_id, item=item))
+        for part_id in sorted(list(draft.active_part_ids)):
+            events.extend(_end_response_reasoning_part(drafts, raw, part_id, item=item))
+        if not draft.active_part_ids:
+            drafts.pop(item_id, None)
+    return events
+
+
+def _response_reasoning_metadata(
+    raw: Mapping[str, Any],
+    drafts: Mapping[str, _ReasoningDraft],
+    *,
+    item: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
+    item_id = (
+        str(item.get("id"))
+        if item is not None and item.get("id") not in (None, "")
+        else _response_reasoning_item_id(raw)
+    )
+    draft = drafts.get(item_id) if item_id else None
+    encrypted = None
+    if item is not None and "encrypted_content" in item:
+        encrypted = item.get("encrypted_content")
+    elif draft is not None:
+        encrypted = draft.encrypted_content
+    metadata: Dict[str, Any] = {"provider": "openai"}
+    if item_id:
+        metadata["item_id"] = item_id
+    if raw.get("summary_index") not in (None, ""):
+        metadata["summary_index"] = raw.get("summary_index")
+    if encrypted is not None:
+        metadata["encrypted_content"] = encrypted
+    return metadata
+
+
+def _response_reasoning_provider_metadata(
+    raw: Mapping[str, Any],
+    drafts: Mapping[str, _ReasoningDraft],
+    *,
+    item: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
+    metadata = _response_reasoning_metadata(raw, drafts, item=item)
+    openai: Dict[str, Any] = {}
+    if metadata.get("item_id"):
+        openai["itemId"] = metadata["item_id"]
+    if "encrypted_content" in metadata:
+        openai["reasoningEncryptedContent"] = metadata["encrypted_content"]
+    return {"openai": openai} if openai else {}
+
+
+def _response_usage(raw: Mapping[str, Any]) -> Dict[str, Any]:
+    response = raw.get("response")
+    if isinstance(response, Mapping):
+        usage = response.get("usage")
+        if isinstance(usage, Mapping):
+            return dict(usage)
+    return _dict_or_empty(raw.get("usage"))
+
+
+def _response_finish_reason(raw: Mapping[str, Any], *, has_function_call: bool) -> str:
+    response = raw.get("response")
+    details = response.get("incomplete_details") if isinstance(response, Mapping) else None
+    reason = details.get("reason") if isinstance(details, Mapping) else None
+    if reason in (None, ""):
+        return "tool_calls" if has_function_call else "stop"
+    if reason == "max_output_tokens":
+        return "length"
+    if reason == "content_filter":
+        return "content_filter"
+    return "tool_calls" if has_function_call else str(reason)
+
+
+def _response_finish_metadata(raw: Mapping[str, Any]) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    response = raw.get("response")
+    if isinstance(response, Mapping):
+        if response.get("id") not in (None, ""):
+            metadata["response_id"] = response.get("id")
+        if response.get("service_tier") not in (None, ""):
+            metadata["service_tier"] = response.get("service_tier")
+        details = response.get("incomplete_details")
+        if isinstance(details, Mapping) and details.get("reason") not in (None, ""):
+            metadata["incomplete_reason"] = details.get("reason")
+    if raw.get("type") not in (None, ""):
+        metadata["provider_event_type"] = raw.get("type")
+    return metadata
+
+
+def _response_provider_metadata(raw: Mapping[str, Any]) -> Dict[str, Any]:
+    openai: Dict[str, Any] = {}
+    response = raw.get("response")
+    if isinstance(response, Mapping):
+        if response.get("id") not in (None, ""):
+            openai["responseId"] = response.get("id")
+        if response.get("service_tier") not in (None, ""):
+            openai["serviceTier"] = response.get("service_tier")
+        usage = response.get("usage")
+        if isinstance(usage, Mapping):
+            openai["usage"] = dict(usage)
+    return {"openai": openai} if openai else {}
+
+
+def _provider_error_event(raw: Mapping[str, Any], *, fallback: str) -> LLMEvent:
+    message, metadata, provider_metadata = _provider_error_payload(raw, fallback=fallback)
+    return LLMEvent(
+        LLMEventType.PROVIDER_ERROR,
+        error=message,
+        text=message,
+        raw=dict(raw),
+        metadata=metadata,
+        provider_metadata=provider_metadata,
+    )
+
+
+def _provider_error_payload(
+    raw: Mapping[str, Any],
+    *,
+    fallback: str,
+) -> tuple[str, Dict[str, Any], Dict[str, Any]]:
+    nested: Mapping[str, Any] = {}
+    response = raw.get("response")
+    if isinstance(response, Mapping):
+        error = response.get("error")
+        if isinstance(error, Mapping):
+            nested = error
+    top_error = raw.get("error")
+    if isinstance(top_error, Mapping):
+        nested = top_error
+    message = _optional_str(raw.get("message")) or _optional_str(nested.get("message"))
+    code = _optional_str(raw.get("code")) or _optional_str(nested.get("code"))
+    param = _optional_str(raw.get("param")) or _optional_str(nested.get("param"))
+    retryable = raw.get("retryable")
+    if retryable is None:
+        retryable = nested.get("retryable")
+    if message and code:
+        formatted = f"{code}: {message}"
+    else:
+        formatted = message or code or fallback
+
+    metadata: Dict[str, Any] = {"provider": "openai"}
+    if code:
+        metadata["code"] = code
+    if param:
+        metadata["param"] = param
+    if isinstance(retryable, bool):
+        metadata["retryable"] = retryable
+    if raw.get("type") not in (None, ""):
+        metadata["provider_event_type"] = raw.get("type")
+    if isinstance(response, Mapping) and response.get("id") not in (None, ""):
+        metadata["response_id"] = response.get("id")
+
+    openai: Dict[str, Any] = {"error": {key: value for key, value in metadata.items() if key != "provider"}}
+    if isinstance(response, Mapping) and response.get("id") not in (None, ""):
+        openai["responseId"] = response.get("id")
+    return formatted, metadata, {"openai": openai}
+
+
+def _has_completed_tool_call(drafts: Mapping[str, _ToolCallDraft]) -> bool:
+    seen: set[int] = set()
+    for draft in drafts.values():
+        draft_identity = id(draft)
+        if draft_identity in seen:
+            continue
+        seen.add(draft_identity)
+        if draft.completed or draft.name:
+            return True
+    return False
+
+
 def _ensure_response_tool_started(draft: _ToolCallDraft) -> List[LLMEvent]:
     if draft.started or not draft.name:
         return []
@@ -902,8 +1368,39 @@ def _complete_response_tool_draft(draft: _ToolCallDraft) -> List[LLMEvent]:
     return events
 
 
+def _complete_all_response_tool_drafts(
+    drafts: Mapping[str, _ToolCallDraft],
+) -> List[LLMEvent]:
+    events: List[LLMEvent] = []
+    seen: set[int] = set()
+    for draft in sorted(drafts.values(), key=lambda item: item.index):
+        draft_identity = id(draft)
+        if draft_identity in seen:
+            continue
+        seen.add(draft_identity)
+        events.extend(_complete_response_tool_draft(draft))
+    return events
+
+
 def _is_responses_function_call_item(item: Mapping[str, Any]) -> bool:
     return str(item.get("type") or "") in {"function_call", "tool_call"}
+
+
+def _is_responses_reasoning_item(item: Mapping[str, Any]) -> bool:
+    return str(item.get("type") or "") == "reasoning"
+
+
+def _is_responses_hosted_tool_item(item: Mapping[str, Any]) -> bool:
+    return str(item.get("type") or "") in {
+        "web_search_call",
+        "web_search_preview_call",
+        "file_search_call",
+        "code_interpreter_call",
+        "computer_use_call",
+        "image_generation_call",
+        "local_shell_call",
+        "mcp_call",
+    }
 
 
 def _copilot_stream_value_text(value: Any) -> str:

--- a/src/efp_runtime/llm/adapter.py
+++ b/src/efp_runtime/llm/adapter.py
@@ -274,7 +274,14 @@ class DefaultLLMEventAdapter:
                     raw=draft.raw,
                 )
 
+        seen_response_drafts: set[int] = set()
         for draft in sorted(response_tool_drafts.values(), key=lambda item: item.index):
+            draft_identity = id(draft)
+            if draft_identity in seen_response_drafts:
+                continue
+            seen_response_drafts.add(draft_identity)
+            if not draft.name:
+                continue
             for event in _complete_response_tool_draft(draft):
                 yield event
 
@@ -303,8 +310,9 @@ class DefaultLLMEventAdapter:
             return [LLMEvent(LLMEventType.REASONING_DELTA, delta=delta, text=delta, raw=dict(raw))], True
 
         if response_type == "response.function_call_arguments.delta":
-            call_id = _response_call_id(raw, response_tool_drafts)
-            draft = _response_tool_draft(response_tool_drafts, call_id, raw)
+            draft = _response_existing_tool_draft(response_tool_drafts, raw)
+            if draft is None or not draft.name:
+                return [], True
             delta = str(raw.get("delta") or "")
             events = _ensure_response_tool_started(draft)
             if delta:
@@ -326,33 +334,40 @@ class DefaultLLMEventAdapter:
             item = raw.get("item")
             if not isinstance(item, Mapping) or not _is_responses_function_call_item(item):
                 return [], True
-            call_id = _response_item_draft_key(raw, item, response_tool_drafts)
-            draft = _response_tool_draft(response_tool_drafts, call_id, raw, item=item)
+            draft_key = _response_output_key(raw, item)
+            if draft_key is None:
+                return [], True
+            draft = _response_tool_draft(response_tool_drafts, draft_key, raw, item=item)
+            if draft is None:
+                return [], True
             events = _ensure_response_tool_started(draft)
-            arguments = item.get("arguments")
+            arguments = _response_tool_arguments(item)
             if arguments not in (None, "") and not draft.arguments_text:
                 arguments_text = _copilot_stream_value_text(arguments)
-                draft.arguments_chunks.append(arguments_text)
-                events.append(
-                    LLMEvent(
-                        LLMEventType.TOOL_INPUT_DELTA,
-                        tool_call_id=draft.id,
-                        tool_name=draft.name,
-                        delta=arguments_text,
-                        text=arguments_text,
-                        raw=dict(draft.raw),
+                if arguments_text and draft.name:
+                    draft.arguments_chunks.append(arguments_text)
+                    events.append(
+                        LLMEvent(
+                            LLMEventType.TOOL_INPUT_DELTA,
+                            tool_call_id=draft.id,
+                            tool_name=draft.name,
+                            delta=arguments_text,
+                            text=arguments_text,
+                            raw=dict(draft.raw),
+                        )
                     )
-                )
             if response_type == "response.output_item.done":
                 events.extend(_complete_response_tool_draft(draft))
             return events, True
 
         if response_type == "response.function_call_arguments.done":
-            call_id = _response_call_id(raw, response_tool_drafts)
-            draft = _response_tool_draft(response_tool_drafts, call_id, raw)
+            draft = _response_existing_tool_draft(response_tool_drafts, raw)
+            if draft is None or not draft.name:
+                return [], True
             arguments = raw.get("arguments")
             if arguments not in (None, "") and not draft.arguments_text:
                 draft.arguments_chunks.append(_copilot_stream_value_text(arguments))
+                draft.raw.update(dict(raw))
             events = _ensure_response_tool_started(draft)
             events.extend(_end_response_tool_input(draft))
             return events, True
@@ -677,51 +692,93 @@ def _format_error(error: Any) -> str:
     return str(error)
 
 
-def _response_call_id(
+def _response_output_key(
     raw: Mapping[str, Any],
-    drafts: Mapping[str, _ToolCallDraft],
-    *,
-    fallback: Any = None,
-) -> str:
-    for key in ("call_id", "id", "item_id", "tool_call_id"):
-        value = raw.get(key)
-        if value not in (None, ""):
-            return str(value)
-    if fallback not in (None, ""):
-        return str(fallback)
+    item: Mapping[str, Any] | None = None,
+) -> Optional[str]:
     output_index = raw.get("output_index")
     if output_index not in (None, ""):
-        return f"call_{output_index}"
-    return f"call_{len(drafts)}"
+        return f"output_index:{output_index}"
+    if item is not None and _is_responses_function_call_item(item):
+        call_id = item.get("call_id")
+        if call_id not in (None, ""):
+            return f"call_id:{call_id}"
+    return None
+
+
+def _response_existing_tool_draft(
+    drafts: Mapping[str, _ToolCallDraft],
+    raw: Mapping[str, Any],
+) -> Optional[_ToolCallDraft]:
+    output_key = _response_output_key(raw)
+    if output_key is not None and output_key in drafts:
+        return drafts[output_key]
+
+    for key in ("call_id", "tool_call_id"):
+        value = raw.get(key)
+        if value in (None, ""):
+            continue
+        draft = drafts.get(f"call_id:{value}")
+        if draft is not None:
+            return draft
+        draft = _response_draft_by_id(drafts, str(value))
+        if draft is not None:
+            return draft
+    return None
+
+
+def _response_draft_by_id(
+    drafts: Mapping[str, _ToolCallDraft],
+    call_id: str,
+) -> Optional[_ToolCallDraft]:
+    seen: set[int] = set()
+    for draft in drafts.values():
+        draft_identity = id(draft)
+        if draft_identity in seen:
+            continue
+        seen.add(draft_identity)
+        if draft.id == call_id:
+            return draft
+    return None
 
 
 def _response_tool_draft(
     drafts: Dict[str, _ToolCallDraft],
-    call_id: str,
+    draft_key: str,
     raw: Mapping[str, Any],
     *,
-    item: Mapping[str, Any] | None = None,
-) -> _ToolCallDraft:
-    draft = drafts.get(call_id)
-    source = item if item is not None else raw
-    tool_name = _response_tool_name(source, raw=raw, draft=draft)
+    item: Mapping[str, Any],
+) -> Optional[_ToolCallDraft]:
+    draft_id = _response_tool_call_id(item)
+    if not draft_id:
+        return None
+    draft = drafts.get(draft_key)
+    if draft is None:
+        draft = _response_draft_by_id(drafts, draft_id)
+    tool_name = _response_tool_name(item, draft=draft)
     if draft is None:
         draft = _ToolCallDraft(
             index=len(drafts),
-            id=str(source.get("call_id") or source.get("id") or call_id),
+            id=draft_id,
             name=tool_name,
             raw=dict(raw),
         )
-        drafts[call_id] = draft
+        drafts[draft_key] = draft
     else:
         draft.raw.update(dict(raw))
-        if source.get("call_id") or source.get("id"):
-            draft.id = str(source.get("call_id") or source.get("id"))
+        draft.id = draft_id
         if tool_name:
             draft.name = tool_name
-    if item is not None:
-        draft.raw["item"] = dict(item)
+    draft.raw["item"] = dict(item)
     return draft
+
+
+def _response_tool_call_id(item: Mapping[str, Any]) -> str:
+    for key in ("call_id", "id", "tool_call_id"):
+        value = item.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return ""
 
 
 def _response_tool_name(
@@ -738,8 +795,9 @@ def _response_tool_name(
     if draft is not None:
         if draft.name:
             return draft.name
-        for candidate in _response_tool_name_candidates(draft.raw):
-            name = _tool_name_from_mapping(candidate)
+        item = draft.raw.get("item")
+        if isinstance(item, Mapping):
+            name = _tool_name_from_mapping(item)
             if name:
                 return name
     return ""
@@ -774,19 +832,17 @@ def _tool_name_from_mapping(source: Mapping[str, Any]) -> str:
     return ""
 
 
-def _response_item_draft_key(
-    raw: Mapping[str, Any],
-    item: Mapping[str, Any],
-    drafts: Mapping[str, _ToolCallDraft],
-) -> str:
-    for value in (raw.get("item_id"), item.get("id"), item.get("call_id")):
-        if value not in (None, ""):
-            return str(value)
-    return _response_call_id(item, drafts)
+def _response_tool_arguments(item: Mapping[str, Any]) -> Any:
+    if "arguments" in item:
+        return item.get("arguments")
+    function = item.get("function")
+    if isinstance(function, Mapping) and "arguments" in function:
+        return function.get("arguments")
+    return None
 
 
 def _ensure_response_tool_started(draft: _ToolCallDraft) -> List[LLMEvent]:
-    if draft.started:
+    if draft.started or not draft.name:
         return []
     draft.started = True
     return [
@@ -800,7 +856,7 @@ def _ensure_response_tool_started(draft: _ToolCallDraft) -> List[LLMEvent]:
 
 
 def _end_response_tool_input(draft: _ToolCallDraft) -> List[LLMEvent]:
-    if draft.input_ended:
+    if draft.input_ended or not draft.name:
         return []
     draft.input_ended = True
     return [
@@ -817,32 +873,12 @@ def _end_response_tool_input(draft: _ToolCallDraft) -> List[LLMEvent]:
 def _complete_response_tool_draft(draft: _ToolCallDraft) -> List[LLMEvent]:
     if draft.completed:
         return []
+    if not draft.name:
+        draft.completed = True
+        return []
     events = _ensure_response_tool_started(draft)
     events.extend(_end_response_tool_input(draft))
     draft.completed = True
-    if not draft.name:
-        item_id = _response_draft_item_id(draft)
-        location = f"call_id={draft.id}"
-        if item_id and item_id != draft.id:
-            location = f"{location}, item_id={item_id}"
-        message = (
-            "Provider emitted incomplete function call without tool name "
-            f"({location})."
-        )
-        events.append(
-            LLMEvent(
-                LLMEventType.ERROR,
-                tool_call_id=draft.id,
-                error=message,
-                raw={
-                    "call_id": draft.id,
-                    "item_id": item_id,
-                    "type": draft.raw.get("type"),
-                },
-                metadata={"index": draft.index},
-            )
-        )
-        return events
     tool_call = _make_tool_call(
         {
             "id": draft.id,
@@ -864,20 +900,6 @@ def _complete_response_tool_draft(draft: _ToolCallDraft) -> List[LLMEvent]:
         )
     )
     return events
-
-
-def _response_draft_item_id(draft: _ToolCallDraft) -> Optional[str]:
-    for key in ("item_id", "id"):
-        value = draft.raw.get(key)
-        if value not in (None, ""):
-            return str(value)
-    item = draft.raw.get("item")
-    if isinstance(item, Mapping):
-        for key in ("id", "call_id"):
-            value = item.get(key)
-            if value not in (None, ""):
-                return str(value)
-    return None
 
 
 def _is_responses_function_call_item(item: Mapping[str, Any]) -> bool:

--- a/src/efp_runtime/llm/adapter.py
+++ b/src/efp_runtime/llm/adapter.py
@@ -128,6 +128,7 @@ class DefaultLLMEventAdapter:
         text_started = False
         text_part_id = _stable_part_id("text", 0)
         tool_drafts: Dict[int, _ToolCallDraft] = {}
+        response_tool_drafts: Dict[str, _ToolCallDraft] = {}
         usage: Dict[str, Any] = {}
         finish_reason: Optional[str] = None
 
@@ -147,6 +148,21 @@ class DefaultLLMEventAdapter:
 
             if raw.get("usage"):
                 usage = _dict_or_empty(raw.get("usage"))
+
+            response_events, consumed_response_chunk = self._normalize_responses_stream_chunk(
+                raw,
+                response_tool_drafts,
+            )
+            for event in response_events:
+                if event.type == LLMEventType.TEXT_DELTA and not text_started:
+                    yield LLMEvent(LLMEventType.TEXT_START, part_id=text_part_id, raw=raw)
+                    text_started = True
+                if event.type in (LLMEventType.TEXT_DELTA, LLMEventType.TEXT_END):
+                    event.part_id = event.part_id or text_part_id
+                yield event
+            if consumed_response_chunk:
+                finish_reason = finish_reason or _extract_finish_reason(raw)
+                continue
 
             for event in self._normalize_simple_chunk(raw):
                 if event.type == LLMEventType.TEXT_DELTA and not text_started:
@@ -256,9 +272,116 @@ class DefaultLLMEventAdapter:
                     raw=draft.raw,
                 )
 
+        for draft in sorted(response_tool_drafts.values(), key=lambda item: item.index):
+            if draft.started:
+                yield LLMEvent(
+                    LLMEventType.TOOL_INPUT_END,
+                    tool_call_id=draft.id,
+                    tool_name=draft.name,
+                    text=draft.arguments_text,
+                    raw=draft.raw,
+                )
+                tool_call = _make_tool_call(
+                    {
+                        "id": draft.id,
+                        "type": "function",
+                        "function": {
+                            "name": draft.name,
+                            "arguments": draft.arguments_text,
+                        },
+                    },
+                    draft.index,
+                )
+                yield LLMEvent(
+                    LLMEventType.TOOL_CALL_COMPLETE,
+                    tool_call_id=tool_call.call_id,
+                    tool_name=tool_call.tool_name,
+                    tool_call=tool_call,
+                    raw=draft.raw,
+                )
+
         if started:
             metadata = {"finish_reason": finish_reason} if finish_reason else {}
             yield LLMEvent(LLMEventType.STEP_FINISH, usage=usage, metadata=metadata)
+
+    def _normalize_responses_stream_chunk(
+        self,
+        raw: Mapping[str, Any],
+        response_tool_drafts: Dict[str, _ToolCallDraft],
+    ) -> tuple[List[LLMEvent], bool]:
+        response_type = raw.get("type")
+        if not isinstance(response_type, str) or not response_type.startswith("response."):
+            return [], False
+
+        if response_type in {"response.output_text.delta"}:
+            delta = str(raw.get("delta") or "")
+            return [LLMEvent(LLMEventType.TEXT_DELTA, delta=delta, text=delta, raw=dict(raw))], True
+
+        if response_type in {
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+        }:
+            delta = str(raw.get("delta") or "")
+            return [LLMEvent(LLMEventType.REASONING_DELTA, delta=delta, text=delta, raw=dict(raw))], True
+
+        if response_type == "response.function_call_arguments.delta":
+            call_id = _response_call_id(raw, response_tool_drafts)
+            draft = _response_tool_draft(response_tool_drafts, call_id, raw)
+            delta = str(raw.get("delta") or "")
+            events = _ensure_response_tool_started(draft)
+            if delta:
+                draft.arguments_chunks.append(delta)
+                draft.raw.update(dict(raw))
+                events.append(
+                    LLMEvent(
+                        LLMEventType.TOOL_INPUT_DELTA,
+                        tool_call_id=draft.id,
+                        tool_name=draft.name,
+                        delta=delta,
+                        text=delta,
+                        raw=dict(draft.raw),
+                    )
+                )
+            return events, True
+
+        if response_type in {"response.output_item.added", "response.output_item.done"}:
+            item = raw.get("item")
+            if not isinstance(item, Mapping) or not _is_responses_function_call_item(item):
+                return [], True
+            call_id = _response_item_draft_key(raw, item, response_tool_drafts)
+            draft = _response_tool_draft(response_tool_drafts, call_id, raw, item=item)
+            events = _ensure_response_tool_started(draft)
+            arguments = item.get("arguments")
+            if arguments not in (None, "") and not draft.arguments_text:
+                arguments_text = _copilot_stream_value_text(arguments)
+                draft.arguments_chunks.append(arguments_text)
+                events.append(
+                    LLMEvent(
+                        LLMEventType.TOOL_INPUT_DELTA,
+                        tool_call_id=draft.id,
+                        tool_name=draft.name,
+                        delta=arguments_text,
+                        text=arguments_text,
+                        raw=dict(draft.raw),
+                    )
+                )
+            if response_type == "response.output_item.done":
+                events.extend(_complete_response_tool_draft(draft))
+                response_tool_drafts.pop(call_id, None)
+            return events, True
+
+        if response_type == "response.function_call_arguments.done":
+            call_id = _response_call_id(raw, response_tool_drafts)
+            draft = _response_tool_draft(response_tool_drafts, call_id, raw)
+            arguments = raw.get("arguments")
+            if arguments not in (None, "") and not draft.arguments_text:
+                draft.arguments_chunks.append(_copilot_stream_value_text(arguments))
+            events = _ensure_response_tool_started(draft)
+            events.extend(_complete_response_tool_draft(draft))
+            response_tool_drafts.pop(call_id, None)
+            return events, True
+
+        return [], True
 
     def _normalize_simple_chunk(self, raw: Mapping[str, Any]) -> List[LLMEvent]:
         event_type = raw.get("type") or raw.get("event")
@@ -280,7 +403,11 @@ class DefaultLLMEventAdapter:
         if response_type in {"response.output_text.delta", "output_text.delta"}:
             delta = str(raw.get("delta") or "")
             return [LLMEvent(LLMEventType.TEXT_DELTA, delta=delta, text=delta, raw=dict(raw))]
-        if response_type in {"response.reasoning_text.delta", "reasoning_delta"}:
+        if response_type in {
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+            "reasoning_delta",
+        }:
             delta = str(raw.get("delta") or "")
             return [LLMEvent(LLMEventType.REASONING_DELTA, delta=delta, text=delta, raw=dict(raw))]
         if response_type in {
@@ -572,6 +699,121 @@ def _format_error(error: Any) -> str:
         if message:
             return str(message)
     return str(error)
+
+
+def _response_call_id(
+    raw: Mapping[str, Any],
+    drafts: Mapping[str, _ToolCallDraft],
+    *,
+    fallback: Any = None,
+) -> str:
+    for key in ("call_id", "id", "item_id", "tool_call_id"):
+        value = raw.get(key)
+        if value not in (None, ""):
+            return str(value)
+    if fallback not in (None, ""):
+        return str(fallback)
+    output_index = raw.get("output_index")
+    if output_index not in (None, ""):
+        return f"call_{output_index}"
+    return f"call_{len(drafts)}"
+
+
+def _response_tool_draft(
+    drafts: Dict[str, _ToolCallDraft],
+    call_id: str,
+    raw: Mapping[str, Any],
+    *,
+    item: Mapping[str, Any] | None = None,
+) -> _ToolCallDraft:
+    draft = drafts.get(call_id)
+    source = item if item is not None else raw
+    if draft is None:
+        draft = _ToolCallDraft(
+            index=len(drafts),
+            id=str(source.get("call_id") or source.get("id") or call_id),
+            name=str(source.get("name") or source.get("tool_name") or ""),
+            raw=dict(raw),
+        )
+        drafts[call_id] = draft
+    else:
+        draft.raw.update(dict(raw))
+        if source.get("call_id") or source.get("id"):
+            draft.id = str(source.get("call_id") or source.get("id"))
+        if source.get("name") or source.get("tool_name"):
+            draft.name = str(source.get("name") or source.get("tool_name"))
+    if item is not None:
+        draft.raw["item"] = dict(item)
+    return draft
+
+
+def _response_item_draft_key(
+    raw: Mapping[str, Any],
+    item: Mapping[str, Any],
+    drafts: Mapping[str, _ToolCallDraft],
+) -> str:
+    for value in (raw.get("item_id"), item.get("id"), item.get("call_id")):
+        if value not in (None, ""):
+            return str(value)
+    return _response_call_id(item, drafts)
+
+
+def _ensure_response_tool_started(draft: _ToolCallDraft) -> List[LLMEvent]:
+    if draft.started:
+        return []
+    draft.started = True
+    return [
+        LLMEvent(
+            LLMEventType.TOOL_INPUT_START,
+            tool_call_id=draft.id,
+            tool_name=draft.name,
+            raw=dict(draft.raw),
+        )
+    ]
+
+
+def _complete_response_tool_draft(draft: _ToolCallDraft) -> List[LLMEvent]:
+    tool_call = _make_tool_call(
+        {
+            "id": draft.id,
+            "type": "function",
+            "function": {
+                "name": draft.name,
+                "arguments": draft.arguments_text,
+            },
+        },
+        draft.index,
+    )
+    return [
+        LLMEvent(
+            LLMEventType.TOOL_INPUT_END,
+            tool_call_id=draft.id,
+            tool_name=draft.name,
+            text=draft.arguments_text,
+            raw=dict(draft.raw),
+        ),
+        LLMEvent(
+            LLMEventType.TOOL_CALL_COMPLETE,
+            tool_call_id=tool_call.call_id,
+            tool_name=tool_call.tool_name,
+            tool_call=tool_call,
+            raw=dict(draft.raw),
+        ),
+    ]
+
+
+def _is_responses_function_call_item(item: Mapping[str, Any]) -> bool:
+    return str(item.get("type") or "") in {"function_call", "tool_call"}
+
+
+def _copilot_stream_value_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ""
+    if isinstance(value, (Mapping, list)):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return str(value)
 
 
 _LLM_EVENT_TYPE_VALUES = {event_type.value for event_type in LLMEventType}

--- a/src/efp_runtime/llm/adapter.py
+++ b/src/efp_runtime/llm/adapter.py
@@ -19,6 +19,8 @@ class _ToolCallDraft:
     arguments_chunks: List[str] = field(default_factory=list)
     raw: Dict[str, Any] = field(default_factory=dict)
     started: bool = False
+    input_ended: bool = False
+    completed: bool = False
 
     @property
     def arguments_text(self) -> str:
@@ -273,32 +275,8 @@ class DefaultLLMEventAdapter:
                 )
 
         for draft in sorted(response_tool_drafts.values(), key=lambda item: item.index):
-            if draft.started:
-                yield LLMEvent(
-                    LLMEventType.TOOL_INPUT_END,
-                    tool_call_id=draft.id,
-                    tool_name=draft.name,
-                    text=draft.arguments_text,
-                    raw=draft.raw,
-                )
-                tool_call = _make_tool_call(
-                    {
-                        "id": draft.id,
-                        "type": "function",
-                        "function": {
-                            "name": draft.name,
-                            "arguments": draft.arguments_text,
-                        },
-                    },
-                    draft.index,
-                )
-                yield LLMEvent(
-                    LLMEventType.TOOL_CALL_COMPLETE,
-                    tool_call_id=tool_call.call_id,
-                    tool_name=tool_call.tool_name,
-                    tool_call=tool_call,
-                    raw=draft.raw,
-                )
+            for event in _complete_response_tool_draft(draft):
+                yield event
 
         if started:
             metadata = {"finish_reason": finish_reason} if finish_reason else {}
@@ -367,7 +345,6 @@ class DefaultLLMEventAdapter:
                 )
             if response_type == "response.output_item.done":
                 events.extend(_complete_response_tool_draft(draft))
-                response_tool_drafts.pop(call_id, None)
             return events, True
 
         if response_type == "response.function_call_arguments.done":
@@ -377,8 +354,7 @@ class DefaultLLMEventAdapter:
             if arguments not in (None, "") and not draft.arguments_text:
                 draft.arguments_chunks.append(_copilot_stream_value_text(arguments))
             events = _ensure_response_tool_started(draft)
-            events.extend(_complete_response_tool_draft(draft))
-            response_tool_drafts.pop(call_id, None)
+            events.extend(_end_response_tool_input(draft))
             return events, True
 
         return [], True
@@ -772,7 +748,27 @@ def _ensure_response_tool_started(draft: _ToolCallDraft) -> List[LLMEvent]:
     ]
 
 
+def _end_response_tool_input(draft: _ToolCallDraft) -> List[LLMEvent]:
+    if draft.input_ended:
+        return []
+    draft.input_ended = True
+    return [
+        LLMEvent(
+            LLMEventType.TOOL_INPUT_END,
+            tool_call_id=draft.id,
+            tool_name=draft.name,
+            text=draft.arguments_text,
+            raw=dict(draft.raw),
+        )
+    ]
+
+
 def _complete_response_tool_draft(draft: _ToolCallDraft) -> List[LLMEvent]:
+    if draft.completed:
+        return []
+    events = _ensure_response_tool_started(draft)
+    events.extend(_end_response_tool_input(draft))
+    draft.completed = True
     tool_call = _make_tool_call(
         {
             "id": draft.id,
@@ -784,22 +780,16 @@ def _complete_response_tool_draft(draft: _ToolCallDraft) -> List[LLMEvent]:
         },
         draft.index,
     )
-    return [
-        LLMEvent(
-            LLMEventType.TOOL_INPUT_END,
-            tool_call_id=draft.id,
-            tool_name=draft.name,
-            text=draft.arguments_text,
-            raw=dict(draft.raw),
-        ),
+    events.append(
         LLMEvent(
             LLMEventType.TOOL_CALL_COMPLETE,
             tool_call_id=tool_call.call_id,
             tool_name=tool_call.tool_name,
             tool_call=tool_call,
             raw=dict(draft.raw),
-        ),
-    ]
+        )
+    )
+    return events
 
 
 def _is_responses_function_call_item(item: Mapping[str, Any]) -> bool:

--- a/src/efp_runtime/llm/events.py
+++ b/src/efp_runtime/llm/events.py
@@ -14,14 +14,19 @@ class LLMEventType(str, Enum):
     TEXT_START = "text_start"
     TEXT_DELTA = "text_delta"
     TEXT_END = "text_end"
+    REASONING_START = "reasoning_start"
     REASONING_DELTA = "reasoning_delta"
+    REASONING_END = "reasoning_end"
     TOOL_INPUT_START = "tool_input_start"
     TOOL_INPUT_DELTA = "tool_input_delta"
     TOOL_INPUT_END = "tool_input_end"
     TOOL_CALL_COMPLETE = "tool_call_complete"
     TOOL_RESULT = "tool_result"
+    TOOL_ERROR = "tool_error"
     STEP_START = "step_start"
     STEP_FINISH = "step_finish"
+    FINISH = "finish"
+    PROVIDER_ERROR = "provider_error"
     ERROR = "error"
 
 
@@ -42,6 +47,7 @@ class LLMEvent:
     error: Optional[str] = None
     raw: Dict[str, Any] = field(default_factory=dict)
     metadata: Dict[str, Any] = field(default_factory=dict)
+    provider_metadata: Dict[str, Any] = field(default_factory=dict)
 
     @property
     def type_value(self) -> str:

--- a/src/efp_runtime/llm/provider.py
+++ b/src/efp_runtime/llm/provider.py
@@ -8,7 +8,7 @@ provider data.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterable, Iterable, Mapping
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 import inspect
@@ -162,10 +162,83 @@ class GitHubCopilotHTTPTransport:
 
     async def send(self, payload: dict[str, Any]) -> TransportOutput:
         if payload.get("stream") is True:
-            raise ProviderTransportError(
-                "GitHub Copilot HTTP transport does not support streaming responses"
-            )
+            return self._send_stream(payload)
         return await asyncio.to_thread(self._send_sync, payload)
+
+    async def _send_stream(self, payload: dict[str, Any]) -> AsyncIterator[Mapping[str, Any]]:
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        done = object()
+        loop = asyncio.get_running_loop()
+
+        def worker() -> None:
+            try:
+                for chunk in self._send_stream_sync(payload):
+                    loop.call_soon_threadsafe(queue.put_nowait, chunk)
+            except BaseException as exc:  # noqa: BLE001 - propagated through async iterator.
+                loop.call_soon_threadsafe(queue.put_nowait, exc)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, done)
+
+        task = asyncio.create_task(asyncio.to_thread(worker))
+        try:
+            while True:
+                item = await queue.get()
+                if item is done:
+                    break
+                if isinstance(item, BaseException):
+                    raise item
+                yield item
+        finally:
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+        if not task.done():
+            await task
+
+    def _send_stream_sync(self, payload: dict[str, Any]) -> Iterable[Mapping[str, Any]]:
+        try:
+            body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise ProviderTransportError(
+                "GitHub Copilot HTTP transport received a non-JSON payload"
+            ) from exc
+
+        request = urllib_request.Request(
+            self.endpoint,
+            data=body,
+            headers=self._headers(stream=True),
+            method="POST",
+        )
+        try:
+            with urllib_request.urlopen(request, timeout=self.timeout) as response:
+                yield from parse_sse_json_events(_iter_response_lines(response))
+        except urllib_error.HTTPError as exc:
+            response_text = _read_http_error_body(exc)
+            model_unavailable_error = _model_unavailable_error_from_http_error(
+                exc,
+                response_text=response_text,
+                token=self._token,
+            )
+            if model_unavailable_error is not None:
+                raise model_unavailable_error from None
+            message = _format_http_error(
+                exc,
+                self._token,
+                response_text=response_text,
+            )
+            raise ProviderTransportError(message) from None
+        except urllib_error.URLError as exc:
+            reason = _redact_secret(str(getattr(exc, "reason", exc)), self._token)
+            raise ProviderTransportError(
+                "GitHub Copilot HTTP transport failed: {0}".format(reason)
+            ) from None
+        except TimeoutError:
+            raise ProviderTransportError(
+                _format_timeout_message("GitHub Copilot HTTP transport", self.timeout)
+            ) from None
 
     def _send_sync(self, payload: dict[str, Any]) -> dict[str, Any]:
         try:
@@ -228,11 +301,11 @@ class GitHubCopilotHTTPTransport:
             )
         return data
 
-    def _headers(self) -> dict[str, str]:
+    def _headers(self, *, stream: bool = False) -> dict[str, str]:
         return {
             "Authorization": "Bearer {0}".format(self._token),
             "Content-Type": "application/json",
-            "Accept": "application/vnd.github.copilot-chat-preview+json",
+            "Accept": "text/event-stream" if stream else "application/vnd.github.copilot-chat-preview+json",
             "User-Agent": self.user_agent,
             "Editor-Version": self.editor_version,
             "Editor-Plugin-Version": self.editor_plugin_version,
@@ -455,6 +528,44 @@ def github_copilot_provider_from_env(
         reasoning_effort=configured_reasoning_effort,
         adapter=adapter,
     )
+
+
+def parse_sse_json_events(lines: Iterable[bytes | str]) -> Iterable[Mapping[str, Any]]:
+    """Parse text/event-stream data blocks into JSON object chunks."""
+
+    data_lines: list[str] = []
+
+    def flush() -> Iterable[Mapping[str, Any]]:
+        if not data_lines:
+            return []
+        raw_data = "\n".join(data_lines).strip()
+        data_lines.clear()
+        if not raw_data or raw_data == "[DONE]":
+            return []
+        try:
+            parsed = json.loads(raw_data)
+        except json.JSONDecodeError as exc:
+            raise ProviderTransportError(
+                "GitHub Copilot HTTP transport returned invalid SSE JSON"
+            ) from exc
+        if isinstance(parsed, Mapping):
+            return [dict(parsed)]
+        return [{"data": parsed}]
+
+    for raw_line in lines:
+        if isinstance(raw_line, bytes):
+            line = raw_line.decode("utf-8", errors="replace")
+        else:
+            line = str(raw_line)
+        line = line.rstrip("\r\n")
+        if not line:
+            yield from flush()
+            continue
+        if line.startswith("#"):
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    yield from flush()
 
 
 def validate_copilot_reasoning_effort(value: Any) -> str:
@@ -1010,6 +1121,14 @@ def _read_http_error_body(exc: urllib_error.HTTPError) -> str:
         return ""
 
 
+def _iter_response_lines(response: Any) -> Iterable[bytes]:
+    while True:
+        line = response.readline()
+        if not line:
+            break
+        yield line
+
+
 def _redact_secret(text: str, secret: str) -> str:
     if not text or not secret:
         return text
@@ -1082,6 +1201,7 @@ __all__ = [
     "exchange_github_token_for_copilot_token",
     "github_copilot_provider_from_env",
     "is_github_source_token",
+    "parse_sse_json_events",
     "parse_copilot_api_base_url",
     "validate_copilot_reasoning_effort",
 ]

--- a/src/efp_runtime/loop/stream_events.py
+++ b/src/efp_runtime/loop/stream_events.py
@@ -12,12 +12,17 @@ from ..llm.events import LLMEvent, LLMEventType
 _RUNTIME_EVENT_TYPES = {
     LLMEventType.STEP_START.value: "llm.step_start",
     LLMEventType.TEXT_DELTA.value: "llm.text_delta",
+    LLMEventType.REASONING_START.value: "llm.reasoning_start",
     LLMEventType.REASONING_DELTA.value: "llm.reasoning_delta",
+    LLMEventType.REASONING_END.value: "llm.reasoning_end",
     LLMEventType.TOOL_INPUT_START.value: "llm.tool_call_delta",
     LLMEventType.TOOL_INPUT_DELTA.value: "llm.tool_call_delta",
     LLMEventType.TOOL_INPUT_END.value: "llm.tool_call_delta",
     LLMEventType.TOOL_CALL_COMPLETE.value: "llm.tool_call_done",
+    LLMEventType.TOOL_ERROR.value: "llm.tool_error",
     LLMEventType.STEP_FINISH.value: "llm.step_finish",
+    LLMEventType.FINISH.value: "llm.finish",
+    LLMEventType.PROVIDER_ERROR.value: "llm.provider_error",
     LLMEventType.ERROR.value: "llm.error",
 }
 
@@ -73,12 +78,22 @@ def runtime_event_from_llm_event(
         "run_id": run_id,
         "iteration": iteration,
         "llm_event_type": event.type_value,
+        "event_type": event.type_value,
     }
     _set_if_present(payload, "event_id", _event_id(event))
+    if event.metadata:
+        payload["metadata"] = dict(event.metadata)
+    if event.provider_metadata:
+        payload["provider_metadata"] = dict(event.provider_metadata)
+    safe_raw = _safe_raw_payload(event.raw)
+    if safe_raw:
+        payload["raw"] = safe_raw
 
     if event.type_value in (
         LLMEventType.TEXT_DELTA.value,
+        LLMEventType.REASONING_START.value,
         LLMEventType.REASONING_DELTA.value,
+        LLMEventType.REASONING_END.value,
     ):
         delta = event.delta or event.text
         _set_if_present(payload, "delta", delta)
@@ -89,17 +104,26 @@ def runtime_event_from_llm_event(
         LLMEventType.TOOL_INPUT_DELTA.value,
         LLMEventType.TOOL_INPUT_END.value,
         LLMEventType.TOOL_CALL_COMPLETE.value,
+        LLMEventType.TOOL_ERROR.value,
     ):
         _set_if_present(payload, "tool_call_id", event.tool_call_id)
         _set_if_present(payload, "tool_name", event.tool_name)
         _add_tool_arguments(payload, event)
 
-    if event.type_value == LLMEventType.STEP_FINISH.value and event.usage:
+    if event.type_value in {LLMEventType.STEP_FINISH.value, LLMEventType.FINISH.value} and event.usage:
         payload["usage"] = dict(event.usage)
     if event.metadata.get("finish_reason"):
         payload["finish_reason"] = event.metadata["finish_reason"]
-    if event.type_value == LLMEventType.ERROR.value:
+    if event.type_value in {
+        LLMEventType.ERROR.value,
+        LLMEventType.PROVIDER_ERROR.value,
+        LLMEventType.TOOL_ERROR.value,
+    }:
         _set_if_present(payload, "error", event.error or event.text)
+        _set_if_present(payload, "message", event.error or event.text)
+        _set_if_present(payload, "code", event.metadata.get("code"))
+        if "retryable" in event.metadata:
+            payload["retryable"] = event.metadata["retryable"]
 
     return RuntimeEvent(
         type=runtime_type,
@@ -167,6 +191,41 @@ def _event_id(event: LLMEvent) -> Optional[str]:
         if value is not None:
             return str(value)
     return None
+
+
+def _safe_raw_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
+    allowed_keys = {
+        "type",
+        "id",
+        "item_id",
+        "output_index",
+        "summary_index",
+        "call_id",
+        "tool_call_id",
+        "finish_reason",
+        "code",
+        "message",
+        "param",
+        "sequence_number",
+    }
+    payload = {key: raw[key] for key in allowed_keys if key in raw}
+    response = raw.get("response")
+    if isinstance(response, Mapping):
+        safe_response = {
+            key: response[key]
+            for key in ("id", "service_tier", "incomplete_details", "usage", "error")
+            if key in response
+        }
+        if safe_response:
+            payload["response"] = safe_response
+    item = raw.get("item")
+    if isinstance(item, Mapping):
+        payload["item"] = {
+            key: item[key]
+            for key in ("type", "id", "call_id", "name", "status")
+            if key in item
+        }
+    return payload
 
 
 def _mapping_value(mapping: Mapping[str, Any], key: str) -> Optional[Any]:

--- a/src/efp_runtime/session/processor.py
+++ b/src/efp_runtime/session/processor.py
@@ -52,6 +52,8 @@ class SessionProcessor:
         self._text_buffers: Dict[str, List[str]] = {}
         self._active_text_part_id: Optional[str] = None
         self._reasoning_part: Optional[MessagePart] = None
+        self._reasoning_parts: Dict[str, MessagePart] = {}
+        self._active_reasoning_part_id: Optional[str] = None
         self._tool_inputs: Dict[str, _ToolInputDraft] = {}
 
     async def consume(
@@ -90,9 +92,19 @@ class SessionProcessor:
             self._finalize_text_part(event.part_id, event.text)
             return
 
+        if event_type == LLMEventType.REASONING_START:
+            self._ensure_assistant_message(event.message_id)
+            self._start_reasoning_part(event)
+            return
+
         if event_type == LLMEventType.REASONING_DELTA:
             self._ensure_assistant_message(event.message_id)
-            self._append_reasoning_delta(event.delta or event.text)
+            self._append_reasoning_delta(event)
+            return
+
+        if event_type == LLMEventType.REASONING_END:
+            self._ensure_assistant_message(event.message_id)
+            self._end_reasoning_part(event)
             return
 
         if event_type == LLMEventType.TOOL_INPUT_START:
@@ -121,6 +133,11 @@ class SessionProcessor:
             self._append_tool_result(event)
             return
 
+        if event_type == LLMEventType.TOOL_ERROR:
+            self._handle_tool_error(event)
+            self._record_runtime_event("llm.tool_error", event)
+            return
+
         if event_type == LLMEventType.STEP_FINISH:
             self._finalize_open_text_parts()
             assistant_message = self.last_assistant_message
@@ -135,12 +152,20 @@ class SessionProcessor:
             self._record_runtime_event("llm.step_finish", event)
             return
 
+        if event_type == LLMEventType.FINISH:
+            self._record_runtime_event("llm.finish", event)
+            return
+
+        if event_type == LLMEventType.PROVIDER_ERROR:
+            self._handle_provider_error(event)
+            return
+
         if event_type == LLMEventType.ERROR:
             message = self._ensure_assistant_message(event.message_id)
             message.append_part(
                 MessagePart.error_part(
                     event.error or event.text,
-                    metadata=dict(event.metadata),
+                    metadata=self._event_metadata(event),
                 )
             )
             message.status = "error"
@@ -159,6 +184,8 @@ class SessionProcessor:
         self.current_message = message
         self.last_assistant_message = message
         self._reasoning_part = None
+        self._reasoning_parts = {}
+        self._active_reasoning_part_id = None
         return message
 
     def _ensure_assistant_message(self, message_id: Optional[str] = None) -> Message:
@@ -195,19 +222,71 @@ class SessionProcessor:
         for part_id in list(self._text_buffers):
             self._finalize_text_part(part_id)
 
-    def _append_reasoning_delta(self, delta: str) -> None:
+    def _start_reasoning_part(self, event: LLMEvent) -> MessagePart | None:
+        if self.current_message is None:
+            return None
+        part_id = self._reasoning_part_id(event)
+        existing = self._reasoning_parts.get(part_id)
+        if existing is not None:
+            existing.metadata.update(self._event_metadata(event))
+            self._reasoning_part = existing
+            self._active_reasoning_part_id = part_id
+            return existing
+        part = self.current_message.append_part(
+            MessagePart(
+                type=MessagePartType.REASONING,
+                part_id=part_id,
+                reasoning="",
+                text="",
+                metadata=self._event_metadata(event),
+            )
+        )
+        self._reasoning_parts[part_id] = part
+        self._reasoning_part = part
+        self._active_reasoning_part_id = part_id
+        return part
+
+    def _append_reasoning_delta(self, event: LLMEvent) -> None:
+        delta = event.delta or event.text
         if not delta or self.current_message is None:
             return
-        if self._reasoning_part is None:
-            self._reasoning_part = self.current_message.append_part(
-                MessagePart(
-                    type=MessagePartType.REASONING,
-                    reasoning="",
-                    text="",
-                )
-            )
-        self._reasoning_part.reasoning = (self._reasoning_part.reasoning or "") + delta
-        self._reasoning_part.text = (self._reasoning_part.text or "") + delta
+        part_id = self._reasoning_part_id(event)
+        part = self._reasoning_parts.get(part_id)
+        if part is None:
+            part = self._start_reasoning_part(event)
+        if part is None:
+            return
+        part.metadata.update(self._event_metadata(event))
+        part.reasoning = (part.reasoning or "") + delta
+        part.text = (part.text or "") + delta
+        self._reasoning_part = part
+        self._active_reasoning_part_id = part_id
+
+    def _end_reasoning_part(self, event: LLMEvent) -> None:
+        part_id = self._reasoning_part_id(event)
+        part = self._reasoning_parts.get(part_id)
+        if part is None:
+            return
+        part.metadata.update(self._event_metadata(event))
+        if self._active_reasoning_part_id == part_id:
+            self._active_reasoning_part_id = None
+            self._reasoning_part = None
+
+    def _reasoning_part_id(self, event: LLMEvent) -> str:
+        return (
+            event.part_id
+            or _optional_metadata_str(event.metadata, "part_id")
+            or _optional_metadata_str(event.metadata, "reasoning_id")
+            or _optional_metadata_str(event.metadata, "item_id")
+            or self._active_reasoning_part_id
+            or "reasoning_0"
+        )
+
+    def _event_metadata(self, event: LLMEvent) -> Dict[str, Any]:
+        metadata = dict(event.metadata)
+        if event.provider_metadata:
+            metadata["provider_metadata"] = dict(event.provider_metadata)
+        return metadata
 
     def _start_tool_input(self, event: LLMEvent) -> None:
         call_id = event.tool_call_id or f"call_{len(self._tool_inputs)}"
@@ -298,6 +377,46 @@ class SessionProcessor:
         )
         message.append_part(MessagePart.tool_result_part(event.tool_result))
         self.session.messages.append(message)
+
+    def _handle_tool_error(self, event: LLMEvent) -> None:
+        call_id = event.tool_call_id or ""
+        if not call_id:
+            return
+        part = self._find_tool_call_part(call_id)
+        if part is None or part.tool_call is None:
+            return
+        part.tool_call.status = "error"
+        previous_state = part.metadata.get("tool_state")
+        previous_state = dict(previous_state) if isinstance(previous_state, dict) else {}
+        previous_time = previous_state.get("time")
+        previous_time = dict(previous_time) if isinstance(previous_time, dict) else {}
+        _set_tool_part_state(
+            part,
+            {
+                **previous_state,
+                "status": "error",
+                "error": event.error or event.text,
+                "metadata": self._event_metadata(event),
+                "time": {
+                    "start": previous_time.get("start") or part.created_at,
+                    "end": utc_now_iso(),
+                },
+            },
+        )
+
+    def _handle_provider_error(self, event: LLMEvent) -> None:
+        self._finalize_open_text_parts()
+        message = self._ensure_assistant_message(event.message_id)
+        message.append_part(
+            MessagePart.error_part(
+                event.error or event.text or "Provider error",
+                metadata=self._event_metadata(event),
+            )
+        )
+        message.status = "error"
+        message.completed_at = message.completed_at or utc_now_iso()
+        self.session.status = RuntimeStatus.ERROR
+        self._record_runtime_event("llm.provider_error", event)
 
     def _ensure_pending_tool_call_part(
         self,
@@ -430,6 +549,8 @@ class SessionProcessor:
                     "tool_call_id": event.tool_call_id,
                     "usage": dict(event.usage),
                     "error": event.error,
+                    "metadata": dict(event.metadata),
+                    "provider_metadata": dict(event.provider_metadata),
                     **dict(event.metadata),
                 },
             )
@@ -454,6 +575,13 @@ def _parse_arguments(arguments_text: str) -> Any:
         return json.loads(arguments_text)
     except json.JSONDecodeError:
         return arguments_text
+
+
+def _optional_metadata_str(metadata: Mapping[str, Any], key: str) -> Optional[str]:
+    value = metadata.get(key)
+    if value in (None, ""):
+        return None
+    return str(value)
 
 
 def _pending_tool_state(draft: _ToolInputDraft) -> dict[str, Any]:

--- a/src/efp_runtime/system_prompt.py
+++ b/src/efp_runtime/system_prompt.py
@@ -124,8 +124,11 @@ class SystemPromptBuilder:
                 )
             )
 
-        if self.include_runtime_reminders:
-            reminder = self._runtime_reminder_message(runtime_metadata)
+        if self.include_runtime_reminders or _metadata_value(runtime_metadata, "runtime_mode") == "plan":
+            reminder = self._runtime_reminder_message(
+                runtime_metadata,
+                plan_mode_only=not self.include_runtime_reminders,
+            )
             if reminder is not None:
                 messages.append(reminder)
 
@@ -202,26 +205,29 @@ class SystemPromptBuilder:
     def _runtime_reminder_message(
         self,
         metadata: Mapping[str, Any],
+        *,
+        plan_mode_only: bool = False,
     ) -> Message | None:
         lines: list[str] = []
-        max_iterations = _metadata_value(metadata, "max_iterations")
-        if max_iterations is not None:
-            lines.append(
-                f"- This run is close-bounded by max_iterations={max_iterations}; "
-                "converge on the task, avoid extra provider or tool loops, and "
-                "use available task or background capabilities when appropriate."
-            )
-        if _metadata_bool(metadata, "enable_question_tool"):
-            lines.append(
-                "- Use the question tool only when truly blocked after reading relevant context; otherwise make a supported decision."
-            )
+        if not plan_mode_only:
+            max_iterations = _metadata_value(metadata, "max_iterations")
+            if max_iterations is not None:
+                lines.append(
+                    f"- This run is close-bounded by max_iterations={max_iterations}; "
+                    "converge on the task, avoid extra provider or tool loops, and "
+                    "use available task or background capabilities when appropriate."
+                )
+            if _metadata_bool(metadata, "enable_question_tool"):
+                lines.append(
+                    "- Use the question tool only when truly blocked after reading relevant context; otherwise make a supported decision."
+                )
         if _metadata_value(metadata, "runtime_mode") == "plan":
             lines.append(
                 "- Plan mode is active: do read-only analysis, do not write files, "
                 "do not run shell commands that mutate state, and finish through "
                 "plan_exit when available."
             )
-        if _metadata_bool(
+        if not plan_mode_only and _metadata_bool(
             metadata,
             "tool_output_truncation_enabled",
             "tool_output_paths_enabled",

--- a/src/gateway/event_bus.py
+++ b/src/gateway/event_bus.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
+from collections import deque
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from datetime import datetime, timezone
+from typing import Any, Deque, Dict, List, Mapping
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +35,9 @@ class _ListenerRecord:
 class EventBus:
     """Simple in-memory event bus for agent events."""
 
-    def __init__(self):
+    def __init__(self, *, history_limit: int = 1000):
         self._listeners: List[_ListenerRecord] = []
+        self._history: Deque[str] = deque(maxlen=max(1, int(history_limit)))
         self._lock = asyncio.Lock()
 
     @staticmethod
@@ -96,15 +100,11 @@ class EventBus:
 
     async def emit(self, event_type: str, data: Dict[str, Any]):
         """Emit an event to matching listeners."""
-        import json
-
-        event = json.dumps({
-            "type": event_type,
-            "data": data,
-            "ts": asyncio.get_event_loop().time()
-        })
+        event_data = _event_record(event_type, data, ts=time.time())
+        event = _serialize_event_record(event_data)
 
         async with self._lock:
+            self._history.append(event)
             listeners = list(self._listeners)
 
         for listener in listeners:
@@ -120,16 +120,13 @@ class EventBus:
 
         This is called from sync callbacks, so we need to be careful about the event loop.
         """
-        import json
         logger.info(f"[EventBus] emit_sync: {event_type}")
 
-        event = json.dumps({
-            "type": event_type,
-            "data": data,
-            "ts": 0
-        })
+        event_data = _event_record(event_type, data, ts=time.time())
+        event = _serialize_event_record(event_data)
 
         listeners = list(self._listeners)
+        self._history.append(event)
 
         for listener in listeners:
             if not self._event_matches_filters(event_type, data, listener.filters):
@@ -139,6 +136,94 @@ class EventBus:
                 logger.info("[EventBus] Event sent to listener")
             except Exception as e:
                 logger.error(f"[EventBus] Error: {e}")
+
+    async def replay_events(
+        self,
+        *,
+        filters: Dict[str, str] | None = None,
+        replay_limit: int = 100,
+        last_event_at: str | None = None,
+    ) -> List[str]:
+        """Return recent cached events matching the same filters used by live listeners."""
+
+        normalized_filters = self._normalize_filters(filters)
+        limit = _normalize_replay_limit(replay_limit)
+        async with self._lock:
+            history = list(self._history)
+
+        matching: List[str] = []
+        for event in history:
+            parsed = _parse_event_record(event)
+            if parsed is None:
+                continue
+            data = parsed.get("data")
+            if not isinstance(data, dict):
+                continue
+            event_type = str(parsed.get("type") or "")
+            if not self._event_matches_filters(event_type, data, normalized_filters):
+                continue
+            if not _event_is_after(parsed, last_event_at):
+                continue
+            matching.append(event)
+        if limit <= 0:
+            return []
+        return matching[-limit:]
+
+
+def _event_record(event_type: str, data: Mapping[str, Any], *, ts: float) -> dict[str, Any]:
+    return {
+        "type": event_type,
+        "data": dict(data),
+        "ts": ts,
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def _serialize_event_record(record: Mapping[str, Any]) -> str:
+    import json
+
+    return json.dumps(dict(record), ensure_ascii=False, default=str)
+
+
+def _parse_event_record(event: str) -> dict[str, Any] | None:
+    import json
+
+    try:
+        parsed = json.loads(event)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _normalize_replay_limit(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 100
+    if parsed < 0:
+        return 0
+    return min(parsed, 500)
+
+
+def _event_is_after(event: Mapping[str, Any], last_event_at: str | None) -> bool:
+    if not last_event_at:
+        return True
+    marker = str(last_event_at).strip()
+    if not marker:
+        return True
+    try:
+        marker_float = float(marker)
+    except ValueError:
+        marker_float = None
+    if marker_float is not None:
+        try:
+            return float(event.get("ts") or 0) > marker_float
+        except (TypeError, ValueError):
+            return True
+    created_at = event.get("created_at")
+    if not created_at:
+        return True
+    return str(created_at) > marker
 
 
 # Global event bus instance

--- a/src/gateway/events.py
+++ b/src/gateway/events.py
@@ -26,6 +26,9 @@ async def handle_websocket(request: web.Request) -> WebSocketResponse:
     query = request.rel_url.query
     filter_keys = ("session_id", "task_id", "group_id", "coordination_run_id", "agent_id", "request_id")
     filters = {key: str(query.get(key, "")).strip() for key in filter_keys if str(query.get(key, "")).strip()}
+    replay_requested = str(query.get("replay", "")).strip().lower() in {"1", "true", "yes", "on"}
+    replay_limit = _parse_replay_limit(query.get("replay_limit"))
+    last_event_at = str(query.get("last_event_at", "")).strip() or None
 
     # Register this connection as a listener
     await event_bus.add_listener(queue, filters=filters)
@@ -54,8 +57,18 @@ async def handle_websocket(request: web.Request) -> WebSocketResponse:
         # Send welcome message
         await ws.send_str(json.dumps({
             "type": "connected",
-            "message": "Connected to EFP event bus"
+            "message": "Connected to EFP event bus",
+            "filters": filters,
         }))
+
+        if replay_requested:
+            replayed_events = await event_bus.replay_events(
+                filters=filters,
+                replay_limit=replay_limit,
+                last_event_at=last_event_at,
+            )
+            for event in replayed_events:
+                await ws.send_str(event)
         
         # Start background task to read events from queue
         event_reader = asyncio.create_task(read_events())
@@ -92,6 +105,16 @@ def setup_event_routes(app: web.Application):
     """Set up event routes."""
     app.router.add_get('/api/events', handle_websocket)
     logger.info("WebSocket event route registered: GET /api/events")
+
+
+def _parse_replay_limit(value, default: int = 100) -> int:
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+    if parsed < 0:
+        return 0
+    return min(parsed, 500)
 
 
 

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -43,6 +43,10 @@ from src.gateway.runtime_chat import (
     RuntimeChatError,
     run_runtime_chat,
 )
+from src.gateway.runtime_event_projection import (
+    RuntimeEventProjector,
+    is_projected_runtime_event,
+)
 from src.gateway.runtime_request_contracts import (
     build_stream_start_event_payload,
     extract_trusted_client_request_id,
@@ -692,6 +696,20 @@ async def _run_chat_via_execution_bus(
     )
 
 
+async def _emit_gateway_runtime_event(event_payload: Dict[str, Any]) -> None:
+    """Best-effort bridge from chat SSE events to the gateway WebSocket bus."""
+
+    try:
+        maybe_result = emit_agent_event(
+            str(event_payload.get("type") or event_payload.get("event_type") or "runtime_event"),
+            event_payload,
+        )
+        if asyncio.iscoroutine(maybe_result):
+            await maybe_result
+    except Exception:
+        logger.debug("Best-effort gateway runtime event emit failed", exc_info=True)
+
+
 def _resolve_runtime_agent_identity(request: web.Request) -> tuple[Optional[str], Optional[str]]:
     """Resolve runtime agent identity from server-side state/config, never from client body."""
     runtime_agent_id: Optional[str] = None
@@ -1270,6 +1288,12 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         # Run EFP runtime and stream runtime events where available.
         runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
         set_log_context(agent_id=runtime_agent_id)
+        runtime_event_projector = RuntimeEventProjector(
+            request_id=request_id,
+            agent_id=runtime_agent_id,
+            agent_name=runtime_agent_name,
+            model=model,
+        )
         if runtime_agent_id and session_id:
             try:
                 await publish_session_metadata(
@@ -1308,8 +1332,13 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         while not run_task.done() or not event_queue.empty():
             try:
                 event = await asyncio.wait_for(event_queue.get(), timeout=0.15)
-                escaped = str(event).replace('\n', '\\n').replace('\r', '\\r')
-                await response.write(f"event: progress\ndata: {escaped}\n\n".encode())
+                if isinstance(event, dict) and is_projected_runtime_event(event):
+                    event_payloads = [event]
+                else:
+                    event_payloads = runtime_event_projector.project(event)
+                for event_payload in event_payloads:
+                    await _emit_gateway_runtime_event(event_payload)
+                    await response.write(_sse_event_bytes("runtime_event", event_payload))
             except asyncio.TimeoutError:
                 continue
 
@@ -1403,11 +1432,19 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             metadata=execution_metadata,
         )
         if response is not None and response_prepared:
-            error_data = json.dumps(
-                {'error': str(e), "error_type": stream_error_type, "details": stream_details}
-            )
             try:
-                await response.write(f"event: error\ndata: {error_data}\n\n".encode())
+                await response.write(
+                    _sse_event_bytes(
+                        "error",
+                        {
+                            "error": str(e),
+                            "error_type": stream_error_type,
+                            "details": stream_details,
+                            "session_id": session_id,
+                            "request_id": request_id,
+                        },
+                    )
+                )
                 await response.write(_sse_event_bytes("done", {"ok": False, "session_id": session_id, "request_id": request_id}))
             except Exception:
                 pass

--- a/src/gateway/runtime_chat.py
+++ b/src/gateway/runtime_chat.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from src.config import DEFAULT_LLM_MODEL, PORTAL_MANAGED_RUNTIME_FIELDS, config
+from src.gateway.runtime_event_projection import RuntimeEventProjector
 from src.workspace_defaults import resolve_runtime_workspace
 from src.efp_runtime.event_bus import RuntimeEventBus
 from src.efp_runtime.events import RuntimeEvent
@@ -114,7 +115,18 @@ async def run_runtime_chat(
     subscription = None
     if stream_callback is not None:
         subscription = event_bus.subscribe(session_id=session_id)
-        forwarder = asyncio.create_task(_forward_runtime_events(subscription, stream_callback))
+        forwarder = asyncio.create_task(
+            _forward_runtime_events(
+                subscription,
+                stream_callback,
+                projector=RuntimeEventProjector(
+                    request_id=request_id,
+                    agent_id=agent_id,
+                    agent_name=agent_name,
+                    model=runtime_model,
+                ),
+            )
+        )
 
     run_metadata = _run_metadata(
         request_path=request_path,
@@ -361,7 +373,7 @@ def _build_github_copilot_provider(model: str) -> GitHubCopilotProvider:
         transport=transport,
         model=model,
         endpoint="responses",
-        stream=False,
+        stream=True,
         metadata={"gateway": "runtime_api"},
         reasoning_effort=_resolve_reasoning_effort(llm_config),
     )
@@ -569,16 +581,26 @@ def _compose_user_prompt(
     return "\n\n".join(parts).strip()
 
 
-async def _forward_runtime_events(subscription: Any, stream_callback: Any) -> None:
+async def _forward_runtime_events(
+    subscription: Any,
+    stream_callback: Any,
+    *,
+    projector: RuntimeEventProjector | None = None,
+) -> None:
     try:
         async for event in subscription:
-            payload = event.to_dict() if hasattr(event, "to_dict") else event
-            if hasattr(stream_callback, "put"):
-                await stream_callback.put(payload)
-            elif callable(stream_callback):
-                maybe_result = stream_callback(payload)
-                if asyncio.iscoroutine(maybe_result):
-                    await maybe_result
+            payloads = (
+                projector.project(event)
+                if projector is not None
+                else [event.to_dict() if hasattr(event, "to_dict") else event]
+            )
+            for payload in payloads:
+                if hasattr(stream_callback, "put"):
+                    await stream_callback.put(payload)
+                elif callable(stream_callback):
+                    maybe_result = stream_callback(payload)
+                    if asyncio.iscoroutine(maybe_result):
+                        await maybe_result
     except asyncio.CancelledError:
         raise
     except Exception:

--- a/src/gateway/runtime_event_projection.py
+++ b/src/gateway/runtime_event_projection.py
@@ -1,0 +1,865 @@
+"""Project native runtime events into Portal session.next event payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+from typing import Any
+
+from src.utils.redaction import redact_value, safe_preview
+
+
+DEFAULT_ENGINE = "efp-native"
+MAX_SHORT_ID_LENGTH = 64
+MAX_PREVIEW_LENGTH = 500
+FAILED_RUN_STATUSES = {"error", "failed", "cancelled"}
+PENDING_RUN_STATUSES = {"waiting_for_permission", "waiting_for_question"}
+FAILED_TOOL_STATUSES = {
+    "error",
+    "failed",
+    "failure",
+    "permission_denied",
+    "denied",
+    "disabled",
+}
+
+
+@dataclass
+class RuntimeEventProjector:
+    """Stateful projector for one runtime request stream."""
+
+    request_id: str | None = None
+    agent_id: str | None = None
+    agent_name: str | None = None
+    model: str | None = None
+    engine: str = DEFAULT_ENGINE
+    _text_started: set[str] = field(default_factory=set)
+    _reasoning_started: set[str] = field(default_factory=set)
+    _tool_input_started: set[str] = field(default_factory=set)
+
+    def project(self, event: Any) -> list[dict[str, Any]]:
+        raw_event = coerce_runtime_event_dict(event)
+        if is_projected_runtime_event(raw_event):
+            return [raw_event]
+
+        raw_type = _event_type(raw_event)
+        payload = _payload(raw_event)
+        created_at = _created_at(raw_event, payload)
+        outputs: list[dict[str, Any]] = []
+
+        if raw_type == "run_start":
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.step.started",
+                    state="running",
+                    summary="Runtime step started",
+                    created_at=created_at,
+                    data={
+                        "run_id": payload.get("run_id"),
+                        "model": self.model,
+                        "agent_id": self.agent_id,
+                        "agent_name": self.agent_name,
+                        "timestamp": created_at,
+                        "sessionID": _session_id(raw_event, payload),
+                        "max_iterations": payload.get("max_iterations"),
+                        "enabled_tool_ids": _redacted(payload.get("enabled_tool_ids")),
+                        "disabled_tool_ids": _redacted(payload.get("disabled_tool_ids")),
+                    },
+                )
+            )
+            return outputs
+
+        if raw_type == "iteration_start":
+            iteration = payload.get("iteration")
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "runtime.iteration.started",
+                    state="running",
+                    summary=f"Iteration {iteration} started" if iteration is not None else "Iteration started",
+                    created_at=created_at,
+                    data={"run_id": payload.get("run_id"), "iteration": iteration},
+                )
+            )
+            return outputs
+
+        if raw_type == "llm.text_delta":
+            part_id = _part_id(raw_event, payload) or _stable_part_id("text", raw_event, payload)
+            if part_id not in self._text_started:
+                self._text_started.add(part_id)
+                outputs.append(
+                    self._build(
+                        raw_event,
+                        payload,
+                        "session.next.text.started",
+                        state="running",
+                        summary="Assistant text started",
+                        created_at=created_at,
+                        part_id=part_id,
+                        data={
+                            "message_id": _message_id(raw_event, payload),
+                            "part_id": part_id,
+                            "content": "",
+                            "text": "",
+                        },
+                    )
+                )
+            delta = _text_delta(payload)
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.text.delta",
+                    state="running",
+                    summary=safe_preview(delta, 160) if delta else "Assistant text delta",
+                    created_at=created_at,
+                    part_id=part_id,
+                    data={
+                        "message_id": _message_id(raw_event, payload),
+                        "part_id": part_id,
+                        "delta": delta,
+                        "text_delta": delta,
+                        "content_delta": delta,
+                        "message_delta": delta,
+                        "content": delta,
+                        "text": delta,
+                    },
+                )
+            )
+            return outputs
+
+        if raw_type == "llm.reasoning_delta":
+            reasoning_id = _reasoning_id(raw_event, payload)
+            if reasoning_id not in self._reasoning_started:
+                self._reasoning_started.add(reasoning_id)
+                outputs.append(
+                    self._build(
+                        raw_event,
+                        payload,
+                        "session.next.reasoning.started",
+                        state="running",
+                        summary="Reasoning started",
+                        created_at=created_at,
+                        data={"reasoning_id": reasoning_id, "reasoningID": reasoning_id},
+                    )
+                )
+            delta = _text_delta(payload)
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.reasoning.delta",
+                    state="running",
+                    summary=safe_preview(delta, 160) if delta else "Reasoning delta",
+                    created_at=created_at,
+                    data={
+                        "reasoning_id": reasoning_id,
+                        "reasoningID": reasoning_id,
+                        "delta": delta,
+                        "reasoning_delta": delta,
+                        "text_delta": delta,
+                        "content": delta,
+                        "text": delta,
+                    },
+                )
+            )
+            return outputs
+
+        if raw_type == "llm.tool_call_delta":
+            return self._project_llm_tool_delta(raw_event, payload, created_at)
+
+        if raw_type == "llm.tool_call_done":
+            tool_data = _tool_data(payload)
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.tool.called",
+                    state="running",
+                    summary=_tool_summary("Tool call requested", tool_data),
+                    created_at=created_at,
+                    data=tool_data,
+                )
+            )
+            return outputs
+
+        if raw_type == "tool_call_start":
+            tool_data = _tool_data(payload)
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.tool.progress",
+                    state="running",
+                    summary=_tool_summary("Tool execution started", tool_data),
+                    created_at=created_at,
+                    data={**tool_data, "status": "running"},
+                )
+            )
+            return outputs
+
+        if raw_type == "tool_result_appended":
+            tool_data = _tool_data(payload)
+            status = str(payload.get("status") or "").strip().lower()
+            failed = status in FAILED_TOOL_STATUSES or bool(payload.get("error"))
+            target_type = "session.next.tool.failed" if failed else "session.next.tool.success"
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    target_type,
+                    state="failed" if failed else "success",
+                    summary=_tool_summary("Tool failed" if failed else "Tool completed", tool_data),
+                    created_at=created_at,
+                    data={
+                        **tool_data,
+                        "status": payload.get("status"),
+                        "success": not failed,
+                        "output_preview": _first_preview(
+                            payload,
+                            "output",
+                            "content",
+                            "result",
+                            "error",
+                        ),
+                        "content_preview": _first_preview(payload, "content", "output", "result", "error"),
+                        "error": _redacted(payload.get("error")),
+                    },
+                )
+            )
+            return outputs
+
+        if raw_type == "tool.permission_requested":
+            request_payload = _mapping_or_empty(payload.get("permission_request"))
+            data = {
+                **_tool_data(payload),
+                "permission_request": _redacted(request_payload),
+                "permissionRequest": _redacted(request_payload),
+                "permission_request_id": request_payload.get("id") or request_payload.get("request_id"),
+                "action": request_payload.get("action"),
+                "risk": request_payload.get("risk"),
+                "reason": request_payload.get("reason") or raw_event.get("message"),
+            }
+            event_payload = self._build(
+                raw_event,
+                payload,
+                "permission.requested",
+                state="pending",
+                summary="Permission requested",
+                created_at=created_at,
+                data=data,
+            )
+            event_payload["permission_request"] = data["permission_request"]
+            outputs.append(event_payload)
+            return outputs
+
+        if raw_type == "tool.question_requested":
+            question_payload = _mapping_or_empty(payload.get("question_request"))
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "question.requested",
+                    state="pending",
+                    summary="Question requested",
+                    created_at=created_at,
+                    data={
+                        **_tool_data(payload),
+                        "question_request": _redacted(question_payload),
+                        "questionRequest": _redacted(question_payload),
+                        "question_request_id": question_payload.get("id") or question_payload.get("request_id"),
+                        "question": question_payload.get("question") or question_payload.get("prompt") or raw_event.get("message"),
+                    },
+                )
+            )
+            return outputs
+
+        if raw_type in {"session_compaction_started", "provider.context_overflow_retry"}:
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.compaction.started",
+                    state="running",
+                    summary=raw_event.get("message") or "Compaction started",
+                    created_at=created_at,
+                    data=_compaction_data(payload),
+                )
+            )
+            return outputs
+
+        if raw_type in {
+            "session_compacted",
+            "session_compaction_completed",
+            "overflow_retry.compaction_applied",
+        }:
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.compaction.ended",
+                    state="success",
+                    summary=raw_event.get("message") or "Compaction completed",
+                    created_at=created_at,
+                    data=_compaction_data(payload),
+                )
+            )
+            return outputs
+
+        if raw_type == "usage.updated":
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "usage.updated",
+                    state="running",
+                    summary="Usage updated",
+                    created_at=created_at,
+                    data={
+                        "run_id": payload.get("run_id"),
+                        "iteration": payload.get("iteration"),
+                        "usage": _redacted(payload.get("usage")),
+                        "step_usage": _redacted(payload.get("step_usage")),
+                        "iteration_usage": _redacted(payload.get("iteration_usage")),
+                        "pricing_enabled": payload.get("pricing_enabled"),
+                    },
+                )
+            )
+            return outputs
+
+        if raw_type == "run_finish":
+            status = str(payload.get("status") or "").strip().lower()
+            failed = status in FAILED_RUN_STATUSES
+            pending = status in PENDING_RUN_STATUSES
+            outputs.extend(self._project_open_parts_ended(raw_event, payload, created_at))
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.step.failed" if failed else "session.next.step.ended",
+                    state="failed" if failed else "pending" if pending else "success",
+                    summary=f"Runtime step {status or 'finished'}",
+                    created_at=created_at,
+                    data={
+                        "run_id": payload.get("run_id"),
+                        "status": payload.get("status"),
+                        "iterations": payload.get("iterations"),
+                        "usage": _redacted(payload.get("usage")),
+                        "tokens": _tokens_from_usage(payload.get("usage")),
+                        "cost": _cost_from_usage(payload.get("usage")),
+                        "terminal_reason": payload.get("terminal_reason"),
+                    },
+                )
+            )
+            return outputs
+
+        if raw_type == "llm.step_finish":
+            outputs.extend(self._project_open_parts_ended(raw_event, payload, created_at))
+            return outputs
+
+        if raw_type in {"error", "llm.error", "run_cancelled"}:
+            outputs.extend(self._project_open_parts_ended(raw_event, payload, created_at))
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.step.failed",
+                    state="failed",
+                    summary=raw_event.get("message") or safe_preview(payload.get("error"), 160) or "Runtime step failed",
+                    created_at=created_at,
+                    data={
+                        "run_id": payload.get("run_id"),
+                        "iteration": payload.get("iteration"),
+                        "phase": payload.get("phase"),
+                        "error": _redacted(payload.get("error") or raw_event.get("message")),
+                        "error_type": payload.get("error_type"),
+                    },
+                )
+            )
+            return outputs
+
+        outputs.append(
+            self._build(
+                raw_event,
+                payload,
+                "runtime.event",
+                state=_state_from_payload(payload),
+                summary=raw_event.get("message") or raw_type,
+                created_at=created_at,
+                data={
+                    "run_id": payload.get("run_id"),
+                    "iteration": payload.get("iteration"),
+                    "payload_preview": safe_preview(payload, MAX_PREVIEW_LENGTH),
+                },
+            )
+        )
+        return outputs
+
+    def _project_llm_tool_delta(
+        self,
+        raw_event: Mapping[str, Any],
+        payload: Mapping[str, Any],
+        created_at: str,
+    ) -> list[dict[str, Any]]:
+        llm_event_type = str(payload.get("llm_event_type") or "").strip()
+        call_id = _short_call_id(payload.get("tool_call_id") or payload.get("call_id"))
+        outputs: list[dict[str, Any]] = []
+        tool_data = _tool_data(payload)
+        tool_data["llm_event_type"] = llm_event_type
+
+        if llm_event_type == "tool_input_start":
+            if call_id:
+                self._tool_input_started.add(call_id)
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.tool.input.started",
+                    state="running",
+                    summary=_tool_summary("Tool input started", tool_data),
+                    created_at=created_at,
+                    data=tool_data,
+                )
+            )
+            return outputs
+
+        if call_id and call_id not in self._tool_input_started:
+            self._tool_input_started.add(call_id)
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.tool.input.started",
+                    state="running",
+                    summary=_tool_summary("Tool input started", tool_data),
+                    created_at=created_at,
+                    data=tool_data,
+                )
+            )
+
+        if llm_event_type == "tool_input_delta":
+            delta = str(payload.get("arguments_delta") or payload.get("delta") or payload.get("text") or "")
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.tool.input.delta",
+                    state="running",
+                    summary=safe_preview(delta, 160) if delta else _tool_summary("Tool input delta", tool_data),
+                    created_at=created_at,
+                    data={
+                        **tool_data,
+                        "delta": delta,
+                        "input_delta": delta,
+                        "arguments_delta": delta,
+                        "input_preview": safe_preview(delta, MAX_PREVIEW_LENGTH),
+                        "arguments_preview": safe_preview(delta, MAX_PREVIEW_LENGTH),
+                    },
+                )
+            )
+            return outputs
+
+        if llm_event_type == "tool_input_end":
+            arguments = payload.get("arguments")
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.tool.input.ended",
+                    state="running",
+                    summary=_tool_summary("Tool input ended", tool_data),
+                    created_at=created_at,
+                    data={
+                        **tool_data,
+                        "arguments": _redacted(arguments),
+                        "input": _redacted(arguments),
+                        "input_preview": safe_preview(arguments, MAX_PREVIEW_LENGTH),
+                        "arguments_preview": safe_preview(arguments, MAX_PREVIEW_LENGTH),
+                    },
+                )
+            )
+            return outputs
+
+        outputs.append(
+            self._build(
+                raw_event,
+                payload,
+                "session.next.tool.input.delta",
+                state="running",
+                summary=_tool_summary("Tool input event", tool_data),
+                created_at=created_at,
+                data=tool_data,
+            )
+        )
+        return outputs
+
+    def _project_open_parts_ended(
+        self,
+        raw_event: Mapping[str, Any],
+        payload: Mapping[str, Any],
+        created_at: str,
+    ) -> list[dict[str, Any]]:
+        outputs: list[dict[str, Any]] = []
+        for part_id in sorted(self._text_started):
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.text.ended",
+                    state="success",
+                    summary="Assistant text ended",
+                    created_at=created_at,
+                    part_id=part_id,
+                    data={"part_id": part_id, "message_id": _message_id(raw_event, payload)},
+                )
+            )
+        self._text_started.clear()
+        for reasoning_id in sorted(self._reasoning_started):
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.reasoning.ended",
+                    state="success",
+                    summary="Reasoning ended",
+                    created_at=created_at,
+                    data={"reasoning_id": reasoning_id, "reasoningID": reasoning_id},
+                )
+            )
+        self._reasoning_started.clear()
+        return outputs
+
+    def _build(
+        self,
+        raw_event: Mapping[str, Any],
+        payload: Mapping[str, Any],
+        target_type: str,
+        *,
+        state: str,
+        summary: Any,
+        created_at: str,
+        data: Mapping[str, Any] | None = None,
+        part_id: str | None = None,
+    ) -> dict[str, Any]:
+        raw_type = _event_type(raw_event)
+        session_id = _session_id(raw_event, payload)
+        message_id = _message_id(raw_event, payload)
+        resolved_part_id = part_id or _part_id(raw_event, payload)
+        clean_data = {
+            "type": target_type,
+            "event_type": target_type,
+            "engine": self.engine,
+            "session_id": session_id,
+            "request_id": self.request_id,
+            "agent_id": self.agent_id,
+            "agent_name": self.agent_name,
+            "model": self.model,
+            "message_id": message_id,
+            "part_id": resolved_part_id,
+            "raw_type": raw_type,
+            "created_at": created_at,
+            "state": state,
+            "summary": safe_preview(summary, 240),
+        }
+        clean_data.update({key: value for key, value in dict(data or {}).items() if value is not None})
+        clean_data = _redacted(clean_data)
+        event_id = _event_id(
+            target_type=target_type,
+            raw_event=raw_event,
+            payload=payload,
+            request_id=self.request_id,
+            session_id=session_id,
+            part_id=resolved_part_id,
+        )
+        return {
+            "id": event_id,
+            "type": target_type,
+            "event_type": target_type,
+            "engine": self.engine,
+            "session_id": session_id,
+            "request_id": self.request_id,
+            "agent_id": self.agent_id,
+            "message_id": message_id,
+            "part_id": resolved_part_id,
+            "raw_type": raw_type,
+            "created_at": created_at,
+            "state": state,
+            "summary": clean_data["summary"],
+            "properties": dict(clean_data),
+            "data": dict(clean_data),
+        }
+
+
+def project_runtime_event(
+    event: Any,
+    *,
+    request_id: str | None = None,
+    agent_id: str | None = None,
+    agent_name: str | None = None,
+    model: str | None = None,
+    engine: str = DEFAULT_ENGINE,
+) -> list[dict[str, Any]]:
+    return RuntimeEventProjector(
+        request_id=request_id,
+        agent_id=agent_id,
+        agent_name=agent_name,
+        model=model,
+        engine=engine,
+    ).project(event)
+
+
+def coerce_runtime_event_dict(event: Any) -> dict[str, Any]:
+    if hasattr(event, "to_dict"):
+        converted = event.to_dict()
+        if isinstance(converted, Mapping):
+            return dict(converted)
+    if isinstance(event, Mapping):
+        return dict(event)
+    if isinstance(event, str):
+        text = event.strip()
+        if text.startswith("{") and text.endswith("}"):
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, Mapping):
+                    return dict(parsed)
+            except json.JSONDecodeError:
+                pass
+        return {"type": "runtime.message", "message": safe_preview(event, MAX_PREVIEW_LENGTH), "payload": {"text": event}}
+    return {
+        "type": "runtime.event",
+        "message": safe_preview(event, MAX_PREVIEW_LENGTH),
+        "payload": {"value_preview": safe_preview(event, MAX_PREVIEW_LENGTH)},
+    }
+
+
+def is_projected_runtime_event(event: Mapping[str, Any]) -> bool:
+    event_type = event.get("event_type") or event.get("type")
+    return (
+        isinstance(event_type, str)
+        and (
+            event_type.startswith("session.next.")
+            or event_type in {"permission.requested", "question.requested", "usage.updated", "runtime.iteration.started", "runtime.event"}
+        )
+        and isinstance(event.get("data"), Mapping)
+        and isinstance(event.get("properties"), Mapping)
+    )
+
+
+def _event_type(event: Mapping[str, Any]) -> str:
+    value = event.get("type") or event.get("event_type") or "runtime.event"
+    return str(value)
+
+
+def _payload(event: Mapping[str, Any]) -> dict[str, Any]:
+    payload = event.get("payload")
+    if isinstance(payload, Mapping):
+        return dict(payload)
+    data = event.get("data")
+    if isinstance(data, Mapping):
+        return dict(data)
+    return {}
+
+
+def _created_at(event: Mapping[str, Any], payload: Mapping[str, Any]) -> str:
+    for value in (event.get("created_at"), payload.get("created_at"), payload.get("timestamp")):
+        if value:
+            return str(value)
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _session_id(event: Mapping[str, Any], payload: Mapping[str, Any]) -> str | None:
+    return _optional_str(event.get("session_id") or payload.get("session_id") or payload.get("sessionID"))
+
+
+def _message_id(event: Mapping[str, Any], payload: Mapping[str, Any]) -> str | None:
+    return _optional_str(event.get("message_id") or payload.get("message_id"))
+
+
+def _part_id(event: Mapping[str, Any], payload: Mapping[str, Any]) -> str | None:
+    return _optional_str(event.get("part_id") or payload.get("part_id"))
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _text_delta(payload: Mapping[str, Any]) -> str:
+    return str(payload.get("delta") or payload.get("text") or payload.get("content") or "")
+
+
+def _stable_part_id(prefix: str, raw_event: Mapping[str, Any], payload: Mapping[str, Any]) -> str:
+    digest = _digest(
+        [
+            prefix,
+            _session_id(raw_event, payload),
+            payload.get("run_id"),
+            payload.get("iteration"),
+            _message_id(raw_event, payload),
+        ]
+    )
+    return f"{prefix}_{digest[:12]}"
+
+
+def _reasoning_id(raw_event: Mapping[str, Any], payload: Mapping[str, Any]) -> str:
+    part_id = _part_id(raw_event, payload)
+    if part_id:
+        return _short_identifier(part_id, prefix="reasoning")
+    digest = _digest(
+        [
+            "reasoning",
+            _session_id(raw_event, payload),
+            payload.get("run_id"),
+            payload.get("iteration"),
+            _message_id(raw_event, payload),
+        ]
+    )
+    return f"reasoning_{digest[:12]}"
+
+
+def _tool_data(payload: Mapping[str, Any]) -> dict[str, Any]:
+    raw_call_id = payload.get("tool_call_id") or payload.get("call_id")
+    call_id = _short_call_id(raw_call_id)
+    arguments = payload.get("arguments")
+    if arguments is None and payload.get("arguments_text") is not None:
+        arguments = payload.get("arguments_text")
+    data = {
+        "tool_call_id": call_id,
+        "call_id": call_id,
+        "tool_name": payload.get("tool_name") or payload.get("name") or payload.get("tool"),
+        "arguments": _redacted(arguments),
+        "input": _redacted(arguments),
+        "arguments_preview": safe_preview(arguments, MAX_PREVIEW_LENGTH) if arguments is not None else None,
+        "input_preview": safe_preview(arguments, MAX_PREVIEW_LENGTH) if arguments is not None else None,
+        "iteration": payload.get("iteration"),
+        "run_id": payload.get("run_id"),
+    }
+    if raw_call_id is not None and str(raw_call_id) != str(call_id):
+        data["raw_call_id_hash"] = _digest([raw_call_id])[:16]
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def _short_call_id(value: Any) -> str | None:
+    if value is None:
+        return None
+    return _short_identifier(str(value), prefix="call")
+
+
+def _short_identifier(value: str, *, prefix: str) -> str:
+    text = str(value)
+    if len(text) <= MAX_SHORT_ID_LENGTH:
+        return text
+    return f"{prefix}_{_digest([text])[:16]}"
+
+
+def _first_preview(payload: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = payload.get(key)
+        if value not in (None, ""):
+            return safe_preview(value, MAX_PREVIEW_LENGTH)
+    return None
+
+
+def _tool_summary(default: str, data: Mapping[str, Any]) -> str:
+    tool_name = data.get("tool_name")
+    if tool_name:
+        return f"{default}: {tool_name}"
+    return default
+
+
+def _compaction_data(payload: Mapping[str, Any]) -> dict[str, Any]:
+    compaction = payload.get("compaction")
+    return {
+        "run_id": payload.get("run_id"),
+        "iteration": payload.get("iteration"),
+        "attempt": payload.get("attempt"),
+        "trigger": payload.get("trigger") or payload.get("compaction_trigger"),
+        "compaction": _redacted(compaction),
+        "summary_preview": _first_preview(payload, "summary", "compaction_summary"),
+        "stored_message_count": payload.get("stored_message_count"),
+        "overflow": payload.get("overflow"),
+    }
+
+
+def _mapping_or_empty(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _tokens_from_usage(usage: Any) -> Any:
+    if not isinstance(usage, Mapping):
+        return None
+    for key in ("total_tokens", "tokens"):
+        if usage.get(key) is not None:
+            return usage.get(key)
+    input_tokens = usage.get("prompt_tokens") or usage.get("input_tokens") or 0
+    output_tokens = usage.get("completion_tokens") or usage.get("output_tokens") or 0
+    if input_tokens or output_tokens:
+        return input_tokens + output_tokens
+    return None
+
+
+def _cost_from_usage(usage: Any) -> Any:
+    if not isinstance(usage, Mapping):
+        return None
+    for key in ("estimated_cost", "cost", "total_cost"):
+        if usage.get(key) is not None:
+            return usage.get(key)
+    return None
+
+
+def _state_from_payload(payload: Mapping[str, Any]) -> str:
+    status = str(payload.get("status") or payload.get("state") or "").strip().lower()
+    if status in FAILED_RUN_STATUSES or status in FAILED_TOOL_STATUSES:
+        return "failed"
+    if status in PENDING_RUN_STATUSES or status == "pending":
+        return "pending"
+    if status in {"success", "completed", "complete"}:
+        return "success"
+    return "running"
+
+
+def _event_id(
+    *,
+    target_type: str,
+    raw_event: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    request_id: str | None,
+    session_id: str | None,
+    part_id: str | None,
+) -> str:
+    source = {
+        "target_type": target_type,
+        "raw_type": _event_type(raw_event),
+        "request_id": request_id,
+        "session_id": session_id,
+        "message_id": _message_id(raw_event, payload),
+        "part_id": part_id,
+        "tool_call_id": _short_call_id(payload.get("tool_call_id") or payload.get("call_id")),
+        "run_id": payload.get("run_id"),
+        "iteration": payload.get("iteration"),
+        "llm_event_type": payload.get("llm_event_type"),
+        "created_at": raw_event.get("created_at") or payload.get("created_at") or payload.get("timestamp"),
+        "delta_hash": _digest([payload.get("delta"), payload.get("arguments_delta"), payload.get("text")])[:12],
+        "status": payload.get("status"),
+    }
+    return f"efp_{_digest([source])[:16]}"
+
+
+def _digest(parts: Any) -> str:
+    try:
+        text = json.dumps(parts, sort_keys=True, default=str, separators=(",", ":"))
+    except (TypeError, ValueError):
+        text = str(parts)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redacted(value: Any) -> Any:
+    return redact_value(value)

--- a/src/gateway/runtime_event_projection.py
+++ b/src/gateway/runtime_event_projection.py
@@ -134,6 +134,22 @@ class RuntimeEventProjector:
             )
             return outputs
 
+        if raw_type == "llm.reasoning_start":
+            reasoning_id = _reasoning_id(raw_event, payload)
+            self._reasoning_started.add(reasoning_id)
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.reasoning.started",
+                    state="running",
+                    summary="Reasoning started",
+                    created_at=created_at,
+                    data={"reasoning_id": reasoning_id, "reasoningID": reasoning_id},
+                )
+            )
+            return outputs
+
         if raw_type == "llm.reasoning_delta":
             reasoning_id = _reasoning_id(raw_event, payload)
             if reasoning_id not in self._reasoning_started:
@@ -171,6 +187,22 @@ class RuntimeEventProjector:
             )
             return outputs
 
+        if raw_type == "llm.reasoning_end":
+            reasoning_id = _reasoning_id(raw_event, payload)
+            self._reasoning_started.discard(reasoning_id)
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.reasoning.ended",
+                    state="success",
+                    summary="Reasoning ended",
+                    created_at=created_at,
+                    data={"reasoning_id": reasoning_id, "reasoningID": reasoning_id},
+                )
+            )
+            return outputs
+
         if raw_type == "llm.tool_call_delta":
             return self._project_llm_tool_delta(raw_event, payload, created_at)
 
@@ -185,6 +217,25 @@ class RuntimeEventProjector:
                     summary=_tool_summary("Tool call requested", tool_data),
                     created_at=created_at,
                     data=tool_data,
+                )
+            )
+            return outputs
+
+        if raw_type == "llm.tool_error":
+            tool_data = _tool_data(payload)
+            outputs.append(
+                self._build(
+                    raw_event,
+                    payload,
+                    "session.next.tool.failed",
+                    state="failed",
+                    summary=_tool_summary("Tool failed", tool_data),
+                    created_at=created_at,
+                    data={
+                        **tool_data,
+                        "status": "error",
+                        "error": _redacted(payload.get("error") or payload.get("message")),
+                    },
                 )
             )
             return outputs
@@ -359,11 +410,11 @@ class RuntimeEventProjector:
             )
             return outputs
 
-        if raw_type == "llm.step_finish":
+        if raw_type in {"llm.step_finish", "llm.finish"}:
             outputs.extend(self._project_open_parts_ended(raw_event, payload, created_at))
             return outputs
 
-        if raw_type in {"error", "llm.error", "run_cancelled"}:
+        if raw_type in {"error", "llm.error", "llm.provider_error", "run_cancelled"}:
             outputs.extend(self._project_open_parts_ended(raw_event, payload, created_at))
             outputs.append(
                 self._build(
@@ -379,6 +430,8 @@ class RuntimeEventProjector:
                         "phase": payload.get("phase"),
                         "error": _redacted(payload.get("error") or raw_event.get("message")),
                         "error_type": payload.get("error_type"),
+                        "code": payload.get("code"),
+                        "retryable": payload.get("retryable"),
                     },
                 )
             )

--- a/tests/_lightweight_runtime_api_loader.py
+++ b/tests/_lightweight_runtime_api_loader.py
@@ -70,6 +70,15 @@ def load_runtime_api_lightweight():
             self.error_type = error_type
             self.details = dict(details or {})
 
+    class _RuntimeEventProjector:
+        def __init__(self, **_kwargs):
+            pass
+
+        def project(self, event):
+            if isinstance(event, dict):
+                return [event]
+            return [{"type": "runtime.event", "event_type": "runtime.event", "data": {}, "properties": {}}]
+
     class _RuntimeSessionArtifacts:
         def __init__(self):
             self.storage_dir = Path("/tmp/efp-lightweight-runtime-api")
@@ -185,6 +194,11 @@ def load_runtime_api_lightweight():
             "src.gateway.runtime_request_contracts",
             build_stream_start_event_payload=lambda *_a, **_k: {},
             extract_trusted_client_request_id=lambda *_a, **_k: None,
+        ),
+        "src.gateway.runtime_event_projection": _module(
+            "src.gateway.runtime_event_projection",
+            RuntimeEventProjector=_RuntimeEventProjector,
+            is_projected_runtime_event=lambda event: isinstance(event, dict) and "event_type" in event,
         ),
         "src.runtime.capability_registry": _module("src.runtime.capability_registry", get_capability_registry=lambda: {}),
         "src.gateway.event_bus": _module("src.gateway.event_bus", emit_agent_event=lambda *_a, **_k: None),

--- a/tests/runtime/test_auto_session_compaction.py
+++ b/tests/runtime/test_auto_session_compaction.py
@@ -188,7 +188,7 @@ async def test_token_budget_converts_to_char_budget_for_auto_compaction():
     assert result.status == LoopStatus.COMPLETED
     request_metadata = provider.requests[0].provider_request.metadata
     assert request_metadata["provider_id"] == "github-copilot"
-    assert request_metadata["model_id"] == "gpt-5.4-mini"
+    assert request_metadata["model_id"] == "gpt-5.4"
     assert request_metadata["context_window_tokens"] == 400_000
     assert request_metadata["max_context_tokens"] == 20
     assert request_metadata["max_context_chars"] == 80

--- a/tests/runtime/test_llm_event_adapter.py
+++ b/tests/runtime/test_llm_event_adapter.py
@@ -186,3 +186,76 @@ async def test_streaming_responses_function_arguments_done_and_item_done_complet
     ]
     assert complete_events[0].tool_call.call_id == "call_search"
     assert complete_events[0].tool_call.arguments == {"query": "efp"}
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_output_item_nested_function_name_completes_tool_call():
+    adapter = DefaultLLMEventAdapter()
+    chunks = [
+        {
+            "type": "response.output_item.added",
+            "item_id": "fc_1",
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_search",
+                "function": {"name": "search"},
+                "arguments": "",
+            },
+        },
+        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '{"query":'},
+        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '"efp"}'},
+        {
+            "type": "response.output_item.done",
+            "item_id": "fc_1",
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_search",
+                "function": {"name": "search"},
+                "arguments": '{"query":"efp"}',
+            },
+        },
+        {"type": "response.completed", "usage": {"total_tokens": 12}},
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+    complete_events = [
+        event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE
+    ]
+
+    assert len(complete_events) == 1
+    assert complete_events[0].tool_call.call_id == "call_search"
+    assert complete_events[0].tool_call.tool_name == "search"
+    assert complete_events[0].tool_call.arguments == {"query": "efp"}
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_incomplete_function_call_without_tool_name_emits_error():
+    adapter = DefaultLLMEventAdapter()
+    chunks = [
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_missing_name",
+            "delta": '{"query":"efp"}',
+        },
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "fc_missing_name",
+            "arguments": '{"query":"efp"}',
+        },
+        {"type": "response.completed", "usage": {"total_tokens": 12}},
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+    complete_events = [
+        event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE
+    ]
+    error_events = [event for event in events if event.type == LLMEventType.ERROR]
+
+    assert complete_events == []
+    assert len(error_events) == 1
+    assert error_events[0].tool_call_id == "fc_missing_name"
+    assert "function call" in (error_events[0].error or "")
+    assert "tool name" in (error_events[0].error or "")
+    assert "fc_missing_name" in (error_events[0].error or "")

--- a/tests/runtime/test_llm_event_adapter.py
+++ b/tests/runtime/test_llm_event_adapter.py
@@ -89,13 +89,15 @@ async def test_streaming_responses_chunks_emit_text_reasoning_and_tool_input_eve
         {"type": "response.reasoning_summary_text.delta", "delta": "Thinking"},
         {
             "type": "response.output_item.added",
+            "output_index": 0,
             "item_id": "fc_1",
             "item": {"type": "function_call", "id": "fc_1", "call_id": "call_search", "name": "search", "arguments": ""},
         },
-        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '{"query":'},
-        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '"efp"}'},
+        {"type": "response.function_call_arguments.delta", "output_index": 0, "item_id": "fc_1", "delta": '{"query":'},
+        {"type": "response.function_call_arguments.delta", "output_index": 0, "item_id": "fc_1", "delta": '"efp"}'},
         {
             "type": "response.output_item.done",
+            "output_index": 0,
             "item_id": "fc_1",
             "item": {
                 "type": "function_call",
@@ -142,6 +144,7 @@ async def test_streaming_responses_function_arguments_done_and_item_done_complet
     chunks = [
         {
             "type": "response.output_item.added",
+            "output_index": 0,
             "item_id": "fc_1",
             "item": {
                 "type": "function_call",
@@ -151,15 +154,17 @@ async def test_streaming_responses_function_arguments_done_and_item_done_complet
                 "arguments": "",
             },
         },
-        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '{"query":'},
-        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '"efp"}'},
+        {"type": "response.function_call_arguments.delta", "output_index": 0, "item_id": "fc_1", "delta": '{"query":'},
+        {"type": "response.function_call_arguments.delta", "output_index": 0, "item_id": "fc_1", "delta": '"efp"}'},
         {
             "type": "response.function_call_arguments.done",
+            "output_index": 0,
             "item_id": "fc_1",
             "arguments": '{"query":"efp"}',
         },
         {
             "type": "response.output_item.done",
+            "output_index": 0,
             "item_id": "fc_1",
             "item": {
                 "type": "function_call",
@@ -194,6 +199,7 @@ async def test_streaming_responses_output_item_nested_function_name_completes_to
     chunks = [
         {
             "type": "response.output_item.added",
+            "output_index": 0,
             "item_id": "fc_1",
             "item": {
                 "type": "function_call",
@@ -203,10 +209,11 @@ async def test_streaming_responses_output_item_nested_function_name_completes_to
                 "arguments": "",
             },
         },
-        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '{"query":'},
-        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '"efp"}'},
+        {"type": "response.function_call_arguments.delta", "output_index": 0, "item_id": "fc_1", "delta": '{"query":'},
+        {"type": "response.function_call_arguments.delta", "output_index": 0, "item_id": "fc_1", "delta": '"efp"}'},
         {
             "type": "response.output_item.done",
+            "output_index": 0,
             "item_id": "fc_1",
             "item": {
                 "type": "function_call",
@@ -231,7 +238,7 @@ async def test_streaming_responses_output_item_nested_function_name_completes_to
 
 
 @pytest.mark.asyncio
-async def test_streaming_responses_incomplete_function_call_without_tool_name_emits_error():
+async def test_streaming_responses_orphan_function_call_arguments_are_ignored():
     adapter = DefaultLLMEventAdapter()
     chunks = [
         {
@@ -254,8 +261,162 @@ async def test_streaming_responses_incomplete_function_call_without_tool_name_em
     error_events = [event for event in events if event.type == LLMEventType.ERROR]
 
     assert complete_events == []
-    assert len(error_events) == 1
-    assert error_events[0].tool_call_id == "fc_missing_name"
-    assert "function call" in (error_events[0].error or "")
-    assert "tool name" in (error_events[0].error or "")
-    assert "fc_missing_name" in (error_events[0].error or "")
+    assert error_events == []
+    assert all(event.tool_call_id != "fc_missing_name" for event in events)
+    assert events[-1].type == LLMEventType.STEP_FINISH
+    assert events[-1].usage == {"total_tokens": 12}
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_orphan_encrypted_item_id_arguments_are_ignored():
+    adapter = DefaultLLMEventAdapter()
+    encrypted_item_id = (
+        "zWKh9D/etpetECfeACpT2ONLWvuJm9K3bvtlp5KzCsZasSD0KlemPHSlmZWvSrujW+"
+        "xIkWK0pts86n/TlXVf+kzTF4DP4h1wwnpZSgt+8bElTmnXob8QuFenDahD1AvaGsTQY"
+        "OBnNj7N1JXs5F1Gbc2PBIs99duvBNM4dMC15mFJtaQjKg9vMBeuT/cMOEeGP24A4Nvtf"
+        "WdlFquq2WAOLUf/bZLT0orolyXrZpRq/hy8Sb1Oa+a7RPsalyrusQ6MEmS7W35J7bZq"
+        "D7vGZT2Zd1fNRWPNJ0M9vW8YtaPrSGe4In+Ai/xPNyuSiOBB1Z6tL/1luzi5lKD6Z3ZsGSEp6MmJ8sLzhR4uc1PYHBCMcrhLwwdUTCSPb82rwmN4JkyU+tcAwo4lZ8qChBDnutDUnw=="
+    )
+    chunks = [
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": encrypted_item_id,
+            "delta": '{"query":"efp"}',
+        },
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": encrypted_item_id,
+            "arguments": '{"query":"efp"}',
+        },
+        {"type": "response.completed", "usage": {"total_tokens": 12}},
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+
+    assert [event for event in events if event.type == LLMEventType.ERROR] == []
+    assert [event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE] == []
+    assert encrypted_item_id not in {
+        event.tool_call_id for event in events if event.tool_call_id
+    }
+    assert events[-1].type == LLMEventType.STEP_FINISH
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_function_call_uses_output_index_not_encrypted_item_id():
+    adapter = DefaultLLMEventAdapter()
+    encrypted_added_item_id = "encrypted-added"
+    encrypted_delta_item_id = (
+        "zWKh9D/rotatingEncryptedItemIdThatChangesOnEachCopilotResponsesEvent"
+        "uSiOBB1Z6tL/1luzi5lKD6Z3ZsGSEp6MmJ8sLzhR4uc1PYHBCMcrhLwwdUTCSPb82rwmN4JkyU+tc=="
+    )
+    chunks = [
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item_id": encrypted_added_item_id,
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_search",
+                "name": "search",
+                "arguments": "",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "output_index": 0,
+            "item_id": encrypted_delta_item_id,
+            "delta": '{"query":"efp"}',
+        },
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item_id": "encrypted-done",
+            "item": {
+                "type": "function_call",
+                "id": "fc_done",
+                "call_id": "call_search",
+                "name": "search",
+                "arguments": '{"query":"efp"}',
+            },
+        },
+        {"type": "response.completed", "usage": {"total_tokens": 12}},
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+    tool_events = [
+        event for event in events
+        if event.type in {
+            LLMEventType.TOOL_INPUT_START,
+            LLMEventType.TOOL_INPUT_DELTA,
+            LLMEventType.TOOL_INPUT_END,
+            LLMEventType.TOOL_CALL_COMPLETE,
+        }
+    ]
+
+    assert [event.type for event in tool_events] == [
+        LLMEventType.TOOL_INPUT_START,
+        LLMEventType.TOOL_INPUT_DELTA,
+        LLMEventType.TOOL_INPUT_END,
+        LLMEventType.TOOL_CALL_COMPLETE,
+    ]
+    assert {event.tool_call_id for event in tool_events} == {"call_search"}
+    assert encrypted_added_item_id not in {event.tool_call_id for event in tool_events}
+    assert encrypted_delta_item_id not in {event.tool_call_id for event in tool_events}
+    assert [event for event in events if event.type == LLMEventType.ERROR] == []
+    complete_event = next(
+        event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE
+    )
+    assert complete_event.tool_name == "search"
+    assert complete_event.tool_call.tool_name == "search"
+    assert complete_event.tool_call.arguments == {"query": "efp"}
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_delta_before_output_item_added_is_ignored():
+    adapter = DefaultLLMEventAdapter()
+    chunks = [
+        {
+            "type": "response.function_call_arguments.delta",
+            "output_index": 0,
+            "item_id": "encrypted-before-added",
+            "delta": '{"ignored":true}',
+        },
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item_id": "encrypted-added",
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_search",
+                "name": "search",
+                "arguments": "",
+            },
+        },
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item_id": "encrypted-done",
+            "item": {
+                "type": "function_call",
+                "id": "fc_done",
+                "call_id": "call_search",
+                "name": "search",
+                "arguments": '{"query":"efp"}',
+            },
+        },
+        {"type": "response.completed", "usage": {"total_tokens": 12}},
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+    complete_event = next(
+        event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE
+    )
+
+    assert [event.delta for event in events if event.type == LLMEventType.TOOL_INPUT_DELTA] == [
+        '{"query":"efp"}',
+    ]
+    assert [event for event in events if event.type == LLMEventType.ERROR] == []
+    assert complete_event.tool_call.call_id == "call_search"
+    assert complete_event.tool_call.arguments == {"query": "efp"}

--- a/tests/runtime/test_llm_event_adapter.py
+++ b/tests/runtime/test_llm_event_adapter.py
@@ -79,3 +79,58 @@ async def test_streaming_chat_chunks_emit_text_deltas():
     assert [event.delta for event in text_events] == ["Hello", " world"]
     assert events[-1].type == LLMEventType.STEP_FINISH
     assert events[-1].usage == {"total_tokens": 7}
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_chunks_emit_text_reasoning_and_tool_input_events():
+    adapter = DefaultLLMEventAdapter()
+    chunks = [
+        {"type": "response.output_text.delta", "delta": "Hello"},
+        {"type": "response.reasoning_summary_text.delta", "delta": "Thinking"},
+        {
+            "type": "response.output_item.added",
+            "item_id": "fc_1",
+            "item": {"type": "function_call", "id": "fc_1", "call_id": "call_search", "name": "search", "arguments": ""},
+        },
+        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '{"query":'},
+        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '"efp"}'},
+        {
+            "type": "response.output_item.done",
+            "item_id": "fc_1",
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_search",
+                "name": "search",
+                "arguments": '{"query":"efp"}',
+            },
+        },
+        {"type": "response.completed", "usage": {"total_tokens": 12}},
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+
+    assert [event.delta for event in events if event.type == LLMEventType.TEXT_DELTA] == ["Hello"]
+    assert [event.delta for event in events if event.type == LLMEventType.REASONING_DELTA] == ["Thinking"]
+    tool_input_events = [
+        event.type for event in events
+        if event.type in {
+            LLMEventType.TOOL_INPUT_START,
+            LLMEventType.TOOL_INPUT_DELTA,
+            LLMEventType.TOOL_INPUT_END,
+            LLMEventType.TOOL_CALL_COMPLETE,
+        }
+    ]
+    assert tool_input_events == [
+        LLMEventType.TOOL_INPUT_START,
+        LLMEventType.TOOL_INPUT_DELTA,
+        LLMEventType.TOOL_INPUT_DELTA,
+        LLMEventType.TOOL_INPUT_END,
+        LLMEventType.TOOL_CALL_COMPLETE,
+    ]
+    completed = next(event.tool_call for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE)
+    assert completed.call_id == "call_search"
+    assert completed.tool_name == "search"
+    assert completed.arguments == {"query": "efp"}
+    assert events[-1].type == LLMEventType.STEP_FINISH
+    assert events[-1].usage == {"total_tokens": 12}

--- a/tests/runtime/test_llm_event_adapter.py
+++ b/tests/runtime/test_llm_event_adapter.py
@@ -134,3 +134,55 @@ async def test_streaming_responses_chunks_emit_text_reasoning_and_tool_input_eve
     assert completed.arguments == {"query": "efp"}
     assert events[-1].type == LLMEventType.STEP_FINISH
     assert events[-1].usage == {"total_tokens": 12}
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_function_arguments_done_and_item_done_complete_once():
+    adapter = DefaultLLMEventAdapter()
+    chunks = [
+        {
+            "type": "response.output_item.added",
+            "item_id": "fc_1",
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_search",
+                "name": "search",
+                "arguments": "",
+            },
+        },
+        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '{"query":'},
+        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '"efp"}'},
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "fc_1",
+            "arguments": '{"query":"efp"}',
+        },
+        {
+            "type": "response.output_item.done",
+            "item_id": "fc_1",
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_search",
+                "name": "search",
+                "arguments": '{"query":"efp"}',
+            },
+        },
+        {"type": "response.completed", "usage": {"total_tokens": 12}},
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+
+    assert [event.type for event in events].count(LLMEventType.TOOL_INPUT_START) == 1
+    assert [event.type for event in events].count(LLMEventType.TOOL_INPUT_END) == 1
+    complete_events = [
+        event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE
+    ]
+    assert len(complete_events) == 1
+    assert [event.delta for event in events if event.type == LLMEventType.TOOL_INPUT_DELTA] == [
+        '{"query":',
+        '"efp"}',
+    ]
+    assert complete_events[0].tool_call.call_id == "call_search"
+    assert complete_events[0].tool_call.arguments == {"query": "efp"}

--- a/tests/runtime/test_llm_event_adapter.py
+++ b/tests/runtime/test_llm_event_adapter.py
@@ -2,6 +2,17 @@ import pytest
 
 from efp_runtime.llm.adapter import DefaultLLMEventAdapter
 from efp_runtime.llm.events import LLMEventType
+from efp_runtime.session.models import MessagePartType
+from efp_runtime.session.processor import RuntimeSession, SessionProcessor
+from efp_runtime.session.status import RuntimeStatus
+
+
+def _assert_responses_finished(events, usage=None):
+    assert events[-2].type == LLMEventType.STEP_FINISH
+    assert events[-1].type == LLMEventType.FINISH
+    if usage is not None:
+        assert events[-2].usage == usage
+        assert events[-1].usage == usage
 
 
 def test_non_streaming_response_normalizes_two_tool_calls():
@@ -134,8 +145,7 @@ async def test_streaming_responses_chunks_emit_text_reasoning_and_tool_input_eve
     assert completed.call_id == "call_search"
     assert completed.tool_name == "search"
     assert completed.arguments == {"query": "efp"}
-    assert events[-1].type == LLMEventType.STEP_FINISH
-    assert events[-1].usage == {"total_tokens": 12}
+    _assert_responses_finished(events, {"total_tokens": 12})
 
 
 @pytest.mark.asyncio
@@ -259,12 +269,15 @@ async def test_streaming_responses_orphan_function_call_arguments_are_ignored():
         event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE
     ]
     error_events = [event for event in events if event.type == LLMEventType.ERROR]
+    provider_error_events = [
+        event for event in events if event.type == LLMEventType.PROVIDER_ERROR
+    ]
 
     assert complete_events == []
     assert error_events == []
+    assert provider_error_events == []
     assert all(event.tool_call_id != "fc_missing_name" for event in events)
-    assert events[-1].type == LLMEventType.STEP_FINISH
-    assert events[-1].usage == {"total_tokens": 12}
+    _assert_responses_finished(events, {"total_tokens": 12})
 
 
 @pytest.mark.asyncio
@@ -298,7 +311,7 @@ async def test_streaming_responses_orphan_encrypted_item_id_arguments_are_ignore
     assert encrypted_item_id not in {
         event.tool_call_id for event in events if event.tool_call_id
     }
-    assert events[-1].type == LLMEventType.STEP_FINISH
+    _assert_responses_finished(events, {"total_tokens": 12})
 
 
 @pytest.mark.asyncio
@@ -367,9 +380,60 @@ async def test_streaming_responses_function_call_uses_output_index_not_encrypted
     complete_event = next(
         event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE
     )
+    assert len([event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE]) == 1
     assert complete_event.tool_name == "search"
     assert complete_event.tool_call.tool_name == "search"
     assert complete_event.tool_call.arguments == {"query": "efp"}
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_standard_item_id_arguments_use_final_item_arguments():
+    adapter = DefaultLLMEventAdapter()
+    chunks = [
+        {
+            "type": "response.output_item.added",
+            "item_id": "fc_1",
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_search",
+                "name": "search",
+                "arguments": "",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_1",
+            "delta": '{"query":"wrong"}',
+        },
+        {
+            "type": "response.output_item.done",
+            "item_id": "fc_1",
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_search",
+                "name": "search",
+                "arguments": '{"query":"efp","limit":2}',
+            },
+        },
+        {"type": "response.completed", "response": {"usage": {"total_tokens": 12}}},
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+    complete_events = [
+        event for event in events if event.type == LLMEventType.TOOL_CALL_COMPLETE
+    ]
+
+    assert len(complete_events) == 1
+    assert [event.delta for event in events if event.type == LLMEventType.TOOL_INPUT_DELTA] == [
+        '{"query":"wrong"}',
+    ]
+    assert complete_events[0].tool_call.call_id == "call_search"
+    assert complete_events[0].tool_call.tool_name == "search"
+    assert complete_events[0].tool_call.arguments == {"query": "efp", "limit": 2}
+    assert complete_events[0].tool_call.arguments_text == '{"query":"efp","limit":2}'
+    _assert_responses_finished(events, {"total_tokens": 12})
 
 
 @pytest.mark.asyncio
@@ -420,3 +484,146 @@ async def test_streaming_responses_delta_before_output_item_added_is_ignored():
     assert [event for event in events if event.type == LLMEventType.ERROR] == []
     assert complete_event.tool_call.call_id == "call_search"
     assert complete_event.tool_call.arguments == {"query": "efp"}
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_failed_and_top_level_error_emit_provider_error():
+    adapter = DefaultLLMEventAdapter()
+    failed_chunks = [
+        {
+            "type": "response.failed",
+            "response": {
+                "id": "resp_failed",
+                "error": {
+                    "code": "rate_limit_exceeded",
+                    "message": "Slow down",
+                },
+            },
+        }
+    ]
+    top_level_chunks = [
+        {
+            "type": "error",
+            "code": "context_length_exceeded",
+            "message": "Too many tokens",
+            "retryable": False,
+        }
+    ]
+
+    failed_events = [event async for event in adapter.normalize_stream(failed_chunks)]
+    top_level_events = [event async for event in adapter.normalize_stream(top_level_chunks)]
+
+    failed_provider_error = next(
+        event for event in failed_events if event.type == LLMEventType.PROVIDER_ERROR
+    )
+    top_level_provider_error = next(
+        event for event in top_level_events if event.type == LLMEventType.PROVIDER_ERROR
+    )
+
+    assert failed_provider_error.error == "rate_limit_exceeded: Slow down"
+    assert failed_provider_error.metadata["code"] == "rate_limit_exceeded"
+    assert failed_provider_error.metadata["response_id"] == "resp_failed"
+    assert top_level_provider_error.error == "context_length_exceeded: Too many tokens"
+    assert top_level_provider_error.metadata["retryable"] is False
+    assert [event for event in failed_events if event.type == LLMEventType.STEP_FINISH] == []
+    assert [event for event in top_level_events if event.type == LLMEventType.STEP_FINISH] == []
+
+    processor = SessionProcessor(RuntimeSession(session_id="s-provider-error"))
+    message = await processor.consume(failed_events)
+
+    assert processor.session.status is RuntimeStatus.ERROR
+    assert message.status == "error"
+    assert message.parts[-1].type is MessagePartType.ERROR
+    assert message.parts[-1].text == "rate_limit_exceeded: Slow down"
+    assert message.parts[-1].metadata["code"] == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_reasoning_item_lifecycle_updates_session_part():
+    adapter = DefaultLLMEventAdapter()
+    chunks = [
+        {
+            "type": "response.output_item.added",
+            "item_id": "rs_1",
+            "item": {
+                "type": "reasoning",
+                "id": "rs_1",
+                "encrypted_content": "enc_reasoning",
+            },
+        },
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": "rs_1",
+            "summary_index": 0,
+            "delta": "Thinking",
+        },
+        {
+            "type": "response.output_item.done",
+            "item_id": "rs_1",
+            "item": {
+                "type": "reasoning",
+                "id": "rs_1",
+                "encrypted_content": "enc_reasoning",
+            },
+        },
+        {"type": "response.completed", "response": {"usage": {"total_tokens": 9}}},
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+    event_types = [event.type for event in events]
+
+    assert LLMEventType.REASONING_START in event_types
+    assert [event.delta for event in events if event.type == LLMEventType.REASONING_DELTA] == [
+        "Thinking",
+    ]
+    assert LLMEventType.REASONING_END in event_types
+    reasoning_start = next(
+        event for event in events if event.type == LLMEventType.REASONING_START
+    )
+    assert reasoning_start.metadata["item_id"] == "rs_1"
+    assert reasoning_start.metadata["encrypted_content"] == "enc_reasoning"
+    _assert_responses_finished(events, {"total_tokens": 9})
+
+    processor = SessionProcessor(RuntimeSession(session_id="s-reasoning"))
+    message = await processor.consume(events)
+    reasoning_parts = [
+        part for part in message.parts if part.type is MessagePartType.REASONING
+    ]
+
+    assert len(reasoning_parts) == 1
+    assert reasoning_parts[0].reasoning == "Thinking"
+    assert reasoning_parts[0].text == "Thinking"
+    assert reasoning_parts[0].metadata["item_id"] == "rs_1"
+    assert reasoning_parts[0].metadata["encrypted_content"] == "enc_reasoning"
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_completed_emits_step_finish_and_finish_with_usage():
+    adapter = DefaultLLMEventAdapter()
+    chunks = [
+        {"type": "response.output_text.delta", "delta": "Done"},
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_1",
+                "service_tier": "default",
+                "usage": {
+                    "input_tokens": 3,
+                    "output_tokens": 4,
+                    "total_tokens": 7,
+                },
+            },
+        },
+    ]
+
+    events = [event async for event in adapter.normalize_stream(chunks)]
+    step_finish = next(event for event in events if event.type == LLMEventType.STEP_FINISH)
+    finish = next(event for event in events if event.type == LLMEventType.FINISH)
+
+    assert events[-2].type == LLMEventType.STEP_FINISH
+    assert events[-1].type == LLMEventType.FINISH
+    assert step_finish.usage == {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7}
+    assert finish.usage == step_finish.usage
+    assert step_finish.metadata["finish_reason"] == "stop"
+    assert step_finish.metadata["response_id"] == "resp_1"
+    assert step_finish.provider_metadata["openai"]["responseId"] == "resp_1"

--- a/tests/runtime/test_llm_stream_events.py
+++ b/tests/runtime/test_llm_stream_events.py
@@ -263,6 +263,79 @@ def test_subagent_child_config_preserves_emit_llm_stream_events():
     assert RuntimeConfig().emit_llm_stream_events is True
 
 
+@pytest.mark.asyncio
+async def test_bridge_projects_new_llm_event_contract_payloads():
+    from efp_runtime.loop.stream_events import bridge_llm_stream_events
+
+    runtime_events = []
+    llm_events = [
+        LLMEvent(
+            LLMEventType.REASONING_START,
+            part_id="reasoning-1",
+            metadata={"item_id": "rs_1"},
+            provider_metadata={"openai": {"itemId": "rs_1"}},
+            raw={"type": "response.output_item.added", "item_id": "rs_1"},
+        ),
+        LLMEvent(
+            LLMEventType.REASONING_DELTA,
+            part_id="reasoning-1",
+            delta="think",
+        ),
+        LLMEvent(LLMEventType.REASONING_END, part_id="reasoning-1"),
+        LLMEvent(
+            LLMEventType.FINISH,
+            usage={"total_tokens": 7},
+            metadata={"finish_reason": "stop"},
+        ),
+        LLMEvent(
+            LLMEventType.PROVIDER_ERROR,
+            error="rate_limit_exceeded: Slow down",
+            metadata={"code": "rate_limit_exceeded", "retryable": True},
+            provider_metadata={"openai": {"error": {"code": "rate_limit_exceeded"}}},
+            raw={"type": "response.failed", "response": {"id": "resp_1"}},
+        ),
+        LLMEvent(
+            LLMEventType.TOOL_ERROR,
+            tool_call_id="call-1",
+            tool_name="search",
+            error="tool failed",
+        ),
+    ]
+
+    yielded = [
+        event
+        async for event in bridge_llm_stream_events(
+            llm_events,
+            runtime_events=runtime_events,
+            session_id="s-1",
+            run_id="run-1",
+            iteration=1,
+        )
+    ]
+
+    assert yielded == llm_events
+    assert [event.type for event in runtime_events] == [
+        "llm.reasoning_start",
+        "llm.reasoning_delta",
+        "llm.reasoning_end",
+        "llm.finish",
+        "llm.provider_error",
+        "llm.tool_error",
+    ]
+    reasoning_payload = runtime_events[0].payload
+    assert reasoning_payload["event_type"] == "reasoning_start"
+    assert reasoning_payload["metadata"] == {"item_id": "rs_1"}
+    assert reasoning_payload["provider_metadata"] == {"openai": {"itemId": "rs_1"}}
+    assert reasoning_payload["raw"] == {
+        "type": "response.output_item.added",
+        "item_id": "rs_1",
+    }
+    assert runtime_events[3].payload["usage"] == {"total_tokens": 7}
+    assert runtime_events[4].payload["code"] == "rate_limit_exceeded"
+    assert runtime_events[4].payload["retryable"] is True
+    assert runtime_events[5].payload["tool_call_id"] == "call-1"
+
+
 def test_llm_stream_events_import_boundary():
     code = """
 import json

--- a/tests/runtime/test_provider_transport.py
+++ b/tests/runtime/test_provider_transport.py
@@ -21,6 +21,7 @@ from efp_runtime.llm.provider import (
     ProviderTransportError,
     RecordingTransport,
     SUPPORTED_COPILOT_REASONING_EFFORTS,
+    parse_sse_json_events,
     parse_copilot_api_base_url,
     github_copilot_provider_from_env,
 )
@@ -841,23 +842,52 @@ def test_github_source_token_exchange_keeps_explicit_base_url(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_github_copilot_http_transport_rejects_stream_without_network(
+async def test_github_copilot_http_transport_stream_parses_sse_chunks(
     monkeypatch,
 ):
-    called = False
+    requests = []
+    body = (
+        b"event: response.output_text.delta\n"
+        b'data: {"type":"response.output_text.delta","delta":"hello"}\n\n'
+        b'data: {"type":"response.reasoning_summary_text.delta","delta":"thinking"}\n\n'
+        b'data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\\"query\\":"}\n\n'
+        b"data: [DONE]\n\n"
+    )
 
     def fake_urlopen(request, timeout):
-        nonlocal called
-        called = True
-        return _FakeHTTPResponse({})
+        requests.append((request, timeout))
+        return _FakeStreamingHTTPResponse(body)
 
     monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
 
-    transport = GitHubCopilotHTTPTransport(token="secret-token")
-    with pytest.raises(ProviderTransportError, match="does not support streaming"):
-        await transport.send({"model": "gpt-5-mini", "stream": True})
+    transport = GitHubCopilotHTTPTransport(token="secret-token", timeout=12)
+    stream = await transport.send({"model": "gpt-5-mini", "stream": True})
+    chunks = [chunk async for chunk in stream]
 
-    assert called is False
+    assert chunks == [
+        {"type": "response.output_text.delta", "delta": "hello"},
+        {"type": "response.reasoning_summary_text.delta", "delta": "thinking"},
+        {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '{"query":'},
+    ]
+    request, timeout = requests[0]
+    assert timeout == 12
+    assert _request_headers(request)["accept"] == "text/event-stream"
+
+
+def test_parse_sse_json_events_supports_multiline_data_and_done():
+    chunks = list(
+        parse_sse_json_events(
+            [
+                'data: {"type":"response.output_text.delta",',
+                'data: "delta":"hi"}',
+                "",
+                "data: [DONE]",
+                "",
+            ]
+        )
+    )
+
+    assert chunks == [{"type": "response.output_text.delta", "delta": "hi"}]
 
 
 @pytest.mark.asyncio
@@ -1500,6 +1530,20 @@ class _FakeHTTPResponse:
         if isinstance(self.payload, bytes):
             return self.payload
         return json.dumps(self.payload).encode("utf-8")
+
+
+class _FakeStreamingHTTPResponse:
+    def __init__(self, body):
+        self._lines = io.BytesIO(body)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def readline(self):
+        return self._lines.readline()
 
 
 def _request_headers(request):

--- a/tests/runtime/test_provider_transport.py
+++ b/tests/runtime/test_provider_transport.py
@@ -1277,7 +1277,7 @@ async def test_transport_send_error_maps_to_loop_error_status():
     assert error_part.type is MessagePartType.ERROR
     assert "OpenAI-compatible transport failed" in error_part.text
     assert "network disabled" in error_part.text
-    assert any(event.type == "llm.error" for event in result.runtime_events)
+    assert any(event.type == "llm.provider_error" for event in result.runtime_events)
 
 
 def test_provider_transport_imports_standalone_with_pythonpath_src():

--- a/tests/runtime/test_runtime_chat_gateway.py
+++ b/tests/runtime/test_runtime_chat_gateway.py
@@ -118,6 +118,7 @@ def test_build_github_copilot_provider_uses_responses_and_config_reasoning(monke
     provider = runtime_chat._build_github_copilot_provider("gpt-5.4")
 
     assert provider.endpoint == "responses"
+    assert provider.stream is True
     assert provider.reasoning_effort == "xhigh"
     assert provider.transport.endpoint == "https://copilot-api.enterprise.example/responses"
     assert provider.transport.timeout == 300

--- a/tests/runtime/test_tool_selection_controls.py
+++ b/tests/runtime/test_tool_selection_controls.py
@@ -149,7 +149,7 @@ async def test_without_model_hint_keeps_default_file_tool_selection():
     assert provider.requests[0].metadata["model_aware_tool_selection"] == {
         "enabled": True,
         "ran": True,
-        "model_hint": "gpt-5-mini",
+        "model_hint": "gpt-5.4",
         "mode": "patch",
         "forced_disabled": ["edit", "write"],
     }

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -131,3 +131,45 @@ async def test_event_bus_request_id_filter_does_not_match_parent_request_id():
     assert "parent_request_id" not in event["data"]
     assert event["data"]["request_id"] == "req-1"
     assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_event_bus_replay_returns_recent_matching_session_and_request_events():
+    bus = EventBus()
+
+    await bus.emit("session.next.text.delta", {"session_id": "s-1", "request_id": "req-1", "delta": "a"})
+    await bus.emit("session.next.text.delta", {"session_id": "s-1", "request_id": "req-2", "delta": "b"})
+    await bus.emit("session.next.tool.success", {"session_id": "s-1", "request_id": "req-1", "tool_name": "search"})
+
+    replayed = await bus.replay_events(
+        filters={"session_id": "s-1", "request_id": "req-1"},
+        replay_limit=10,
+    )
+
+    assert len(replayed) == 2
+    parsed = [json.loads(event) for event in replayed]
+    assert [event["type"] for event in parsed] == [
+        "session.next.text.delta",
+        "session.next.tool.success",
+    ]
+    assert all(event["data"]["request_id"] == "req-1" for event in parsed)
+
+
+@pytest.mark.asyncio
+async def test_event_bus_replay_limit_and_last_event_at():
+    bus = EventBus()
+
+    await bus.emit("runtime.event", {"session_id": "s-1", "request_id": "req-1", "step": 1})
+    first = json.loads((await bus.replay_events(filters={"session_id": "s-1"}))[0])
+    await asyncio.sleep(0.001)
+    await bus.emit("runtime.event", {"session_id": "s-1", "request_id": "req-1", "step": 2})
+    await bus.emit("runtime.event", {"session_id": "s-1", "request_id": "req-1", "step": 3})
+
+    replayed = await bus.replay_events(
+        filters={"session_id": "s-1", "request_id": "req-1"},
+        replay_limit=1,
+        last_event_at=str(first["ts"]),
+    )
+
+    assert len(replayed) == 1
+    assert json.loads(replayed[0])["data"]["step"] == 3

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -11,11 +12,13 @@ events = load_module_from_repo_path("src.gateway.events", "src/gateway/events.py
 class _FakeWS:
     def __init__(self):
         self.closed = False
+        self.sent = []
 
     async def prepare(self, request):
         return self
 
     async def send_str(self, _data):
+        self.sent.append(_data)
         return None
 
     def exception(self):
@@ -102,5 +105,54 @@ async def test_handle_websocket_passes_combined_session_and_request_filters_and_
     assert captured["filters"] == {
         "session_id": "s-keep",
         "request_id": "req-keep",
+    }
+    assert captured.get("removed") is True
+
+
+@pytest.mark.asyncio
+async def test_handle_websocket_replays_matching_events_after_connected(monkeypatch):
+    captured = {}
+
+    async def _fake_add_listener(queue, filters=None):
+        captured["queue"] = queue
+        captured["filters"] = filters
+
+    async def _fake_remove_listener(_queue):
+        captured["removed"] = True
+
+    async def _fake_replay_events(**kwargs):
+        captured["replay"] = kwargs
+        return [
+            '{"type":"session.next.text.delta","data":{"session_id":"s-1","request_id":"req-1","delta":"hi"},"ts":1}'
+        ]
+
+    monkeypatch.setattr(events.web, "WebSocketResponse", _FakeWS)
+    monkeypatch.setattr(events.event_bus, "add_listener", _fake_add_listener)
+    monkeypatch.setattr(events.event_bus, "remove_listener", _fake_remove_listener)
+    monkeypatch.setattr(events.event_bus, "replay_events", _fake_replay_events)
+    monkeypatch.setattr(events.event_bus, "_listeners", [])
+
+    request = SimpleNamespace(
+        rel_url=SimpleNamespace(
+            query={
+                "session_id": "s-1",
+                "request_id": "req-1",
+                "replay": "1",
+                "replay_limit": "5",
+                "last_event_at": "2026-06-02T01:00:00Z",
+            }
+        )
+    )
+
+    ws = await events.handle_websocket(request)
+
+    assert json.loads(ws.sent[0])["type"] == "connected"
+    replayed = json.loads(ws.sent[1])
+    assert replayed["type"] == "session.next.text.delta"
+    assert replayed["data"]["request_id"] == "req-1"
+    assert captured["replay"] == {
+        "filters": {"session_id": "s-1", "request_id": "req-1"},
+        "replay_limit": 5,
+        "last_event_at": "2026-06-02T01:00:00Z",
     }
     assert captured.get("removed") is True

--- a/tests/test_model_fallback.py
+++ b/tests/test_model_fallback.py
@@ -320,7 +320,7 @@ class TestFallbackAttempt:
 def test_readme_llm_example_uses_default_llm_model():
     text = Path("README.md").read_text(encoding="utf-8")
     llm_section = text[text.find("### LLM Providers"): text.find("### Control-Plane Runtime Settings")]
-    assert 'model: "gpt-5.4-mini"' in llm_section
+    assert 'model: "gpt-5.4"' in llm_section
     assert 'model: "gpt-4o"' not in llm_section
 
 

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -1414,10 +1414,10 @@ async def test_api_chat_publish_failure_does_not_break_response(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_api_chat_stream_emits_progress_before_done_while_task_running(monkeypatch):
+async def test_api_chat_stream_emits_runtime_event_json_before_done_while_task_running(monkeypatch):
     from src.gateway import runtime_api
 
-    observed = {"task_running_during_progress": False}
+    observed = {"task_running_during_runtime_event": False}
 
     async def _fake_run_chat_via_execution_bus(**kwargs):
         stream_callback = kwargs["stream_callback"]
@@ -1436,9 +1436,9 @@ async def test_api_chat_stream_emits_progress_before_done_while_task_running(mon
 
         async def write(self, data):
             decoded = data.decode()
-            if "event: progress" in decoded:
+            if "event: runtime_event" in decoded:
                 pending_tasks = [t for t in asyncio.all_tasks() if not t.done()]
-                observed["task_running_during_progress"] = any(
+                observed["task_running_during_runtime_event"] = any(
                     getattr(getattr(t, "get_coro", lambda: None)(), "__name__", "") == "_fake_run_chat_via_execution_bus"
                     for t in pending_tasks
                 )
@@ -1457,10 +1457,15 @@ async def test_api_chat_stream_emits_progress_before_done_while_task_running(mon
 
     response = await runtime_api.api_chat_stream(_Request())
 
-    progress_index = next(i for i, chunk in enumerate(response.writes) if "event: progress" in chunk)
+    runtime_event_index = next(i for i, chunk in enumerate(response.writes) if "event: runtime_event" in chunk)
     done_index = next(i for i, chunk in enumerate(response.writes) if "event: done" in chunk)
-    assert progress_index < done_index
-    assert observed["task_running_during_progress"] is True
+    assert runtime_event_index < done_index
+    assert observed["task_running_during_runtime_event"] is True
+    runtime_event_chunk = response.writes[runtime_event_index]
+    runtime_event_data = json.loads(runtime_event_chunk.split("data: ", 1)[1].strip())
+    assert isinstance(runtime_event_data, dict)
+    assert runtime_event_data["type"] == "runtime.event"
+    assert runtime_event_data["event_type"] == "runtime.event"
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_event_projection.py
+++ b/tests/test_runtime_event_projection.py
@@ -133,3 +133,83 @@ def test_projector_maps_permission_and_run_finish_usage_aliases():
     assert finish["state"] == "success"
     assert finish["data"]["tokens"] == 12
     assert finish["data"]["cost"] == 0.01
+
+
+def test_projector_maps_new_llm_reasoning_error_and_finish_events():
+    projector = RuntimeEventProjector(request_id="req-1")
+
+    reasoning_start = projector.project(
+        RuntimeEvent(
+            type="llm.reasoning_start",
+            session_id="s-1",
+            part_id="reasoning-1",
+            payload={"run_id": "run-1", "iteration": 1, "event_type": "reasoning_start"},
+            created_at="2026-06-02T01:02:03Z",
+        )
+    )
+    reasoning_delta = projector.project(
+        RuntimeEvent(
+            type="llm.reasoning_delta",
+            session_id="s-1",
+            part_id="reasoning-1",
+            payload={"run_id": "run-1", "iteration": 1, "delta": "think"},
+            created_at="2026-06-02T01:02:04Z",
+        )
+    )
+    reasoning_end = projector.project(
+        RuntimeEvent(
+            type="llm.reasoning_end",
+            session_id="s-1",
+            part_id="reasoning-1",
+            payload={"run_id": "run-1", "iteration": 1},
+            created_at="2026-06-02T01:02:05Z",
+        )
+    )
+
+    assert reasoning_start[0]["type"] == "session.next.reasoning.started"
+    assert reasoning_delta[0]["type"] == "session.next.reasoning.delta"
+    assert reasoning_delta[0]["data"]["delta"] == "think"
+    assert reasoning_end[0]["type"] == "session.next.reasoning.ended"
+
+    provider_error = projector.project(
+        RuntimeEvent(
+            type="llm.provider_error",
+            session_id="s-1",
+            payload={
+                "run_id": "run-1",
+                "iteration": 1,
+                "error": "rate_limit_exceeded: Slow down",
+                "code": "rate_limit_exceeded",
+                "retryable": True,
+            },
+            created_at="2026-06-02T01:02:06Z",
+        )
+    )
+    tool_error = projector.project(
+        RuntimeEvent(
+            type="llm.tool_error",
+            session_id="s-1",
+            payload={
+                "tool_call_id": "call-1",
+                "tool_name": "search",
+                "error": "tool failed",
+            },
+            created_at="2026-06-02T01:02:07Z",
+        )
+    )
+
+    assert provider_error[0]["type"] == "session.next.step.failed"
+    assert provider_error[0]["data"]["code"] == "rate_limit_exceeded"
+    assert provider_error[0]["data"]["retryable"] is True
+    assert tool_error[0]["type"] == "session.next.tool.failed"
+    assert tool_error[0]["data"]["tool_name"] == "search"
+
+    finish = projector.project(
+        RuntimeEvent(
+            type="llm.finish",
+            session_id="s-1",
+            payload={"run_id": "run-1", "iteration": 1},
+            created_at="2026-06-02T01:02:08Z",
+        )
+    )
+    assert finish == []

--- a/tests/test_runtime_event_projection.py
+++ b/tests/test_runtime_event_projection.py
@@ -1,0 +1,135 @@
+from src.efp_runtime.events import RuntimeEvent
+from src.gateway.runtime_event_projection import RuntimeEventProjector
+
+
+def test_projector_maps_run_start_to_session_next_step_started():
+    projector = RuntimeEventProjector(
+        request_id="req-1",
+        agent_id="agent-1",
+        agent_name="Agent One",
+        model="gpt-5.4",
+    )
+    event = RuntimeEvent(
+        type="run_start",
+        session_id="s-1",
+        payload={"run_id": "run-1", "max_iterations": 4},
+        created_at="2026-06-02T01:02:03Z",
+    )
+
+    projected = projector.project(event)
+
+    assert len(projected) == 1
+    payload = projected[0]
+    assert payload["type"] == "session.next.step.started"
+    assert payload["event_type"] == "session.next.step.started"
+    assert payload["engine"] == "efp-native"
+    assert payload["session_id"] == "s-1"
+    assert payload["request_id"] == "req-1"
+    assert payload["agent_id"] == "agent-1"
+    assert payload["data"]["model"] == "gpt-5.4"
+    assert payload["data"]["sessionID"] == "s-1"
+    assert payload["properties"]["run_id"] == "run-1"
+
+
+def test_projector_emits_text_started_before_first_delta_and_ended_on_finish():
+    projector = RuntimeEventProjector(request_id="req-1", model="gpt-5.4")
+
+    projected = projector.project(
+        RuntimeEvent(
+            type="llm.text_delta",
+            session_id="s-1",
+            part_id="part-1",
+            payload={"run_id": "run-1", "iteration": 1, "delta": "hello"},
+            created_at="2026-06-02T01:02:03Z",
+        )
+    )
+
+    assert [event["type"] for event in projected] == [
+        "session.next.text.started",
+        "session.next.text.delta",
+    ]
+    assert projected[1]["data"]["delta"] == "hello"
+    assert projected[1]["properties"]["content_delta"] == "hello"
+
+    finish = projector.project(
+        RuntimeEvent(
+            type="llm.step_finish",
+            session_id="s-1",
+            payload={"run_id": "run-1", "iteration": 1},
+            created_at="2026-06-02T01:02:04Z",
+        )
+    )
+    assert [event["type"] for event in finish] == ["session.next.text.ended"]
+
+
+def test_projector_hashes_long_tool_call_id_and_maps_tool_lifecycle():
+    projector = RuntimeEventProjector(request_id="req-1")
+    long_call_id = "call_" + ("very_long_tool_call_id_" * 8)
+
+    input_events = projector.project(
+        RuntimeEvent(
+            type="llm.tool_call_delta",
+            session_id="s-1",
+            payload={
+                "llm_event_type": "tool_input_delta",
+                "tool_call_id": long_call_id,
+                "tool_name": "search",
+                "arguments_delta": '{"token":"secret-value","query":"efp"}',
+            },
+            created_at="2026-06-02T01:02:03Z",
+        )
+    )
+
+    assert [event["type"] for event in input_events] == [
+        "session.next.tool.input.started",
+        "session.next.tool.input.delta",
+    ]
+    call_id = input_events[1]["data"]["tool_call_id"]
+    assert len(call_id) <= 64
+    assert call_id.startswith("call_")
+    assert long_call_id not in input_events[1]["id"]
+    assert "secret-value" not in input_events[1]["data"]["arguments_preview"]
+
+    done = projector.project(
+        RuntimeEvent(
+            type="llm.tool_call_done",
+            session_id="s-1",
+            payload={"tool_call_id": long_call_id, "tool_name": "search", "arguments": {"query": "efp"}},
+            created_at="2026-06-02T01:02:04Z",
+        )
+    )
+    assert done[0]["type"] == "session.next.tool.called"
+    assert done[0]["data"]["tool_name"] == "search"
+
+
+def test_projector_maps_permission_and_run_finish_usage_aliases():
+    projector = RuntimeEventProjector(request_id="req-1", agent_id="agent-1")
+
+    permission = projector.project(
+        RuntimeEvent(
+            type="tool.permission_requested",
+            session_id="s-1",
+            payload={
+                "tool_call_id": "call-1",
+                "tool_name": "write_file",
+                "permission_request": {"id": "perm-1", "action": "ask", "reason": "needs approval"},
+            },
+            created_at="2026-06-02T01:02:03Z",
+        )
+    )[0]
+    assert permission["type"] == "permission.requested"
+    assert permission["permission_request"]["id"] == "perm-1"
+    assert permission["data"]["permission_request"]["id"] == "perm-1"
+
+    finish = projector.project(
+        RuntimeEvent(
+            type="run_finish",
+            session_id="s-1",
+            payload={"status": "completed", "iterations": 1, "usage": {"total_tokens": 12, "estimated_cost": 0.01}},
+            created_at="2026-06-02T01:02:04Z",
+        )
+    )[-1]
+    assert finish["type"] == "session.next.step.ended"
+    assert finish["state"] == "success"
+    assert finish["data"]["tokens"] == 12
+    assert finish["data"]["cost"] == 0.01


### PR DESCRIPTION
## Summary
- Add native realtime `session.next.*` runtime events and project them through `/api/chat/stream` JSON `runtime_event` SSE and gateway WebSocket replay.
- Stream Copilot `/responses` SSE chunks through the runtime adapter and provider transport.
- Fix Responses function-call completion so `response.function_call_arguments.done` ends tool input without causing a later `response.output_item.done` to emit a duplicate `tool_call_complete`.
- Align stale default-model expectations with the current `gpt-5.4` default and restore the minimal provider-only plan-mode reminder.

## Root Cause
Responses streams can send both `response.function_call_arguments.done` and a later `response.output_item.done` for the same function call. The adapter previously completed and removed the draft on the arguments-done event, so the output-item-done event created a second draft and completed the same tool call again.

## Validation
- `PYTHONPATH=src pytest -q tests/runtime/test_llm_event_adapter.py tests/runtime/test_provider_transport.py tests/test_runtime_event_projection.py tests/test_event_bus.py tests/test_events.py tests/test_runtime_api.py tests/runtime/test_runtime_chat_gateway.py` - 203 passed, 1 warning
- `pytest -q tests/runtime/test_auto_session_compaction.py::test_token_budget_converts_to_char_budget_for_auto_compaction tests/runtime/test_plan_mode.py::test_plan_mode_reminder_is_provider_only_context tests/runtime/test_tool_selection_controls.py::test_without_model_hint_keeps_default_file_tool_selection tests/test_model_fallback.py::test_readme_llm_example_uses_default_llm_model` - 4 passed
- `pytest -q` - 2332 passed, 3 skipped, 9 warnings
- `git diff --check` - passed
- duplicate completion script - `complete_count 1`