### PR TITLE
Fix runtime profile external CLI config handling

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -105,6 +105,18 @@ RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS = [
     ),
 ]
 
+_ATLASSIAN_INSTANCE_URL_FIELDS = ("url", "base_url", "baseUrl", "uri")
+
+
+def _first_atlassian_instance_url(value: Dict[str, Any]) -> str:
+    if not isinstance(value, dict):
+        return ""
+    for field in _ATLASSIAN_INSTANCE_URL_FIELDS:
+        text = str(value.get(field) or "").strip()
+        if text:
+            return text.rstrip("/")
+    return ""
+
 
 class ServiceReloadManager:
     """Manager for services that need to be reinitialized when config changes."""
@@ -187,7 +199,7 @@ def _has_atlassian_profile_instances(section: Any) -> bool:
     for instance in instances:
         if not isinstance(instance, dict) or instance.get("enabled") is False:
             continue
-        if str(instance.get("base_url") or instance.get("url") or "").strip():
+        if _first_atlassian_instance_url(instance):
             return True
     return False
 
@@ -467,14 +479,18 @@ class Config:
         """Apply Portal-managed snapshot into config.yaml and reload."""
         previous_sections = set(self._managed_sections)
         filtered_overlay = self._filter_managed_overlay_sections(overlay_config or {})
-        if _should_inject_runtime_profile_external_cli_instructions(filtered_overlay):
-            filtered_overlay["instruction_texts"] = list(RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS)
-        new_sections = set(filtered_overlay.keys())
+        external_cli_overlay = copy.deepcopy(filtered_overlay)
+        if _should_inject_runtime_profile_external_cli_instructions(external_cli_overlay):
+            external_cli_overlay["instruction_texts"] = list(RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS)
+        persisted_overlay = copy.deepcopy(external_cli_overlay)
+        persisted_overlay.pop("jira", None)
+        persisted_overlay.pop("confluence", None)
+        new_sections = set(external_cli_overlay.keys())
 
         config_document = self._load_yaml_document(self.config_path)
         self._decrypt_sensitive_fields(config_document)
         self._prune_by_field_tree(config_document, self.PORTAL_MANAGED_FIELD_TREE)
-        self._deep_merge_into(config_document, filtered_overlay)
+        self._deep_merge_into(config_document, persisted_overlay)
         self._persist_runtime_config(config_document)
 
         from src.external_cli.profile_config import (
@@ -483,9 +499,9 @@ class Config:
         )
 
         try:
-            apply_runtime_profile_external_config(filtered_overlay)
+            apply_runtime_profile_external_config(external_cli_overlay, config_path=self.config_path)
         except Exception as exc:
-            error = redact_runtime_profile_external_config_error(exc, filtered_overlay)
+            error = redact_runtime_profile_external_config_error(exc, external_cli_overlay)
             self._set_external_config_status("apply", False, error)
             logger.warning(
                 "Runtime profile external CLI config apply failed: %s",
@@ -524,7 +540,7 @@ class Config:
         )
 
         try:
-            clear_runtime_profile_external_config()
+            clear_runtime_profile_external_config(config_path=self.config_path)
         except Exception as exc:
             error = redact_runtime_profile_external_config_error(exc)
             self._set_external_config_status("clear", False, error)
@@ -769,10 +785,10 @@ class Config:
         instances = jira_config.get("instances", [])
         
         # Backward compatibility: if instances is empty but url exists, convert old format
-        if not instances and jira_config.get("url"):
+        if not instances and _first_atlassian_instance_url(jira_config):
             instances = [{
                 "name": "Default",
-                "url": jira_config.get("url", ""),
+                "url": _first_atlassian_instance_url(jira_config),
                 "project": jira_config.get("project", ""),
                 "username": jira_config.get("username", ""),
                 "password": jira_config.get("password", ""),
@@ -781,7 +797,7 @@ class Config:
                 "timeout": jira_config.get("timeout", 30.0),
             }]
         
-        return instances
+        return self._normalize_atlassian_instances(instances)
     
     def find_jira_instance(self, url: str = None, name: str = None) -> Optional[Dict[str, Any]]:
         """Find Jira instance by URL or name."""
@@ -817,17 +833,37 @@ class Config:
         instances = confluence_config.get("instances", [])
         
         # Backward compatibility: if instances is empty but url exists, convert old format
-        if not instances and confluence_config.get("url"):
+        if not instances and _first_atlassian_instance_url(confluence_config):
             instances = [{
                 "name": "Default",
-                "url": confluence_config.get("url", ""),
+                "url": _first_atlassian_instance_url(confluence_config),
                 "username": confluence_config.get("username", ""),
                 "password": confluence_config.get("password", ""),
                 "token": confluence_config.get("token", ""),
                 "space": confluence_config.get("space", ""),
             }]
         
-        return instances
+        return self._normalize_atlassian_instances(instances)
+
+    def _normalize_atlassian_instances(self, instances: Any) -> List[Dict[str, Any]]:
+        if not isinstance(instances, list):
+            return []
+        normalized: List[Dict[str, Any]] = []
+        seen: set[tuple[str, str]] = set()
+        for raw in instances:
+            if not isinstance(raw, dict):
+                continue
+            url = _first_atlassian_instance_url(raw)
+            if not url:
+                continue
+            item = copy.deepcopy(raw)
+            item["url"] = url
+            key = (str(item.get("name") or "").strip().lower(), url.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized.append(item)
+        return normalized
     
     def find_confluence_instance(
         self,

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -36,10 +36,14 @@ class _CliEnvironment:
     secrets: tuple[str, ...] = ()
 
 
-def apply_runtime_profile_external_config(profile_config: dict[str, Any]) -> None:
+def apply_runtime_profile_external_config(
+    profile_config: dict[str, Any],
+    *,
+    config_path: Path | str | None = None,
+) -> None:
     """Apply external CLI config for the sanitized Portal profile using real CLIs."""
 
-    cli_environment = _build_cli_environment(profile_config)
+    cli_environment = _build_cli_environment(profile_config, config_path=config_path)
     previous = _load_metadata()
     if previous:
         clear_runtime_profile_external_config(metadata=previous, cli_environment=cli_environment)
@@ -71,6 +75,7 @@ def clear_runtime_profile_external_config(
     *,
     metadata: dict[str, Any] | None = None,
     cli_environment: _CliEnvironment | None = None,
+    config_path: Path | str | None = None,
 ) -> None:
     """Remove external CLI config previously managed by runtime profile apply."""
 
@@ -78,7 +83,7 @@ def clear_runtime_profile_external_config(
     if not meta or meta.get("managed_by") != _MANAGED_BY:
         return
 
-    cli_environment = cli_environment or _CliEnvironment(env=os.environ.copy())
+    cli_environment = cli_environment or _build_cli_environment(None, config_path=config_path)
     _clear_new_metadata(meta, cli_environment=cli_environment)
     _clear_legacy_metadata(meta)
     _remove_file_if_exists(_metadata_path())
@@ -108,6 +113,7 @@ def _apply_atlassian_product(
     product_meta: dict[str, Any] = {"instances": []}
     metadata[product] = product_meta
     for instance in instances:
+        _remove_atlassian_instance_if_exists(product, instance["name"], cli_environment=cli_environment)
         _add_atlassian_instance(
             product,
             instance,
@@ -167,6 +173,18 @@ def _remove_atlassian_instance(product: str, name: str, *, cli_environment: _Cli
         env=cli_environment.env,
         env_secrets=cli_environment.secrets,
     )
+
+
+def _remove_atlassian_instance_if_exists(product: str, name: str, *, cli_environment: _CliEnvironment) -> None:
+    try:
+        _run_cli(
+            [product, "--json", "instance", "remove", name, "--yes"],
+            allowed_returncodes=tuple(range(256)),
+            env=cli_environment.env,
+            env_secrets=cli_environment.secrets,
+        )
+    except RuntimeError:
+        return
 
 
 def _apply_github(
@@ -354,8 +372,14 @@ def _metadata_gh_hosts(gh_meta: dict[str, Any]) -> list[str]:
     return [host] if host else []
 
 
-def _build_cli_environment(profile_config: dict[str, Any] | None) -> _CliEnvironment:
+def _build_cli_environment(
+    profile_config: dict[str, Any] | None,
+    *,
+    config_path: Path | str | None = None,
+) -> _CliEnvironment:
     env = os.environ.copy()
+    if config_path is not None:
+        env["EFP_CONFIG"] = str(config_path)
     proxy_config = profile_config.get("proxy") if isinstance(profile_config, dict) else None
     if not isinstance(proxy_config, dict):
         return _CliEnvironment(env=env)
@@ -409,7 +433,7 @@ def _build_product_instances(product_config: Any, *, product: str) -> list[dict[
     for index, raw in enumerate(raw_instances, 1):
         if not isinstance(raw, dict) or raw.get("enabled") is False:
             continue
-        base_url = _normalize_base_url(raw.get("base_url") or raw.get("url"))
+        base_url = _profile_instance_base_url(raw)
         if not base_url:
             continue
         name = _unique_instance_name(str(raw.get("name") or f"{product}-{index}").strip(), used_names, product, index)
@@ -432,6 +456,10 @@ def _build_product_instances(product_config: Any, *, product: str) -> list[dict[
             }
         instances.append(instance)
     return instances
+
+
+def _profile_instance_base_url(raw: dict[str, Any]) -> str:
+    return _normalize_base_url(raw.get("base_url") or raw.get("baseUrl") or raw.get("url") or raw.get("uri"))
 
 
 def _unique_instance_name(raw_name: str, used_names: set[str], product: str, index: int) -> str:

--- a/tests/test_config_runtime_profile_automation_removed.py
+++ b/tests/test_config_runtime_profile_automation_removed.py
@@ -1,4 +1,5 @@
 from src.config import Config
+from src.external_cli import profile_config as profile_config_module
 
 
 def _write_base_config(path):
@@ -53,6 +54,11 @@ def test_set_managed_overlay_allows_llm_response_flow_subtree(tmp_path):
 
 def test_set_managed_overlay_ignores_provider_automation_subtrees(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(
+        profile_config_module,
+        "apply_runtime_profile_external_config",
+        lambda overlay, **_: None,
+    )
     config_path = tmp_path / "config.yaml"
     _write_base_config(config_path)
 
@@ -94,11 +100,15 @@ def test_set_managed_overlay_ignores_provider_automation_subtrees(tmp_path, monk
     assert effective["github"]["base_url"] == "https://api.github.com"
     assert "automation" not in effective["github"]
 
-    assert effective["jira"]["enabled"] is True
-    assert "automation" not in effective["jira"]
+    assert "jira" not in effective
+    assert "confluence" not in effective
 
-    assert effective["confluence"]["enabled"] is True
-    assert "automation" not in effective["confluence"]
+    assert cfg.get_managed_overlay_meta()["managed_sections"] == [
+        "confluence",
+        "github",
+        "instruction_texts",
+        "jira",
+    ]
 
 
 def test_set_managed_overlay_applies_and_clears_llm_temperature(tmp_path):

--- a/tests/test_runtime_profile_client.py
+++ b/tests/test_runtime_profile_client.py
@@ -276,7 +276,7 @@ async def test_bootstrap_runtime_profile_external_cli_failure_still_returns_true
         ),
     )
 
-    def _fail_external_config(_overlay):
+    def _fail_external_config(_overlay, **_):
         raise RuntimeError(f"External CLI command failed: gh auth login stderr: {token}")
 
     monkeypatch.setattr(

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -51,6 +51,10 @@ def _command_calls(recorder, prefix):
     return [call for call in recorder.calls if call["args"][: len(prefix)] == prefix]
 
 
+def _command_indices(recorder, prefix):
+    return [index for index, call in enumerate(recorder.calls) if call["args"][: len(prefix)] == prefix]
+
+
 RUNTIME_OVERLAY_FIELDS = {
     "enabled_tools": ["read"],
     "disabled_tools": ["write"],
@@ -131,6 +135,10 @@ def _write_base_config(path):
     )
 
 
+def _read_yaml(path):
+    return YAML().load(path.read_text(encoding="utf-8")) or {}
+
+
 def test_runtime_profile_apply_writes_config_yaml_without_sidecar(tmp_path):
     config_path = tmp_path / "config.yaml"
     runtime_profile_path = tmp_path / "runtime_profile.yaml"
@@ -154,13 +162,152 @@ def test_runtime_profile_apply_writes_config_yaml_without_sidecar(tmp_path):
     effective = cfg.get_effective_config()
     assert effective["llm"]["provider"] == "anthropic"
     assert effective["llm"].get("model") is None
-    assert effective["jira"]["enabled"] is True
+    assert "jira" not in effective
     assert "unknown" not in effective
 
     meta = cfg.get_managed_overlay_meta()
     assert meta["runtime_profile_id"] == "rp_1"
     assert meta["revision"] == 3
     assert meta["managed_sections"] == ["jira", "llm"]
+
+
+def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persisted(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    _write_base_config(config_path)
+    applied = []
+
+    monkeypatch.setattr(
+        profile_config_module,
+        "apply_runtime_profile_external_config",
+        lambda overlay, **_: applied.append(json.loads(json.dumps(overlay))),
+    )
+
+    cfg = Config(str(config_path))
+    cfg.set_managed_overlay(
+        "rp_atlassian",
+        1,
+        {
+            "jira": {
+                "enabled": True,
+                "instances": [
+                    {
+                        "name": "jira-main",
+                        "url": "https://jira.example.test",
+                        "username": "bot",
+                        "token": "jira-token",
+                    }
+                ],
+            },
+            "confluence": {
+                "enabled": True,
+                "instances": [
+                    {
+                        "name": "docs",
+                        "url": "https://conf.example.test/wiki",
+                        "username": "bot",
+                        "token": "conf-token",
+                    }
+                ],
+            },
+        },
+    )
+
+    persisted = _read_yaml(config_path)
+    assert "jira" not in persisted
+    assert "confluence" not in persisted
+    assert persisted["instruction_texts"]
+    assert "jira-token" not in config_path.read_text(encoding="utf-8")
+    assert "conf-token" not in config_path.read_text(encoding="utf-8")
+    assert applied[0]["jira"]["instances"][0]["token"] == "jira-token"
+    assert applied[0]["confluence"]["instances"][0]["token"] == "conf-token"
+    assert cfg.get_managed_overlay_meta()["managed_sections"] == [
+        "confluence",
+        "instruction_texts",
+        "jira",
+    ]
+
+
+def test_runtime_profile_apply_prunes_previous_portal_atlassian_entries(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "llm:\n"
+        "  provider: openai\n"
+        "jira:\n"
+        "  enabled: true\n"
+        "  instances:\n"
+        "    - name: jira-main\n"
+        "      url: https://jira.example.test\n"
+        "      username: bot\n"
+        "      token: jira-token\n"
+        "confluence:\n"
+        "  enabled: true\n"
+        "  instances:\n"
+        "    - name: docs\n"
+        "      url: https://conf.example.test/wiki\n"
+        "      username: bot\n"
+        "      token: conf-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        profile_config_module,
+        "apply_runtime_profile_external_config",
+        lambda overlay, **_: None,
+    )
+
+    cfg = Config(str(config_path))
+    cfg.set_managed_overlay("rp_prune", 2, {"llm": {"provider": "anthropic"}})
+
+    persisted = _read_yaml(config_path)
+    assert "jira" not in persisted
+    assert "confluence" not in persisted
+    raw_text = config_path.read_text(encoding="utf-8")
+    assert "jira-token" not in raw_text
+    assert "conf-token" not in raw_text
+    cfg.load()
+    effective = cfg.get_effective_config()
+    assert "jira" not in effective
+    assert "confluence" not in effective
+
+
+def test_runtime_profile_config_instances_normalize_cli_native_and_drop_blank_urls():
+    cfg = Config.__new__(Config)
+    cfg._config = {
+        "jira": {
+            "enabled": True,
+            "instances": [
+                {
+                    "name": "jira-main",
+                    "base_url": "https://jira.example.test/",
+                    "rest_path": "/rest/api/3",
+                },
+                {
+                    "name": "jira-main",
+                    "url": "https://jira.example.test",
+                    "username": "duplicate",
+                },
+                {"name": "name-only"},
+                {"name": "jira-uri", "uri": "https://jira-uri.example.test"},
+            ],
+        },
+        "confluence": {
+            "enabled": True,
+            "instances": [
+                {"name": "docs", "baseUrl": "https://conf.example.test/wiki/"},
+                {"name": "docs", "base_url": "https://conf.example.test/wiki"},
+                {"name": "blank", "base_url": " "},
+            ],
+        },
+    }
+
+    jira_instances = cfg.get_jira_instances()
+    assert [item["name"] for item in jira_instances] == ["jira-main", "jira-uri"]
+    assert jira_instances[0]["url"] == "https://jira.example.test"
+    assert jira_instances[0]["base_url"] == "https://jira.example.test/"
+    assert jira_instances[1]["url"] == "https://jira-uri.example.test"
+
+    confluence_instances = cfg.get_confluence_instances()
+    assert [item["name"] for item in confluence_instances] == ["docs"]
+    assert confluence_instances[0]["url"] == "https://conf.example.test/wiki"
 
 
 def test_runtime_profile_apply_preserves_and_clears_runtime_top_level_fields(tmp_path):
@@ -352,7 +499,7 @@ def test_set_managed_overlay_external_cli_failure_is_non_fatal(tmp_path, monkeyp
     token = "gh-secret-token"
     proxy_password = "proxy-url-secret"
 
-    def _fail_external_config(_overlay):
+    def _fail_external_config(_overlay, **_):
         raise RuntimeError(f"External CLI command failed: gh auth login stderr: {token} proxy {proxy_password}")
 
     monkeypatch.setattr(
@@ -408,7 +555,7 @@ def test_clear_managed_overlay_external_cli_failure_is_non_fatal(tmp_path, monke
     monkeypatch.setattr(
         profile_config_module,
         "apply_runtime_profile_external_config",
-        lambda _overlay: None,
+        lambda _overlay, **_: None,
     )
     cfg = Config(str(config_path))
     cfg.runtime_profile_path = runtime_profile_path
@@ -421,7 +568,7 @@ def test_clear_managed_overlay_external_cli_failure_is_non_fatal(tmp_path, monke
     monkeypatch.setattr(
         profile_config_module,
         "clear_runtime_profile_external_config",
-        lambda: (_ for _ in ()).throw(RuntimeError("External CLI command failed: jira instance remove")),
+        lambda **_: (_ for _ in ()).throw(RuntimeError("External CLI command failed: jira instance remove")),
     )
     caplog.set_level("WARNING")
 
@@ -513,8 +660,22 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
         },
     )
 
+    jira_remove = _command_calls(recorder, ["jira", "--json", "instance", "remove"])
+    assert jira_remove == [
+        {
+            "args": ["jira", "--json", "instance", "remove", "jira-main", "--yes"],
+            "input": None,
+            "text": True,
+            "capture_output": True,
+            "check": False,
+        }
+    ]
     jira_add = _command_calls(recorder, ["jira", "--json", "instance", "add"])
     assert len(jira_add) == 1
+    assert _command_indices(recorder, ["jira", "--json", "instance", "remove"])[0] < _command_indices(
+        recorder,
+        ["jira", "--json", "instance", "add"],
+    )[0]
     assert jira_add[0]["args"] == [
         "jira",
         "--json",
@@ -536,8 +697,22 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
     ]
     assert jira_add[0]["input"] == "jira-token"
 
+    confluence_remove = _command_calls(recorder, ["confluence", "--json", "instance", "remove"])
+    assert confluence_remove == [
+        {
+            "args": ["confluence", "--json", "instance", "remove", "docs", "--yes"],
+            "input": None,
+            "text": True,
+            "capture_output": True,
+            "check": False,
+        }
+    ]
     confluence_add = _command_calls(recorder, ["confluence", "--json", "instance", "add"])
     assert len(confluence_add) == 1
+    assert _command_indices(recorder, ["confluence", "--json", "instance", "remove"])[0] < _command_indices(
+        recorder,
+        ["confluence", "--json", "instance", "add"],
+    )[0]
     assert confluence_add[0]["args"] == [
         "confluence",
         "--json",
@@ -642,7 +817,14 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
             "text": True,
             "capture_output": True,
             "check": False,
-        }
+        },
+        {
+            "args": ["jira", "--json", "instance", "remove", "jira-main", "--yes"],
+            "input": None,
+            "text": True,
+            "capture_output": True,
+            "check": False,
+        },
     ]
     assert _command_calls(recorder, ["confluence", "--json", "instance", "remove"]) == [
         {
@@ -651,7 +833,14 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
             "text": True,
             "capture_output": True,
             "check": False,
-        }
+        },
+        {
+            "args": ["confluence", "--json", "instance", "remove", "docs", "--yes"],
+            "input": None,
+            "text": True,
+            "capture_output": True,
+            "check": False,
+        },
     ]
     assert _command_calls(recorder, ["gh", "auth", "logout"]) == [
         {
@@ -677,6 +866,136 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
         "check": False,
     }
     assert not metadata_path.exists()
+
+
+def test_managed_overlay_external_cli_env_uses_config_path_with_profile_proxy(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    config_path = tmp_path / "config.yaml"
+    _write_base_config(config_path)
+    for key in [
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("EFP_CONFIG", str(tmp_path / "wrong-config.yaml"))
+    recorder = _CliRecorder(record_env=True)
+    monkeypatch.setattr(profile_config_module.subprocess, "run", recorder.run)
+
+    cfg = Config(str(config_path))
+    cfg.set_managed_overlay(
+        "rp_external_env",
+        1,
+        {
+            "proxy": {
+                "enabled": True,
+                "url": "http://proxy.example.test:8080",
+                "username": "proxy-user",
+                "password": "proxy-password",
+                "no_proxy": "localhost,.svc",
+            },
+            "jira": {
+                "enabled": True,
+                "instances": [{"name": "jira-main", "url": "https://jira.example.test"}],
+            },
+            "confluence": {
+                "enabled": True,
+                "instances": [{"name": "docs", "url": "https://conf.example.test/wiki"}],
+            },
+        },
+    )
+
+    expected_proxy = "http://proxy-user:proxy-password@proxy.example.test:8080"
+    atlassian_calls = [call for call in recorder.calls if call["args"][0] in {"jira", "confluence"}]
+    assert [call["args"][:4] for call in atlassian_calls] == [
+        ["jira", "--json", "instance", "remove"],
+        ["jira", "--json", "instance", "add"],
+        ["confluence", "--json", "instance", "remove"],
+        ["confluence", "--json", "instance", "add"],
+    ]
+    for call in atlassian_calls:
+        assert call["env"]["EFP_CONFIG"] == str(config_path)
+        for key in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "all_proxy", "ALL_PROXY"):
+            assert call["env"][key] == expected_proxy
+        assert call["env"]["no_proxy"] == "localhost,.svc"
+        assert call["env"]["NO_PROXY"] == "localhost,.svc"
+
+    recorder.calls.clear()
+    monkeypatch.setenv("EFP_CONFIG", str(tmp_path / "wrong-clear-config.yaml"))
+    cfg.clear_managed_overlay()
+
+    remove_prefixes = (
+        ["jira", "--json", "instance", "remove"],
+        ["confluence", "--json", "instance", "remove"],
+    )
+    remove_calls = [call for call in recorder.calls if call["args"][:4] in remove_prefixes]
+    assert [call["args"][0] for call in remove_calls] == ["jira", "confluence"]
+    for call in remove_calls:
+        assert call["env"]["EFP_CONFIG"] == str(config_path)
+
+
+def test_runtime_profile_external_cli_reapply_removes_same_name_before_add(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    recorder = _CliRecorder()
+    monkeypatch.setattr(profile_config_module.subprocess, "run", recorder.run)
+
+    profile = {
+        "jira": {
+            "enabled": True,
+            "instances": [
+                {"name": "jira-main", "uri": "https://jira.example.test", "token": "jira-token"},
+                {"name": "jira-empty"},
+            ],
+        },
+        "confluence": {
+            "enabled": True,
+            "instances": [
+                {"name": "docs", "baseUrl": "https://conf.example.test/wiki", "token": "conf-token"},
+                {"name": "docs-empty", "url": ""},
+            ],
+        },
+    }
+
+    profile_config_module.apply_runtime_profile_external_config(profile)
+    recorder.calls.clear()
+    profile_config_module.apply_runtime_profile_external_config(profile)
+
+    jira_remove = _command_calls(recorder, ["jira", "--json", "instance", "remove"])
+    jira_add = _command_calls(recorder, ["jira", "--json", "instance", "add"])
+    assert [call["args"][4] for call in jira_remove] == ["jira-main", "jira-main"]
+    assert len(jira_add) == 1
+    assert all(
+        index < _command_indices(recorder, ["jira", "--json", "instance", "add"])[0]
+        for index in _command_indices(recorder, ["jira", "--json", "instance", "remove"])
+    )
+
+    confluence_remove = _command_calls(recorder, ["confluence", "--json", "instance", "remove"])
+    confluence_add = _command_calls(recorder, ["confluence", "--json", "instance", "add"])
+    assert [call["args"][4] for call in confluence_remove] == ["docs", "docs"]
+    assert len(confluence_add) == 1
+    assert confluence_add[0]["args"][5:7] == ["--base-url", "https://conf.example.test/wiki"]
+    assert all(
+        index < _command_indices(recorder, ["confluence", "--json", "instance", "add"])[0]
+        for index in _command_indices(recorder, ["confluence", "--json", "instance", "remove"])
+    )
+
+    all_argv = json.dumps([call["args"] for call in recorder.calls])
+    assert "jira-empty" not in all_argv
+    assert "docs-empty" not in all_argv
+    metadata = json.loads(
+        (home / ".config" / "efp" / "runtime-profile-external-config.json").read_text(encoding="utf-8")
+    )
+    assert metadata["jira"]["instances"] == [{"name": "jira-main"}]
+    assert metadata["confluence"]["instances"] == [{"name": "docs"}]
 
 
 def test_runtime_profile_external_cli_inherits_docker_proxy_env_without_profile_proxy(tmp_path, monkeypatch):
@@ -708,6 +1027,7 @@ def test_runtime_profile_external_cli_uses_profile_proxy_env_and_redacts_metadat
 ):
     home = tmp_path / "home"
     home.mkdir()
+    config_path = tmp_path / "config.yaml"
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("HTTPS_PROXY", "http://docker.proxy.local:8443")
     recorder = _CliRecorder(record_env=True)
@@ -742,7 +1062,8 @@ def test_runtime_profile_external_cli_uses_profile_proxy_env_and_redacts_metadat
                 "access_token": "gh-token",
                 "api_base_url": "https://github.example.test/api/v3",
             },
-        }
+        },
+        config_path=config_path,
     )
 
     gh_logout = _command_calls(recorder, ["gh", "auth", "logout"])
@@ -750,6 +1071,7 @@ def test_runtime_profile_external_cli_uses_profile_proxy_env_and_redacts_metadat
     gh_login = _command_calls(recorder, ["gh", "auth", "login"])
     assert len(gh_login) == 1
     for call in (gh_logout[0], gh_login[0]):
+        assert call["env"]["EFP_CONFIG"] == str(config_path)
         for key in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "all_proxy", "ALL_PROXY"):
             assert call["env"][key] == expected_proxy
         assert call["env"]["no_proxy"] == "localhost,.internal"
@@ -1027,7 +1349,7 @@ def test_runtime_profile_external_cli_instructions_are_injected(tmp_path, monkey
     monkeypatch.setattr(
         profile_config_module,
         "apply_runtime_profile_external_config",
-        lambda overlay: applied.append(json.loads(json.dumps(overlay))),
+        lambda overlay, **_: applied.append(json.loads(json.dumps(overlay))),
     )
 
     cfg = Config(str(config_path))
@@ -1065,6 +1387,42 @@ def test_runtime_profile_external_cli_instructions_are_injected(tmp_path, monkey
     assert applied[0]["instruction_texts"] == instructions
 
 
+def test_runtime_profile_external_cli_instructions_require_real_atlassian_url(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    _write_base_config(config_path)
+    applied = []
+
+    monkeypatch.setattr(
+        profile_config_module,
+        "apply_runtime_profile_external_config",
+        lambda overlay, **_: applied.append(json.loads(json.dumps(overlay))),
+    )
+
+    cfg = Config(str(config_path))
+    cfg.set_managed_overlay(
+        "rp_no_instructions",
+        1,
+        {
+            "jira": {
+                "enabled": True,
+                "instances": [{"name": "jira-main"}],
+            },
+            "confluence": {
+                "enabled": True,
+                "instances": [{"name": "docs", "baseUrl": " "}],
+            },
+        },
+    )
+
+    cfg.load()
+    effective = cfg.get_effective_config()
+    assert "instruction_texts" not in effective
+    assert "jira" not in effective
+    assert "confluence" not in effective
+    assert "instruction_texts" not in applied[0]
+    assert cfg.get_managed_overlay_meta()["managed_sections"] == ["confluence", "jira"]
+
+
 def test_runtime_profile_external_cli_instructions_preserve_portal_texts(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
     _write_base_config(config_path)
@@ -1072,7 +1430,7 @@ def test_runtime_profile_external_cli_instructions_preserve_portal_texts(tmp_pat
     monkeypatch.setattr(
         profile_config_module,
         "apply_runtime_profile_external_config",
-        lambda overlay: None,
+        lambda overlay, **_: None,
     )
 
     cfg = Config(str(config_path))


### PR DESCRIPTION
## Summary
- stop persisting Portal-style Jira/Confluence runtime profile sections into config.yaml
- apply Jira/Confluence config through the external CLIs with idempotent same-name removal
- normalize CLI-native base_url/baseUrl/uri instances and filter blank endpoints
- pass Config.config_path to external CLIs via EFP_CONFIG so runtime and CLI use the same file

## Tests
- python -m pytest tests/test_runtime_profile_overlay.py tests/test_config_instances.py tests/test_config.py tests/test_runtime_profile_client.py tests/test_config_runtime_profile_automation_removed.py -q
- git diff --check