### PR TITLE
[codex] Restrict system prompt routes to AGENTS

### DIFF
--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -37,6 +37,10 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+SYSTEM_PROMPT_AGENTS_SECTION = "agents"
+SYSTEM_PROMPT_AGENTS_FILENAME = "AGENTS.md"
+UNSUPPORTED_SYSTEM_PROMPT_SECTIONS = ["soul", "user", "tools", "memory", "daily_notes"]
+
 
 def _runtime_workspace_root() -> Path:
     """Canonical runtime workspace root."""
@@ -45,6 +49,76 @@ def _runtime_workspace_root() -> Path:
     except Exception:
         config_data = getattr(config, "_config", None)
     return resolve_runtime_workspace(config_data).resolve()
+
+
+def _agents_md_path() -> Path:
+    return _runtime_workspace_root() / SYSTEM_PROMPT_AGENTS_FILENAME
+
+
+def _default_agents_md_template_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "workspace" / "AGENTS.md.example"
+
+
+def _read_default_agents_md_template() -> str:
+    path = _default_agents_md_template_path()
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return "# AGENTS.md\n\n"
+
+
+def _write_agents_md(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(content, encoding="utf-8")
+    tmp_path.replace(path)
+    return path
+
+
+def _ensure_agents_md() -> Path:
+    path = _agents_md_path()
+    if path.exists():
+        return path
+    return _write_agents_md(path, _read_default_agents_md_template())
+
+
+def _read_agents_md() -> str:
+    return _ensure_agents_md().read_text(encoding="utf-8")
+
+
+def _agents_metadata() -> dict[str, object]:
+    return {
+        "enabled": True,
+        "editable": True,
+        "label": SYSTEM_PROMPT_AGENTS_FILENAME,
+        "filename": SYSTEM_PROMPT_AGENTS_FILENAME,
+        "path": SYSTEM_PROMPT_AGENTS_FILENAME,
+        "can_disable": False,
+    }
+
+
+def _agents_system_prompt_config_payload() -> dict[str, object]:
+    _ensure_agents_md()
+    return {
+        "engine": "native",
+        "runtime_type": "native",
+        "sections": [SYSTEM_PROMPT_AGENTS_SECTION],
+        SYSTEM_PROMPT_AGENTS_SECTION: _agents_metadata(),
+        "unsupported_sections": UNSUPPORTED_SYSTEM_PROMPT_SECTIONS,
+    }
+
+
+def _unsupported_system_prompt_response(name: str) -> web.Response:
+    return web.json_response(
+        {
+            "error": "EFP Native runtime only supports AGENTS.md",
+            "engine": "native",
+            "runtime_type": "native",
+            "section": name,
+            "supported_sections": [SYSTEM_PROMPT_AGENTS_SECTION],
+        },
+        status=422,
+    )
 
 
 
@@ -301,189 +375,120 @@ class Gateway:
     # ============================================
     
     async def handle_system_prompt_config_get(self, request: Request) -> web.Response:
-        """Get system prompt configuration (enabled states).
-        
-        GET /api/agent/system-prompt/config
-        Returns: {"soul": {"enabled": true}, "user": {...}, ...}
-        """
-        from src.config import config as runtime_config
-        
-        # Return explicit object with all supported sections and their effective enabled state
-        # This ensures the UI always knows the current effective config
-        sections = ["soul", "user", "agents", "tools", "memory", "daily_notes"]
-        system_prompt = {}
-        for section in sections:
-            enabled = runtime_config.get(f"llm.system-prompt.{section}.enabled", True)
-            system_prompt[section] = {"enabled": bool(enabled)}
-        
-        return web.json_response(system_prompt)
+        """Get the runtime-owned system prompt configuration."""
+
+        return web.json_response(_agents_system_prompt_config_payload())
     
     async def handle_system_prompt_config_put(self, request: Request) -> web.Response:
-        """Update system prompt configuration.
-        
-        PUT /api/agent/system-prompt/config
-        Body: {"soul": {"enabled": true}, "user": {...}, ...}
+        """Validate system prompt configuration updates.
+
+        Native runtime only supports AGENTS.md, which is always enabled.
         """
-        from src.config import config as runtime_config
-        from pathlib import Path
-        from ruamel.yaml import YAML
-        import os
-        
+
         try:
             data = await request.json()
-            
-            # Load config.yaml directly
-            config_path = Path.home() / ".efp" / "config.yaml"
-            if not config_path.exists():
-                return web.json_response({"status": "error", "message": "Config not found"}, status=404)
-            
-            yaml = YAML()
-            yaml.preserve_quotes = True
-            yaml.indent(mapping=2, sequence=4, offset=2)
-            
-            with open(config_path, 'r') as f:
-                config_data = yaml.load(f) or {}
-            
-            # Update system-prompt section
-            if "llm" not in config_data:
-                config_data["llm"] = {}
-            if "system-prompt" not in config_data["llm"]:
-                config_data["llm"]["system-prompt"] = {}
-            
-            # Validate and update settings
-            valid_sections = {"soul", "user", "agents", "tools", "memory", "daily_notes"}
-            for name, settings in data.items():
-                if name not in valid_sections:
-                    return web.json_response(
-                        {"status": "error", "message": f"Invalid section: {name}"},
-                        status=400
-                    )
-                if name not in config_data["llm"]["system-prompt"]:
-                    config_data["llm"]["system-prompt"][name] = {}
-                for k, v in settings.items():
-                    # Validate enabled is boolean
-                    if k == "enabled" and not isinstance(v, bool):
-                        return web.json_response(
-                            {"status": "error", "message": f"enabled must be boolean for section {name}"},
-                            status=400
-                        )
-                    config_data["llm"]["system-prompt"][name][k] = v
-            
-            # Save
-            with open(config_path, 'w', encoding='utf-8') as f:
-                yaml.dump(config_data, f)
-            
-            # Reload runtime config (without forcing LLM service reinit)
-            runtime_config.reload()
-            
-            return web.json_response({"status": "ok"})
         except asyncio.CancelledError:
             raise
-        except Exception as e:
-            return web.json_response({"status": "error", "message": str(e)}, status=400)
+        except Exception:
+            return web.json_response({"error": "Invalid payload", "engine": "native"}, status=400)
+
+        if not isinstance(data, dict):
+            return web.json_response({"error": "Invalid payload", "engine": "native"}, status=400)
+        for section in data:
+            if section != SYSTEM_PROMPT_AGENTS_SECTION:
+                return _unsupported_system_prompt_response(section)
+        section_payload = data.get(SYSTEM_PROMPT_AGENTS_SECTION, {})
+        if not isinstance(section_payload, dict):
+            return web.json_response({"error": "Invalid section payload", "engine": "native"}, status=400)
+        if "enabled" in section_payload and not isinstance(section_payload["enabled"], bool):
+            return web.json_response({"error": "Invalid enabled", "engine": "native"}, status=400)
+        if section_payload.get("enabled") is False:
+            return web.json_response(
+                {
+                    "error": "EFP Native AGENTS.md cannot be disabled",
+                    "engine": "native",
+                    "runtime_type": "native",
+                    "section": SYSTEM_PROMPT_AGENTS_SECTION,
+                    "supported_sections": [SYSTEM_PROMPT_AGENTS_SECTION],
+                },
+                status=422,
+            )
+        _ensure_agents_md()
+        return web.json_response(
+            {
+                "status": "ok",
+                "engine": "native",
+                "runtime_type": "native",
+                "sections": [SYSTEM_PROMPT_AGENTS_SECTION],
+                SYSTEM_PROMPT_AGENTS_SECTION: _agents_metadata(),
+            }
+        )
     
     async def handle_system_prompt_get(self, request: Request) -> web.Response:
-        """Get system prompt file content and enabled state.
-        
-        GET /api/agent/system-prompt/{name}
-        name: soul, user, agents, tools, memory, daily_notes
-        Returns: {"enabled": true, "content": "..."}
-        """
-        from src.config import config as runtime_config
-        from pathlib import Path
-        
+        """Get AGENTS.md content and enabled state."""
+
         name = request.match_info.get("name")
-        allowed = ["soul", "user", "agents", "tools", "memory", "daily_notes"]
-        if name not in allowed:
-            return web.json_response({"error": "Invalid name"}, status=400)
-        
-        # Get enabled state
-        enabled = runtime_config.get(f"llm.system-prompt.{name}.enabled", True)
-        
-        # Get file path (fixed path) - not applicable for daily_notes
-        content = ""
-        if name != "daily_notes":
-            workspace = _runtime_workspace_root()
-            file_path = workspace / f"{name.upper()}.md"
-            if file_path.exists():
-                content = file_path.read_text(encoding="utf-8")
-        
+        if name != SYSTEM_PROMPT_AGENTS_SECTION:
+            return _unsupported_system_prompt_response(str(name or ""))
+        content = _read_agents_md()
         return web.json_response({
-            "enabled": enabled,
-            "content": content
+            "enabled": True,
+            "content": content,
+            "engine": "native",
+            "runtime_type": "native",
+            "section": SYSTEM_PROMPT_AGENTS_SECTION,
+            **_agents_metadata(),
         })
     
     async def handle_system_prompt_put(self, request: Request) -> web.Response:
-        """Update system prompt file content and/or enabled state.
-        
-        PUT /api/agent/system-prompt/{name}
-        Body: {"enabled": true, "content": "..."}
+        """Update AGENTS.md content.
+
+        The AGENTS.md section is always enabled and cannot be toggled off.
         """
-        from src.config import config as runtime_config
-        from pathlib import Path
-        from ruamel.yaml import YAML
-        
+
         name = request.match_info.get("name")
-        # Note: daily_notes is not included here - it's config-only, not a file
-        allowed = ["soul", "user", "agents", "tools", "memory"]
-        if name not in allowed:
-            return web.json_response({"error": "Invalid name"}, status=400)
-        
+        if name != SYSTEM_PROMPT_AGENTS_SECTION:
+            return _unsupported_system_prompt_response(str(name or ""))
+
         try:
             data = await request.json()
-            
-            # Update file content if provided
-            if "content" in data:
-                workspace = _runtime_workspace_root()
-                workspace.mkdir(parents=True, exist_ok=True)
-                file_path = workspace / f"{name.upper()}.md"
-                file_path.write_text(data["content"], encoding="utf-8")
-                
-                # Clear memory cache so changes take effect immediately
-                from src.agents.memory import memory_system
-                memory_system.clear_cache()
-            
-            # Update enabled state if provided
-            if "enabled" in data:
-                # Validate enabled is a boolean
-                if not isinstance(data["enabled"], bool):
-                    return web.json_response(
-                        {"status": "error", "message": "enabled must be a boolean"},
-                        status=400
-                    )
-                config_path = Path.home() / ".efp" / "config.yaml"
-                if not config_path.exists():
-                    return web.json_response(
-                        {"status": "error", "message": "Config file not found"},
-                        status=404
-                    )
-                yaml = YAML()
-                yaml.preserve_quotes = True
-                yaml.indent(mapping=2, sequence=4, offset=2)
-                
-                with open(config_path, 'r', encoding='utf-8') as f:
-                    config_data = yaml.load(f) or {}
-                
-                if "llm" not in config_data:
-                    config_data["llm"] = {}
-                if "system-prompt" not in config_data["llm"]:
-                    config_data["llm"]["system-prompt"] = {}
-                if name not in config_data["llm"]["system-prompt"]:
-                    config_data["llm"]["system-prompt"][name] = {}
-                
-                config_data["llm"]["system-prompt"][name]["enabled"] = bool(data["enabled"])
-                
-                with open(config_path, 'w', encoding='utf-8') as f:
-                    yaml.dump(config_data, f)
-                
-                # Reload runtime config
-                runtime_config.reload()
-            
-            return web.json_response({"status": "ok"})
         except asyncio.CancelledError:
             raise
-        except Exception as e:
-            return web.json_response({"status": "error", "message": str(e)}, status=400)
+        except Exception:
+            return web.json_response({"error": "Invalid payload", "engine": "native"}, status=400)
+
+        if not isinstance(data, dict):
+            return web.json_response({"error": "Invalid payload", "engine": "native"}, status=400)
+        if "enabled" in data and not isinstance(data["enabled"], bool):
+            return web.json_response({"error": "Invalid enabled", "engine": "native"}, status=400)
+        if "content" in data and not isinstance(data["content"], str):
+            return web.json_response({"error": "Invalid content", "engine": "native"}, status=400)
+        if data.get("enabled") is False:
+            return web.json_response(
+                {
+                    "error": "EFP Native AGENTS.md cannot be disabled",
+                    "engine": "native",
+                    "runtime_type": "native",
+                    "section": SYSTEM_PROMPT_AGENTS_SECTION,
+                    "supported_sections": [SYSTEM_PROMPT_AGENTS_SECTION],
+                },
+                status=422,
+            )
+        if "content" in data:
+            _write_agents_md(_agents_md_path(), data["content"])
+        else:
+            _ensure_agents_md()
+
+        return web.json_response(
+            {
+                "status": "ok",
+                "engine": "native",
+                "runtime_type": "native",
+                "section": SYSTEM_PROMPT_AGENTS_SECTION,
+                "enabled": True,
+                "path": SYSTEM_PROMPT_AGENTS_FILENAME,
+            }
+        )
 
 
     async def handle_config_reload(self, request: Request) -> web.Response:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -206,6 +206,87 @@ class TestGatewayRequestHandling:
         assert data["service"] == "engineering-flow-platform"
 
 
+class TestGatewaySystemPromptContract:
+    """System prompt compatibility routes should match runtime behavior."""
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_routes_are_agents_only(self, monkeypatch, tmp_path):
+        from aiohttp.test_utils import TestClient, TestServer
+        from src.gateway import server as gateway_server
+
+        class _FakeConfig:
+            jira = {}
+            server = {"host": "127.0.0.1", "port": 0}
+
+            def get_effective_config(self):
+                return {"workspace": {"path": str(tmp_path)}}
+
+        monkeypatch.setattr(gateway_server, "config", _FakeConfig())
+        monkeypatch.setattr(gateway_server, "bootstrap_runtime_profile_sync", lambda: True)
+        monkeypatch.setattr(gateway_server, "setup_runtime_api_routes", lambda app: None)
+
+        client = TestClient(TestServer(gateway_server.Gateway().app))
+        await client.start_server()
+        try:
+            cfg_response = await client.get("/api/agent/system-prompt/config")
+            cfg = await cfg_response.json()
+            assert cfg_response.status == 200
+            assert cfg["engine"] == "native"
+            assert cfg["runtime_type"] == "native"
+            assert cfg["sections"] == ["agents"]
+            assert cfg["agents"]["can_disable"] is False
+            assert (tmp_path / "AGENTS.md").exists()
+
+            ok_response = await client.put(
+                "/api/agent/system-prompt/config",
+                json={"agents": {"enabled": True}},
+            )
+            assert ok_response.status == 200
+
+            disabled_response = await client.put(
+                "/api/agent/system-prompt/config",
+                json={"agents": {"enabled": False}},
+            )
+            assert disabled_response.status == 422
+
+            unsupported_response = await client.put(
+                "/api/agent/system-prompt/config",
+                json={"soul": {"enabled": True}},
+            )
+            assert unsupported_response.status == 422
+
+            write_response = await client.put(
+                "/api/agent/system-prompt/agents",
+                json={"content": "Native agents only."},
+            )
+            assert write_response.status == 200
+            assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == "Native agents only."
+
+            get_response = await client.get("/api/agent/system-prompt/agents")
+            body = await get_response.json()
+            assert get_response.status == 200
+            assert body["enabled"] is True
+            assert body["content"] == "Native agents only."
+            assert body["can_disable"] is False
+
+            invalid_enabled_response = await client.put(
+                "/api/agent/system-prompt/agents",
+                json={"enabled": "yes"},
+            )
+            assert invalid_enabled_response.status == 400
+
+            for name in ["soul", "user", "tools", "memory", "daily_notes"]:
+                get_unsupported = await client.get(f"/api/agent/system-prompt/{name}")
+                put_unsupported = await client.put(
+                    f"/api/agent/system-prompt/{name}",
+                    json={"content": "x"},
+                )
+                assert get_unsupported.status == 422
+                assert put_unsupported.status == 422
+        finally:
+            await client.close()
+
+
 class TestGatewayIntegration:
     """Gateway integration tests."""
 


### PR DESCRIPTION
## What changed

- Make the native runtime `/api/agent/system-prompt/*` compatibility routes expose only the `agents` section.
- Read and write workspace `AGENTS.md` through those routes, creating it from the existing example template when missing.
- Reject unsupported legacy sections such as `soul`, `user`, `tools`, `memory`, and `daily_notes` with `422`.
- Reject attempts to disable `AGENTS.md`, matching the OpenCode runtime contract.
- Add a gateway contract test covering the native AGENTS-only API behavior.

## Why

The native runtime execution path already injects only `AGENTS.md`, but its compatibility API still advertised older system prompt sections. That mismatch made Portal's Assistant details panel differ between native and OpenCode runtimes.

## Validation

- `python -m pytest tests/test_gateway.py -k system_prompt`
- `python -m pytest tests/runtime/test_instruction_context.py::test_builder_loads_agents_as_only_workspace_default_file tests/runtime/test_system_prompt_stack.py::test_default_runtime_injects_only_agents_instruction_before_skills`
- Also validated the matching Portal UI and OpenCode AGENTS.md contract locally before publish.