### PR TITLE
Add AWS CLI runtime profile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
         ca-certificates \
         curl \
         gnupg \
+        unzip \
     && mkdir -p -m 755 /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -36,6 +37,12 @@ RUN apt-get update \
         gh \
         tesseract-ocr \
         google-chrome-stable \
+    && AWS_CLI_ARCH="$(dpkg --print-architecture)" \
+    && case "$AWS_CLI_ARCH" in amd64) AWS_CLI_ARCH="x86_64" ;; arm64) AWS_CLI_ARCH="aarch64" ;; *) echo "Unsupported AWS CLI architecture: $AWS_CLI_ARCH" >&2; exit 1 ;; esac \
+    && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_CLI_ARCH}.zip" -o /tmp/awscliv2.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli \
+    && rm -rf /tmp/aws /tmp/awscliv2.zip \
     && python3.11 -m venv "$VIRTUAL_ENV" \
     && "$VIRTUAL_ENV/bin/python" -m pip install --no-cache-dir --upgrade pip setuptools wheel \
     && rm -rf /var/lib/apt/lists/*
@@ -62,6 +69,7 @@ RUN set -eux; \
     printf '%s\n' '#!/usr/bin/env bash' 'exec /usr/bin/google-chrome-stable --no-sandbox "$@"' > /usr/local/bin/google-chrome; \
     chmod 0755 /usr/local/bin/google-chrome \
     && google-chrome --version >/dev/null \
+    && aws --version >/dev/null \
     && jira version --json >/dev/null \
     && jira commands --json >/dev/null \
     && jira schema issue.map-csv --json >/dev/null \

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,11 @@ _yaml = YAML()
 _yaml.preserve_quotes = True
 _yaml.indent(mapping=2, sequence=4, offset=2)
 
+
+def _home_path() -> Path:
+    return Path(os.environ.get("HOME") or Path.home())
+
+
 DEFAULT_LLM_MODEL = "gpt-5.4"
 DEFAULT_LLM_TEMPERATURE = 0.7
 
@@ -90,17 +95,17 @@ PORTAL_MANAGED_RUNTIME_FIELDS = frozenset(
 RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS = [
     (
         "Use bash for external CLI tools configured by the runtime profile: "
-        "jira, confluence, gh, and git."
+        "jira, confluence, gh, aws, and git."
     ),
     (
         "For jira and confluence, always pass --json. Before complex commands, "
         "inspect commands/schema/help llm; prefer --dry-run for writes, and use "
         "--yes only when a destructive action was explicitly confirmed."
     ),
-    "Use gh for GitHub issues, pull requests, and api calls; use git for clone, fetch, push, and status.",
+    "Use gh for GitHub issues, pull requests, and api calls; use aws for AWS operations; use git for clone, fetch, push, and status.",
     (
         "Credentials were applied by the runtime profile through the real CLIs; "
-        "if jira or confluence returns auth_failed, or gh/git authentication fails, "
+        "if jira or confluence returns auth_failed, aws returns an auth error, or gh/git authentication fails, "
         "report a runtime profile configuration problem."
     ),
 ]
@@ -186,6 +191,7 @@ def _should_inject_runtime_profile_external_cli_instructions(overlay: Dict[str, 
         _has_atlassian_profile_instances(overlay.get("jira"))
         or _has_atlassian_profile_instances(overlay.get("confluence"))
         or _has_github_profile_token(overlay.get("github"))
+        or _has_aws_profile_config(overlay.get("aws"))
         or _has_git_profile_user(overlay.get("git"))
     )
 
@@ -208,6 +214,27 @@ def _has_github_profile_token(section: Any) -> bool:
     if not isinstance(section, dict) or section.get("enabled") is False:
         return False
     return bool(str(section.get("api_token") or section.get("token") or section.get("access_token") or "").strip())
+
+
+def _has_aws_profile_config(section: Any) -> bool:
+    if not isinstance(section, dict) or section.get("enabled") is False:
+        return False
+    return bool(
+        str(
+            section.get("access_key_id")
+            or section.get("aws_access_key_id")
+            or section.get("secret_access_key")
+            or section.get("aws_secret_access_key")
+            or section.get("session_token")
+            or section.get("aws_session_token")
+            or section.get("region")
+            or section.get("default_region")
+            or section.get("profile")
+            or section.get("profile_name")
+            or section.get("account_id")
+            or ""
+        ).strip()
+    )
 
 
 def _has_git_profile_user(section: Any) -> bool:
@@ -237,6 +264,7 @@ class Config:
         "jira",
         "confluence",
         "github",
+        "aws",
         "git",
         "debug",
         *PORTAL_MANAGED_RUNTIME_FIELDS,
@@ -290,6 +318,21 @@ class Config:
             "base_url": True,
             "api_base_url": True,
         },
+        "aws": {
+            "enabled": True,
+            "profile": True,
+            "profile_name": True,
+            "region": True,
+            "default_region": True,
+            "output": True,
+            "account_id": True,
+            "access_key_id": True,
+            "aws_access_key_id": True,
+            "secret_access_key": True,
+            "aws_secret_access_key": True,
+            "session_token": True,
+            "aws_session_token": True,
+        },
         "git": {
             "user": {
                 "name": True,
@@ -308,7 +351,7 @@ class Config:
             self.config_path = self._find_config()
         else:
             self.config_path = Path(config_path)
-        self.runtime_profile_path = Path.home() / ".efp" / "runtime_profile.yaml"
+        self.runtime_profile_path = _home_path() / ".efp" / "runtime_profile.yaml"
         self._config: Dict[str, Any] = {}
         self._base_config: Dict[str, Any] = {}
         self._managed_overlay_meta: Dict[str, Any] = {
@@ -327,12 +370,16 @@ class Config:
 
     def _find_config(self) -> Path:
         """Find the first existing config file from default paths."""
-        for path in self.DEFAULT_PATHS:
+        default_paths = [
+            _home_path() / ".efp" / "config.yaml",
+            Path(__file__).parent / "config.yaml",
+        ]
+        for path in default_paths:
             if path.exists():
                 return path
         # Return the primary path even if it doesn't exist
         import shutil
-        target = self.DEFAULT_PATHS[0]
+        target = default_paths[0]
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(self.PROJECT_EXAMPLE, target)
         return target
@@ -485,6 +532,7 @@ class Config:
         persisted_overlay = copy.deepcopy(external_cli_overlay)
         persisted_overlay.pop("jira", None)
         persisted_overlay.pop("confluence", None)
+        persisted_overlay.pop("aws", None)
         new_sections = set(external_cli_overlay.keys())
 
         config_document = self._load_yaml_document(self.config_path)

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import configparser
 import json
 import os
 import shlex
@@ -28,6 +29,10 @@ _PROXY_URL_ENV_KEYS = ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY",
 _PROFILE_SECRET_KEY_NAMES = frozenset({"api_key", "password", "token", "api_token", "access_token", "secret"})
 _yaml = YAML()
 _yaml.default_flow_style = False
+
+
+def _home_path() -> Path:
+    return Path(os.environ.get("HOME") or Path.home())
 
 
 @dataclass(frozen=True)
@@ -59,6 +64,7 @@ def apply_runtime_profile_external_config(
             cli_environment=cli_environment,
         )
         _apply_github(profile_config, metadata=metadata, cli_environment=cli_environment)
+        _apply_aws(profile_config, metadata=metadata)
         _apply_git_user(profile_config, metadata=metadata, cli_environment=cli_environment)
     except Exception:
         if _metadata_has_managed_entries(metadata):
@@ -303,6 +309,10 @@ def _clear_new_metadata(meta: dict[str, Any], *, cli_environment: _CliEnvironmen
         for host in _metadata_gh_hosts(gh):
             _logout_gh_host(host, cli_environment=cli_environment)
 
+    aws = meta.get("aws") if isinstance(meta.get("aws"), dict) else {}
+    if aws:
+        _restore_aws_profile(aws)
+
     git = meta.get("git") if isinstance(meta.get("git"), dict) else {}
     if "managed" in git:
         _restore_git_user(git, cli_environment=cli_environment)
@@ -343,7 +353,7 @@ def _clear_legacy_metadata(meta: dict[str, Any]) -> None:
 
 
 def _metadata_has_managed_entries(metadata: dict[str, Any]) -> bool:
-    return any(key in metadata for key in ("jira", "confluence", "gh", "git"))
+    return any(key in metadata for key in ("jira", "confluence", "gh", "aws", "git"))
 
 
 def _metadata_instance_names(product_meta: dict[str, Any]) -> list[str]:
@@ -522,6 +532,95 @@ def _build_gh_login(profile_config: dict[str, Any]) -> tuple[str, str] | None:
     return host, token
 
 
+def _apply_aws(
+    profile_config: dict[str, Any],
+    *,
+    metadata: dict[str, Any],
+) -> None:
+    aws_profile = _build_aws_profile(profile_config)
+    if aws_profile is None:
+        return
+
+    profile_name = aws_profile["profile"]
+    config_section = _aws_config_section_name(profile_name)
+    credentials_section = profile_name
+    config_path = _aws_config_path()
+    credentials_path = _aws_credentials_path()
+
+    previous_config = _read_ini_section(config_path, config_section)
+    previous_credentials = _read_ini_section(credentials_path, credentials_section)
+
+    config_values = {}
+    for key in ("region", "output"):
+        if aws_profile.get(key):
+            config_values[key] = aws_profile[key]
+    _set_ini_section_exact(config_path, config_section, config_values)
+
+    credential_values = {}
+    if aws_profile.get("access_key_id"):
+        credential_values["aws_access_key_id"] = aws_profile["access_key_id"]
+    if aws_profile.get("secret_access_key"):
+        credential_values["aws_secret_access_key"] = aws_profile["secret_access_key"]
+    if aws_profile.get("session_token"):
+        credential_values["aws_session_token"] = aws_profile["session_token"]
+    if credential_values:
+        _set_ini_section_exact(credentials_path, credentials_section, credential_values)
+
+    metadata["aws"] = {
+        "profile": profile_name,
+        "config_path": str(config_path),
+        "credentials_path": str(credentials_path),
+        "config_section": config_section,
+        "credentials_section": credentials_section,
+        "previous": {
+            "config": previous_config,
+            "credentials": previous_credentials,
+        },
+    }
+
+
+def _build_aws_profile(profile_config: dict[str, Any]) -> dict[str, str] | None:
+    aws = profile_config.get("aws") if isinstance(profile_config, dict) else None
+    if not isinstance(aws, dict) or aws.get("enabled") is False:
+        return None
+    profile = _single_line(aws.get("profile") or aws.get("profile_name") or "default") or "default"
+    built = {
+        "profile": profile,
+        "region": _single_line(aws.get("region") or aws.get("default_region")),
+        "output": _single_line(aws.get("output")),
+        "account_id": _single_line(aws.get("account_id")),
+        "access_key_id": _single_line(aws.get("access_key_id") or aws.get("aws_access_key_id")),
+        "secret_access_key": _string_or_empty(aws.get("secret_access_key") or aws.get("aws_secret_access_key")),
+        "session_token": _string_or_empty(aws.get("session_token") or aws.get("aws_session_token")),
+    }
+    if not any(value for key, value in built.items() if key != "profile"):
+        return None
+    return built
+
+
+def _restore_aws_profile(aws_meta: dict[str, Any]) -> None:
+    profile_name = _string_or_empty(aws_meta.get("profile")) or "default"
+    config_section = _string_or_empty(aws_meta.get("config_section")) or _aws_config_section_name(profile_name)
+    credentials_section = _string_or_empty(aws_meta.get("credentials_section")) or profile_name
+    previous = aws_meta.get("previous") if isinstance(aws_meta.get("previous"), dict) else {}
+
+    config_path = Path(str(aws_meta.get("config_path") or _aws_config_path()))
+    credentials_path = Path(str(aws_meta.get("credentials_path") or _aws_credentials_path()))
+
+    previous_config = previous.get("config") if isinstance(previous.get("config"), dict) else None
+    previous_credentials = previous.get("credentials") if isinstance(previous.get("credentials"), dict) else None
+
+    if previous_config is None:
+        _remove_ini_section(config_path, config_section)
+    else:
+        _set_ini_section_exact(config_path, config_section, previous_config)
+
+    if previous_credentials is None:
+        _remove_ini_section(credentials_path, credentials_section)
+    else:
+        _set_ini_section_exact(credentials_path, credentials_section, previous_credentials)
+
+
 def _extract_git_user(profile_config: dict[str, Any]) -> tuple[str, str] | None:
     git = profile_config.get("git") if isinstance(profile_config, dict) else None
     user = git.get("user") if isinstance(git, dict) and isinstance(git.get("user"), dict) else None
@@ -633,10 +732,13 @@ def _is_profile_secret_key(key: str) -> bool:
     normalized = "".join(ch for ch in str(key or "").lower() if ch.isalnum())
     return normalized in {
         "apikey",
+        "accesskeyid",
         "password",
         "token",
         "apitoken",
         "accesstoken",
+        "secretaccesskey",
+        "sessiontoken",
         "secret",
     } or str(key or "").lower() in _PROFILE_SECRET_KEY_NAMES
 
@@ -703,8 +805,73 @@ def _single_line(value: Any) -> str:
     return _string_or_empty(value).replace("\x00", "").replace("\r", " ").replace("\n", " ")
 
 
+def _aws_config_path() -> Path:
+    return _home_path() / ".aws" / "config"
+
+
+def _aws_credentials_path() -> Path:
+    return _home_path() / ".aws" / "credentials"
+
+
+def _aws_config_section_name(profile_name: str) -> str:
+    profile = _string_or_empty(profile_name) or "default"
+    return "default" if profile == "default" else f"profile {profile}"
+
+
+def _new_ini_parser() -> configparser.RawConfigParser:
+    parser = configparser.RawConfigParser()
+    parser.optionxform = str
+    return parser
+
+
+def _read_ini(path: Path) -> configparser.RawConfigParser:
+    parser = _new_ini_parser()
+    if path.exists():
+        parser.read(path, encoding="utf-8")
+    return parser
+
+
+def _read_ini_section(path: Path, section: str) -> dict[str, str] | None:
+    parser = _read_ini(path)
+    if not parser.has_section(section):
+        return None
+    return {key: value for key, value in parser.items(section)}
+
+
+def _write_ini(path: Path, parser: configparser.RawConfigParser) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        parser.write(handle)
+    _chmod_private(path)
+
+
+def _set_ini_section_exact(path: Path, section: str, values: dict[str, Any]) -> None:
+    parser = _read_ini(path)
+    if parser.has_section(section):
+        parser.remove_section(section)
+    parser.add_section(section)
+    for key, value in values.items():
+        text = _string_or_empty(value)
+        if text:
+            parser.set(section, key, text)
+    _write_ini(path, parser)
+
+
+def _remove_ini_section(path: Path, section: str) -> None:
+    if not path.exists():
+        return
+    parser = _read_ini(path)
+    if not parser.has_section(section):
+        return
+    parser.remove_section(section)
+    if parser.sections():
+        _write_ini(path, parser)
+    else:
+        _remove_file_if_exists(path)
+
+
 def _metadata_path() -> Path:
-    return Path.home() / ".config" / "efp" / "runtime-profile-external-config.json"
+    return _home_path() / ".config" / "efp" / "runtime-profile-external-config.json"
 
 
 def _write_private_text(path: Path, text: str) -> None:

--- a/tests/test_docker_runtime_contract.py
+++ b/tests/test_docker_runtime_contract.py
@@ -4,6 +4,8 @@ import stat
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 def _text(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
@@ -41,6 +43,9 @@ def test_dockerfile_installs_gh_and_copies_runtime_tools_binaries():
     assert "https://cli.github.com/packages" in text
     assert "githubcli-archive-keyring.gpg" in text
     assert " gh \\" in text or "\n        gh\n" in text
+    assert "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_CLI_ARCH}.zip" in text
+    assert "/tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli" in text
+    assert "aws --version" in text
     assert "google-chrome-stable" in text
     assert "google-chrome --version" in text
     assert "COPY runtime-tools/ /tmp/runtime-tools/" in text
@@ -64,6 +69,9 @@ def test_dockerfile_installs_gh_and_copies_runtime_tools_binaries():
 
 
 def test_prepare_runtime_tools_script_discovers_all_cmd_tools(tmp_path):
+    if os.name == "nt":
+        pytest.skip("prepare-runtime-tools.sh execution contract requires a POSIX shell")
+
     project_root = tmp_path / "runtime"
     script_dir = project_root / "scripts"
     script_dir.mkdir(parents=True)

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -209,22 +209,81 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
                     }
                 ],
             },
+            "aws": {
+                "enabled": True,
+                "profile": "prod",
+                "region": "us-east-1",
+                "output": "json",
+                "access_key_id": "AKIA_TEST",
+                "secret_access_key": "aws-secret",
+            },
         },
     )
 
     persisted = _read_yaml(config_path)
     assert "jira" not in persisted
     assert "confluence" not in persisted
+    assert "aws" not in persisted
     assert persisted["instruction_texts"]
     assert "jira-token" not in config_path.read_text(encoding="utf-8")
     assert "conf-token" not in config_path.read_text(encoding="utf-8")
+    assert "aws-secret" not in config_path.read_text(encoding="utf-8")
     assert applied[0]["jira"]["instances"][0]["token"] == "jira-token"
     assert applied[0]["confluence"]["instances"][0]["token"] == "conf-token"
+    assert applied[0]["aws"]["secret_access_key"] == "aws-secret"
     assert cfg.get_managed_overlay_meta()["managed_sections"] == [
+        "aws",
         "confluence",
         "instruction_texts",
         "jira",
     ]
+
+
+def test_runtime_profile_aws_external_config_writes_and_clears_aws_cli_files(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    profile_config_module.apply_runtime_profile_external_config(
+        {
+            "aws": {
+                "enabled": True,
+                "profile": "prod",
+                "region": "us-east-1",
+                "output": "json",
+                "access_key_id": "AKIA_TEST",
+                "secret_access_key": "aws-secret",
+                "session_token": "aws-session",
+            }
+        }
+    )
+
+    aws_config = home / ".aws" / "config"
+    aws_credentials = home / ".aws" / "credentials"
+    if os.name != "nt":
+        assert aws_config.stat().st_mode & 0o777 == 0o600
+        assert aws_credentials.stat().st_mode & 0o777 == 0o600
+
+    config_text = aws_config.read_text(encoding="utf-8")
+    assert "[profile prod]" in config_text
+    assert "region = us-east-1" in config_text
+    assert "output = json" in config_text
+
+    credentials_text = aws_credentials.read_text(encoding="utf-8")
+    assert "[prod]" in credentials_text
+    assert "aws_access_key_id = AKIA_TEST" in credentials_text
+    assert "aws_secret_access_key = aws-secret" in credentials_text
+    assert "aws_session_token = aws-session" in credentials_text
+
+    metadata_path = home / ".config" / "efp" / "runtime-profile-external-config.json"
+    metadata_text = metadata_path.read_text(encoding="utf-8")
+    assert "aws-secret" not in metadata_text
+    assert json.loads(metadata_text)["aws"]["profile"] == "prod"
+
+    profile_config_module.clear_runtime_profile_external_config()
+    assert not aws_config.exists()
+    assert not aws_credentials.exists()
+    assert not metadata_path.exists()
 
 
 def test_runtime_profile_apply_prunes_previous_portal_atlassian_entries(tmp_path, monkeypatch):
@@ -784,7 +843,8 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
 
     metadata_path = home / ".config" / "efp" / "runtime-profile-external-config.json"
     metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-    assert metadata_path.stat().st_mode & 0o777 == 0o600
+    if os.name != "nt":
+        assert metadata_path.stat().st_mode & 0o777 == 0o600
     assert metadata == {
         "version": 2,
         "managed_by": "efp_runtime_profile",
@@ -1229,13 +1289,13 @@ def test_runtime_profile_clear_legacy_metadata_removes_generated_files(tmp_path,
     metadata_path = home / ".config" / "efp" / "runtime-profile-external-config.json"
     metadata_path.write_text(
         json.dumps(
-            {
-                "version": 1,
-                "managed_by": "efp_runtime_profile",
-                "atlassian": {
-                    "path": str(atlassian_path),
-                    "sha256": hashlib.sha256(atlassian_text.encode("utf-8")).hexdigest(),
-                },
+                {
+                    "version": 1,
+                    "managed_by": "efp_runtime_profile",
+                    "atlassian": {
+                        "path": str(atlassian_path),
+                        "sha256": hashlib.sha256(atlassian_path.read_bytes()).hexdigest(),
+                    },
                 "gh": {
                     "path": str(hosts_path),
                     "hosts": {
@@ -1374,7 +1434,7 @@ def test_runtime_profile_external_cli_instructions_are_injected(tmp_path, monkey
     instructions = cfg.get_effective_config()["instruction_texts"]
     joined = "\n".join(instructions)
     assert "Use bash" in joined
-    assert "jira, confluence, gh, and git" in joined
+    assert "jira, confluence, gh, aws, and git" in joined
     assert "always pass --json" in joined
     assert "commands/schema/help llm" in joined
     assert "--dry-run" in joined


### PR DESCRIPTION
Installs AWS CLI v2 and applies AWS runtime profile config to ~/.aws/config and credentials with cleanup/restore support. Tests: python -m pytest tests/test_runtime_profile_overlay.py tests/test_docker_runtime_contract.py tests/test_config_managed_overlay.py -q