### PR TITLE
[codex] Add native runtime task recovery

### DIFF
--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -59,6 +59,7 @@ from src.efp_runtime.session.gateway_facade import (
     runtime_session_manager as session_manager,
 )
 from src.sessions.usage import usage_tracker
+from src.workspace_defaults import resolve_runtime_workspace
 
 logger = logging.getLogger(__name__)
 runtime_task_tracker = RuntimeTaskTracker()
@@ -1533,7 +1534,34 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
             runtime_agent_id or "-",
         )
         request_id = f"task-{parsed['task_id']}"
-        runtime_task_tracker.create_pending(
+        existing_record = runtime_task_tracker.get(parsed["task_id"])
+        if existing_record is not None:
+            if existing_record.status in {"accepted", "running"}:
+                try:
+                    _schedule_runtime_task_record(existing_record)
+                except Exception as exc:
+                    sanitized_message = sanitize_exception_message(exc)
+                    logger.error("Task execute duplicate scheduling failed | task_id=%s", parsed["task_id"], exc_info=True)
+                    logger.debug("Task execute duplicate scheduling error detail: %s", sanitized_message)
+                    failure_payload = {
+                        "ok": False,
+                        "task_id": parsed["task_id"],
+                        "execution_type": "task",
+                        "request_id": existing_record.request_id,
+                        "status": "error",
+                        "trace_id": existing_record.trace_id,
+                        "portal_dispatch_id": existing_record.portal_dispatch_id,
+                        "error": sanitized_message,
+                    }
+                    runtime_task_tracker.mark_internal_failure(
+                        parsed["task_id"],
+                        payload=failure_payload,
+                        error_message=sanitized_message,
+                    )
+                    return web.json_response(failure_payload, status=500)
+            return web.json_response(_runtime_task_status_payload(existing_record), status=200)
+
+        record = runtime_task_tracker.create_pending(
             task_id=parsed["task_id"],
             request_id=request_id,
             task_type=parsed["task_type"],
@@ -1543,30 +1571,20 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
             trace_id=trace_headers.get("trace_id"),
             portal_dispatch_id=trace_headers.get("portal_dispatch_id"),
             portal_task_id=metadata.get("portal_task_id"),
-        )
-
-        background_coro = _run_task_execution_in_background(
-            task_id=parsed["task_id"],
-            request_id=request_id,
-            task_type=parsed["task_type"],
-            session_id=parsed["session_id"],
-            source=parsed["source"] or "portal",
-            runtime_agent_id=runtime_agent_id,
             context_ref=parsed["context_ref"] or None,
             merged_input_payload=merged_input_payload,
             metadata=metadata,
             trace_headers=trace_headers,
         )
+
         try:
-            background_task = _spawn_runtime_background_task(background_coro)
+            _schedule_runtime_task_record(record)
         except Exception as exc:
-            background_coro.close()
             runtime_task_tracker.remove(parsed["task_id"])
             logger.error("Task execute scheduling failed | task_id=%s", parsed["task_id"], exc_info=True)
             logger.debug("Task execute scheduling error detail: %s", sanitize_exception_message(exc))
             return web.json_response({"error": "Internal server error"}, status=500)
 
-        runtime_task_tracker.set_background_task(parsed["task_id"], background_task)
         await _emit_task_lifecycle_event(
             "task.accepted",
             task_id=parsed["task_id"],
@@ -1602,6 +1620,89 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
 
 def _spawn_runtime_background_task(coro: Any) -> asyncio.Task:
     return asyncio.create_task(coro)
+
+
+def _runtime_task_status_payload(record: Any) -> Dict[str, Any]:
+    if record.status in {"accepted", "running"}:
+        return {
+            "ok": True,
+            "task_id": record.task_id,
+            "execution_type": "task",
+            "request_id": record.request_id,
+            "status": record.status,
+            "trace_id": record.trace_id,
+            "portal_dispatch_id": record.portal_dispatch_id,
+            "accepted_at": record.accepted_at,
+            "started_at": record.started_at,
+            "finished_at": record.finished_at,
+            "resume_count": getattr(record, "resume_count", 0),
+            "last_resumed_at": getattr(record, "last_resumed_at", None),
+        }
+    payload = dict(record.payload)
+    payload["accepted_at"] = record.accepted_at
+    payload["started_at"] = record.started_at
+    payload["finished_at"] = record.finished_at
+    payload["resume_count"] = getattr(record, "resume_count", 0)
+    payload["last_resumed_at"] = getattr(record, "last_resumed_at", None)
+    return payload
+
+
+def _has_runtime_task_resume_payload(record: Any) -> bool:
+    return isinstance(getattr(record, "merged_input_payload", None), dict) and isinstance(getattr(record, "metadata", None), dict)
+
+
+def _schedule_runtime_task_record(record: Any, *, resumed: bool = False) -> bool:
+    if record.status not in {"accepted", "running"}:
+        return False
+    background_task = getattr(record, "background_task", None)
+    if background_task is not None and not background_task.done():
+        return False
+    if not _has_runtime_task_resume_payload(record):
+        runtime_task_tracker.mark_stale(
+            record.task_id,
+            reason="Persisted runtime task request is incomplete",
+            payload={
+                "ok": False,
+                "task_id": record.task_id,
+                "execution_type": "task",
+                "request_id": record.request_id,
+                "status": "stale",
+                "trace_id": record.trace_id,
+                "portal_dispatch_id": record.portal_dispatch_id,
+                "error": "Persisted runtime task request is incomplete",
+            },
+        )
+        return False
+
+    metadata = dict(record.metadata or {})
+    trace_headers = dict(record.trace_headers or {})
+    if not trace_headers.get("trace_id"):
+        trace_headers["trace_id"] = record.trace_id
+    if not trace_headers.get("portal_dispatch_id"):
+        trace_headers["portal_dispatch_id"] = record.portal_dispatch_id
+    if resumed:
+        metadata["runtime_task_resumed"] = True
+        metadata["runtime_task_resume_count"] = getattr(record, "resume_count", 0)
+
+    background_coro = _run_task_execution_in_background(
+        task_id=record.task_id,
+        request_id=record.request_id,
+        task_type=record.task_type,
+        session_id=record.session_id,
+        source=record.source or "portal",
+        runtime_agent_id=record.agent_id,
+        context_ref=record.context_ref or None,
+        merged_input_payload=dict(record.merged_input_payload or {}),
+        metadata=metadata,
+        trace_headers=trace_headers,
+    )
+    try:
+        spawned = _spawn_runtime_background_task(background_coro)
+    except Exception:
+        background_coro.close()
+        raise
+    runtime_task_tracker.set_background_task(record.task_id, spawned)
+    return True
 
 
 async def _emit_task_lifecycle_event(
@@ -1824,25 +1925,7 @@ async def api_task_status(request: web.Request) -> web.Response:
         record = runtime_task_tracker.get(task_id)
         if record is None:
             return web.json_response({"error": "Task not found"}, status=404)
-        if record.status in {"accepted", "running"}:
-            payload = {
-                "ok": True,
-                "task_id": record.task_id,
-                "execution_type": "task",
-                "request_id": record.request_id,
-                "status": record.status,
-                "trace_id": record.trace_id,
-                "portal_dispatch_id": record.portal_dispatch_id,
-                "accepted_at": record.accepted_at,
-                "started_at": record.started_at,
-                "finished_at": record.finished_at,
-            }
-            return web.json_response(payload)
-        payload = dict(record.payload)
-        payload["accepted_at"] = record.accepted_at
-        payload["started_at"] = record.started_at
-        payload["finished_at"] = record.finished_at
-        return web.json_response(payload)
+        return web.json_response(_runtime_task_status_payload(record))
     finally:
         clear_log_context()
 
@@ -1873,6 +1956,82 @@ async def api_task_cancel(request: web.Request) -> web.Response:
         return web.json_response(payload)
     finally:
         clear_log_context()
+
+
+def _runtime_task_persistence_storage_dir() -> Optional[Path]:
+    enabled = str(os.getenv("EFP_RUNTIME_TASKS_PERSISTENCE", "true")).strip().lower()
+    if enabled in {"0", "false", "no", "off"}:
+        return None
+    explicit = str(os.getenv("EFP_RUNTIME_TASKS_DIR", "")).strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    try:
+        config_data = global_config.get_effective_config()
+    except Exception:
+        config_data = getattr(global_config, "_config", {}) or {}
+    return resolve_runtime_workspace(config_data) / ".efp" / "runtime_tasks"
+
+
+async def resume_persisted_runtime_tasks() -> int:
+    storage_dir = _runtime_task_persistence_storage_dir()
+    if storage_dir is None:
+        runtime_task_tracker.configure_storage(None)
+        return 0
+
+    runtime_task_tracker.configure_storage(storage_dir)
+    loaded_count = runtime_task_tracker.load_persisted_records()
+    resumed_count = 0
+    for record in runtime_task_tracker.list_active():
+        background_task = getattr(record, "background_task", None)
+        if background_task is not None and not background_task.done():
+            continue
+        resumed_record = runtime_task_tracker.mark_resuming(record.task_id) or record
+        try:
+            scheduled = _schedule_runtime_task_record(resumed_record, resumed=True)
+        except Exception as exc:
+            sanitized_message = sanitize_exception_message(exc)
+            logger.error("Persisted runtime task resume failed | task_id=%s", record.task_id, exc_info=True)
+            runtime_task_tracker.mark_internal_failure(
+                record.task_id,
+                payload={
+                    "ok": False,
+                    "task_id": record.task_id,
+                    "execution_type": "task",
+                    "request_id": record.request_id,
+                    "status": "error",
+                    "trace_id": record.trace_id,
+                    "portal_dispatch_id": record.portal_dispatch_id,
+                    "error": sanitized_message,
+                },
+                error_message=sanitized_message,
+            )
+            continue
+        if not scheduled:
+            continue
+        resumed_count += 1
+        await _emit_task_lifecycle_event(
+            "task.resumed",
+            task_id=record.task_id,
+            portal_task_id=record.portal_task_id,
+            agent_id=record.agent_id,
+            session_id=record.session_id,
+            trace_id=record.trace_id,
+            portal_dispatch_id=record.portal_dispatch_id,
+        )
+    if loaded_count or resumed_count:
+        logger.info(
+            "Runtime task recovery initialized | storage_dir=%s loaded=%s resumed=%s",
+            storage_dir,
+            loaded_count,
+            resumed_count,
+        )
+    return resumed_count
+
+
+async def _resume_runtime_tasks_on_startup(_app: web.Application) -> None:
+    await resume_persisted_runtime_tasks()
+
+
 def _parse_bool_query(value: Optional[str]) -> Optional[bool]:
     if value is None:
         return None
@@ -2232,6 +2391,9 @@ async def api_skills(request: web.Request) -> web.Response:
 def setup_runtime_api_routes(app: web.Application):
     """Register API-only runtime routes used by Portal and runtime clients."""
     from src.gateway.server_files import setup_server_files_routes
+
+    if not any(handler is _resume_runtime_tasks_on_startup for handler in app.on_startup):
+        app.on_startup.append(_resume_runtime_tasks_on_startup)
 
     app.router.add_post('/api/chat', api_chat)
     app.router.add_post('/api/chat/stream', api_chat_stream)

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -1,11 +1,14 @@
-"""In-memory tracker for async runtime task execution state."""
+"""Tracker for async runtime task execution state."""
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 
@@ -33,15 +36,37 @@ class RuntimeTaskRecord:
     portal_task_id: Optional[str]
     payload: Dict[str, Any]
     error_message: Optional[str]
-    background_task: Optional[asyncio.Task[Any]]
+    context_ref: Optional[Dict[str, Any]] = None
+    merged_input_payload: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = None
+    trace_headers: Optional[Dict[str, Optional[str]]] = None
+    resume_count: int = 0
+    last_resumed_at: Optional[str] = None
+    background_task: Optional[asyncio.Task[Any]] = None
 
 
 class RuntimeTaskTracker:
-    """Small in-memory tracker for internal runtime task polling."""
+    """Small tracker for internal runtime task polling.
 
-    def __init__(self, *, max_records: int = 512):
+    Persistence is optional so unit tests and direct imports can continue to use
+    the in-memory behavior, while the runtime server can opt in during startup.
+    """
+
+    def __init__(self, *, max_records: int = 512, storage_dir: Optional[str | Path] = None):
         self._records: "OrderedDict[str, RuntimeTaskRecord]" = OrderedDict()
         self._max_records = max(1, int(max_records))
+        self._storage_dir: Optional[Path] = None
+        self.configure_storage(storage_dir)
+
+    @property
+    def storage_dir(self) -> Optional[Path]:
+        return self._storage_dir
+
+    def configure_storage(self, storage_dir: Optional[str | Path]) -> None:
+        if storage_dir is None:
+            self._storage_dir = None
+            return
+        self._storage_dir = Path(storage_dir).expanduser()
 
     def create_pending(
         self,
@@ -55,6 +80,10 @@ class RuntimeTaskTracker:
         trace_id: Optional[str],
         portal_dispatch_id: Optional[str],
         portal_task_id: Optional[str],
+        context_ref: Optional[Dict[str, Any]] = None,
+        merged_input_payload: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        trace_headers: Optional[Dict[str, Optional[str]]] = None,
     ) -> RuntimeTaskRecord:
         record = RuntimeTaskRecord(
             task_id=task_id,
@@ -72,10 +101,15 @@ class RuntimeTaskTracker:
             portal_task_id=portal_task_id,
             payload={},
             error_message=None,
+            context_ref=_optional_json_dict(context_ref),
+            merged_input_payload=_optional_json_dict(merged_input_payload),
+            metadata=_optional_json_dict(metadata),
+            trace_headers=_optional_json_dict(trace_headers),
             background_task=None,
         )
         self._records[task_id] = record
         self._records.move_to_end(task_id)
+        self._persist_record(record)
         self.prune()
         return record
 
@@ -94,6 +128,7 @@ class RuntimeTaskTracker:
         record.status = "running"
         if not record.started_at:
             record.started_at = _utc_now_iso()
+        self._persist_record(record)
         return record
 
     def mark_terminal(self, task_id: str, *, status: str, payload: Dict[str, Any], error_message: Optional[str] = None) -> Optional[RuntimeTaskRecord]:
@@ -110,6 +145,7 @@ class RuntimeTaskTracker:
         record.finished_at = _utc_now_iso()
         if not record.started_at:
             record.started_at = record.finished_at
+        self._persist_record(record)
         self.prune()
         return record
 
@@ -132,6 +168,7 @@ class RuntimeTaskTracker:
         record.finished_at = _utc_now_iso()
         record.error_message = reason
         record.payload = dict(payload or {"ok": False, "task_id": task_id, "execution_type": "task", "request_id": record.request_id, "status": "cancelled", "error": reason})
+        self._persist_record(record)
         return record
 
     def mark_stale(self, task_id: str, *, reason: str = "Task stale", payload: Optional[Dict[str, Any]] = None) -> Optional[RuntimeTaskRecord]:
@@ -142,6 +179,41 @@ class RuntimeTaskTracker:
 
     def remove(self, task_id: str) -> None:
         self._records.pop(task_id, None)
+        self._delete_record_file(task_id)
+
+    def list_active(self) -> list[RuntimeTaskRecord]:
+        return [record for record in self._records.values() if record.status not in _TASK_TERMINAL_STATUSES]
+
+    def mark_resuming(self, task_id: str) -> Optional[RuntimeTaskRecord]:
+        record = self._records.get(task_id)
+        if record is None or record.status in _TASK_TERMINAL_STATUSES:
+            return record
+        record.resume_count += 1
+        record.last_resumed_at = _utc_now_iso()
+        self._persist_record(record)
+        return record
+
+    def load_persisted_records(self) -> int:
+        if self._storage_dir is None or not self._storage_dir.exists():
+            return 0
+        loaded: list[RuntimeTaskRecord] = []
+        for path in sorted(self._storage_dir.glob("*.json")):
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                record = _record_from_json(raw)
+            except Exception:
+                continue
+            loaded.append(record)
+
+        loaded.sort(key=lambda record: record.accepted_at or "")
+        for record in loaded:
+            existing = self._records.get(record.task_id)
+            if existing is not None and existing.background_task is not None and not existing.background_task.done():
+                continue
+            self._records[record.task_id] = record
+            self._records.move_to_end(record.task_id)
+        self.prune()
+        return len(loaded)
 
     def prune(self) -> None:
         while len(self._records) > self._max_records:
@@ -153,6 +225,111 @@ class RuntimeTaskTracker:
             if removable_task_id is None:
                 break
             self._records.pop(removable_task_id, None)
+            self._delete_record_file(removable_task_id)
 
-    def reset(self) -> None:
+    def reset(self, *, clear_storage: bool = True) -> None:
         self._records.clear()
+        if clear_storage and self._storage_dir is not None and self._storage_dir.exists():
+            for path in self._storage_dir.glob("*.json"):
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+
+    def _persist_record(self, record: RuntimeTaskRecord) -> None:
+        if self._storage_dir is None:
+            return
+        try:
+            self._storage_dir.mkdir(parents=True, exist_ok=True)
+            path = self._record_path(record.task_id)
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            tmp_path.write_text(json.dumps(_record_to_json(record), ensure_ascii=False, sort_keys=True), encoding="utf-8")
+            tmp_path.replace(path)
+        except (OSError, TypeError, ValueError):
+            return
+
+    def _delete_record_file(self, task_id: str) -> None:
+        if self._storage_dir is None:
+            return
+        try:
+            self._record_path(task_id).unlink(missing_ok=True)
+        except OSError:
+            return
+
+    def _record_path(self, task_id: str) -> Path:
+        assert self._storage_dir is not None
+        digest = hashlib.sha256(task_id.encode("utf-8")).hexdigest()
+        return self._storage_dir / f"{digest}.json"
+
+
+def _optional_json_dict(value: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        return None
+    safe = _json_safe(value)
+    return safe if isinstance(safe, dict) else dict(value)
+
+
+def _json_safe(value: Any) -> Any:
+    return json.loads(json.dumps(value, ensure_ascii=False, default=str))
+
+
+def _record_to_json(record: RuntimeTaskRecord) -> Dict[str, Any]:
+    return _json_safe(
+        {
+            "task_id": record.task_id,
+            "request_id": record.request_id,
+            "task_type": record.task_type,
+            "source": record.source,
+            "session_id": record.session_id,
+            "agent_id": record.agent_id,
+            "status": record.status,
+            "accepted_at": record.accepted_at,
+            "started_at": record.started_at,
+            "finished_at": record.finished_at,
+            "trace_id": record.trace_id,
+            "portal_dispatch_id": record.portal_dispatch_id,
+            "portal_task_id": record.portal_task_id,
+            "payload": record.payload,
+            "error_message": record.error_message,
+            "context_ref": record.context_ref,
+            "merged_input_payload": record.merged_input_payload,
+            "metadata": record.metadata,
+            "trace_headers": record.trace_headers,
+            "resume_count": record.resume_count,
+            "last_resumed_at": record.last_resumed_at,
+        }
+    )
+
+
+def _record_from_json(raw: Dict[str, Any]) -> RuntimeTaskRecord:
+    if not isinstance(raw, dict):
+        raise ValueError("persisted runtime task record must be an object")
+    task_id = str(raw.get("task_id") or "").strip()
+    if not task_id:
+        raise ValueError("persisted runtime task record missing task_id")
+    return RuntimeTaskRecord(
+        task_id=task_id,
+        request_id=str(raw.get("request_id") or f"task-{task_id}"),
+        task_type=str(raw.get("task_type") or ""),
+        source=str(raw.get("source") or "portal"),
+        session_id=str(raw["session_id"]) if raw.get("session_id") is not None else None,
+        agent_id=str(raw["agent_id"]) if raw.get("agent_id") is not None else None,
+        status=str(raw.get("status") or "accepted"),
+        accepted_at=str(raw.get("accepted_at") or _utc_now_iso()),
+        started_at=str(raw["started_at"]) if raw.get("started_at") is not None else None,
+        finished_at=str(raw["finished_at"]) if raw.get("finished_at") is not None else None,
+        trace_id=str(raw["trace_id"]) if raw.get("trace_id") is not None else None,
+        portal_dispatch_id=str(raw["portal_dispatch_id"]) if raw.get("portal_dispatch_id") is not None else None,
+        portal_task_id=str(raw["portal_task_id"]) if raw.get("portal_task_id") is not None else task_id,
+        payload=dict(raw.get("payload") or {}),
+        error_message=str(raw["error_message"]) if raw.get("error_message") is not None else None,
+        context_ref=_optional_json_dict(raw.get("context_ref")),
+        merged_input_payload=_optional_json_dict(raw.get("merged_input_payload")),
+        metadata=_optional_json_dict(raw.get("metadata")),
+        trace_headers=_optional_json_dict(raw.get("trace_headers")),
+        resume_count=int(raw.get("resume_count") or 0),
+        last_resumed_at=str(raw["last_resumed_at"]) if raw.get("last_resumed_at") is not None else None,
+        background_task=None,
+    )

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -2946,6 +2946,160 @@ def test_runtime_task_tracker_prune_removes_terminal_records_even_if_oldest_is_r
     assert len(remaining_terminal) == 1
 
 
+def test_runtime_task_tracker_persists_and_loads_active_records(tmp_path):
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    tracker.create_pending(
+        task_id="task-persist",
+        request_id="task-task-persist",
+        task_type="adapter_action_task",
+        source="portal",
+        session_id="session-1",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="portal-task-1",
+        context_ref={"workspace": "w1"},
+        merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
+        metadata={"task_id": "task-persist", "portal_task_id": "portal-task-1"},
+        trace_headers={"trace_id": "trace-1", "portal_dispatch_id": "dispatch-1"},
+    )
+    tracker.mark_running("task-persist")
+
+    loaded = RuntimeTaskTracker(storage_dir=tmp_path)
+    assert loaded.load_persisted_records() == 1
+
+    record = loaded.get("task-persist")
+    assert record is not None
+    assert record.status == "running"
+    assert record.background_task is None
+    assert record.context_ref == {"workspace": "w1"}
+    assert record.merged_input_payload["action_id"] == "jira.transition"
+    assert record.metadata["portal_task_id"] == "portal-task-1"
+    assert [item.task_id for item in loaded.list_active()] == ["task-persist"]
+
+
+@pytest.mark.asyncio
+async def test_api_tasks_execute_duplicate_active_task_reuses_existing_record(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    release = asyncio.Event()
+    spawned = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        await release.wait()
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    class _Request:
+        headers = INTERNAL_HEADERS
+
+        async def json(self):
+            return {
+                "task_id": "task-dedupe-1",
+                "task_type": "adapter_action_task",
+                "input_payload": {"action_id": "jira.transition"},
+            }
+
+    first_response = await runtime_api.api_tasks_execute(_Request())
+    second_response = await runtime_api.api_tasks_execute(_Request())
+    second_body = json.loads(second_response.body)
+
+    assert first_response.status == 202
+    assert second_response.status == 200
+    assert second_body["task_id"] == "task-dedupe-1"
+    assert second_body["status"] in {"accepted", "running"}
+    assert len(spawned) == 1
+
+    release.set()
+    await spawned[0]
+
+
+@pytest.mark.asyncio
+async def test_resume_persisted_runtime_tasks_replays_active_record(tmp_path, monkeypatch):
+    from src.gateway import runtime_api
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    initial = RuntimeTaskTracker(storage_dir=tmp_path)
+    initial.create_pending(
+        task_id="task-resume-1",
+        request_id="task-task-resume-1",
+        task_type="adapter_action_task",
+        source="portal",
+        session_id="session-1",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="portal-task-1",
+        context_ref={"workspace": "w1"},
+        merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
+        metadata={"task_id": "task-resume-1", "portal_task_id": "portal-task-1"},
+        trace_headers={"trace_id": "trace-1", "portal_dispatch_id": "dispatch-1"},
+    )
+    initial.mark_running("task-resume-1")
+
+    runtime_api.runtime_task_tracker.reset()
+    tracker = RuntimeTaskTracker()
+    monkeypatch.setattr(runtime_api, "runtime_task_tracker", tracker)
+    monkeypatch.setenv("EFP_RUNTIME_TASKS_DIR", str(tmp_path))
+    spawned = []
+    captured = {}
+    emitted = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured.update(kwargs)
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    async def _fake_emit_task_lifecycle_event(event_type, **kwargs):
+        emitted.append(event_type)
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_emit_task_lifecycle_event", _fake_emit_task_lifecycle_event)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    resumed = await runtime_api.resume_persisted_runtime_tasks()
+
+    assert resumed == 1
+    assert len(spawned) == 1
+    await spawned[0]
+
+    record = tracker.get("task-resume-1")
+    assert record is not None
+    assert record.status == "success"
+    assert record.resume_count == 1
+    assert captured["metadata"]["runtime_task_resumed"] is True
+    assert captured["metadata"]["runtime_task_resume_count"] == 1
+    assert "task.resumed" in emitted
+
+
 @pytest.mark.asyncio
 async def test_api_chat_returns_display_blocks(monkeypatch):
     from src.gateway import runtime_api


### PR DESCRIPTION
## Summary

Adds Native runtime task recovery so Portal-submitted async tasks survive runtime process restarts in the same operational shape as the OpenCode runtime path.

## What changed

- Persist `/api/tasks/execute` task records under the runtime workspace at `.efp/runtime_tasks` by default, with `EFP_RUNTIME_TASKS_DIR` and `EFP_RUNTIME_TASKS_PERSISTENCE=false` overrides.
- Store enough task request context to replay active tasks after restart: context ref, merged input payload, metadata, trace headers, task/session/agent identity, and polling state.
- Add startup recovery that loads persisted records and re-schedules only active `accepted`/`running` tasks; terminal tasks remain queryable and are not re-run.
- Make duplicate task execution requests idempotent by returning the existing record and avoiding a second background task.
- Preserve cancel and terminal behavior, including persisted cancelled/error/success payloads.

## Notes

Native recovery cannot attach to a dead in-process coroutine after the Python runtime exits. The implementation restores Portal-level behavior by replaying the persisted task request with the same task id. Replayed tasks receive `runtime_task_resumed` and `runtime_task_resume_count` metadata so downstream handlers can detect restart recovery and apply task/dedupe-key safeguards where needed.

## Validation

- Local: `python -m compileall -q src/runtime/runtime_task_tracker.py src/gateway/runtime_api.py tests/test_runtime_api.py`
- Local: `git diff --check`
- VM233 / Python 3.11: targeted new task recovery tests, 3 passed
- VM233 / Python 3.11: selected task API regression, 4 passed
- VM233 / Python 3.11: `tests/test_runtime_api.py`, 115 passed
- VM233 / Python 3.11: CI subset plus runtime API and adapter boundary tests, 227 passed
- VM233 / Python 3.11: full test suite, 2366 passed, 3 skipped

Docker smoke was not run on VM233 because Docker is not installed there; the Docker runtime contract tests passed and GitHub Actions should cover the actual image build/smoke path.