### PR TITLE
[codex] add native long task parity

### DIFF
--- a/src/efp_runtime/questions.py
+++ b/src/efp_runtime/questions.py
@@ -127,13 +127,21 @@ class QuestionBroker:
         request = self._pending.pop(request_id, None)
         if request is None:
             raise KeyError(f"Unknown question request: {request_id}")
+        self.seed_answer(request.session_id, request.tool_call_id, answers)
+
+    def seed_answer(
+        self,
+        session_id: Optional[str],
+        tool_call_id: Optional[str],
+        answers: Iterable[AnswerValue],
+    ) -> None:
         answer_items: Iterable[AnswerValue]
         if isinstance(answers, str):
             answer_items = [answers]
         else:
             answer_items = answers
         normalized_answers = [_normalize_answer(answer) for answer in answer_items]
-        self._answers[(request.session_id, request.tool_call_id)] = normalized_answers
+        self._answers[(session_id, tool_call_id)] = normalized_answers
 
     def consume_answer(
         self,

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -1729,15 +1729,55 @@ def _runtime_task_waiting_for_user(record: Any) -> bool:
     )
 
 
+def _rehydrate_waiting_runtime_task_session_lane(session_key: Optional[str]) -> Optional[Any]:
+    if not session_key or runtime_task_session_coordinator.active_task_id(session_key):
+        return None
+    finder = getattr(runtime_task_tracker, "find_waiting_for_user_by_session", None)
+    waiting_record = finder(session_key) if callable(finder) else None
+    if waiting_record is None:
+        return None
+    decision = runtime_task_session_coordinator.schedule(
+        session_key,
+        waiting_record.task_id,
+        admitted_seq=int(getattr(waiting_record, "admitted_seq", 0) or 0),
+        delivery=str(getattr(waiting_record, "input_delivery", "steer") or "steer"),
+    )
+    if decision.action not in {"start", "active"}:
+        return None
+    runtime_task_session_coordinator.hold_for_user_input(session_key, waiting_record.task_id)
+    logger.info(
+        "Runtime task session lane rehydrated for pending user input | task_id=%s session_id=%s",
+        waiting_record.task_id,
+        session_key,
+    )
+    return waiting_record
+
+
+def _rehydrate_waiting_runtime_task_session_lanes() -> int:
+    lister = getattr(runtime_task_tracker, "list_waiting_for_user", None)
+    waiting_records = lister() if callable(lister) else []
+    rehydrated_count = 0
+    for record in waiting_records:
+        session_key = _runtime_task_session_key(record)
+        if not session_key:
+            continue
+        rehydrated = _rehydrate_waiting_runtime_task_session_lane(session_key)
+        if rehydrated is not None and rehydrated.task_id == record.task_id:
+            rehydrated_count += 1
+    return rehydrated_count
+
+
 def _reconcile_runtime_task_session_lane(session_key: Optional[str]) -> None:
     if not session_key:
         return
     active_task_id = runtime_task_session_coordinator.active_task_id(session_key)
     if not active_task_id:
+        _rehydrate_waiting_runtime_task_session_lane(session_key)
         return
     active_record = runtime_task_tracker.get(active_task_id)
     if active_record is None:
         runtime_task_session_coordinator.clear(session_key)
+        _rehydrate_waiting_runtime_task_session_lane(session_key)
         return
     if _runtime_task_waiting_for_user(active_record):
         return
@@ -2430,6 +2470,7 @@ async def resume_persisted_runtime_tasks() -> int:
 
     runtime_task_tracker.configure_storage(storage_dir)
     loaded_count = runtime_task_tracker.load_persisted_records()
+    rehydrated_waiting_count = _rehydrate_waiting_runtime_task_session_lanes()
     resumed_count = 0
     for record in runtime_task_tracker.list_active():
         background_task = getattr(record, "background_task", None)
@@ -2474,10 +2515,11 @@ async def resume_persisted_runtime_tasks() -> int:
         )
     if loaded_count or resumed_count:
         logger.info(
-            "Runtime task recovery initialized | storage_dir=%s loaded=%s resumed=%s",
+            "Runtime task recovery initialized | storage_dir=%s loaded=%s resumed=%s waiting_lanes=%s",
             storage_dir,
             loaded_count,
             resumed_count,
+            rehydrated_waiting_count,
         )
     return resumed_count
 

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -325,6 +325,39 @@ def _parse_task_execute_request(data: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _resolve_runtime_task_session_id(
+    *,
+    task_id: str,
+    task_type: str,
+    session_id: Optional[str],
+    input_payload: Dict[str, Any],
+    metadata: Dict[str, Any],
+) -> Optional[str]:
+    """Return the durable Native task session id for task-style execution."""
+    for value in (
+        input_payload.get("task_session_id"),
+        metadata.get("portal_task_session_id"),
+        metadata.get("runtime_task_session_id"),
+        input_payload.get("_runtime_session_id"),
+        metadata.get("task_session_id"),
+    ):
+        if isinstance(value, str) and value.strip():
+            return _safe_runtime_task_session_id(value.strip())
+    if session_id:
+        return _safe_runtime_task_session_id(session_id)
+    if task_type == "agent_async_task" and task_id:
+        return _safe_runtime_task_session_id(f"agent-task-{task_id}")
+    if task_type == "generic_agent_task" and task_id:
+        return _safe_runtime_task_session_id(f"generic-task-{task_id}")
+    return None
+
+
+def _safe_runtime_task_session_id(value: str) -> str:
+    """Keep task-backed chat session ids portable across file-backed stores."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "").strip()).strip(".-")
+    return cleaned or f"task-session-{hashlib.sha256(str(value).encode('utf-8')).hexdigest()[:16]}"
+
+
 def _sanitize_trace_value(value: Any, max_len: int = 128) -> Optional[str]:
     if value is None:
         return None
@@ -1524,6 +1557,16 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
             metadata["portal_workflow_rule_id"] = parsed["workflow_rule_id"]
         if parsed["shared_context_ref"]:
             metadata["shared_context_ref"] = parsed["shared_context_ref"]
+        task_session_id = _resolve_runtime_task_session_id(
+            task_id=parsed["task_id"],
+            task_type=parsed["task_type"],
+            session_id=parsed["session_id"],
+            input_payload=merged_input_payload,
+            metadata=metadata,
+        )
+        if task_session_id:
+            merged_input_payload["task_session_id"] = task_session_id
+            metadata["runtime_task_session_id"] = task_session_id
         runtime_agent_id, _runtime_agent_name = _resolve_runtime_agent_identity(request)
         set_log_context(agent_id=runtime_agent_id)
         logger.info(
@@ -1536,6 +1579,30 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
         request_id = f"task-{parsed['task_id']}"
         existing_record = runtime_task_tracker.get(parsed["task_id"])
         if existing_record is not None:
+            if not runtime_task_tracker.admission_matches(
+                existing_record,
+                task_type=parsed["task_type"],
+                source=parsed["source"] or "portal",
+                session_id=parsed["session_id"],
+                task_session_id=task_session_id,
+                context_ref=parsed["context_ref"] or None,
+                merged_input_payload=merged_input_payload,
+                metadata=metadata,
+            ):
+                return web.json_response(
+                    {
+                        "ok": False,
+                        "task_id": parsed["task_id"],
+                        "execution_type": "task",
+                        "request_id": existing_record.request_id,
+                        "status": existing_record.status,
+                        "error": "task_id_conflicts_with_existing_admission",
+                        "admission_id": existing_record.admission_id,
+                        "input_hash": existing_record.input_hash,
+                        "engine": "native",
+                    },
+                    status=409,
+                )
             if existing_record.status in {"accepted", "running"}:
                 try:
                     _schedule_runtime_task_record(existing_record)
@@ -1575,6 +1642,7 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
             merged_input_payload=merged_input_payload,
             metadata=metadata,
             trace_headers=trace_headers,
+            task_session_id=task_session_id,
         )
 
         try:
@@ -1590,7 +1658,7 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
             task_id=parsed["task_id"],
             portal_task_id=metadata.get("portal_task_id"),
             agent_id=runtime_agent_id,
-            session_id=parsed["session_id"],
+            session_id=parsed["session_id"] or task_session_id,
             trace_id=trace_headers.get("trace_id"),
             portal_dispatch_id=trace_headers.get("portal_dispatch_id"),
         )
@@ -1604,6 +1672,10 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
                 "status": "accepted",
                 "trace_id": trace_headers.get("trace_id"),
                 "portal_dispatch_id": trace_headers.get("portal_dispatch_id"),
+                "engine": "native",
+                "admission_id": record.admission_id,
+                "input_hash": record.input_hash,
+                "task_session_id": record.task_session_id,
             },
             status=202,
         )
@@ -1622,6 +1694,24 @@ def _spawn_runtime_background_task(coro: Any) -> asyncio.Task:
     return asyncio.create_task(coro)
 
 
+def _runtime_task_observability_fields(record: Any) -> Dict[str, Any]:
+    return {
+        "engine": "native",
+        "admission_id": getattr(record, "admission_id", None),
+        "admitted_at": getattr(record, "admitted_at", None),
+        "input_hash": getattr(record, "input_hash", None),
+        "task_session_id": getattr(record, "task_session_id", None),
+        "active_attempt_id": getattr(record, "active_attempt_id", None),
+        "attempt_count": getattr(record, "attempt_count", 0),
+        "last_attempt_started_at": getattr(record, "last_attempt_started_at", None),
+        "last_progress_at": getattr(record, "last_progress_at", None),
+        "pending_permission_request": getattr(record, "pending_permission_request", None),
+        "pending_question_request": getattr(record, "pending_question_request", None),
+        "completion_source": getattr(record, "completion_source", None),
+        "cancel_requested": getattr(record, "cancel_requested", False),
+    }
+
+
 def _runtime_task_status_payload(record: Any) -> Dict[str, Any]:
     if record.status in {"accepted", "running"}:
         return {
@@ -1637,6 +1727,7 @@ def _runtime_task_status_payload(record: Any) -> Dict[str, Any]:
             "finished_at": record.finished_at,
             "resume_count": getattr(record, "resume_count", 0),
             "last_resumed_at": getattr(record, "last_resumed_at", None),
+            **_runtime_task_observability_fields(record),
         }
     payload = dict(record.payload)
     payload["accepted_at"] = record.accepted_at
@@ -1644,6 +1735,7 @@ def _runtime_task_status_payload(record: Any) -> Dict[str, Any]:
     payload["finished_at"] = record.finished_at
     payload["resume_count"] = getattr(record, "resume_count", 0)
     payload["last_resumed_at"] = getattr(record, "last_resumed_at", None)
+    payload.update(_runtime_task_observability_fields(record))
     return payload
 
 
@@ -1683,12 +1775,17 @@ def _schedule_runtime_task_record(record: Any, *, resumed: bool = False) -> bool
     if resumed:
         metadata["runtime_task_resumed"] = True
         metadata["runtime_task_resume_count"] = getattr(record, "resume_count", 0)
+    metadata["runtime_task_admission_id"] = getattr(record, "admission_id", None)
+    metadata["runtime_task_input_hash"] = getattr(record, "input_hash", None)
+    metadata["runtime_task_session_id"] = getattr(record, "task_session_id", None)
+    metadata["runtime_task_attempt_count"] = getattr(record, "attempt_count", 0)
+    execution_session_id = record.session_id or getattr(record, "task_session_id", None)
 
     background_coro = _run_task_execution_in_background(
         task_id=record.task_id,
         request_id=record.request_id,
         task_type=record.task_type,
-        session_id=record.session_id,
+        session_id=execution_session_id,
         source=record.source or "portal",
         runtime_agent_id=record.agent_id,
         context_ref=record.context_ref or None,
@@ -1772,8 +1869,17 @@ async def _run_task_execution_in_background(
     trace_headers: Dict[str, Optional[str]],
 ) -> None:
     execution_started_at = time.perf_counter()
+    attempt_id: Optional[str] = None
     try:
-        runtime_task_tracker.mark_running(task_id)
+        running_record = runtime_task_tracker.mark_running(task_id)
+        if running_record is not None:
+            attempt_id = getattr(running_record, "active_attempt_id", None)
+            metadata = dict(metadata)
+            metadata["runtime_task_admission_id"] = getattr(running_record, "admission_id", None)
+            metadata["runtime_task_input_hash"] = getattr(running_record, "input_hash", None)
+            metadata["runtime_task_session_id"] = getattr(running_record, "task_session_id", None)
+            metadata["runtime_task_attempt_id"] = attempt_id
+            metadata["runtime_task_attempt_count"] = getattr(running_record, "attempt_count", 0)
         await _emit_task_lifecycle_event(
             "task.started",
             task_id=task_id,
@@ -1824,13 +1930,21 @@ async def _run_task_execution_in_background(
             execution_result=execution_result,
             trace_headers=trace_headers,
         )
+        current = runtime_task_tracker.get(task_id)
+        if current is not None:
+            response_payload.update(_runtime_task_observability_fields(current))
         status = str(execution_result.status or "error")
-        runtime_task_tracker.mark_terminal(
+        terminal_record = runtime_task_tracker.mark_terminal(
             task_id,
             status=status,
             payload=response_payload,
             error_message=str(response_payload.get("error") or "") or None,
+            attempt_id=attempt_id,
+            completion_source="execution_result",
         )
+        if terminal_record is None:
+            logger.info("Task result ignored because attempt is no longer current | task_id=%s attempt_id=%s", task_id, attempt_id or "-")
+            return
         await _emit_task_lifecycle_event(
             "task.completed" if status == "success" else "task.failed",
             task_id=task_id,
@@ -1862,6 +1976,9 @@ async def _run_task_execution_in_background(
                 "portal_dispatch_id": trace_headers.get("portal_dispatch_id"),
                 "error": "Task cancelled",
             }
+            current = runtime_task_tracker.get(task_id)
+            if current is not None:
+                cancelled_payload.update(_runtime_task_observability_fields(current))
             runtime_task_tracker.cancel(
                 task_id,
                 reason="Task cancelled",
@@ -1891,11 +2008,18 @@ async def _run_task_execution_in_background(
             "portal_dispatch_id": trace_headers.get("portal_dispatch_id"),
             "error": sanitized_message,
         }
-        runtime_task_tracker.mark_internal_failure(
+        current = runtime_task_tracker.get(task_id)
+        if current is not None:
+            failure_payload.update(_runtime_task_observability_fields(current))
+        terminal_record = runtime_task_tracker.mark_internal_failure(
             task_id,
             payload=failure_payload,
             error_message=sanitized_message,
+            attempt_id=attempt_id,
         )
+        if terminal_record is None:
+            logger.info("Task failure ignored because attempt is no longer current | task_id=%s attempt_id=%s", task_id, attempt_id or "-")
+            return
         await _emit_task_lifecycle_event(
             "task.failed",
             task_id=task_id,
@@ -1944,14 +2068,15 @@ async def api_task_cancel(request: web.Request) -> web.Response:
         if record is None:
             return web.json_response({"error": "Task not found"}, status=404)
         if record.status in {"success", "error", "blocked", "cancelled", "stale"}:
-            payload = dict(record.payload or {"task_id": task_id, "status": record.status})
+            payload = _runtime_task_status_payload(record)
             payload["cancel_requested"] = True
             payload["status"] = record.status
             return web.json_response(payload)
         payload = {"ok": False, "task_id": task_id, "execution_type": "task", "request_id": record.request_id, "status": "cancelled", "cancel_requested": True, "trace_id": record.trace_id, "portal_dispatch_id": record.portal_dispatch_id, "accepted_at": record.accepted_at, "started_at": record.started_at, "finished_at": None, "error": "Task cancelled by request"}
+        payload.update(_runtime_task_observability_fields(record))
         cancelled = runtime_task_tracker.cancel(task_id, reason="Task cancelled by request", payload=payload)
         if cancelled:
-            payload["finished_at"] = cancelled.finished_at
+            payload = _runtime_task_status_payload(cancelled)
         await _emit_task_lifecycle_event("task.cancelled", task_id=task_id, portal_task_id=record.portal_task_id, agent_id=record.agent_id, session_id=record.session_id, trace_id=record.trace_id, portal_dispatch_id=record.portal_dispatch_id)
         return web.json_response(payload)
     finally:
@@ -1991,18 +2116,22 @@ async def resume_persisted_runtime_tasks() -> int:
         except Exception as exc:
             sanitized_message = sanitize_exception_message(exc)
             logger.error("Persisted runtime task resume failed | task_id=%s", record.task_id, exc_info=True)
+            failure_payload = {
+                "ok": False,
+                "task_id": record.task_id,
+                "execution_type": "task",
+                "request_id": record.request_id,
+                "status": "error",
+                "trace_id": record.trace_id,
+                "portal_dispatch_id": record.portal_dispatch_id,
+                "error": sanitized_message,
+            }
+            current = runtime_task_tracker.get(record.task_id)
+            if current is not None:
+                failure_payload.update(_runtime_task_observability_fields(current))
             runtime_task_tracker.mark_internal_failure(
                 record.task_id,
-                payload={
-                    "ok": False,
-                    "task_id": record.task_id,
-                    "execution_type": "task",
-                    "request_id": record.request_id,
-                    "status": "error",
-                    "trace_id": record.trace_id,
-                    "portal_dispatch_id": record.portal_dispatch_id,
-                    "error": sanitized_message,
-                },
+                payload=failure_payload,
                 error_message=sanitized_message,
             )
             continue

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -30,6 +30,7 @@ from src.hooks.file_context.storage import storage as file_context_storage
 from src.config import config as global_config, DEFAULT_LLM_MODEL
 from src.runtime.chat_orchestration_adapter import execute_runtime_task_request
 from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+from src.runtime.runtime_task_session_coordinator import RuntimeTaskSessionCoordinator
 from src.runtime.portal_session_metadata_client import (
     extract_session_metadata_publish_fields,
     publish_session_metadata,
@@ -63,6 +64,7 @@ from src.workspace_defaults import resolve_runtime_workspace
 
 logger = logging.getLogger(__name__)
 runtime_task_tracker = RuntimeTaskTracker()
+runtime_task_session_coordinator = RuntimeTaskSessionCoordinator()
 runtime_session_artifacts = RuntimeSessionArtifacts()
 
 
@@ -356,6 +358,20 @@ def _safe_runtime_task_session_id(value: str) -> str:
     """Keep task-backed chat session ids portable across file-backed stores."""
     cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "").strip()).strip(".-")
     return cleaned or f"task-session-{hashlib.sha256(str(value).encode('utf-8')).hexdigest()[:16]}"
+
+
+def _resolve_runtime_task_delivery(input_payload: Dict[str, Any], metadata: Dict[str, Any]) -> str:
+    for value in (
+        input_payload.get("delivery"),
+        input_payload.get("runtime_task_delivery"),
+        metadata.get("delivery"),
+        metadata.get("runtime_task_delivery"),
+    ):
+        if isinstance(value, str) and value.strip().lower() == "queue":
+            return "queue"
+        if isinstance(value, str) and value.strip().lower() == "steer":
+            return "steer"
+    return "steer"
 
 
 def _sanitize_trace_value(value: Any, max_len: int = 128) -> Optional[str]:
@@ -1567,6 +1583,8 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
         if task_session_id:
             merged_input_payload["task_session_id"] = task_session_id
             metadata["runtime_task_session_id"] = task_session_id
+        input_delivery = _resolve_runtime_task_delivery(merged_input_payload, metadata)
+        metadata["runtime_task_delivery"] = input_delivery
         runtime_agent_id, _runtime_agent_name = _resolve_runtime_agent_identity(request)
         set_log_context(agent_id=runtime_agent_id)
         logger.info(
@@ -1585,6 +1603,7 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
                 source=parsed["source"] or "portal",
                 session_id=parsed["session_id"],
                 task_session_id=task_session_id,
+                input_delivery=input_delivery,
                 context_ref=parsed["context_ref"] or None,
                 merged_input_payload=merged_input_payload,
                 metadata=metadata,
@@ -1643,6 +1662,7 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
             metadata=metadata,
             trace_headers=trace_headers,
             task_session_id=task_session_id,
+            input_delivery=input_delivery,
         )
 
         try:
@@ -1676,6 +1696,7 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
                 "admission_id": record.admission_id,
                 "input_hash": record.input_hash,
                 "task_session_id": record.task_session_id,
+                "delivery": record.input_delivery,
             },
             status=202,
         )
@@ -1694,13 +1715,69 @@ def _spawn_runtime_background_task(coro: Any) -> asyncio.Task:
     return asyncio.create_task(coro)
 
 
+def _runtime_task_session_key(record: Any) -> Optional[str]:
+    return getattr(record, "task_session_id", None) or getattr(record, "session_id", None)
+
+
+def _runtime_task_waiting_for_user(record: Any) -> bool:
+    return bool(
+        getattr(record, "status", None) == "blocked"
+        and (
+            getattr(record, "pending_permission_request", None) is not None
+            or getattr(record, "pending_question_request", None) is not None
+        )
+    )
+
+
+def _reconcile_runtime_task_session_lane(session_key: Optional[str]) -> None:
+    if not session_key:
+        return
+    active_task_id = runtime_task_session_coordinator.active_task_id(session_key)
+    if not active_task_id:
+        return
+    active_record = runtime_task_tracker.get(active_task_id)
+    if active_record is None:
+        runtime_task_session_coordinator.clear(session_key)
+        return
+    if _runtime_task_waiting_for_user(active_record):
+        return
+    background_task = getattr(active_record, "background_task", None)
+    active_status = getattr(active_record, "status", None)
+    if active_status in {"accepted", "running"} and background_task is not None and not background_task.done():
+        return
+    if active_status in {"accepted", "running"} and background_task is None:
+        return
+    runtime_task_session_coordinator.complete(session_key, active_task_id)
+
+
+def _schedule_next_runtime_task_session_record(next_task_id: Optional[str]) -> None:
+    if not next_task_id:
+        return
+    next_record = runtime_task_tracker.get(next_task_id)
+    if next_record is None or next_record.status not in {"accepted", "running"}:
+        return
+    try:
+        _schedule_runtime_task_record(next_record)
+    except Exception:
+        logger.warning("Failed to schedule next runtime task session record | task_id=%s", next_task_id, exc_info=True)
+
+
 def _runtime_task_observability_fields(record: Any) -> Dict[str, Any]:
+    session_key = _runtime_task_session_key(record)
+    lane_snapshot = runtime_task_session_coordinator.snapshot(session_key, record.task_id) if session_key else None
     return {
         "engine": "native",
         "admission_id": getattr(record, "admission_id", None),
+        "admitted_seq": getattr(record, "admitted_seq", 0),
         "admitted_at": getattr(record, "admitted_at", None),
+        "delivery": getattr(record, "input_delivery", "steer"),
         "input_hash": getattr(record, "input_hash", None),
         "task_session_id": getattr(record, "task_session_id", None),
+        "session_lane_status": lane_snapshot.lane_status if lane_snapshot else None,
+        "session_active_task_id": lane_snapshot.active_task_id if lane_snapshot else None,
+        "session_queue_position": lane_snapshot.queue_position if lane_snapshot else None,
+        "session_pending_count": lane_snapshot.pending_count if lane_snapshot else 0,
+        "session_interrupt_seq": lane_snapshot.interrupt_seq if lane_snapshot else None,
         "active_attempt_id": getattr(record, "active_attempt_id", None),
         "attempt_count": getattr(record, "attempt_count", 0),
         "last_attempt_started_at": getattr(record, "last_attempt_started_at", None),
@@ -1778,8 +1855,50 @@ def _schedule_runtime_task_record(record: Any, *, resumed: bool = False) -> bool
     metadata["runtime_task_admission_id"] = getattr(record, "admission_id", None)
     metadata["runtime_task_input_hash"] = getattr(record, "input_hash", None)
     metadata["runtime_task_session_id"] = getattr(record, "task_session_id", None)
+    metadata["runtime_task_delivery"] = getattr(record, "input_delivery", "steer")
     metadata["runtime_task_attempt_count"] = getattr(record, "attempt_count", 0)
     execution_session_id = record.session_id or getattr(record, "task_session_id", None)
+    session_key = _runtime_task_session_key(record) or execution_session_id
+    if session_key:
+        _reconcile_runtime_task_session_lane(session_key)
+        decision = runtime_task_session_coordinator.schedule(
+            session_key,
+            record.task_id,
+            admitted_seq=int(getattr(record, "admitted_seq", 0) or 0),
+            delivery=str(getattr(record, "input_delivery", "steer") or "steer"),
+        )
+        if decision.action == "queued":
+            logger.info(
+                "Runtime task queued behind active session lane | task_id=%s session_id=%s active_task_id=%s queue_position=%s pending_count=%s",
+                record.task_id,
+                session_key,
+                decision.active_task_id or "-",
+                decision.queue_position or "-",
+                decision.pending_count,
+            )
+            return True
+        if decision.action == "active":
+            logger.debug(
+                "Runtime task owns active session lane | task_id=%s session_id=%s",
+                record.task_id,
+                session_key,
+            )
+        if decision.action == "suppressed":
+            runtime_task_tracker.mark_stale(
+                record.task_id,
+                reason="Runtime task suppressed by session interrupt",
+                payload={
+                    "ok": False,
+                    "task_id": record.task_id,
+                    "execution_type": "task",
+                    "request_id": record.request_id,
+                    "status": "stale",
+                    "trace_id": record.trace_id,
+                    "portal_dispatch_id": record.portal_dispatch_id,
+                    "error": "Runtime task suppressed by session interrupt",
+                },
+            )
+            return False
 
     background_coro = _run_task_execution_in_background(
         task_id=record.task_id,
@@ -1797,6 +1916,8 @@ def _schedule_runtime_task_record(record: Any, *, resumed: bool = False) -> bool
         spawned = _spawn_runtime_background_task(background_coro)
     except Exception:
         background_coro.close()
+        if session_key:
+            runtime_task_session_coordinator.complete(session_key, record.task_id)
         raise
     runtime_task_tracker.set_background_task(record.task_id, spawned)
     return True
@@ -1870,6 +1991,12 @@ async def _run_task_execution_in_background(
 ) -> None:
     execution_started_at = time.perf_counter()
     attempt_id: Optional[str] = None
+    metadata_session_key = metadata.get("runtime_task_session_id") if isinstance(metadata, dict) else None
+    session_key = (
+        _safe_runtime_task_session_id(metadata_session_key)
+        if isinstance(metadata_session_key, str) and metadata_session_key.strip()
+        else session_id
+    )
     try:
         running_record = runtime_task_tracker.mark_running(task_id)
         if running_record is not None:
@@ -2029,6 +2156,15 @@ async def _run_task_execution_in_background(
             trace_id=trace_headers.get("trace_id"),
             portal_dispatch_id=trace_headers.get("portal_dispatch_id"),
         )
+    finally:
+        next_task_id: Optional[str] = None
+        if session_key:
+            current = runtime_task_tracker.get(task_id)
+            if current is not None and _runtime_task_waiting_for_user(current):
+                runtime_task_session_coordinator.hold_for_user_input(session_key, task_id)
+            elif current is None or getattr(current, "status", None) in {"success", "error", "blocked", "cancelled", "stale"}:
+                next_task_id = runtime_task_session_coordinator.complete(session_key, task_id)
+        _schedule_next_runtime_task_session_record(next_task_id)
 
 
 async def api_task_status(request: web.Request) -> web.Response:
@@ -2067,18 +2203,207 @@ async def api_task_cancel(request: web.Request) -> web.Response:
         record = runtime_task_tracker.get(task_id)
         if record is None:
             return web.json_response({"error": "Task not found"}, status=404)
-        if record.status in {"success", "error", "blocked", "cancelled", "stale"}:
+        waiting_for_user = _runtime_task_waiting_for_user(record)
+        if record.status in {"success", "error", "blocked", "cancelled", "stale"} and not waiting_for_user:
             payload = _runtime_task_status_payload(record)
             payload["cancel_requested"] = True
             payload["status"] = record.status
             return web.json_response(payload)
+        session_key = _runtime_task_session_key(record)
+        if session_key:
+            runtime_task_session_coordinator.cancel(
+                session_key,
+                task_id,
+                admitted_seq=int(getattr(record, "admitted_seq", 0) or 0),
+            )
         payload = {"ok": False, "task_id": task_id, "execution_type": "task", "request_id": record.request_id, "status": "cancelled", "cancel_requested": True, "trace_id": record.trace_id, "portal_dispatch_id": record.portal_dispatch_id, "accepted_at": record.accepted_at, "started_at": record.started_at, "finished_at": None, "error": "Task cancelled by request"}
         payload.update(_runtime_task_observability_fields(record))
-        cancelled = runtime_task_tracker.cancel(task_id, reason="Task cancelled by request", payload=payload)
+        cancelled = runtime_task_tracker.cancel(task_id, reason="Task cancelled by request", payload=payload, force=waiting_for_user)
         if cancelled:
             payload = _runtime_task_status_payload(cancelled)
+        if waiting_for_user:
+            next_task_id = runtime_task_session_coordinator.complete(session_key, task_id) if session_key else None
+            _schedule_next_runtime_task_session_record(next_task_id)
         await _emit_task_lifecycle_event("task.cancelled", task_id=task_id, portal_task_id=record.portal_task_id, agent_id=record.agent_id, session_id=record.session_id, trace_id=record.trace_id, portal_dispatch_id=record.portal_dispatch_id)
         return web.json_response(payload)
+    finally:
+        clear_log_context()
+
+
+def _pending_request_id(pending: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not isinstance(pending, dict):
+        return None
+    value = pending.get("request_id") or pending.get("id")
+    return str(value).strip() if value is not None and str(value).strip() else None
+
+
+def _pending_request_matches(pending: Optional[Dict[str, Any]], request_id: Optional[str]) -> bool:
+    pending_id = _pending_request_id(pending)
+    if request_id:
+        return pending_id == request_id
+    return pending_id is not None
+
+
+def _permission_response_decision(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"approve", "approved", "allow", "allowed", "accept", "accepted"}:
+        return "approve"
+    if normalized in {"deny", "denied", "reject", "rejected"}:
+        return "deny"
+    raise ValueError("decision must be approve/allow or deny/reject")
+
+
+def _metadata_with_permission_response(
+    metadata: Optional[Dict[str, Any]],
+    *,
+    pending_request: Dict[str, Any],
+    decision: str,
+    always: bool,
+    reason: Optional[str],
+) -> Dict[str, Any]:
+    merged = dict(metadata or {})
+    profile = dict(merged.get("runtime_profile") or {}) if isinstance(merged.get("runtime_profile"), dict) else {}
+    profile_config = dict(profile.get("config") or {}) if isinstance(profile.get("config"), dict) else {}
+    tool_permissions = dict(profile_config.get("tool_permissions") or {}) if isinstance(profile_config.get("tool_permissions"), dict) else {}
+    request_metadata = pending_request.get("metadata") if isinstance(pending_request.get("metadata"), dict) else {}
+    tool_id = (
+        pending_request.get("tool_id")
+        or pending_request.get("tool")
+        or request_metadata.get("tool_name")
+    )
+    if not isinstance(tool_id, str) or not tool_id.strip():
+        raise ValueError("pending permission request is missing tool_id")
+    rule: Dict[str, Any] = {"action": "allow" if decision == "approve" else "deny"}
+    patterns = pending_request.get("patterns")
+    if isinstance(patterns, list) and patterns:
+        rule["patterns"] = patterns
+    elif pending_request.get("args") is not None:
+        rule["patterns"] = [json.dumps(pending_request.get("args"), ensure_ascii=False, sort_keys=True, default=str)]
+    if reason:
+        rule["reason"] = reason
+    tool_permissions[tool_id.strip()] = rule
+    profile_config["tool_permissions"] = tool_permissions
+    profile["source"] = "portal.runtime_profile"
+    profile["config"] = profile_config
+    merged["runtime_profile"] = profile
+    merged["runtime_task_resume_after_user_input"] = True
+    merged["runtime_permission_response"] = {
+        "request_id": _pending_request_id(pending_request),
+        "decision": decision,
+        "always": bool(always),
+        "reason": reason,
+        "tool_id": tool_id.strip(),
+    }
+    return merged
+
+
+def _metadata_with_question_response(
+    metadata: Optional[Dict[str, Any]],
+    *,
+    pending_request: Dict[str, Any],
+    answers: Any,
+) -> Dict[str, Any]:
+    merged = dict(metadata or {})
+    merged["runtime_task_resume_after_user_input"] = True
+    merged["runtime_question_response"] = {
+        "request_id": _pending_request_id(pending_request),
+        "request": dict(pending_request),
+        "answers": answers,
+    }
+    return merged
+
+
+def _resume_runtime_task_after_user_input(record: Any, *, metadata: Dict[str, Any]) -> Any:
+    merged_input_payload = dict(record.merged_input_payload or {})
+    merged_input_payload["_runtime_resume"] = True
+    resumed = runtime_task_tracker.resume_after_user_input(
+        record.task_id,
+        merged_input_payload=merged_input_payload,
+        metadata=metadata,
+    )
+    if resumed is None:
+        return None
+    _schedule_runtime_task_record(resumed)
+    return resumed
+
+
+async def api_task_permission_respond(request: web.Request) -> web.Response:
+    clear_log_context()
+    trace_headers = _extract_task_trace_headers(request)
+    set_log_context(path="/api/tasks/{task_id}/permission/respond", trace_id=trace_headers.get("trace_id"))
+    try:
+        task_id = str(request.match_info.get("task_id") or "").strip()
+        if not task_id:
+            return web.json_response({"error": "task_id is required"}, status=400)
+        data = await request.json()
+        if not isinstance(data, dict):
+            return web.json_response({"error": "Request body must be a JSON object"}, status=400)
+        record = runtime_task_tracker.get(task_id)
+        if record is None:
+            return web.json_response({"error": "Task not found"}, status=404)
+        pending = getattr(record, "pending_permission_request", None)
+        if not isinstance(pending, dict):
+            return web.json_response({"error": "Task is not waiting for permission"}, status=409)
+        request_id = str(data.get("request_id") or data.get("id") or "").strip() or None
+        if not _pending_request_matches(pending, request_id):
+            return web.json_response({"error": "permission_request_id_mismatch"}, status=409)
+        decision = _permission_response_decision(data.get("decision") or data.get("action") or data.get("reply"))
+        metadata = _metadata_with_permission_response(
+            record.metadata,
+            pending_request=pending,
+            decision=decision,
+            always=bool(data.get("always")),
+            reason=str(data.get("reason")).strip() if data.get("reason") is not None else None,
+        )
+        resumed = _resume_runtime_task_after_user_input(record, metadata=metadata)
+        if resumed is None:
+            return web.json_response({"error": "Task not found"}, status=404)
+        return web.json_response(_runtime_task_status_payload(resumed), status=202)
+    except (json.JSONDecodeError, ContentTypeError):
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+    except ValueError as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+    finally:
+        clear_log_context()
+
+
+async def api_task_question_respond(request: web.Request) -> web.Response:
+    clear_log_context()
+    trace_headers = _extract_task_trace_headers(request)
+    set_log_context(path="/api/tasks/{task_id}/question/respond", trace_id=trace_headers.get("trace_id"))
+    try:
+        task_id = str(request.match_info.get("task_id") or "").strip()
+        if not task_id:
+            return web.json_response({"error": "task_id is required"}, status=400)
+        data = await request.json()
+        if not isinstance(data, dict):
+            return web.json_response({"error": "Request body must be a JSON object"}, status=400)
+        record = runtime_task_tracker.get(task_id)
+        if record is None:
+            return web.json_response({"error": "Task not found"}, status=404)
+        pending = getattr(record, "pending_question_request", None)
+        if not isinstance(pending, dict):
+            return web.json_response({"error": "Task is not waiting for a question response"}, status=409)
+        request_id = str(data.get("request_id") or data.get("id") or "").strip() or None
+        if not _pending_request_matches(pending, request_id):
+            return web.json_response({"error": "question_request_id_mismatch"}, status=409)
+        if "answers" in data:
+            answers = data.get("answers")
+        elif "answer" in data:
+            answers = data.get("answer")
+        else:
+            return web.json_response({"error": "answers is required"}, status=400)
+        metadata = _metadata_with_question_response(
+            record.metadata,
+            pending_request=pending,
+            answers=answers,
+        )
+        resumed = _resume_runtime_task_after_user_input(record, metadata=metadata)
+        if resumed is None:
+            return web.json_response({"error": "Task not found"}, status=404)
+        return web.json_response(_runtime_task_status_payload(resumed), status=202)
+    except (json.JSONDecodeError, ContentTypeError):
+        return web.json_response({"error": "Invalid JSON"}, status=400)
     finally:
         clear_log_context()
 
@@ -2529,6 +2854,8 @@ def setup_runtime_api_routes(app: web.Application):
     app.router.add_post('/api/tasks/execute', api_tasks_execute)
     app.router.add_get('/api/tasks/{task_id}', api_task_status)
     app.router.add_post('/api/tasks/{task_id}/cancel', api_task_cancel)
+    app.router.add_post('/api/tasks/{task_id}/permission/respond', api_task_permission_respond)
+    app.router.add_post('/api/tasks/{task_id}/question/respond', api_task_question_respond)
     app.router.add_get('/api/capabilities', api_capabilities)
     app.router.add_get('/api/sessions', api_sessions)
     app.router.add_get('/api/sessions/{session_id}', api_load_session)

--- a/src/gateway/runtime_chat.py
+++ b/src/gateway/runtime_chat.py
@@ -192,6 +192,151 @@ async def run_runtime_chat(
     return payload
 
 
+async def resume_runtime_chat(
+    *,
+    session_id: str,
+    user_name: str | None = None,
+    portal_user_id: str | None = None,
+    portal_user_name: str | None = None,
+    transient_model_message: str | None = None,
+    reasoning_replay: bool | None = None,
+    stream_callback: Any = None,
+    request_path: str = "/api/chat/resume",
+    execution_metadata: Mapping[str, Any] | None = None,
+    agent_id: str | None = None,
+    agent_name: str | None = None,
+    request_id: str | None = None,
+    model: str | None = None,
+    track_usage: bool = True,
+) -> dict[str, Any]:
+    """Resume an existing native runtime session without appending a new user message."""
+
+    runtime_model = _resolve_model(model)
+    provider = _build_github_copilot_provider(runtime_model)
+    event_bus = RuntimeEventBus()
+    runtime = AgentRuntime(
+        provider=provider,
+        config=_runtime_config(
+            runtime_model,
+            track_usage=track_usage,
+            execution_metadata=execution_metadata,
+        ),
+        store=get_runtime_session_store(),
+        event_bus=event_bus,
+        metadata={
+            "gateway": "runtime_api",
+            "request_path": request_path,
+            "agent_id": agent_id,
+            "agent_name": agent_name,
+        },
+    )
+    _seed_runtime_question_response(runtime, session_id=session_id, execution_metadata=execution_metadata)
+
+    forwarder: asyncio.Task | None = None
+    subscription = None
+    if stream_callback is not None:
+        subscription = event_bus.subscribe(session_id=session_id)
+        forwarder = asyncio.create_task(
+            _forward_runtime_events(
+                subscription,
+                stream_callback,
+                projector=RuntimeEventProjector(
+                    request_id=request_id,
+                    agent_id=agent_id,
+                    agent_name=agent_name,
+                    model=runtime_model,
+                ),
+            )
+        )
+
+    run_metadata = _run_metadata(
+        request_path=request_path,
+        request_id=request_id,
+        user_name=user_name,
+        portal_user_id=portal_user_id,
+        portal_user_name=portal_user_name,
+        attached_images=None,
+        attachments=None,
+        transient_model_message=transient_model_message,
+        reasoning_replay=reasoning_replay,
+        execution_metadata=execution_metadata,
+        agent_id=agent_id,
+        agent_name=agent_name,
+        model=runtime_model,
+    )
+
+    try:
+        result = await runtime.resume(
+            session_id=session_id,
+            metadata=run_metadata,
+        )
+        await get_runtime_session_manager().record_runtime_result(
+            session_id,
+            result,
+            request_id=request_id,
+        )
+    except ProviderTransportError as exc:
+        raise RuntimeChatError(
+            str(exc),
+            status_code=401 if "token is required" in str(exc).lower() else 502,
+            error_type="provider_transport_error",
+            details={"provider": "github-copilot"},
+        ) from exc
+    finally:
+        if subscription is not None:
+            subscription.close()
+        if forwarder is not None:
+            await _await_forwarder_done(forwarder)
+
+    payload = _result_payload(
+        result,
+        request_id=request_id,
+        model=runtime_model,
+    )
+    if result.status == LoopStatus.ERROR:
+        raise RuntimeChatError(
+            payload.get("error") or "EFP runtime execution failed.",
+            status_code=_runtime_error_status_code(result),
+            error_type=payload.get("error_type") or "runtime_execution_error",
+            details={
+                "provider": "github-copilot",
+                "runtime_status": result.status,
+                "request_id": request_id,
+            },
+        )
+    return payload
+
+
+def _seed_runtime_question_response(
+    runtime: AgentRuntime,
+    *,
+    session_id: str,
+    execution_metadata: Mapping[str, Any] | None,
+) -> None:
+    if not isinstance(execution_metadata, Mapping):
+        return
+    response = execution_metadata.get("runtime_question_response")
+    if not isinstance(response, Mapping):
+        return
+    request = response.get("request")
+    if not isinstance(request, Mapping):
+        return
+    answers = response.get("answers")
+    if answers is None:
+        return
+    request_session_id = request.get("session_id") if isinstance(request.get("session_id"), str) else session_id
+    tool_call_id = request.get("tool_call_id")
+    if not isinstance(tool_call_id, str) or not tool_call_id.strip():
+        metadata = request.get("metadata")
+        if isinstance(metadata, Mapping):
+            tool_call_id = metadata.get("tool_call_id") if isinstance(metadata.get("tool_call_id"), str) else None
+    if not isinstance(tool_call_id, str) or not tool_call_id.strip():
+        return
+    seed_answer = getattr(runtime.question_broker, "seed_answer", None)
+    if callable(seed_answer):
+        seed_answer(request_session_id, tool_call_id, answers)
+
+
 def _runtime_session_root() -> Path:
     return runtime_session_root()
 

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -1255,6 +1255,14 @@ def _agent_async_has_blockers(payload: Dict[str, Any]) -> bool:
     return bool(blockers)
 
 
+def _runtime_task_should_resume(input_payload: Dict[str, Any], metadata: Dict[str, Any]) -> bool:
+    return bool(
+        input_payload.get("_runtime_resume")
+        or input_payload.get("runtime_task_resume")
+        or metadata.get("runtime_task_resume_after_user_input")
+    )
+
+
 def _agent_async_fallback_response(payload: Dict[str, Any], raw_text: str) -> str:
     response = _agent_async_first_text(
         payload,
@@ -1533,20 +1541,33 @@ async def run_agent_async_task(payload: Dict[str, Any]) -> Dict[str, Any]:
             "schema": input_payload.get("schema"),
         },
     }
-    from src.gateway.runtime_chat import run_runtime_chat
+    from src.gateway.runtime_chat import resume_runtime_chat, run_runtime_chat
 
-    output_payload = await run_runtime_chat(
-        request_id=chat_request_id,
-        session_id=task_session_id or chat_request_id,
-        message=prompt,
-        user_name="Portal Agent Async Task",
-        request_path="/api/tasks/execute/agent_async_task/chat",
-        execution_metadata=chat_metadata,
-        agent_id=agent_id,
-        agent_name=metadata.get("agent_name") if isinstance(metadata.get("agent_name"), str) else None,
-        model=metadata.get("resolved_model") or metadata.get("model"),
-        transient_model_message=AGENT_ASYNC_TASK_DEFAULT_SYSTEM_PROMPT,
-    )
+    if _runtime_task_should_resume(input_payload, metadata):
+        output_payload = await resume_runtime_chat(
+            request_id=chat_request_id,
+            session_id=task_session_id or chat_request_id,
+            user_name="Portal Agent Async Task",
+            request_path="/api/tasks/execute/agent_async_task/chat/resume",
+            execution_metadata=chat_metadata,
+            agent_id=agent_id,
+            agent_name=metadata.get("agent_name") if isinstance(metadata.get("agent_name"), str) else None,
+            model=metadata.get("resolved_model") or metadata.get("model"),
+            transient_model_message=AGENT_ASYNC_TASK_DEFAULT_SYSTEM_PROMPT,
+        )
+    else:
+        output_payload = await run_runtime_chat(
+            request_id=chat_request_id,
+            session_id=task_session_id or chat_request_id,
+            message=prompt,
+            user_name="Portal Agent Async Task",
+            request_path="/api/tasks/execute/agent_async_task/chat",
+            execution_metadata=chat_metadata,
+            agent_id=agent_id,
+            agent_name=metadata.get("agent_name") if isinstance(metadata.get("agent_name"), str) else None,
+            model=metadata.get("resolved_model") or metadata.get("model"),
+            transient_model_message=AGENT_ASYNC_TASK_DEFAULT_SYSTEM_PROMPT,
+        )
     raw_text = _agent_async_first_text(output_payload, ("response", "output", "content", "message"))
     structured_output = output_payload.get("structured_output") if isinstance(output_payload.get("structured_output"), dict) else None
     parsed = dict(structured_output or _extract_agent_async_json_object(raw_text) or {})
@@ -1711,20 +1732,33 @@ async def run_generic_agent_task(payload: Dict[str, Any]) -> Dict[str, Any]:
             "schema": input_payload.get("schema"),
         },
     }
-    from src.gateway.runtime_chat import run_runtime_chat
+    from src.gateway.runtime_chat import resume_runtime_chat, run_runtime_chat
 
-    output_payload = await run_runtime_chat(
-        request_id=chat_request_id,
-        session_id=task_session_id or chat_request_id,
-        message=prompt,
-        user_name="Portal Generic Agent Task",
-        request_path="/api/tasks/execute/generic_agent_task/chat",
-        execution_metadata=chat_metadata,
-        agent_id=agent_id,
-        agent_name=metadata.get("agent_name") if isinstance(metadata.get("agent_name"), str) else None,
-        model=metadata.get("resolved_model") or metadata.get("model"),
-        transient_model_message=GENERIC_AGENT_TASK_DEFAULT_SYSTEM_PROMPT,
-    )
+    if _runtime_task_should_resume(input_payload, metadata):
+        output_payload = await resume_runtime_chat(
+            request_id=chat_request_id,
+            session_id=task_session_id or chat_request_id,
+            user_name="Portal Generic Agent Task",
+            request_path="/api/tasks/execute/generic_agent_task/chat/resume",
+            execution_metadata=chat_metadata,
+            agent_id=agent_id,
+            agent_name=metadata.get("agent_name") if isinstance(metadata.get("agent_name"), str) else None,
+            model=metadata.get("resolved_model") or metadata.get("model"),
+            transient_model_message=GENERIC_AGENT_TASK_DEFAULT_SYSTEM_PROMPT,
+        )
+    else:
+        output_payload = await run_runtime_chat(
+            request_id=chat_request_id,
+            session_id=task_session_id or chat_request_id,
+            message=prompt,
+            user_name="Portal Generic Agent Task",
+            request_path="/api/tasks/execute/generic_agent_task/chat",
+            execution_metadata=chat_metadata,
+            agent_id=agent_id,
+            agent_name=metadata.get("agent_name") if isinstance(metadata.get("agent_name"), str) else None,
+            model=metadata.get("resolved_model") or metadata.get("model"),
+            transient_model_message=GENERIC_AGENT_TASK_DEFAULT_SYSTEM_PROMPT,
+        )
     raw_text = _agent_async_first_text(output_payload, ("response", "output", "content", "message"))
     structured_output = output_payload.get("structured_output") if isinstance(output_payload.get("structured_output"), dict) else None
     parsed = dict(structured_output or _extract_agent_async_json_object(raw_text) or {})

--- a/src/runtime/execution_bus.py
+++ b/src/runtime/execution_bus.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Optional, Protocol
 import json
 import logging
 import os
+import re
 from datetime import datetime
 
 from src import ToolResult, execute_tool
@@ -1194,6 +1195,13 @@ def _non_empty_string(value: Any) -> Optional[str]:
     return None
 
 
+def _safe_runtime_task_session_id(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value).strip()).strip(".-")
+    return cleaned or None
+
+
 def _normalize_agent_mode(value: Any) -> Optional[str]:
     normalized = _non_empty_string(value)
     if normalized in {"specialist", "task"}:
@@ -1322,13 +1330,15 @@ def _normalize_agent_async_skill_output(
     payload["external_actions"] = _agent_async_list(payload.get("external_actions"))
     if not isinstance(payload.get("final_response"), str) or not payload.get("final_response", "").strip():
         payload["final_response"] = _agent_async_fallback_response(payload, raw_text)
-    if "needs_user_input" not in payload or not isinstance(payload.get("needs_user_input"), bool):
+    if agent_status == "blocked":
+        payload["needs_user_input"] = True
+    elif "needs_user_input" not in payload or not isinstance(payload.get("needs_user_input"), bool):
         payload["needs_user_input"] = agent_status == "blocked" or _agent_async_has_blockers(payload)
     error_value = payload.get("error")
     if agent_status == "blocked" and not error_value:
-        error_value = payload["summary"] or "agent_async_task blocked"
+        error_value = payload["summary"] or f"{task_type} blocked"
     elif agent_status == "error" and not error_value:
-        error_value = payload["summary"] or f"agent_async_task skill '{skill_name}' failed"
+        error_value = payload["summary"] or (f"{task_type} skill '{skill_name}' failed" if skill_name else f"{task_type} failed")
     return {
         "status": agent_status,
         "success": agent_status == "success",
@@ -1410,9 +1420,11 @@ def _build_agent_async_chat_prompt(
     context_ref: Optional[Dict[str, Any]],
 ) -> str:
     task_text = _first_non_empty(input_payload.get("user_task"), input_payload.get("followup_task")) or ""
-    task_session_id = (
+    task_session_id = _safe_runtime_task_session_id(
         _non_empty_string(input_payload.get("task_session_id"))
         or _non_empty_string(metadata.get("portal_task_session_id"))
+        or _non_empty_string(metadata.get("runtime_task_session_id"))
+        or _non_empty_string(metadata.get("task_session_id"))
         or ""
     )
     root_task_id = _non_empty_string(input_payload.get("root_task_id")) or _non_empty_string(metadata.get("portal_root_task_id")) or ""
@@ -1489,11 +1501,13 @@ async def run_agent_async_task(payload: Dict[str, Any]) -> Dict[str, Any]:
         or _non_empty_string(metadata.get("task_id"))
         or _non_empty_string(metadata.get("portal_task_id"))
     )
-    task_session_id = (
+    task_session_id = _safe_runtime_task_session_id(
         _non_empty_string(input_payload.get("task_session_id"))
         or _non_empty_string(metadata.get("portal_task_session_id"))
+        or _non_empty_string(metadata.get("runtime_task_session_id"))
+        or _non_empty_string(metadata.get("task_session_id"))
         or _non_empty_string(input_payload.get("_runtime_session_id"))
-        or (f"agent-task:{task_id}" if task_id else None)
+        or (f"agent-task-{task_id}" if task_id else None)
     )
     chat_request_id = _non_empty_string(input_payload.get("_runtime_request_id"))
     chat_request_id = f"{chat_request_id}:chat" if chat_request_id else f"agent-async-chat:{task_id or 'adhoc'}"
@@ -1579,6 +1593,183 @@ async def run_agent_async_task(payload: Dict[str, Any]) -> Dict[str, Any]:
             "chat_request_id": chat_request_id,
             "chat_status": output_payload.get("status"),
             "skill_name": skill_name,
+        },
+        "result": output_payload,
+    }
+
+
+GENERIC_AGENT_TASK_DEFAULT_SYSTEM_PROMPT = (
+    "You are executing an EFP Portal generic_agent_task as an autonomous long-running runtime task. "
+    "Work from the provided user prompt and context, continue independently with available tools, "
+    "and ask for user input only when execution is truly blocked. "
+    "Preserve secrets: never output tokens, credentials, API keys, or raw authorization values. "
+    "Return exactly one JSON object matching the requested task schema."
+)
+
+
+def _build_generic_agent_task_prompt(
+    *,
+    task_id: Optional[str],
+    input_payload: Dict[str, Any],
+    metadata: Dict[str, Any],
+    context_ref: Optional[Dict[str, Any]],
+) -> str:
+    task_text = _first_non_empty(
+        input_payload.get("prompt"),
+        input_payload.get("message"),
+        input_payload.get("user_task"),
+        input_payload.get("task"),
+        input_payload.get("instruction"),
+        input_payload.get("instructions"),
+    ) or ""
+    task_session_id = _safe_runtime_task_session_id(
+        _non_empty_string(input_payload.get("task_session_id"))
+        or _non_empty_string(metadata.get("portal_task_session_id"))
+        or _non_empty_string(metadata.get("runtime_task_session_id"))
+        or _non_empty_string(metadata.get("task_session_id"))
+        or ""
+    )
+    root_task_id = _non_empty_string(input_payload.get("root_task_id")) or _non_empty_string(metadata.get("portal_root_task_id")) or ""
+    parent_task_id = (
+        _non_empty_string(input_payload.get("parent_task_id"))
+        or _non_empty_string(metadata.get("portal_parent_task_id"))
+        or ""
+    )
+    expected_output_schema = input_payload.get("expected_output_schema") if isinstance(input_payload.get("expected_output_schema"), dict) else {}
+    attachments = input_payload.get("attachments") if isinstance(input_payload.get("attachments"), list) else []
+    return (
+        "Generic agent task instructions:\n"
+        "- This is an EFP Portal background task launched from Portal Tasks, not interactive chat.\n"
+        "- Work autonomously as a long-running background agent task.\n"
+        "- Continue with reasonable assumptions when context is incomplete.\n"
+        "- If a tool permission or user answer is required, return status \"blocked\" and include the pending request in blockers.\n\n"
+        "Task identifiers:\n"
+        f"- task_id: {task_id or '(not provided)'}\n"
+        f"- task_session_id: {task_session_id or '(not provided)'}\n"
+        f"- root_task_id: {root_task_id or '(not provided)'}\n"
+        f"- parent_task_id: {parent_task_id or '(none)'}\n\n"
+        "User task content:\n"
+        f"{task_text or _json_for_agent_async_prompt(input_payload)}\n\n"
+        "Available task context:\n"
+        f"- context_ref: {_json_for_agent_async_prompt(context_ref or {})}\n"
+        f"- attachments: {_json_for_agent_async_prompt(attachments)}\n"
+        f"- expected_output_schema: {_json_for_agent_async_prompt(expected_output_schema)}\n"
+        f"- deadline: {_json_for_agent_async_prompt(input_payload.get('deadline'))}\n\n"
+        "Return exactly one JSON object. Do not wrap it in markdown.\n"
+        "The JSON object must match this schema:\n"
+        "{\n"
+        '  "status": "success|blocked|error",\n'
+        '  "summary": "...",\n'
+        '  "final_response": "...",\n'
+        '  "needs_user_input": false,\n'
+        '  "blockers": [],\n'
+        '  "next_recommendation": "...",\n'
+        '  "artifacts": [],\n'
+        '  "audit_trace": [],\n'
+        '  "external_actions": []\n'
+        "}\n"
+    )
+
+
+async def run_generic_agent_task(payload: Dict[str, Any]) -> Dict[str, Any]:
+    input_payload = dict(payload or {})
+    metadata = input_payload.get("_execution_metadata") if isinstance(input_payload.get("_execution_metadata"), dict) else {}
+    context_ref = input_payload.get("_runtime_context_ref") if isinstance(input_payload.get("_runtime_context_ref"), dict) else {}
+    task_id = (
+        _non_empty_string(input_payload.get("_runtime_task_id"))
+        or _non_empty_string(input_payload.get("task_id"))
+        or _non_empty_string(metadata.get("task_id"))
+        or _non_empty_string(metadata.get("portal_task_id"))
+    )
+    task_session_id = _safe_runtime_task_session_id(
+        _non_empty_string(input_payload.get("task_session_id"))
+        or _non_empty_string(metadata.get("portal_task_session_id"))
+        or _non_empty_string(metadata.get("runtime_task_session_id"))
+        or _non_empty_string(metadata.get("task_session_id"))
+        or _non_empty_string(input_payload.get("_runtime_session_id"))
+        or (f"generic-task-{task_id}" if task_id else None)
+    )
+    chat_request_id = _non_empty_string(input_payload.get("_runtime_request_id"))
+    chat_request_id = f"{chat_request_id}:chat" if chat_request_id else f"generic-agent-chat:{task_id or 'adhoc'}"
+    agent_id = _non_empty_string(input_payload.get("_runtime_agent_id")) or _non_empty_string(metadata.get("agent_id"))
+    prompt = _build_generic_agent_task_prompt(
+        task_id=task_id,
+        input_payload=input_payload,
+        metadata=metadata,
+        context_ref=context_ref,
+    )
+    chat_metadata = {
+        **metadata,
+        "path": "/api/tasks/execute/generic_agent_task/chat",
+        "task_type": "generic_agent_task",
+        "execution_mode": "chat_tool_loop",
+        "generic_agent_task": {
+            "task_id": task_id,
+            "task_session_id": task_session_id,
+            "root_task_id": input_payload.get("root_task_id") or metadata.get("portal_root_task_id"),
+            "parent_task_id": input_payload.get("parent_task_id") or metadata.get("portal_parent_task_id"),
+            "schema": input_payload.get("schema"),
+        },
+    }
+    from src.gateway.runtime_chat import run_runtime_chat
+
+    output_payload = await run_runtime_chat(
+        request_id=chat_request_id,
+        session_id=task_session_id or chat_request_id,
+        message=prompt,
+        user_name="Portal Generic Agent Task",
+        request_path="/api/tasks/execute/generic_agent_task/chat",
+        execution_metadata=chat_metadata,
+        agent_id=agent_id,
+        agent_name=metadata.get("agent_name") if isinstance(metadata.get("agent_name"), str) else None,
+        model=metadata.get("resolved_model") or metadata.get("model"),
+        transient_model_message=GENERIC_AGENT_TASK_DEFAULT_SYSTEM_PROMPT,
+    )
+    raw_text = _agent_async_first_text(output_payload, ("response", "output", "content", "message"))
+    structured_output = output_payload.get("structured_output") if isinstance(output_payload.get("structured_output"), dict) else None
+    parsed = dict(structured_output or _extract_agent_async_json_object(raw_text) or {})
+    if not parsed:
+        parsed = {"summary": raw_text, "final_response": raw_text, "raw_text": raw_text}
+    parsed.setdefault("raw_text", raw_text)
+    chat_status = _agent_async_status_from_chat_status(output_payload.get("status"))
+    parsed_status = _normalize_agent_async_status(parsed.get("status"), fallback=chat_status)
+    blockers = _agent_async_list(parsed.get("blockers"))
+    if output_payload.get("pending_permission_request") is not None:
+        parsed_status = "blocked"
+        blockers.append({"type": "permission_request", "request": output_payload.get("pending_permission_request")})
+    if output_payload.get("pending_question_request") is not None:
+        parsed_status = "blocked"
+        blockers.append({"type": "question_request", "request": output_payload.get("pending_question_request")})
+    parsed["status"] = parsed_status
+    parsed["blockers"] = blockers
+    normalized = _normalize_agent_async_skill_output(
+        normalized_skill=make_execution_result(
+            request_id=chat_request_id,
+            status=parsed_status,
+            output_payload=parsed,
+        ),
+        task_type="generic_agent_task",
+        skill_name="",
+    )
+    return {
+        "status": normalized["status"],
+        "success": normalized["success"],
+        "summary": normalized["summary"],
+        "final_response": normalized["final_response"],
+        "needs_user_input": normalized["needs_user_input"],
+        "blockers": normalized["blockers"],
+        "next_recommendation": normalized["next_recommendation"],
+        "artifacts": normalized["artifacts"],
+        "audit_trace": normalized["audit_trace"],
+        "external_actions": normalized["external_actions"],
+        "error": normalized["error"],
+        "raw_text": raw_text,
+        "runtime_events": output_payload.get("runtime_events") if isinstance(output_payload.get("runtime_events"), list) else [],
+        "data": {
+            "execution_mode": "chat_tool_loop",
+            "chat_session_id": task_session_id,
+            "chat_request_id": chat_request_id,
+            "chat_status": output_payload.get("status"),
         },
         "result": output_payload,
     }
@@ -2903,9 +3094,11 @@ def build_default_execution_bus(
             capability = resolve_task_capability_plan(task_type, capability_payload)
             involved_capability_ids = list(capability.get("involved_capability_ids") or [])
             resolved_task_template_id = _resolve_request_task_template_id(request)
-            task_session_id = (
+            task_session_id = _safe_runtime_task_session_id(
                 _non_empty_string(payload.get("task_session_id"))
                 or _non_empty_string(metadata.get("portal_task_session_id"))
+                or _non_empty_string(metadata.get("runtime_task_session_id"))
+                or _non_empty_string(metadata.get("task_session_id"))
                 or request.session_id
             )
             root_task_id = _non_empty_string(payload.get("root_task_id")) or _non_empty_string(metadata.get("portal_root_task_id"))
@@ -2998,7 +3191,7 @@ def build_default_execution_bus(
             agent_task_payload = {
                 **payload,
                 "_runtime_request_id": request.request_id,
-                "_runtime_session_id": request.session_id,
+                "_runtime_session_id": task_session_id or request.session_id,
                 "_runtime_agent_id": request.agent_id,
                 "_runtime_task_id": task_id,
                 "_runtime_context_ref": dict(request.context_ref or {}) if isinstance(request.context_ref, dict) else {},
@@ -3112,6 +3305,138 @@ def build_default_execution_bus(
                     "capability_resolution": capability.get("capability_resolution"),
                     "involved_capability_ids": involved_capability_ids,
                     "resolved_skill_capability_id": f"skill:{skill_name.strip().lower()}",
+                    "result": agent_output.get("result"),
+                    "raw_agent_payload": agent_output.get("raw_agent_payload"),
+                },
+                runtime_events=runtime_events,
+            )
+
+        if task_type == "generic_agent_task":
+            payload = dict(request.input_payload or {})
+            metadata = request.metadata if isinstance(request.metadata, dict) else {}
+            capability = resolve_task_capability_plan(task_type, payload)
+            involved_capability_ids = list(capability.get("involved_capability_ids") or [])
+            resolved_task_template_id = _resolve_request_task_template_id(request)
+            task_session_id = _safe_runtime_task_session_id(
+                _non_empty_string(payload.get("task_session_id"))
+                or _non_empty_string(metadata.get("portal_task_session_id"))
+                or _non_empty_string(metadata.get("runtime_task_session_id"))
+                or _non_empty_string(metadata.get("task_session_id"))
+                or request.session_id
+            )
+            root_task_id = _non_empty_string(payload.get("root_task_id")) or _non_empty_string(metadata.get("portal_root_task_id"))
+            parent_task_id = _non_empty_string(payload.get("parent_task_id")) or _non_empty_string(metadata.get("portal_parent_task_id"))
+            agent_task_payload = {
+                **payload,
+                "_runtime_request_id": request.request_id,
+                "_runtime_session_id": task_session_id or request.session_id,
+                "_runtime_agent_id": request.agent_id,
+                "_runtime_task_id": task_id,
+                "_runtime_context_ref": dict(request.context_ref or {}) if isinstance(request.context_ref, dict) else {},
+                "_execution_metadata": dict(metadata),
+            }
+            try:
+                logger.info(
+                    "Generic agent task start | request_id=%s task_id=%s task_session_id=%s",
+                    request.request_id,
+                    task_id or "-",
+                    task_session_id or "-",
+                )
+                task_result = await run_generic_agent_task(agent_task_payload)
+                normalized_agent = bus._normalize_result(request, task_result)
+                logger.info(
+                    "Generic agent task end | request_id=%s task_id=%s status=%s summary=%s",
+                    request.request_id,
+                    task_id or "-",
+                    normalized_agent.status,
+                    safe_preview(summarize_output_payload(normalized_agent.output_payload), 160),
+                )
+            except Exception as exc:
+                logger.exception(
+                    "Generic agent task failed | request_id=%s task_id=%s error_class=%s error=%s",
+                    request.request_id,
+                    task_id or "-",
+                    exc.__class__.__name__,
+                    sanitize_exception_message(exc),
+                )
+                normalized_agent = make_execution_result(
+                    request_id=request.request_id,
+                    status="error",
+                    output_payload={"error": str(exc)},
+                )
+
+            agent_output = _normalize_agent_async_skill_output(
+                normalized_skill=normalized_agent,
+                task_type=task_type,
+                skill_name="",
+            )
+            agent_status = str(agent_output["status"])
+            success_value = bool(agent_output["success"])
+            runtime_events = list(normalized_agent.runtime_events or [])
+            runtime_events = bus._attach_task_id_to_runtime_events(runtime_events, task_id)
+            if agent_status == "success":
+                event_type = "task.generic_agent.completed"
+            elif agent_status == "blocked":
+                event_type = "task.generic_agent.blocked"
+            else:
+                event_type = "task.generic_agent.failed"
+            runtime_events.append(
+                build_runtime_event(
+                    event_type=event_type,
+                    execution_type=request.execution_type,
+                    state="completed" if success_value else agent_status,
+                    session_id=request.session_id,
+                    request_id=request.request_id,
+                    agent_id=request.agent_id,
+                    summary="generic agent task",
+                    task_id=task_id,
+                    detail_payload={
+                        "task_type": task_type,
+                        "task_template_id": resolved_task_template_id,
+                        "task_session_id": task_session_id,
+                        "root_task_id": root_task_id,
+                        "parent_task_id": parent_task_id,
+                        "success": success_value,
+                        "status": agent_status,
+                        "error": agent_output.get("error"),
+                        "capability_id": capability.get("capability_id"),
+                        "capability_type": capability.get("capability_type"),
+                        "policy_tags": capability.get("policy_tags"),
+                        "requires_identity_binding": capability.get("requires_identity_binding"),
+                        "capability_resolution": capability.get("capability_resolution"),
+                        "involved_capability_ids": involved_capability_ids,
+                    },
+                    legacy_payload={"legacy_type": "task_generic_agent"},
+                )
+            )
+            return make_execution_result(
+                request_id=request.request_id,
+                status=agent_status,
+                output_payload={
+                    "task_type": task_type,
+                    "task_template_id": resolved_task_template_id,
+                    "schema": payload.get("schema") or "generic_agent_task.v1",
+                    "task_session_id": task_session_id,
+                    "root_task_id": root_task_id,
+                    "parent_task_id": parent_task_id,
+                    "status": agent_status,
+                    "success": success_value,
+                    "summary": agent_output.get("summary"),
+                    "final_response": agent_output.get("final_response"),
+                    "needs_user_input": agent_output.get("needs_user_input"),
+                    "blockers": agent_output.get("blockers"),
+                    "next_recommendation": agent_output.get("next_recommendation"),
+                    "artifacts": agent_output.get("artifacts"),
+                    "audit_trace": agent_output.get("audit_trace"),
+                    "external_actions": agent_output.get("external_actions"),
+                    "error": agent_output.get("error"),
+                    "task_boundary": True,
+                    "capability_id": capability.get("capability_id"),
+                    "capability_type": capability.get("capability_type"),
+                    "policy_tags": capability.get("policy_tags"),
+                    "requires_identity_binding": capability.get("requires_identity_binding"),
+                    "capability_resolution": capability.get("capability_resolution"),
+                    "involved_capability_ids": involved_capability_ids,
                     "result": agent_output.get("result"),
                     "raw_agent_payload": agent_output.get("raw_agent_payload"),
                 },

--- a/src/runtime/runtime_task_session_coordinator.py
+++ b/src/runtime/runtime_task_session_coordinator.py
@@ -1,0 +1,257 @@
+"""Session-scoped coordination for async runtime task execution."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from threading import RLock
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class RuntimeTaskSessionDecision:
+    action: str
+    active_task_id: Optional[str] = None
+    queue_position: Optional[int] = None
+    pending_count: int = 0
+    interrupt_seq: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class RuntimeTaskSessionSnapshot:
+    session_id: str
+    task_id: str
+    lane_status: Optional[str]
+    active_task_id: Optional[str]
+    queue_position: Optional[int]
+    pending_count: int
+    interrupt_seq: Optional[int]
+
+
+@dataclass
+class _PendingTask:
+    admitted_seq: int
+    delivery: str = "steer"
+
+
+@dataclass
+class _SessionLane:
+    active_task_id: Optional[str] = None
+    active_seq: Optional[int] = None
+    pending: "OrderedDict[str, _PendingTask]" = None  # type: ignore[assignment]
+    interrupt_seq: Optional[int] = None
+    stopping: bool = False
+    blocked: bool = False
+
+    def __post_init__(self) -> None:
+        if self.pending is None:
+            self.pending = OrderedDict()
+
+
+class RuntimeTaskSessionCoordinator:
+    """Coordinate one active task execution lane per runtime task session.
+
+    This mirrors the important long-task property from OpenCode's
+    SessionRunCoordinator: a session owns one active drain, while additional
+    wakeups are represented as coalesced pending work.
+    """
+
+    def __init__(self) -> None:
+        self._lanes: Dict[str, _SessionLane] = {}
+        self._lock = RLock()
+
+    def schedule(
+        self,
+        session_id: Optional[str],
+        task_id: str,
+        *,
+        admitted_seq: int = 0,
+        delivery: str = "steer",
+    ) -> RuntimeTaskSessionDecision:
+        if not session_id:
+            return RuntimeTaskSessionDecision(action="start")
+        with self._lock:
+            lane = self._lanes.setdefault(session_id, _SessionLane())
+            if not self._is_after_interrupt(lane, admitted_seq):
+                return self._decision("suppressed", lane)
+
+            if lane.active_task_id is None:
+                lane.active_task_id = task_id
+                lane.active_seq = admitted_seq
+                lane.stopping = False
+                lane.blocked = False
+                lane.pending.pop(task_id, None)
+                return self._decision("start", lane)
+
+            if lane.active_task_id == task_id:
+                return self._decision("active", lane)
+
+            if task_id not in lane.pending:
+                lane.pending[task_id] = _PendingTask(admitted_seq=admitted_seq, delivery=_normalize_delivery(delivery))
+            return self._decision("queued", lane, task_id=task_id)
+
+    def hold_for_user_input(self, session_id: Optional[str], task_id: str) -> RuntimeTaskSessionDecision:
+        if not session_id:
+            return RuntimeTaskSessionDecision(action="held")
+        with self._lock:
+            lane = self._lanes.setdefault(session_id, _SessionLane())
+            if lane.active_task_id == task_id:
+                lane.blocked = True
+                lane.stopping = False
+            return self._decision("held", lane, task_id=task_id)
+
+    def complete(self, session_id: Optional[str], task_id: str) -> Optional[str]:
+        if not session_id:
+            return None
+        with self._lock:
+            lane = self._lanes.get(session_id)
+            if lane is None:
+                return None
+            if lane.active_task_id != task_id:
+                lane.pending.pop(task_id, None)
+                if lane.active_task_id is None and not lane.pending:
+                    self._lanes.pop(session_id, None)
+                return None
+            lane.active_task_id = None
+            lane.active_seq = None
+            lane.stopping = False
+            lane.blocked = False
+            next_task_id = self._promote_next(lane)
+            if lane.active_task_id is None and not lane.pending:
+                self._lanes.pop(session_id, None)
+            return next_task_id
+
+    def cancel(self, session_id: Optional[str], task_id: str, *, admitted_seq: int = 0) -> RuntimeTaskSessionDecision:
+        if not session_id:
+            return RuntimeTaskSessionDecision(action="cancelled")
+        with self._lock:
+            lane = self._lanes.get(session_id)
+            if lane is None:
+                return RuntimeTaskSessionDecision(action="cancelled")
+            if lane.active_task_id == task_id:
+                lane.interrupt_seq = self._max_seq(lane.interrupt_seq, admitted_seq)
+                lane.stopping = True
+                lane.blocked = False
+                self._suppress_pending_at_or_before(lane, admitted_seq)
+                return self._decision("interrupting", lane, task_id=task_id)
+            if task_id in lane.pending:
+                lane.pending.pop(task_id, None)
+                if lane.active_task_id is None and not lane.pending:
+                    self._lanes.pop(session_id, None)
+                return self._decision("cancelled_pending", lane, task_id=task_id)
+            return self._decision("cancelled", lane, task_id=task_id)
+
+    def snapshot(self, session_id: Optional[str], task_id: str) -> RuntimeTaskSessionSnapshot:
+        resolved_session_id = session_id or ""
+        with self._lock:
+            lane = self._lanes.get(resolved_session_id)
+            if lane is None:
+                return RuntimeTaskSessionSnapshot(
+                    session_id=resolved_session_id,
+                    task_id=task_id,
+                    lane_status=None,
+                    active_task_id=None,
+                    queue_position=None,
+                    pending_count=0,
+                    interrupt_seq=None,
+                )
+            lane_status: Optional[str] = None
+            if lane.active_task_id == task_id:
+                lane_status = "blocked" if lane.blocked else "interrupting" if lane.stopping else "active"
+            elif task_id in lane.pending:
+                lane_status = "queued"
+            return RuntimeTaskSessionSnapshot(
+                session_id=resolved_session_id,
+                task_id=task_id,
+                lane_status=lane_status,
+                active_task_id=lane.active_task_id,
+                queue_position=self._queue_position(lane, task_id),
+                pending_count=len(lane.pending),
+                interrupt_seq=lane.interrupt_seq,
+            )
+
+    def active_task_id(self, session_id: Optional[str]) -> Optional[str]:
+        if not session_id:
+            return None
+        with self._lock:
+            lane = self._lanes.get(session_id)
+            return lane.active_task_id if lane is not None else None
+
+    def clear(self, session_id: Optional[str]) -> None:
+        if not session_id:
+            return
+        with self._lock:
+            self._lanes.pop(session_id, None)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._lanes.clear()
+
+    def _promote_next(self, lane: _SessionLane) -> Optional[str]:
+        for task_id, pending in list(lane.pending.items()):
+            if not self._is_after_interrupt(lane, pending.admitted_seq):
+                lane.pending.pop(task_id, None)
+        selected_task_id: Optional[str] = None
+        selected_pending: Optional[_PendingTask] = None
+        for task_id, pending in lane.pending.items():
+            if pending.delivery == "steer":
+                selected_task_id = task_id
+                selected_pending = pending
+                break
+        if selected_task_id is None:
+            for task_id, pending in lane.pending.items():
+                selected_task_id = task_id
+                selected_pending = pending
+                break
+        if selected_task_id is None or selected_pending is None:
+            return None
+        lane.pending.pop(selected_task_id, None)
+        lane.active_task_id = selected_task_id
+        lane.active_seq = selected_pending.admitted_seq
+        lane.stopping = False
+        lane.blocked = False
+        return selected_task_id
+        return None
+
+    def _suppress_pending_at_or_before(self, lane: _SessionLane, seq: int) -> None:
+        if seq <= 0:
+            return
+        for task_id, pending in list(lane.pending.items()):
+            if pending.admitted_seq <= seq:
+                lane.pending.pop(task_id, None)
+
+    def _is_after_interrupt(self, lane: _SessionLane, seq: int) -> bool:
+        return lane.interrupt_seq is None or (seq > 0 and seq > lane.interrupt_seq)
+
+    def _queue_position(self, lane: _SessionLane, task_id: str) -> Optional[int]:
+        for index, candidate in enumerate(lane.pending.keys(), start=1):
+            if candidate == task_id:
+                return index
+        return None
+
+    def _decision(self, action: str, lane: _SessionLane, *, task_id: Optional[str] = None) -> RuntimeTaskSessionDecision:
+        return RuntimeTaskSessionDecision(
+            action=action,
+            active_task_id=lane.active_task_id,
+            queue_position=self._queue_position(lane, task_id or ""),
+            pending_count=len(lane.pending),
+            interrupt_seq=lane.interrupt_seq,
+        )
+
+    def _max_seq(self, left: Optional[int], right: int) -> Optional[int]:
+        if right <= 0:
+            return left
+        if left is None:
+            return right
+        return max(left, right)
+
+
+def _normalize_delivery(value: str) -> str:
+    return "queue" if str(value or "").strip().lower() == "queue" else "steer"
+
+
+__all__ = [
+    "RuntimeTaskSessionCoordinator",
+    "RuntimeTaskSessionDecision",
+    "RuntimeTaskSessionSnapshot",
+]

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -43,7 +43,9 @@ class RuntimeTaskRecord:
     resume_count: int = 0
     last_resumed_at: Optional[str] = None
     admission_id: Optional[str] = None
+    admitted_seq: int = 0
     admitted_at: Optional[str] = None
+    input_delivery: str = "steer"
     input_hash: Optional[str] = None
     task_session_id: Optional[str] = None
     active_attempt_id: Optional[str] = None
@@ -67,6 +69,7 @@ class RuntimeTaskTracker:
     def __init__(self, *, max_records: int = 512, storage_dir: Optional[str | Path] = None):
         self._records: "OrderedDict[str, RuntimeTaskRecord]" = OrderedDict()
         self._max_records = max(1, int(max_records))
+        self._next_admitted_seq = 1
         self._storage_dir: Optional[Path] = None
         self.configure_storage(storage_dir)
 
@@ -97,6 +100,7 @@ class RuntimeTaskTracker:
         metadata: Optional[Dict[str, Any]] = None,
         trace_headers: Optional[Dict[str, Optional[str]]] = None,
         task_session_id: Optional[str] = None,
+        input_delivery: str = "steer",
     ) -> RuntimeTaskRecord:
         safe_context_ref = _optional_json_dict(context_ref)
         safe_merged_input_payload = _optional_json_dict(merged_input_payload)
@@ -106,6 +110,7 @@ class RuntimeTaskTracker:
             source=source,
             session_id=session_id,
             task_session_id=task_session_id,
+            input_delivery=_normalize_delivery(input_delivery),
             context_ref=safe_context_ref,
             merged_input_payload=safe_merged_input_payload,
             metadata=safe_metadata,
@@ -131,7 +136,9 @@ class RuntimeTaskTracker:
             metadata=safe_metadata,
             trace_headers=_optional_json_dict(trace_headers),
             admission_id=_admission_id(task_id=task_id, input_hash=input_hash),
+            admitted_seq=self._allocate_admitted_seq(),
             admitted_at=_utc_now_iso(),
+            input_delivery=_normalize_delivery(input_delivery),
             input_hash=input_hash,
             task_session_id=task_session_id,
             background_task=None,
@@ -222,11 +229,11 @@ class RuntimeTaskTracker:
         record = self._records.get(task_id)
         return bool(record and record.status in _TASK_TERMINAL_STATUSES)
 
-    def cancel(self, task_id: str, *, reason: str = "Task cancelled", payload: Optional[Dict[str, Any]] = None) -> Optional[RuntimeTaskRecord]:
+    def cancel(self, task_id: str, *, reason: str = "Task cancelled", payload: Optional[Dict[str, Any]] = None, force: bool = False) -> Optional[RuntimeTaskRecord]:
         record = self._records.get(task_id)
         if record is None:
             return None
-        if record.status in _TASK_TERMINAL_STATUSES:
+        if record.status in _TASK_TERMINAL_STATUSES and not (force and record.status == "blocked"):
             return record
         if record.background_task is not None and not record.background_task.done():
             record.background_task.cancel()
@@ -298,6 +305,33 @@ class RuntimeTaskTracker:
             self._persist_record(record)
         return record
 
+    def resume_after_user_input(
+        self,
+        task_id: str,
+        *,
+        merged_input_payload: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[RuntimeTaskRecord]:
+        record = self._records.get(task_id)
+        if record is None:
+            return None
+        record.status = "accepted"
+        record.finished_at = None
+        record.error_message = None
+        record.payload = {}
+        record.active_attempt_id = None
+        record.background_task = None
+        record.cancel_requested = False
+        record.completion_source = "user_input_response"
+        record.pending_permission_request = None
+        record.pending_question_request = None
+        if merged_input_payload is not None:
+            record.merged_input_payload = _optional_json_dict(merged_input_payload)
+        if metadata is not None:
+            record.metadata = _optional_json_dict(metadata)
+        self._persist_record(record)
+        return record
+
     def admission_matches(
         self,
         record: RuntimeTaskRecord,
@@ -306,6 +340,7 @@ class RuntimeTaskTracker:
         source: Optional[str],
         session_id: Optional[str],
         task_session_id: Optional[str],
+        input_delivery: str = "steer",
         context_ref: Optional[Dict[str, Any]],
         merged_input_payload: Optional[Dict[str, Any]],
         metadata: Optional[Dict[str, Any]],
@@ -315,6 +350,7 @@ class RuntimeTaskTracker:
             source=source,
             session_id=session_id,
             task_session_id=task_session_id,
+            input_delivery=_normalize_delivery(input_delivery),
             context_ref=context_ref,
             merged_input_payload=merged_input_payload,
             metadata=metadata,
@@ -334,6 +370,14 @@ class RuntimeTaskTracker:
             loaded.append(record)
 
         loaded.sort(key=lambda record: record.accepted_at or "")
+        max_admitted_seq = max([record.admitted_seq for record in self._records.values()] or [0])
+        for record in loaded:
+            if record.admitted_seq <= 0:
+                max_admitted_seq += 1
+                record.admitted_seq = max_admitted_seq
+            else:
+                max_admitted_seq = max(max_admitted_seq, record.admitted_seq)
+        self._next_admitted_seq = max(self._next_admitted_seq, max_admitted_seq + 1)
         for record in loaded:
             existing = self._records.get(record.task_id)
             if existing is not None and existing.background_task is not None and not existing.background_task.done():
@@ -357,6 +401,7 @@ class RuntimeTaskTracker:
 
     def reset(self, *, clear_storage: bool = True) -> None:
         self._records.clear()
+        self._next_admitted_seq = 1
         if clear_storage and self._storage_dir is not None and self._storage_dir.exists():
             for path in self._storage_dir.glob("*.json"):
                 try:
@@ -389,6 +434,11 @@ class RuntimeTaskTracker:
         digest = hashlib.sha256(task_id.encode("utf-8")).hexdigest()
         return self._storage_dir / f"{digest}.json"
 
+    def _allocate_admitted_seq(self) -> int:
+        admitted_seq = self._next_admitted_seq
+        self._next_admitted_seq += 1
+        return admitted_seq
+
 
 def _optional_json_dict(value: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     if value is None:
@@ -416,6 +466,7 @@ _VOLATILE_METADATA_KEYS = {
     "runtime_task_admission_id",
     "runtime_task_input_hash",
     "runtime_task_session_id",
+    "runtime_task_delivery",
     "runtime_task_attempt_id",
     "runtime_task_attempt_count",
 }
@@ -432,12 +483,17 @@ def _stable_digest(value: Any) -> str:
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
+def _normalize_delivery(value: Any) -> str:
+    return "queue" if str(value or "").strip().lower() == "queue" else "steer"
+
+
 def build_task_input_hash(
     *,
     task_type: str,
     source: Optional[str],
     session_id: Optional[str],
     task_session_id: Optional[str],
+    input_delivery: str = "steer",
     context_ref: Optional[Dict[str, Any]],
     merged_input_payload: Optional[Dict[str, Any]],
     metadata: Optional[Dict[str, Any]],
@@ -448,6 +504,7 @@ def build_task_input_hash(
             "source": source or "",
             "session_id": session_id or "",
             "task_session_id": task_session_id or "",
+            "input_delivery": _normalize_delivery(input_delivery),
             "context_ref": _optional_json_dict(context_ref),
             "merged_input_payload": _optional_json_dict(merged_input_payload),
             "metadata": _stable_metadata(metadata),
@@ -520,7 +577,9 @@ def _record_to_json(record: RuntimeTaskRecord) -> Dict[str, Any]:
             "resume_count": record.resume_count,
             "last_resumed_at": record.last_resumed_at,
             "admission_id": record.admission_id,
+            "admitted_seq": record.admitted_seq,
             "admitted_at": record.admitted_at,
+            "input_delivery": record.input_delivery,
             "input_hash": record.input_hash,
             "task_session_id": record.task_session_id,
             "active_attempt_id": record.active_attempt_id,
@@ -548,11 +607,13 @@ def _record_from_json(raw: Dict[str, Any]) -> RuntimeTaskRecord:
     source = str(raw.get("source") or "portal")
     session_id = str(raw["session_id"]) if raw.get("session_id") is not None else None
     task_session_id = str(raw["task_session_id"]) if raw.get("task_session_id") is not None else None
+    input_delivery = _normalize_delivery(raw.get("input_delivery") or raw.get("delivery") or "steer")
     input_hash = str(raw["input_hash"]) if raw.get("input_hash") is not None else build_task_input_hash(
         task_type=task_type,
         source=source,
         session_id=session_id,
         task_session_id=task_session_id,
+        input_delivery=input_delivery,
         context_ref=context_ref,
         merged_input_payload=merged_input_payload,
         metadata=metadata,
@@ -580,7 +641,9 @@ def _record_from_json(raw: Dict[str, Any]) -> RuntimeTaskRecord:
         resume_count=int(raw.get("resume_count") or 0),
         last_resumed_at=str(raw["last_resumed_at"]) if raw.get("last_resumed_at") is not None else None,
         admission_id=str(raw["admission_id"]) if raw.get("admission_id") is not None else _admission_id(task_id=task_id, input_hash=input_hash),
+        admitted_seq=int(raw.get("admitted_seq") or 0),
         admitted_at=str(raw["admitted_at"]) if raw.get("admitted_at") is not None else str(raw.get("accepted_at") or _utc_now_iso()),
+        input_delivery=input_delivery,
         input_hash=input_hash,
         task_session_id=task_session_id,
         active_attempt_id=str(raw["active_attempt_id"]) if raw.get("active_attempt_id") is not None else None,

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -260,6 +260,21 @@ class RuntimeTaskTracker:
     def list_active(self) -> list[RuntimeTaskRecord]:
         return [record for record in self._records.values() if record.status not in _TASK_TERMINAL_STATUSES]
 
+    def list_waiting_for_user(self) -> list[RuntimeTaskRecord]:
+        return sorted(
+            [record for record in self._records.values() if _record_waiting_for_user(record)],
+            key=_record_order_key,
+        )
+
+    def find_waiting_for_user_by_session(self, session_id: str) -> Optional[RuntimeTaskRecord]:
+        normalized_session_id = str(session_id or "").strip()
+        if not normalized_session_id:
+            return None
+        for record in self.list_waiting_for_user():
+            if _record_session_key(record) == normalized_session_id:
+                return record
+        return None
+
     def mark_resuming(self, task_id: str) -> Optional[RuntimeTaskRecord]:
         record = self._records.get(task_id)
         if record is None or record.status in _TASK_TERMINAL_STATUSES:
@@ -391,7 +406,7 @@ class RuntimeTaskTracker:
         while len(self._records) > self._max_records:
             removable_task_id: Optional[str] = None
             for task_id, record in self._records.items():
-                if record.status in _TASK_TERMINAL_STATUSES:
+                if record.status in _TASK_TERMINAL_STATUSES and not _record_waiting_for_user(record):
                     removable_task_id = task_id
                     break
             if removable_task_id is None:
@@ -520,6 +535,25 @@ def _admission_id(*, task_id: str, input_hash: str) -> str:
 def _attempt_id(*, task_id: str, attempt_count: int, started_at: str) -> str:
     digest = _stable_digest({"task_id": task_id, "attempt_count": attempt_count, "started_at": started_at})
     return f"task_attempt_{digest[:24]}"
+
+
+def _record_session_key(record: RuntimeTaskRecord) -> Optional[str]:
+    return record.task_session_id or record.session_id
+
+
+def _record_order_key(record: RuntimeTaskRecord) -> tuple[int, str, str]:
+    admitted_seq = int(record.admitted_seq or 0)
+    return (admitted_seq if admitted_seq > 0 else 2**63 - 1, record.accepted_at or "", record.task_id)
+
+
+def _record_waiting_for_user(record: RuntimeTaskRecord) -> bool:
+    return bool(
+        record.status == "blocked"
+        and (
+            record.pending_permission_request is not None
+            or record.pending_question_request is not None
+        )
+    )
 
 
 def _find_observation(value: Any, key: str) -> Optional[Dict[str, Any]]:

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -42,6 +42,18 @@ class RuntimeTaskRecord:
     trace_headers: Optional[Dict[str, Optional[str]]] = None
     resume_count: int = 0
     last_resumed_at: Optional[str] = None
+    admission_id: Optional[str] = None
+    admitted_at: Optional[str] = None
+    input_hash: Optional[str] = None
+    task_session_id: Optional[str] = None
+    active_attempt_id: Optional[str] = None
+    attempt_count: int = 0
+    last_attempt_started_at: Optional[str] = None
+    last_progress_at: Optional[str] = None
+    pending_permission_request: Optional[Dict[str, Any]] = None
+    pending_question_request: Optional[Dict[str, Any]] = None
+    completion_source: Optional[str] = None
+    cancel_requested: bool = False
     background_task: Optional[asyncio.Task[Any]] = None
 
 
@@ -84,7 +96,20 @@ class RuntimeTaskTracker:
         merged_input_payload: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         trace_headers: Optional[Dict[str, Optional[str]]] = None,
+        task_session_id: Optional[str] = None,
     ) -> RuntimeTaskRecord:
+        safe_context_ref = _optional_json_dict(context_ref)
+        safe_merged_input_payload = _optional_json_dict(merged_input_payload)
+        safe_metadata = _optional_json_dict(metadata)
+        input_hash = build_task_input_hash(
+            task_type=task_type,
+            source=source,
+            session_id=session_id,
+            task_session_id=task_session_id,
+            context_ref=safe_context_ref,
+            merged_input_payload=safe_merged_input_payload,
+            metadata=safe_metadata,
+        )
         record = RuntimeTaskRecord(
             task_id=task_id,
             request_id=request_id,
@@ -101,10 +126,14 @@ class RuntimeTaskTracker:
             portal_task_id=portal_task_id,
             payload={},
             error_message=None,
-            context_ref=_optional_json_dict(context_ref),
-            merged_input_payload=_optional_json_dict(merged_input_payload),
-            metadata=_optional_json_dict(metadata),
+            context_ref=safe_context_ref,
+            merged_input_payload=safe_merged_input_payload,
+            metadata=safe_metadata,
             trace_headers=_optional_json_dict(trace_headers),
+            admission_id=_admission_id(task_id=task_id, input_hash=input_hash),
+            admitted_at=_utc_now_iso(),
+            input_hash=input_hash,
+            task_session_id=task_session_id,
             background_task=None,
         )
         self._records[task_id] = record
@@ -125,13 +154,30 @@ class RuntimeTaskTracker:
             return None
         if record.status in _TASK_TERMINAL_STATUSES:
             return record
+        now = _utc_now_iso()
         record.status = "running"
         if not record.started_at:
-            record.started_at = _utc_now_iso()
+            record.started_at = now
+        record.attempt_count += 1
+        record.last_attempt_started_at = now
+        record.active_attempt_id = _attempt_id(
+            task_id=record.task_id,
+            attempt_count=record.attempt_count,
+            started_at=now,
+        )
         self._persist_record(record)
         return record
 
-    def mark_terminal(self, task_id: str, *, status: str, payload: Dict[str, Any], error_message: Optional[str] = None) -> Optional[RuntimeTaskRecord]:
+    def mark_terminal(
+        self,
+        task_id: str,
+        *,
+        status: str,
+        payload: Dict[str, Any],
+        error_message: Optional[str] = None,
+        attempt_id: Optional[str] = None,
+        completion_source: Optional[str] = None,
+    ) -> Optional[RuntimeTaskRecord]:
         record = self._records.get(task_id)
         if record is None:
             return None
@@ -139,18 +185,38 @@ class RuntimeTaskTracker:
             status = "error"
         if record.status == "cancelled" and status != "cancelled":
             return record
+        if attempt_id is not None and record.active_attempt_id != attempt_id:
+            return None
         record.status = status
         record.payload = dict(payload)
         record.error_message = error_message
         record.finished_at = _utc_now_iso()
         if not record.started_at:
             record.started_at = record.finished_at
+        record.active_attempt_id = None
+        if completion_source:
+            record.completion_source = completion_source
+        _apply_observation_from_payload(record, payload)
         self._persist_record(record)
         self.prune()
         return record
 
-    def mark_internal_failure(self, task_id: str, *, payload: Dict[str, Any], error_message: Optional[str]) -> Optional[RuntimeTaskRecord]:
-        return self.mark_terminal(task_id, status="error", payload=payload, error_message=error_message)
+    def mark_internal_failure(
+        self,
+        task_id: str,
+        *,
+        payload: Dict[str, Any],
+        error_message: Optional[str],
+        attempt_id: Optional[str] = None,
+    ) -> Optional[RuntimeTaskRecord]:
+        return self.mark_terminal(
+            task_id,
+            status="error",
+            payload=payload,
+            error_message=error_message,
+            attempt_id=attempt_id,
+            completion_source="internal_failure",
+        )
 
     def is_terminal(self, task_id: str) -> bool:
         record = self._records.get(task_id)
@@ -168,6 +234,9 @@ class RuntimeTaskTracker:
         record.finished_at = _utc_now_iso()
         record.error_message = reason
         record.payload = dict(payload or {"ok": False, "task_id": task_id, "execution_type": "task", "request_id": record.request_id, "status": "cancelled", "error": reason})
+        record.cancel_requested = True
+        record.active_attempt_id = None
+        record.completion_source = "cancel"
         self._persist_record(record)
         return record
 
@@ -190,8 +259,67 @@ class RuntimeTaskTracker:
             return record
         record.resume_count += 1
         record.last_resumed_at = _utc_now_iso()
+        # A persisted active attempt belonged to a previous process. Clear it so
+        # the replacement process owns a fresh attempt and late stale results
+        # cannot be confused with the resumed run.
+        record.active_attempt_id = None
         self._persist_record(record)
         return record
+
+    def update_observation(
+        self,
+        task_id: str,
+        *,
+        pending_permission_request: Optional[Dict[str, Any]] = None,
+        pending_question_request: Optional[Dict[str, Any]] = None,
+        completion_source: Optional[str] = None,
+        progress: Optional[Dict[str, Any]] = None,
+    ) -> Optional[RuntimeTaskRecord]:
+        record = self._records.get(task_id)
+        if record is None:
+            return None
+        changed = False
+        if pending_permission_request is not None:
+            record.pending_permission_request = _optional_json_dict(pending_permission_request)
+            changed = True
+        if pending_question_request is not None:
+            record.pending_question_request = _optional_json_dict(pending_question_request)
+            changed = True
+        if completion_source:
+            record.completion_source = completion_source
+            changed = True
+        if progress is not None:
+            record.last_progress_at = _utc_now_iso()
+            payload = dict(record.payload or {})
+            payload["progress"] = _json_safe(progress)
+            record.payload = payload
+            changed = True
+        if changed:
+            self._persist_record(record)
+        return record
+
+    def admission_matches(
+        self,
+        record: RuntimeTaskRecord,
+        *,
+        task_type: str,
+        source: Optional[str],
+        session_id: Optional[str],
+        task_session_id: Optional[str],
+        context_ref: Optional[Dict[str, Any]],
+        merged_input_payload: Optional[Dict[str, Any]],
+        metadata: Optional[Dict[str, Any]],
+    ) -> bool:
+        expected = build_task_input_hash(
+            task_type=task_type,
+            source=source,
+            session_id=session_id,
+            task_session_id=task_session_id,
+            context_ref=context_ref,
+            merged_input_payload=merged_input_payload,
+            metadata=metadata,
+        )
+        return bool(record.input_hash and record.input_hash == expected)
 
     def load_persisted_records(self) -> int:
         if self._storage_dir is None or not self._storage_dir.exists():
@@ -275,6 +403,98 @@ def _json_safe(value: Any) -> Any:
     return json.loads(json.dumps(value, ensure_ascii=False, default=str))
 
 
+_VOLATILE_METADATA_KEYS = {
+    "trace_id",
+    "span_id",
+    "parent_span_id",
+    "portal_dispatch_id",
+    "path",
+    "external_triggered",
+    "auto_run",
+    "runtime_task_resumed",
+    "runtime_task_resume_count",
+    "runtime_task_admission_id",
+    "runtime_task_input_hash",
+    "runtime_task_session_id",
+    "runtime_task_attempt_id",
+    "runtime_task_attempt_count",
+}
+
+
+def _stable_metadata(value: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not isinstance(value, dict):
+        return None
+    return {key: _json_safe(item) for key, item in sorted(value.items()) if key not in _VOLATILE_METADATA_KEYS}
+
+
+def _stable_digest(value: Any) -> str:
+    encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def build_task_input_hash(
+    *,
+    task_type: str,
+    source: Optional[str],
+    session_id: Optional[str],
+    task_session_id: Optional[str],
+    context_ref: Optional[Dict[str, Any]],
+    merged_input_payload: Optional[Dict[str, Any]],
+    metadata: Optional[Dict[str, Any]],
+) -> str:
+    return _stable_digest(
+        {
+            "task_type": str(task_type or ""),
+            "source": source or "",
+            "session_id": session_id or "",
+            "task_session_id": task_session_id or "",
+            "context_ref": _optional_json_dict(context_ref),
+            "merged_input_payload": _optional_json_dict(merged_input_payload),
+            "metadata": _stable_metadata(metadata),
+        }
+    )
+
+
+def _admission_id(*, task_id: str, input_hash: str) -> str:
+    digest = _stable_digest({"task_id": task_id, "input_hash": input_hash})
+    return f"task_input_{digest[:24]}"
+
+
+def _attempt_id(*, task_id: str, attempt_count: int, started_at: str) -> str:
+    digest = _stable_digest({"task_id": task_id, "attempt_count": attempt_count, "started_at": started_at})
+    return f"task_attempt_{digest[:24]}"
+
+
+def _find_observation(value: Any, key: str) -> Optional[Dict[str, Any]]:
+    if isinstance(value, dict):
+        candidate = value.get(key)
+        if isinstance(candidate, dict):
+            return _optional_json_dict(candidate)
+        for nested in value.values():
+            found = _find_observation(nested, key)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for item in value:
+            found = _find_observation(item, key)
+            if found is not None:
+                return found
+    return None
+
+
+def _apply_observation_from_payload(record: RuntimeTaskRecord, payload: Dict[str, Any]) -> None:
+    permission_request = _find_observation(payload, "pending_permission_request")
+    question_request = _find_observation(payload, "pending_question_request")
+    if permission_request is not None:
+        record.pending_permission_request = permission_request
+    else:
+        record.pending_permission_request = None
+    if question_request is not None:
+        record.pending_question_request = question_request
+    else:
+        record.pending_question_request = None
+
+
 def _record_to_json(record: RuntimeTaskRecord) -> Dict[str, Any]:
     return _json_safe(
         {
@@ -299,6 +519,18 @@ def _record_to_json(record: RuntimeTaskRecord) -> Dict[str, Any]:
             "trace_headers": record.trace_headers,
             "resume_count": record.resume_count,
             "last_resumed_at": record.last_resumed_at,
+            "admission_id": record.admission_id,
+            "admitted_at": record.admitted_at,
+            "input_hash": record.input_hash,
+            "task_session_id": record.task_session_id,
+            "active_attempt_id": record.active_attempt_id,
+            "attempt_count": record.attempt_count,
+            "last_attempt_started_at": record.last_attempt_started_at,
+            "last_progress_at": record.last_progress_at,
+            "pending_permission_request": record.pending_permission_request,
+            "pending_question_request": record.pending_question_request,
+            "completion_source": record.completion_source,
+            "cancel_requested": record.cancel_requested,
         }
     )
 
@@ -309,12 +541,28 @@ def _record_from_json(raw: Dict[str, Any]) -> RuntimeTaskRecord:
     task_id = str(raw.get("task_id") or "").strip()
     if not task_id:
         raise ValueError("persisted runtime task record missing task_id")
+    metadata = _optional_json_dict(raw.get("metadata"))
+    context_ref = _optional_json_dict(raw.get("context_ref"))
+    merged_input_payload = _optional_json_dict(raw.get("merged_input_payload"))
+    task_type = str(raw.get("task_type") or "")
+    source = str(raw.get("source") or "portal")
+    session_id = str(raw["session_id"]) if raw.get("session_id") is not None else None
+    task_session_id = str(raw["task_session_id"]) if raw.get("task_session_id") is not None else None
+    input_hash = str(raw["input_hash"]) if raw.get("input_hash") is not None else build_task_input_hash(
+        task_type=task_type,
+        source=source,
+        session_id=session_id,
+        task_session_id=task_session_id,
+        context_ref=context_ref,
+        merged_input_payload=merged_input_payload,
+        metadata=metadata,
+    )
     return RuntimeTaskRecord(
         task_id=task_id,
         request_id=str(raw.get("request_id") or f"task-{task_id}"),
-        task_type=str(raw.get("task_type") or ""),
-        source=str(raw.get("source") or "portal"),
-        session_id=str(raw["session_id"]) if raw.get("session_id") is not None else None,
+        task_type=task_type,
+        source=source,
+        session_id=session_id,
         agent_id=str(raw["agent_id"]) if raw.get("agent_id") is not None else None,
         status=str(raw.get("status") or "accepted"),
         accepted_at=str(raw.get("accepted_at") or _utc_now_iso()),
@@ -325,11 +573,23 @@ def _record_from_json(raw: Dict[str, Any]) -> RuntimeTaskRecord:
         portal_task_id=str(raw["portal_task_id"]) if raw.get("portal_task_id") is not None else task_id,
         payload=dict(raw.get("payload") or {}),
         error_message=str(raw["error_message"]) if raw.get("error_message") is not None else None,
-        context_ref=_optional_json_dict(raw.get("context_ref")),
-        merged_input_payload=_optional_json_dict(raw.get("merged_input_payload")),
-        metadata=_optional_json_dict(raw.get("metadata")),
+        context_ref=context_ref,
+        merged_input_payload=merged_input_payload,
+        metadata=metadata,
         trace_headers=_optional_json_dict(raw.get("trace_headers")),
         resume_count=int(raw.get("resume_count") or 0),
         last_resumed_at=str(raw["last_resumed_at"]) if raw.get("last_resumed_at") is not None else None,
+        admission_id=str(raw["admission_id"]) if raw.get("admission_id") is not None else _admission_id(task_id=task_id, input_hash=input_hash),
+        admitted_at=str(raw["admitted_at"]) if raw.get("admitted_at") is not None else str(raw.get("accepted_at") or _utc_now_iso()),
+        input_hash=input_hash,
+        task_session_id=task_session_id,
+        active_attempt_id=str(raw["active_attempt_id"]) if raw.get("active_attempt_id") is not None else None,
+        attempt_count=int(raw.get("attempt_count") or 0),
+        last_attempt_started_at=str(raw["last_attempt_started_at"]) if raw.get("last_attempt_started_at") is not None else None,
+        last_progress_at=str(raw["last_progress_at"]) if raw.get("last_progress_at") is not None else None,
+        pending_permission_request=_optional_json_dict(raw.get("pending_permission_request")),
+        pending_question_request=_optional_json_dict(raw.get("pending_question_request")),
+        completion_source=str(raw["completion_source"]) if raw.get("completion_source") is not None else None,
+        cancel_requested=bool(raw.get("cancel_requested")),
         background_task=None,
     )

--- a/tests/test_execution_bus.py
+++ b/tests/test_execution_bus.py
@@ -3367,7 +3367,7 @@ async def test_agent_async_task_routes_to_selected_skill(monkeypatch):
     assert observed["autonomous_instruction"] == "Prefer approve when no blockers remain."
     assert observed["delegation"] == {"source": "github_review"}
     assert observed["_runtime_task_id"] == "task-1"
-    assert observed["_runtime_session_id"] == "agent-task:task-1"
+    assert observed["_runtime_session_id"] == "agent-task-task-1"
     assert observed["_execution_metadata"]["allowed_capability_ids"] == ["skill:review-pull-request"]
     assert result.status == "success"
     assert result.output_payload["task_type"] == "agent_async_task"
@@ -3436,6 +3436,52 @@ async def test_agent_async_task_preserves_blocked_agent_result(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_generic_agent_task_routes_without_skill_name(monkeypatch):
+    observed = {}
+
+    async def _fake_run_generic_agent_task(payload):
+        observed.update(payload)
+        return {
+            "status": "success",
+            "success": True,
+            "summary": "Task complete",
+            "final_response": "Finished the requested work.",
+            "needs_user_input": False,
+            "blockers": [],
+            "runtime_events": [{"event_type": "generic_runtime_applied"}],
+        }
+
+    monkeypatch.setattr("src.runtime.execution_bus.run_generic_agent_task", _fake_run_generic_agent_task)
+    req = make_execution_request(
+        source_type="task",
+        execution_type="task",
+        session_id="generic-task:task-1",
+        metadata={"portal_task_session_id": "generic-task:task-1"},
+        input_payload={
+            "task_id": "task-1",
+            "task_type": "generic_agent_task",
+            "schema": "generic_agent_task.v1",
+            "task_session_id": "generic-task:task-1",
+            "prompt": "Investigate the long-running task.",
+        },
+    )
+
+    result = await build_default_execution_bus().execute(req)
+
+    assert observed["prompt"] == "Investigate the long-running task."
+    assert observed["_runtime_task_id"] == "task-1"
+    assert observed["_runtime_session_id"] == "generic-task-task-1"
+    assert observed["_execution_metadata"]["portal_task_session_id"] == "generic-task:task-1"
+    assert result.status == "success"
+    assert result.output_payload["task_type"] == "generic_agent_task"
+    assert result.output_payload["status"] == "success"
+    assert result.output_payload["success"] is True
+    assert result.output_payload["summary"] == "Task complete"
+    assert result.output_payload["final_response"] == "Finished the requested work."
+    assert any(evt.get("event_type") == "task.generic_agent.completed" for evt in result.runtime_events)
+
+
+@pytest.mark.asyncio
 async def test_run_agent_async_task_uses_native_chat_loop(monkeypatch):
     from src.runtime.execution_bus import run_agent_async_task
 
@@ -3470,7 +3516,7 @@ async def test_run_agent_async_task_uses_native_chat_loop(monkeypatch):
     )
 
     assert captured["request_id"] == "req-agent-1:chat"
-    assert captured["session_id"] == "agent-task:task-agent-1"
+    assert captured["session_id"] == "agent-task-task-agent-1"
     assert captured["message"].startswith("/skill review-pull-request")
     assert "Return exactly one JSON object" in captured["message"]
     assert captured["transient_model_message"].startswith("You are executing an EFP Portal agent_async_task")
@@ -3479,6 +3525,49 @@ async def test_run_agent_async_task_uses_native_chat_loop(monkeypatch):
     assert result["final_response"] == "done"
     assert result["data"]["execution_mode"] == "chat_tool_loop"
     assert result["runtime_events"][0]["event_type"] == "skill_runtime_applied"
+
+
+@pytest.mark.asyncio
+async def test_run_generic_agent_task_uses_native_chat_loop_and_permission_blocker(monkeypatch):
+    from src.runtime.execution_bus import run_generic_agent_task
+
+    captured = {}
+
+    async def _fake_run_runtime_chat(**kwargs):
+        captured.update(kwargs)
+        return {
+            "status": "waiting_for_permission",
+            "response": '{"status":"success","summary":"needs permission","final_response":"waiting","needs_user_input":false,"blockers":[]}',
+            "pending_permission_request": {"id": "perm-1", "tool": "shell"},
+            "runtime_events": [{"event_type": "permission_requested"}],
+        }
+
+    monkeypatch.setattr("src.gateway.runtime_chat.run_runtime_chat", _fake_run_runtime_chat)
+
+    result = await run_generic_agent_task(
+        {
+            "task_type": "generic_agent_task",
+            "prompt": "Run the long task.",
+            "_runtime_request_id": "req-generic-1",
+            "_runtime_task_id": "task-generic-1",
+            "_runtime_session_id": "fallback-session",
+            "_execution_metadata": {
+                "portal_task_session_id": "generic-task:task-generic-1",
+                "resolved_model": "gpt-5",
+            },
+        }
+    )
+
+    assert captured["request_id"] == "req-generic-1:chat"
+    assert captured["session_id"] == "generic-task-task-generic-1"
+    assert captured["message"].startswith("Generic agent task instructions")
+    assert "Run the long task." in captured["message"]
+    assert captured["transient_model_message"].startswith("You are executing an EFP Portal generic_agent_task")
+    assert result["status"] == "blocked"
+    assert result["needs_user_input"] is True
+    assert result["blockers"] == [{"type": "permission_request", "request": {"id": "perm-1", "tool": "shell"}}]
+    assert result["data"]["execution_mode"] == "chat_tool_loop"
+    assert result["runtime_events"][0]["event_type"] == "permission_requested"
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -2950,7 +2950,7 @@ def test_runtime_task_tracker_persists_and_loads_active_records(tmp_path):
     from src.runtime.runtime_task_tracker import RuntimeTaskTracker
 
     tracker = RuntimeTaskTracker(storage_dir=tmp_path)
-    tracker.create_pending(
+    created = tracker.create_pending(
         task_id="task-persist",
         request_id="task-task-persist",
         task_type="adapter_action_task",
@@ -2964,8 +2964,14 @@ def test_runtime_task_tracker_persists_and_loads_active_records(tmp_path):
         merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
         metadata={"task_id": "task-persist", "portal_task_id": "portal-task-1"},
         trace_headers={"trace_id": "trace-1", "portal_dispatch_id": "dispatch-1"},
+        task_session_id="task-session-1",
     )
-    tracker.mark_running("task-persist")
+    running = tracker.mark_running("task-persist")
+    assert created.admission_id
+    assert created.input_hash
+    assert running is not None
+    assert running.attempt_count == 1
+    assert running.active_attempt_id
 
     loaded = RuntimeTaskTracker(storage_dir=tmp_path)
     assert loaded.load_persisted_records() == 1
@@ -2977,7 +2983,63 @@ def test_runtime_task_tracker_persists_and_loads_active_records(tmp_path):
     assert record.context_ref == {"workspace": "w1"}
     assert record.merged_input_payload["action_id"] == "jira.transition"
     assert record.metadata["portal_task_id"] == "portal-task-1"
+    assert record.admission_id == created.admission_id
+    assert record.input_hash == created.input_hash
+    assert record.task_session_id == "task-session-1"
+    assert record.attempt_count == 1
+    assert record.active_attempt_id == running.active_attempt_id
     assert [item.task_id for item in loaded.list_active()] == ["task-persist"]
+
+
+def test_runtime_task_tracker_ignores_stale_attempt_terminal_write():
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    tracker = RuntimeTaskTracker()
+    tracker.create_pending(
+        task_id="task-attempt",
+        request_id="task-task-attempt",
+        task_type="adapter_action_task",
+        source="portal",
+        session_id="session-1",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="portal-task-1",
+        merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
+        metadata={"task_id": "task-attempt"},
+    )
+    first = tracker.mark_running("task-attempt")
+    assert first is not None
+    first_attempt_id = first.active_attempt_id
+    tracker.mark_resuming("task-attempt")
+    second = tracker.mark_running("task-attempt")
+    assert second is not None
+    assert second.active_attempt_id and second.active_attempt_id != first_attempt_id
+
+    ignored = tracker.mark_terminal(
+        "task-attempt",
+        status="success",
+        payload={"ok": True, "status": "success", "from": "old-attempt"},
+        attempt_id=first_attempt_id,
+    )
+
+    record = tracker.get("task-attempt")
+    assert ignored is None
+    assert record is not None
+    assert record.status == "running"
+    assert record.active_attempt_id == second.active_attempt_id
+    assert record.payload == {}
+
+    tracker.mark_terminal(
+        "task-attempt",
+        status="success",
+        payload={"ok": True, "status": "success", "from": "current-attempt"},
+        attempt_id=second.active_attempt_id,
+    )
+    record = tracker.get("task-attempt")
+    assert record is not None
+    assert record.status == "success"
+    assert record.payload["from"] == "current-attempt"
 
 
 @pytest.mark.asyncio
@@ -3023,12 +3085,122 @@ async def test_api_tasks_execute_duplicate_active_task_reuses_existing_record(mo
 
     assert first_response.status == 202
     assert second_response.status == 200
+    first_body = json.loads(first_response.body)
+    assert second_body["admission_id"] == first_body["admission_id"]
+    assert second_body["input_hash"] == first_body["input_hash"]
+    assert second_body["engine"] == "native"
     assert second_body["task_id"] == "task-dedupe-1"
     assert second_body["status"] in {"accepted", "running"}
     assert len(spawned) == 1
 
     release.set()
     await spawned[0]
+
+
+@pytest.mark.asyncio
+async def test_api_tasks_execute_duplicate_conflicting_admission_returns_409(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    release = asyncio.Event()
+    spawned = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        await release.wait()
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    class _Request:
+        headers = INTERNAL_HEADERS
+
+        def __init__(self, action_id):
+            self._action_id = action_id
+
+        async def json(self):
+            return {
+                "task_id": "task-dedupe-conflict",
+                "task_type": "adapter_action_task",
+                "input_payload": {"action_id": self._action_id},
+            }
+
+    first_response = await runtime_api.api_tasks_execute(_Request("jira.transition"))
+    conflict_response = await runtime_api.api_tasks_execute(_Request("jira.close"))
+    conflict_body = json.loads(conflict_response.body)
+
+    assert first_response.status == 202
+    assert conflict_response.status == 409
+    assert conflict_body["error"] == "task_id_conflicts_with_existing_admission"
+    assert conflict_body["engine"] == "native"
+    assert conflict_body["admission_id"]
+    assert len(spawned) == 1
+
+    release.set()
+    await spawned[0]
+
+
+@pytest.mark.asyncio
+async def test_api_tasks_execute_generic_agent_task_uses_file_safe_task_session(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    captured = {}
+    spawned = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured.update(kwargs)
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    class _Request:
+        headers = INTERNAL_HEADERS
+
+        async def json(self):
+            return {
+                "task_id": "task-generic-safe",
+                "task_type": "generic_agent_task",
+                "input_payload": {
+                    "task_session_id": "generic-task:task-generic-safe",
+                    "prompt": "Run a long generic task.",
+                },
+            }
+
+    response = await runtime_api.api_tasks_execute(_Request())
+    body = json.loads(response.body)
+    await spawned[0]
+
+    assert response.status == 202
+    assert body["task_session_id"] == "generic-task-task-generic-safe"
+    assert captured["session_id"] == "generic-task-task-generic-safe"
+    assert captured["input_payload"]["task_session_id"] == "generic-task-task-generic-safe"
+    assert captured["metadata"]["runtime_task_session_id"] == "generic-task-task-generic-safe"
 
 
 @pytest.mark.asyncio
@@ -3097,7 +3269,81 @@ async def test_resume_persisted_runtime_tasks_replays_active_record(tmp_path, mo
     assert record.resume_count == 1
     assert captured["metadata"]["runtime_task_resumed"] is True
     assert captured["metadata"]["runtime_task_resume_count"] == 1
+    assert captured["metadata"]["runtime_task_admission_id"] == record.admission_id
+    assert captured["metadata"]["runtime_task_input_hash"] == record.input_hash
+    assert captured["metadata"]["runtime_task_attempt_id"]
+    assert captured["metadata"]["runtime_task_attempt_count"] == 2
     assert "task.resumed" in emitted
+
+
+@pytest.mark.asyncio
+async def test_run_task_execution_persists_pending_permission_observation(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    runtime_api.runtime_task_tracker.create_pending(
+        task_id="task-permission-1",
+        request_id="task-task-permission-1",
+        task_type="generic_agent_task",
+        source="portal",
+        session_id="generic-task-task-permission-1",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="portal-task-1",
+        merged_input_payload={"task_type": "generic_agent_task", "prompt": "Needs permission"},
+        metadata={"task_id": "task-permission-1", "portal_task_id": "portal-task-1"},
+        task_session_id="generic-task-task-permission-1",
+    )
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "blocked",
+                "output_payload": {
+                    "status": "blocked",
+                    "pending_permission_request": {"id": "perm-1", "tool": "shell"},
+                    "summary": "Permission required",
+                },
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": "approve_permission",
+                "audit_ref": None,
+            },
+        )()
+
+    async def _emit_task_lifecycle_event(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_emit_task_lifecycle_event", _emit_task_lifecycle_event)
+
+    await runtime_api._run_task_execution_in_background(
+        task_id="task-permission-1",
+        request_id="task-task-permission-1",
+        task_type="generic_agent_task",
+        session_id="generic-task-task-permission-1",
+        source="portal",
+        runtime_agent_id="agent-1",
+        context_ref=None,
+        merged_input_payload={"task_type": "generic_agent_task", "prompt": "Needs permission"},
+        metadata={"task_id": "task-permission-1", "portal_task_id": "portal-task-1"},
+        trace_headers={"trace_id": "trace-1", "portal_dispatch_id": "dispatch-1"},
+    )
+
+    record = runtime_api.runtime_task_tracker.get("task-permission-1")
+    assert record is not None
+    assert record.status == "blocked"
+    assert record.pending_permission_request == {"id": "perm-1", "tool": "shell"}
+    assert record.completion_source == "execution_result"
+
+    payload = runtime_api._runtime_task_status_payload(record)
+    assert payload["pending_permission_request"] == {"id": "perm-1", "tool": "shell"}
+    assert payload["attempt_count"] == 1
+    assert payload["active_attempt_id"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3347,6 +3347,405 @@ async def test_run_task_execution_persists_pending_permission_observation(monkey
 
 
 @pytest.mark.asyncio
+async def test_api_tasks_execute_serializes_same_runtime_task_session(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    runtime_api.runtime_task_session_coordinator.reset()
+    release_first = asyncio.Event()
+    spawned = []
+    calls = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        calls.append(kwargs["request_id"])
+        if kwargs["request_id"] == "task-task-lane-1":
+            await release_first.wait()
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True, "request_id": kwargs["request_id"]},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    class _Request:
+        headers = INTERNAL_HEADERS
+
+        def __init__(self, task_id):
+            self._task_id = task_id
+
+        async def json(self):
+            return {
+                "task_id": self._task_id,
+                "task_type": "generic_agent_task",
+                "input_payload": {
+                    "task_session_id": "shared-lane",
+                    "prompt": f"Run {self._task_id}.",
+                },
+            }
+
+    first_response = await runtime_api.api_tasks_execute(_Request("task-lane-1"))
+    second_response = await runtime_api.api_tasks_execute(_Request("task-lane-2"))
+
+    assert first_response.status == 202
+    assert second_response.status == 202
+    assert len(spawned) == 1
+
+    second_record = runtime_api.runtime_task_tracker.get("task-lane-2")
+    assert second_record is not None
+    second_status = runtime_api._runtime_task_status_payload(second_record)
+    assert second_status["session_lane_status"] == "queued"
+    assert second_status["session_active_task_id"] == "task-lane-1"
+    assert second_status["session_queue_position"] == 1
+
+    release_first.set()
+    await spawned[0]
+    assert len(spawned) == 2
+    await spawned[1]
+
+    assert calls == ["task-task-lane-1", "task-task-lane-2"]
+    assert runtime_api.runtime_task_tracker.get("task-lane-1").status == "success"
+    assert runtime_api.runtime_task_tracker.get("task-lane-2").status == "success"
+
+
+@pytest.mark.asyncio
+async def test_runtime_task_session_delivery_promotes_steer_before_queue(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    runtime_api.runtime_task_session_coordinator.reset()
+    release_first = asyncio.Event()
+    spawned = []
+    calls = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        calls.append(kwargs["request_id"])
+        if kwargs["request_id"] == "task-task-delivery-1":
+            await release_first.wait()
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    class _Request:
+        headers = INTERNAL_HEADERS
+
+        def __init__(self, task_id, delivery=None):
+            self._task_id = task_id
+            self._delivery = delivery
+
+        async def json(self):
+            payload = {
+                "task_session_id": "delivery-lane",
+                "prompt": f"Run {self._task_id}.",
+            }
+            if self._delivery:
+                payload["delivery"] = self._delivery
+            return {
+                "task_id": self._task_id,
+                "task_type": "generic_agent_task",
+                "input_payload": payload,
+            }
+
+    await runtime_api.api_tasks_execute(_Request("task-delivery-1"))
+    queue_response = await runtime_api.api_tasks_execute(_Request("task-delivery-queue", "queue"))
+    steer_response = await runtime_api.api_tasks_execute(_Request("task-delivery-steer", "steer"))
+
+    assert json.loads(queue_response.body)["delivery"] == "queue"
+    assert json.loads(steer_response.body)["delivery"] == "steer"
+    assert len(spawned) == 1
+
+    release_first.set()
+    await spawned[0]
+    for _ in range(10):
+        if len(spawned) >= 3:
+            break
+        await asyncio.sleep(0)
+    assert len(spawned) == 3
+    await asyncio.gather(*spawned[1:])
+
+    assert calls == [
+        "task-task-delivery-1",
+        "task-task-delivery-steer",
+        "task-task-delivery-queue",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_blocked_runtime_task_holds_session_lane_until_cancel(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    runtime_api.runtime_task_session_coordinator.reset()
+    spawned = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        if kwargs["request_id"] == "task-task-blocked-lane-1":
+            return type(
+                "R",
+                (),
+                {
+                    "request_id": kwargs["request_id"],
+                    "status": "blocked",
+                    "output_payload": {
+                        "status": "blocked",
+                        "pending_permission_request": {"request_id": "perm-lane", "tool_id": "write"},
+                    },
+                    "artifacts": [],
+                    "runtime_events": [],
+                    "next_action_hint": "approve_permission",
+                    "audit_ref": None,
+                },
+            )()
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    class _ExecuteRequest:
+        headers = INTERNAL_HEADERS
+
+        def __init__(self, task_id):
+            self._task_id = task_id
+
+        async def json(self):
+            return {
+                "task_id": self._task_id,
+                "task_type": "generic_agent_task",
+                "input_payload": {
+                    "task_session_id": "blocked-lane",
+                    "prompt": f"Run {self._task_id}.",
+                },
+            }
+
+    class _CancelRequest:
+        headers = INTERNAL_HEADERS
+        match_info = {"task_id": "task-blocked-lane-1"}
+
+    await runtime_api.api_tasks_execute(_ExecuteRequest("task-blocked-lane-1"))
+    await spawned[0]
+    first_record = runtime_api.runtime_task_tracker.get("task-blocked-lane-1")
+    assert first_record is not None
+    first_status = runtime_api._runtime_task_status_payload(first_record)
+    assert first_status["status"] == "blocked"
+    assert first_status["session_lane_status"] == "blocked"
+
+    await runtime_api.api_tasks_execute(_ExecuteRequest("task-blocked-lane-2"))
+    assert len(spawned) == 1
+    second_record = runtime_api.runtime_task_tracker.get("task-blocked-lane-2")
+    assert second_record is not None
+    assert runtime_api._runtime_task_status_payload(second_record)["session_lane_status"] == "queued"
+
+    cancel_response = await runtime_api.api_task_cancel(_CancelRequest())
+    assert cancel_response.status == 200
+    assert len(spawned) == 2
+    await spawned[1]
+
+    assert runtime_api.runtime_task_tracker.get("task-blocked-lane-1").status == "cancelled"
+    assert runtime_api.runtime_task_tracker.get("task-blocked-lane-2").status == "success"
+
+
+@pytest.mark.asyncio
+async def test_api_task_permission_respond_resumes_blocked_task(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    runtime_api.runtime_task_session_coordinator.reset()
+    spawned = []
+    captured = {}
+    record = runtime_api.runtime_task_tracker.create_pending(
+        task_id="task-permission-respond",
+        request_id="task-task-permission-respond",
+        task_type="generic_agent_task",
+        source="portal",
+        session_id="permission-respond-lane",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="portal-task-1",
+        merged_input_payload={
+            "task_type": "generic_agent_task",
+            "task_session_id": "permission-respond-lane",
+            "prompt": "Needs permission.",
+        },
+        metadata={"task_id": "task-permission-respond", "portal_task_id": "portal-task-1"},
+        task_session_id="permission-respond-lane",
+    )
+    runtime_api.runtime_task_session_coordinator.schedule(
+        "permission-respond-lane",
+        record.task_id,
+        admitted_seq=record.admitted_seq,
+    )
+    runtime_api.runtime_task_tracker.mark_terminal(
+        record.task_id,
+        status="blocked",
+        payload={
+            "ok": False,
+            "status": "blocked",
+            "pending_permission_request": {
+                "request_id": "perm-respond-1",
+                "tool_id": "write",
+                "args": {"file": "demo.txt"},
+                "patterns": ["demo.txt"],
+            },
+        },
+    )
+    runtime_api.runtime_task_session_coordinator.hold_for_user_input("permission-respond-lane", record.task_id)
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured.update(kwargs)
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    class _Request:
+        headers = INTERNAL_HEADERS
+        match_info = {"task_id": "task-permission-respond"}
+
+        async def json(self):
+            return {"request_id": "perm-respond-1", "decision": "approve"}
+
+    response = await runtime_api.api_task_permission_respond(_Request())
+    assert response.status == 202
+    assert len(spawned) == 1
+    await spawned[0]
+
+    assert captured["input_payload"]["_runtime_resume"] is True
+    tool_permissions = captured["metadata"]["runtime_profile"]["config"]["tool_permissions"]
+    assert tool_permissions["write"]["action"] == "allow"
+    assert tool_permissions["write"]["patterns"] == ["demo.txt"]
+    assert runtime_api.runtime_task_tracker.get("task-permission-respond").status == "success"
+
+
+@pytest.mark.asyncio
+async def test_api_task_question_respond_resumes_blocked_task(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    runtime_api.runtime_task_session_coordinator.reset()
+    spawned = []
+    captured = {}
+    record = runtime_api.runtime_task_tracker.create_pending(
+        task_id="task-question-respond",
+        request_id="task-task-question-respond",
+        task_type="generic_agent_task",
+        source="portal",
+        session_id="question-respond-lane",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="portal-task-1",
+        merged_input_payload={
+            "task_type": "generic_agent_task",
+            "task_session_id": "question-respond-lane",
+            "prompt": "Needs answer.",
+        },
+        metadata={"task_id": "task-question-respond", "portal_task_id": "portal-task-1"},
+        task_session_id="question-respond-lane",
+    )
+    runtime_api.runtime_task_session_coordinator.schedule(
+        "question-respond-lane",
+        record.task_id,
+        admitted_seq=record.admitted_seq,
+    )
+    pending_question = {
+        "request_id": "question-respond-1",
+        "session_id": "question-respond-lane",
+        "tool_call_id": "call-question",
+        "questions": [{"question": "Which stack?"}],
+    }
+    runtime_api.runtime_task_tracker.mark_terminal(
+        record.task_id,
+        status="blocked",
+        payload={"ok": False, "status": "blocked", "pending_question_request": pending_question},
+    )
+    runtime_api.runtime_task_session_coordinator.hold_for_user_input("question-respond-lane", record.task_id)
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        captured.update(kwargs)
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    class _Request:
+        headers = INTERNAL_HEADERS
+        match_info = {"task_id": "task-question-respond"}
+
+        async def json(self):
+            return {"request_id": "question-respond-1", "answers": [["TypeScript"]]}
+
+    response = await runtime_api.api_task_question_respond(_Request())
+    assert response.status == 202
+    assert len(spawned) == 1
+    await spawned[0]
+
+    assert captured["input_payload"]["_runtime_resume"] is True
+    question_response = captured["metadata"]["runtime_question_response"]
+    assert question_response["request"]["tool_call_id"] == "call-question"
+    assert question_response["answers"] == [["TypeScript"]]
+    assert runtime_api.runtime_task_tracker.get("task-question-respond").status == "success"
+
+
+@pytest.mark.asyncio
 async def test_api_chat_returns_display_blocks(monkeypatch):
     from src.gateway import runtime_api
 

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3579,6 +3579,118 @@ async def test_blocked_runtime_task_holds_session_lane_until_cancel(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_persisted_blocked_runtime_task_rehydrates_session_lane_before_new_input(monkeypatch, tmp_path):
+    from src.gateway import runtime_api
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    persisted_tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    blocked_record = persisted_tracker.create_pending(
+        task_id="task-persisted-blocked-lane",
+        request_id="task-task-persisted-blocked-lane",
+        task_type="generic_agent_task",
+        source="portal",
+        session_id="persisted-blocked-lane",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="portal-blocked-1",
+        merged_input_payload={
+            "task_type": "generic_agent_task",
+            "task_session_id": "persisted-blocked-lane",
+            "prompt": "Needs permission.",
+        },
+        metadata={"task_id": "task-persisted-blocked-lane", "portal_task_id": "portal-blocked-1"},
+        trace_headers={"trace_id": "trace-1", "portal_dispatch_id": "dispatch-1"},
+        task_session_id="persisted-blocked-lane",
+    )
+    persisted_tracker.mark_terminal(
+        blocked_record.task_id,
+        status="blocked",
+        payload={
+            "ok": False,
+            "status": "blocked",
+            "pending_permission_request": {
+                "request_id": "perm-persisted-1",
+                "tool_id": "write",
+            },
+        },
+    )
+
+    runtime_api.runtime_task_session_coordinator.reset()
+    recovered_tracker = RuntimeTaskTracker()
+    monkeypatch.setattr(runtime_api, "runtime_task_tracker", recovered_tracker)
+    monkeypatch.setenv("EFP_RUNTIME_TASKS_DIR", str(tmp_path))
+    spawned = []
+    calls = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        calls.append(kwargs["request_id"])
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    resumed_count = await runtime_api.resume_persisted_runtime_tasks()
+    assert resumed_count == 0
+    assert spawned == []
+
+    recovered_blocked = runtime_api.runtime_task_tracker.get("task-persisted-blocked-lane")
+    assert recovered_blocked is not None
+    blocked_status = runtime_api._runtime_task_status_payload(recovered_blocked)
+    assert blocked_status["status"] == "blocked"
+    assert blocked_status["session_lane_status"] == "blocked"
+    assert blocked_status["session_active_task_id"] == "task-persisted-blocked-lane"
+
+    class _ExecuteRequest:
+        headers = INTERNAL_HEADERS
+
+        async def json(self):
+            return {
+                "task_id": "task-after-persisted-blocked-lane",
+                "task_type": "generic_agent_task",
+                "input_payload": {
+                    "task_session_id": "persisted-blocked-lane",
+                    "prompt": "Run after restart.",
+                },
+            }
+
+    response = await runtime_api.api_tasks_execute(_ExecuteRequest())
+    assert response.status == 202
+    assert spawned == []
+
+    queued_record = runtime_api.runtime_task_tracker.get("task-after-persisted-blocked-lane")
+    assert queued_record is not None
+    queued_status = runtime_api._runtime_task_status_payload(queued_record)
+    assert queued_status["session_lane_status"] == "queued"
+    assert queued_status["session_active_task_id"] == "task-persisted-blocked-lane"
+
+    class _CancelRequest:
+        headers = INTERNAL_HEADERS
+        match_info = {"task_id": "task-persisted-blocked-lane"}
+
+    cancel_response = await runtime_api.api_task_cancel(_CancelRequest())
+    assert cancel_response.status == 200
+    assert len(spawned) == 1
+    await spawned[0]
+
+    assert calls == ["task-task-after-persisted-blocked-lane"]
+    assert runtime_api.runtime_task_tracker.get("task-persisted-blocked-lane").status == "cancelled"
+    assert runtime_api.runtime_task_tracker.get("task-after-persisted-blocked-lane").status == "success"
+
+
+@pytest.mark.asyncio
 async def test_api_task_permission_respond_resumes_blocked_task(monkeypatch):
     from src.gateway import runtime_api
 


### PR DESCRIPTION
﻿## What changed
- Added a Native runtime task session coordinator that mirrors OpenCode-style one-active-drain-per-session behavior.
- Added durable task admission sequence and `delivery` (`steer`/`queue`) metadata so same-session long tasks are ordered and `steer` work is promoted before queued work.
- Kept permission/question-blocked tasks holding the session lane until cancelled or answered, preventing later tasks from racing ahead.
- Rehydrated persisted permission/question-blocked task lanes on runtime restart, so a refresh or server restart cannot let new same-session work bypass the blocked task.
- Added task-level permission and question response endpoints that reopen the blocked task and resume the same Native runtime session.
- Added `resume_runtime_chat` so `generic_agent_task` and `agent_async_task` can resume pending tool calls without appending a new user prompt.

## Why
Native long-running Portal tasks needed to match anomalyco/opencode's core long-task behavior: durable admission, session-scoped coordination, queued work ordering, interrupt/cancel safety, refresh/restart recovery, and user-input unblock/resume.

## Validation
- Windows local: `python -m py_compile src\runtime\runtime_task_tracker.py src\gateway\runtime_api.py`
- Windows local: `python -m pytest tests/test_runtime_api.py -q -k "persisted_blocked_runtime_task_rehydrates_session_lane_before_new_input or blocked_runtime_task_holds_session_lane_until_cancel or serializes_same_runtime_task_session or delivery_promotes_steer_before_queue or permission_respond_resumes_blocked_task or question_respond_resumes_blocked_task"` -> 6 passed
- Windows local: `python -m pytest tests/test_runtime_api.py tests/test_execution_bus.py tests/runtime/test_question_tool.py tests/runtime/test_permission_resume_loop.py tests/runtime/test_gateway_session_facade_contract.py -q` -> 309 passed
- Windows local: `python -m pytest -q` -> 2328 passed, 48 failed, 5 skipped. The 48 failures match the existing Windows/environment failure bucket: CRLF text expectations, shell command behavior, home/config permission/path assumptions, and server-file newline behavior.
- Linux VM 233, clean clone: `python -m pytest tests/test_runtime_api.py tests/test_execution_bus.py tests/runtime/test_question_tool.py tests/runtime/test_permission_resume_loop.py tests/runtime/test_gateway_session_facade_contract.py -q` -> 309 passed
- Linux VM 233, clean clone: `python -m pytest -q` -> 2378 passed, 3 skipped
- Linux VM 233, anomalyco/opencode dev `5d0f866`: `bun test test/session-run-coordinator.test.ts test/session-runner.test.ts` from `packages/core` -> SessionRunCoordinator 35/35 passed; SessionRunner long-task tests for steer/queue, durable input after interrupt, and prior-process unfinished tool recovery passed. Two unrelated upstream Location move tests failed in this VM environment.
