### PR TITLE
[codex] align AWS auth with ADFS assume

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -219,22 +219,15 @@ def _has_github_profile_token(section: Any) -> bool:
 def _has_aws_profile_config(section: Any) -> bool:
     if not isinstance(section, dict) or section.get("enabled") is False:
         return False
-    return bool(
-        str(
-            section.get("access_key_id")
-            or section.get("aws_access_key_id")
-            or section.get("secret_access_key")
-            or section.get("aws_secret_access_key")
-            or section.get("session_token")
-            or section.get("aws_session_token")
-            or section.get("region")
-            or section.get("default_region")
-            or section.get("profile")
-            or section.get("profile_name")
-            or section.get("account_id")
-            or ""
-        ).strip()
-    )
+    username = str(
+        section.get("username")
+        or section.get("adfs_username")
+        or section.get("account")
+        or section.get("account_name")
+        or ""
+    ).strip()
+    password = str(section.get("password") or section.get("adfs_password") or "").strip()
+    return bool(username and password)
 
 
 def _has_git_profile_user(section: Any) -> bool:
@@ -326,6 +319,16 @@ class Config:
             "default_region": True,
             "output": True,
             "account_id": True,
+            "username": True,
+            "adfs_username": True,
+            "account": True,
+            "account_name": True,
+            "password": True,
+            "adfs_password": True,
+            "assume_command": True,
+            "adfs_command": True,
+            "assume_args": True,
+            "adfs_args": True,
             "access_key_id": True,
             "aws_access_key_id": True,
             "secret_access_key": True,

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -9,6 +9,7 @@ import os
 import shlex
 import stat
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,103 @@ _GIT_INCLUDE_END = "# END EFP_RUNTIME_PROFILE_GIT_INCLUDE"
 _REDACTED_SECRET = "[REDACTED_SECRET]"
 _PROXY_URL_ENV_KEYS = ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "all_proxy", "ALL_PROXY")
 _PROFILE_SECRET_KEY_NAMES = frozenset({"api_key", "password", "token", "api_token", "access_token", "secret"})
+_AWS_ADFS_DEFAULT_COMMAND = "adfs assume"
+_AWS_ADFS_HELPER = r"""#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def _redact(text: str, secrets: list[str]) -> str:
+    value = str(text or "")
+    for secret in sorted((s for s in secrets if s), key=len, reverse=True):
+        value = value.replace(secret, "[REDACTED_SECRET]")
+    return value
+
+
+def _credentials_payload(raw: object) -> dict:
+    data = raw.get("Credentials") if isinstance(raw, dict) and isinstance(raw.get("Credentials"), dict) else raw
+    if not isinstance(data, dict):
+        raise ValueError("credential command did not return a JSON object")
+    payload = {
+        "Version": int(data.get("Version") or 1),
+        "AccessKeyId": data.get("AccessKeyId") or data.get("aws_access_key_id") or data.get("access_key_id"),
+        "SecretAccessKey": data.get("SecretAccessKey") or data.get("aws_secret_access_key") or data.get("secret_access_key"),
+        "SessionToken": data.get("SessionToken") or data.get("Token") or data.get("aws_session_token") or data.get("session_token"),
+    }
+    expiration = data.get("Expiration") or data.get("expiration")
+    if expiration:
+        payload["Expiration"] = expiration
+    missing = [key for key in ("AccessKeyId", "SecretAccessKey", "SessionToken") if not payload.get(key)]
+    if missing:
+        raise ValueError("credential command JSON missing " + ", ".join(missing))
+    return payload
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: aws-adfs-credential-process.py <auth-json>", file=sys.stderr)
+        return 2
+    with open(sys.argv[1], "r", encoding="utf-8") as handle:
+        config = json.load(handle)
+    command = config.get("command")
+    if not isinstance(command, list) or not all(isinstance(arg, str) and arg for arg in command):
+        print("invalid ADFS credential command", file=sys.stderr)
+        return 2
+    username = str(config.get("username") or "")
+    password = str(config.get("password") or "")
+    secrets = [username, password]
+    env = os.environ.copy()
+    if username:
+        env["username"] = username
+        env["ADFS_USERNAME"] = username
+        env["AWS_ADFS_USERNAME"] = username
+    if password:
+        env["password"] = password
+        env["ADFS_PASSWORD"] = password
+        env["AWS_ADFS_PASSWORD"] = password
+    profile = str(config.get("profile") or "").strip()
+    if profile:
+        env["AWS_PROFILE"] = profile
+        env["AWS_DEFAULT_PROFILE"] = profile
+    region = str(config.get("region") or "").strip()
+    if region:
+        env["AWS_REGION"] = region
+        env["AWS_DEFAULT_REGION"] = region
+    output = str(config.get("output") or "").strip()
+    if output:
+        env["AWS_DEFAULT_OUTPUT"] = output
+    command = [
+        arg.replace("{username}", username)
+        .replace("{password}", password)
+        .replace("{profile}", profile)
+        .replace("{region}", region)
+        for arg in command
+    ]
+    stdin_text = f"{username}\n{password}\n" if "--stdin" in command else None
+    result = subprocess.run(command, input=stdin_text, text=True, capture_output=True, check=False, env=env)
+    if result.returncode != 0:
+        detail = _redact((result.stderr or result.stdout or "").strip(), secrets)
+        if detail:
+            print(detail, file=sys.stderr)
+        return result.returncode or 1
+    stdout = (result.stdout or "").strip()
+    try:
+        raw_payload = json.loads(stdout)
+        payload = _credentials_payload(raw_payload)
+    except Exception as exc:
+        print(_redact(f"invalid ADFS credential output: {exc}", secrets), file=sys.stderr)
+        return 1
+    print(json.dumps(payload, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"""
 _yaml = YAML()
 _yaml.default_flow_style = False
 
@@ -537,7 +635,7 @@ def _apply_aws(
     *,
     metadata: dict[str, Any],
 ) -> None:
-    aws_profile = _build_aws_profile(profile_config)
+    aws_profile = _build_aws_adfs_profile(profile_config)
     if aws_profile is None:
         return
 
@@ -550,52 +648,113 @@ def _apply_aws(
     previous_config = _read_ini_section(config_path, config_section)
     previous_credentials = _read_ini_section(credentials_path, credentials_section)
 
-    config_values = {}
-    for key in ("region", "output"):
-        if aws_profile.get(key):
-            config_values[key] = aws_profile[key]
-    _set_ini_section_exact(config_path, config_section, config_values)
-
-    credential_values = {}
-    if aws_profile.get("access_key_id"):
-        credential_values["aws_access_key_id"] = aws_profile["access_key_id"]
-    if aws_profile.get("secret_access_key"):
-        credential_values["aws_secret_access_key"] = aws_profile["secret_access_key"]
-    if aws_profile.get("session_token"):
-        credential_values["aws_session_token"] = aws_profile["session_token"]
-    if credential_values:
-        _set_ini_section_exact(credentials_path, credentials_section, credential_values)
-
+    auth_path = _aws_adfs_auth_path()
+    helper_path = _aws_adfs_helper_path()
     metadata["aws"] = {
         "profile": profile_name,
+        "auth_type": "adfs_credential_process",
         "config_path": str(config_path),
         "credentials_path": str(credentials_path),
         "config_section": config_section,
         "credentials_section": credentials_section,
+        "auth_path": str(auth_path),
+        "helper_path": str(helper_path),
         "previous": {
             "config": previous_config,
             "credentials": previous_credentials,
         },
     }
 
+    _write_aws_adfs_helper(helper_path)
+    _write_private_text(
+        auth_path,
+        json.dumps(
+            {
+                "command": aws_profile["command"],
+                "username": aws_profile["username"],
+                "password": aws_profile["password"],
+                "profile": profile_name,
+                "region": aws_profile.get("region") or "",
+                "output": aws_profile.get("output") or "",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
 
-def _build_aws_profile(profile_config: dict[str, Any]) -> dict[str, str] | None:
+    config_values = {
+        "credential_process": _format_credential_process([sys.executable, str(helper_path), str(auth_path)]),
+    }
+    for key in ("region", "output"):
+        if aws_profile.get(key):
+            config_values[key] = aws_profile[key]
+    _set_ini_section_exact(config_path, config_section, config_values)
+    _remove_ini_section(credentials_path, credentials_section)
+
+
+def _build_aws_adfs_profile(profile_config: dict[str, Any]) -> dict[str, Any] | None:
     aws = profile_config.get("aws") if isinstance(profile_config, dict) else None
     if not isinstance(aws, dict) or aws.get("enabled") is False:
         return None
     profile = _single_line(aws.get("profile") or aws.get("profile_name") or "default") or "default"
+    username = _single_line(
+        aws.get("username")
+        or aws.get("adfs_username")
+        or aws.get("account")
+        or aws.get("account_name")
+    )
+    password = _string_or_empty(aws.get("password") or aws.get("adfs_password"))
+    if not username or not password:
+        return None
+    command = _aws_adfs_command(aws)
     built = {
         "profile": profile,
         "region": _single_line(aws.get("region") or aws.get("default_region")),
         "output": _single_line(aws.get("output")),
-        "account_id": _single_line(aws.get("account_id")),
-        "access_key_id": _single_line(aws.get("access_key_id") or aws.get("aws_access_key_id")),
-        "secret_access_key": _string_or_empty(aws.get("secret_access_key") or aws.get("aws_secret_access_key")),
-        "session_token": _string_or_empty(aws.get("session_token") or aws.get("aws_session_token")),
+        "username": username,
+        "password": password,
+        "command": command,
     }
-    if not any(value for key, value in built.items() if key != "profile"):
-        return None
     return built
+
+
+def _aws_adfs_command(aws: dict[str, Any]) -> list[str]:
+    raw_command = (
+        aws.get("assume_command")
+        or aws.get("adfs_command")
+        or os.environ.get("EFP_AWS_ADFS_ASSUME_COMMAND")
+        or _AWS_ADFS_DEFAULT_COMMAND
+    )
+    command = _shell_words(raw_command)
+    if not command:
+        command = _shell_words(_AWS_ADFS_DEFAULT_COMMAND)
+    args = aws.get("assume_args") or aws.get("adfs_args")
+    command.extend(_shell_words(args))
+    return command
+
+
+def _shell_words(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [_single_line(item) for item in value if _single_line(item)]
+    text = _string_or_empty(value)
+    if not text:
+        return []
+    return shlex.split(text)
+
+
+def _format_credential_process(args: list[str]) -> str:
+    if os.name == "nt":
+        return subprocess.list2cmdline(args)
+    return shlex.join(args)
+
+
+def _write_aws_adfs_helper(path: Path) -> None:
+    _write_private_text(path, _AWS_ADFS_HELPER)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
 
 
 def _restore_aws_profile(aws_meta: dict[str, Any]) -> None:
@@ -619,6 +778,11 @@ def _restore_aws_profile(aws_meta: dict[str, Any]) -> None:
         _remove_ini_section(credentials_path, credentials_section)
     else:
         _set_ini_section_exact(credentials_path, credentials_section, previous_credentials)
+
+    for key in ("auth_path", "helper_path"):
+        raw_path = aws_meta.get(key)
+        if raw_path:
+            _remove_file_if_exists(Path(str(raw_path)))
 
 
 def _extract_git_user(profile_config: dict[str, Any]) -> tuple[str, str] | None:
@@ -739,6 +903,8 @@ def _is_profile_secret_key(key: str) -> bool:
         "accesstoken",
         "secretaccesskey",
         "sessiontoken",
+        "adfspassword",
+        "awspassword",
         "secret",
     } or str(key or "").lower() in _PROFILE_SECRET_KEY_NAMES
 
@@ -811,6 +977,14 @@ def _aws_config_path() -> Path:
 
 def _aws_credentials_path() -> Path:
     return _home_path() / ".aws" / "credentials"
+
+
+def _aws_adfs_auth_path() -> Path:
+    return _home_path() / ".config" / "efp" / "runtime-profile-aws-adfs-auth.json"
+
+
+def _aws_adfs_helper_path() -> Path:
+    return _home_path() / ".config" / "efp" / "aws-adfs-credential-process.py"
 
 
 def _aws_config_section_name(profile_name: str) -> str:

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -1,6 +1,9 @@
 import hashlib
 import json
 import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 from ruamel.yaml import YAML
@@ -214,8 +217,8 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
                 "profile": "prod",
                 "region": "us-east-1",
                 "output": "json",
-                "access_key_id": "AKIA_TEST",
-                "secret_access_key": "aws-secret",
+                "username": "adfs-user",
+                "password": "aws-password",
             },
         },
     )
@@ -227,10 +230,10 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
     assert persisted["instruction_texts"]
     assert "jira-token" not in config_path.read_text(encoding="utf-8")
     assert "conf-token" not in config_path.read_text(encoding="utf-8")
-    assert "aws-secret" not in config_path.read_text(encoding="utf-8")
+    assert "aws-password" not in config_path.read_text(encoding="utf-8")
     assert applied[0]["jira"]["instances"][0]["token"] == "jira-token"
     assert applied[0]["confluence"]["instances"][0]["token"] == "conf-token"
-    assert applied[0]["aws"]["secret_access_key"] == "aws-secret"
+    assert applied[0]["aws"]["password"] == "aws-password"
     assert cfg.get_managed_overlay_meta()["managed_sections"] == [
         "aws",
         "confluence",
@@ -239,7 +242,7 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
     ]
 
 
-def test_runtime_profile_aws_external_config_writes_and_clears_aws_cli_files(tmp_path, monkeypatch):
+def test_runtime_profile_aws_external_config_writes_adfs_credential_process_and_clears_files(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
@@ -251,9 +254,8 @@ def test_runtime_profile_aws_external_config_writes_and_clears_aws_cli_files(tmp
                 "profile": "prod",
                 "region": "us-east-1",
                 "output": "json",
-                "access_key_id": "AKIA_TEST",
-                "secret_access_key": "aws-secret",
-                "session_token": "aws-session",
+                "username": "adfs-user",
+                "password": "aws-password",
             }
         }
     )
@@ -262,28 +264,92 @@ def test_runtime_profile_aws_external_config_writes_and_clears_aws_cli_files(tmp
     aws_credentials = home / ".aws" / "credentials"
     if os.name != "nt":
         assert aws_config.stat().st_mode & 0o777 == 0o600
-        assert aws_credentials.stat().st_mode & 0o777 == 0o600
 
     config_text = aws_config.read_text(encoding="utf-8")
     assert "[profile prod]" in config_text
     assert "region = us-east-1" in config_text
     assert "output = json" in config_text
+    assert "credential_process =" in config_text
+    assert "aws-adfs-credential-process.py" in config_text
+    assert "runtime-profile-aws-adfs-auth.json" in config_text
+    assert not aws_credentials.exists()
 
-    credentials_text = aws_credentials.read_text(encoding="utf-8")
-    assert "[prod]" in credentials_text
-    assert "aws_access_key_id = AKIA_TEST" in credentials_text
-    assert "aws_secret_access_key = aws-secret" in credentials_text
-    assert "aws_session_token = aws-session" in credentials_text
+    auth_path = home / ".config" / "efp" / "runtime-profile-aws-adfs-auth.json"
+    helper_path = home / ".config" / "efp" / "aws-adfs-credential-process.py"
+    auth_text = auth_path.read_text(encoding="utf-8")
+    assert '"command": [' in auth_text
+    assert '"adfs"' in auth_text
+    assert '"assume"' in auth_text
+    assert '"username": "adfs-user"' in auth_text
+    assert '"password": "aws-password"' in auth_text
+    assert helper_path.exists()
+    if os.name != "nt":
+        assert auth_path.stat().st_mode & 0o777 == 0o600
+        assert helper_path.stat().st_mode & 0o777 == 0o700
 
     metadata_path = home / ".config" / "efp" / "runtime-profile-external-config.json"
     metadata_text = metadata_path.read_text(encoding="utf-8")
-    assert "aws-secret" not in metadata_text
-    assert json.loads(metadata_text)["aws"]["profile"] == "prod"
+    assert "aws-password" not in metadata_text
+    metadata = json.loads(metadata_text)
+    assert metadata["aws"]["profile"] == "prod"
+    assert metadata["aws"]["auth_type"] == "adfs_credential_process"
 
     profile_config_module.clear_runtime_profile_external_config()
     assert not aws_config.exists()
     assert not aws_credentials.exists()
+    assert not auth_path.exists()
+    assert not helper_path.exists()
     assert not metadata_path.exists()
+
+
+def test_runtime_profile_aws_credential_process_helper_invokes_adfs_command(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    fake_adfs = tmp_path / "fake_adfs.py"
+    fake_adfs.write_text(
+        "import json, os, sys\n"
+        "assert sys.argv[1:] == ['adfs-user', 'aws-password']\n"
+        "assert os.environ['ADFS_USERNAME'] == 'adfs-user'\n"
+        "assert os.environ['ADFS_PASSWORD'] == 'aws-password'\n"
+        "print(json.dumps({'Credentials': {'AccessKeyId': 'AKIA_ADFS', 'SecretAccessKey': 'SECRET_ADFS', 'SessionToken': 'TOKEN_ADFS', 'Expiration': '2030-01-01T00:00:00Z'}}))\n",
+        encoding="utf-8",
+    )
+
+    profile_config_module.apply_runtime_profile_external_config(
+        {
+            "aws": {
+                "enabled": True,
+                "profile": "prod",
+                "region": "us-east-1",
+                "username": "adfs-user",
+                "password": "aws-password",
+                "assume_command": [sys.executable, str(fake_adfs), "{username}", "{password}"],
+            }
+        }
+    )
+    metadata = json.loads((home / ".config" / "efp" / "runtime-profile-external-config.json").read_text(encoding="utf-8"))
+    helper_path = Path(metadata["aws"]["helper_path"])
+    auth_path = Path(metadata["aws"]["auth_path"])
+
+    result = subprocess.run(
+        [sys.executable, str(helper_path), str(auth_path)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "Version": 1,
+        "AccessKeyId": "AKIA_ADFS",
+        "SecretAccessKey": "SECRET_ADFS",
+        "SessionToken": "TOKEN_ADFS",
+        "Expiration": "2030-01-01T00:00:00Z",
+    }
+    assert "aws-password" not in result.stderr
 
 
 def test_runtime_profile_apply_prunes_previous_portal_atlassian_entries(tmp_path, monkeypatch):


### PR DESCRIPTION
﻿## Summary
- Replace native runtime AWS static credential projection with an ADFS-backed `credential_process` profile.
- Store the Portal-provided AWS username/password in a private auth file and invoke `adfs assume` on demand when AWS CLI/SDK credentials are requested.
- Preserve and restore any pre-existing AWS config/credentials sections when clearing runtime-profile external config.
- Add helper execution coverage to verify the generated credential process normalizes ADFS command output into AWS-compatible JSON.

## Validation
- Windows: `python -m py_compile src\external_cli\profile_config.py src\config.py`
- Windows: `python -m pytest tests\test_runtime_profile_overlay.py -q` -> 29 passed
- VM233 Linux: `python -m pytest tests/test_runtime_profile_overlay.py -q` -> 29 passed

## Notes
- `tests/test_runtime_api_runtime_profile.py` fails on both Windows and VM233 clean `origin/master` with `ModuleNotFoundError: No module named 'src.runtime'`; this is unrelated to the AWS ADFS changes.
