### PR TITLE
[codex] Use AWS auth tool for runtime profile apply

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -219,15 +219,10 @@ def _has_github_profile_token(section: Any) -> bool:
 def _has_aws_profile_config(section: Any) -> bool:
     if not isinstance(section, dict) or section.get("enabled") is False:
         return False
-    username = str(
-        section.get("username")
-        or section.get("adfs_username")
-        or section.get("account")
-        or section.get("account_name")
-        or ""
-    ).strip()
-    password = str(section.get("password") or section.get("adfs_password") or "").strip()
-    return bool(username and password)
+    domain = str(section.get("domain") or "").strip()
+    username = str(section.get("username") or "").strip()
+    password = str(section.get("password") or "").strip()
+    return bool(domain and username and password)
 
 
 def _has_git_profile_user(section: Any) -> bool:
@@ -313,47 +308,9 @@ class Config:
         },
         "aws": {
             "enabled": True,
-            "profile": True,
-            "profile_name": True,
-            "region": True,
-            "default_region": True,
-            "output": True,
-            "account_no": True,
-            "account_id": True,
-            "aws_account_no": True,
-            "username": True,
-            "adfs_username": True,
-            "account": True,
-            "account_name": True,
-            "password": True,
-            "adfs_password": True,
-            "assume_command": True,
-            "adfs_command": True,
-            "assume_args": True,
-            "adfs_args": True,
-            "role": True,
-            "role_name": True,
             "domain": True,
-            "config": True,
-            "config_path": True,
-            "adfs_config": True,
-            "idp_proxy": True,
-            "idpProxy": True,
-            "session_duration_minutes": True,
-            "sessionDurationMinutes": True,
-            "log": True,
-            "log_level": True,
-            "jenkins": True,
-            "no_warning": True,
-            "display_token": True,
-            "nossl": True,
-            "adfs3_uat": True,
-            "access_key_id": True,
-            "aws_access_key_id": True,
-            "secret_access_key": True,
-            "aws_secret_access_key": True,
-            "session_token": True,
-            "aws_session_token": True,
+            "username": True,
+            "password": True,
         },
         "git": {
             "user": {

--- a/src/config.py
+++ b/src/config.py
@@ -511,7 +511,6 @@ class Config:
         persisted_overlay = copy.deepcopy(external_cli_overlay)
         persisted_overlay.pop("jira", None)
         persisted_overlay.pop("confluence", None)
-        persisted_overlay.pop("aws", None)
         new_sections = set(external_cli_overlay.keys())
 
         config_document = self._load_yaml_document(self.config_path)
@@ -698,19 +697,22 @@ class Config:
     
     SENSITIVE_FIELDS = {"api_key", "password", "token", "api_token", "access_token", "secret"}
     
-    def _encrypt_sensitive_fields(self, obj: Any) -> None:
+    def _encrypt_sensitive_fields(self, obj: Any, path: tuple[str, ...] = ()) -> None:
         """Recursively encrypt sensitive fields in config."""
         if self._is_mapping(obj):
             for key, value in obj.items():
+                child_path = (*path, str(key))
+                if path == ("aws",) and key == "password":
+                    continue
                 # Skip encryption for env var placeholders or already encrypted values
                 if key in self.SENSITIVE_FIELDS and isinstance(value, str) and value and not value.startswith("ENC:") and not value.startswith("${"):
                     obj[key] = self._encrypt_value(value)
                 elif self._is_mapping(value) or self._is_sequence(value):
-                    self._encrypt_sensitive_fields(value)
+                    self._encrypt_sensitive_fields(value, child_path)
         elif self._is_sequence(obj):
             for item in obj:
                 if self._is_mapping(item) or self._is_sequence(item):
-                    self._encrypt_sensitive_fields(item)
+                    self._encrypt_sensitive_fields(item, path)
     
     def _decrypt_sensitive_fields(self, obj: Any) -> None:
         """Recursively decrypt sensitive fields in config."""

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -539,122 +539,61 @@ def _apply_aws(
     *,
     metadata: dict[str, Any],
 ) -> None:
-    aws_profile = _build_aws_adfs_profile(profile_config)
-    if aws_profile is None:
+    aws_config = _build_aws_config(profile_config)
+    if aws_config is None:
         return
 
-    profile_name = aws_profile["profile"]
-    config_section = _aws_config_section_name(profile_name)
-    credentials_section = profile_name
-    config_path = _aws_config_path()
     credentials_path = _aws_credentials_path()
+    credentials_section = "default"
 
-    previous_config = _read_ini_section(config_path, config_section)
     previous_credentials = _read_ini_section(credentials_path, credentials_section)
 
     metadata["aws"] = {
-        "profile": profile_name,
         "auth_type": "adfs_assume_cli",
-        "config_path": str(config_path),
         "credentials_path": str(credentials_path),
-        "config_section": config_section,
         "credentials_section": credentials_section,
-        "command": _format_command(aws_profile["command"], (aws_profile["password"],)),
+        "command": _format_command(aws_config["command"], (aws_config["password"],)),
         "previous": {
-            "config": previous_config,
             "credentials": previous_credentials,
         },
     }
 
-    config_values: dict[str, str] = {}
-    for key in ("region", "output"):
-        if aws_profile.get(key):
-            config_values[key] = aws_profile[key]
     try:
-        _set_ini_section_exact(config_path, config_section, config_values)
         _run_cli(
-            aws_profile["command"],
-            env=_aws_adfs_env(aws_profile),
-            secrets=(aws_profile["password"],),
-            env_secrets=(aws_profile["password"],),
+            aws_config["command"],
+            env=_aws_env(aws_config),
+            secrets=(aws_config["password"],),
+            env_secrets=(aws_config["password"],),
         )
     except Exception:
         _restore_aws_profile(metadata["aws"])
         raise
 
 
-def _build_aws_adfs_profile(profile_config: dict[str, Any]) -> dict[str, Any] | None:
+def _build_aws_config(profile_config: dict[str, Any]) -> dict[str, Any] | None:
     aws = profile_config.get("aws") if isinstance(profile_config, dict) else None
     if not isinstance(aws, dict) or aws.get("enabled") is False:
         return None
-    profile = _single_line(aws.get("profile") or aws.get("profile_name") or "default") or "default"
-    username = _single_line(
-        aws.get("username")
-        or aws.get("adfs_username")
-        or aws.get("account")
-        or aws.get("account_name")
-    )
-    password = _string_or_empty(aws.get("password") or aws.get("adfs_password"))
-    if not username or not password:
+    domain = _single_line(aws.get("domain"))
+    username = _single_line(aws.get("username"))
+    password = _string_or_empty(aws.get("password"))
+    if not domain or not username or not password:
         return None
-    region = _single_line(aws.get("region") or aws.get("default_region"))
-    output = _single_line(aws.get("output"))
-    command = _aws_adfs_command(aws, profile=profile, region=region, username=username)
-    built = {
-        "profile": profile,
-        "region": region,
-        "output": output,
+    return {
+        "domain": domain,
         "username": username,
         "password": password,
-        "command": command,
+        "command": _aws_command(domain=domain, username=username),
     }
-    return built
 
 
-def _aws_adfs_command(aws: dict[str, Any], *, profile: str, region: str, username: str) -> list[str]:
-    raw_command = (
-        aws.get("assume_command")
-        or aws.get("adfs_command")
-        or os.environ.get("EFP_AWS_ADFS_ASSUME_COMMAND")
-        or _AWS_ADFS_DEFAULT_COMMAND
-    )
-    command = _shell_words(raw_command)
-    if not command:
-        command = _shell_words(_AWS_ADFS_DEFAULT_COMMAND)
-    if _flag_enabled(aws.get("jenkins"), default=True):
-        command.append("--jenkins")
-    if _flag_enabled(aws.get("no_warning"), default=True):
-        command.append("-n")
-    _append_cli_arg(command, "-u", username)
-    _append_cli_arg(command, "-p", profile)
-    _append_cli_arg(command, "-R", region)
-    _append_cli_arg(command, "-a", _first_aws_text(aws, "account_no", "account_id", "aws_account_no"))
-    _append_cli_arg(command, "-r", _first_aws_text(aws, "role", "role_name"))
-    _append_cli_arg(command, "-d", _first_aws_text(aws, "domain"))
-    _append_cli_arg(command, "-c", _first_aws_text(aws, "config", "config_path", "adfs_config"))
-    _append_cli_arg(command, "--idp-proxy", _first_aws_text(aws, "idp_proxy", "idpProxy"))
-    _append_cli_arg(command, "--session-duration-minutes", _first_aws_text(aws, "session_duration_minutes", "sessionDurationMinutes"))
-    _append_cli_arg(command, "--log", _first_aws_text(aws, "log", "log_level"))
-    if _flag_enabled(aws.get("display_token")):
-        command.append("-t")
-    if _flag_enabled(aws.get("nossl")):
-        command.append("--nossl")
-    if _flag_enabled(aws.get("adfs3_uat")):
-        command.append("--adfs3-uat")
-    command.extend(_shell_words(aws.get("assume_args") or aws.get("adfs_args")))
-    return command
+def _aws_command(*, domain: str, username: str) -> list[str]:
+    return [_AWS_ADFS_DEFAULT_COMMAND, "--jenkins", "-n", "-d", domain, "-u", username]
 
 
-def _aws_adfs_env(aws_profile: dict[str, Any]) -> dict[str, str]:
+def _aws_env(aws_config: dict[str, Any]) -> dict[str, str]:
     env = os.environ.copy()
-    env["AD_PASS"] = aws_profile["password"]
-    env["AWS_PROFILE"] = aws_profile["profile"]
-    env["AWS_DEFAULT_PROFILE"] = aws_profile["profile"]
-    if aws_profile.get("region"):
-        env["AWS_REGION"] = aws_profile["region"]
-        env["AWS_DEFAULT_REGION"] = aws_profile["region"]
-    if aws_profile.get("output"):
-        env["AWS_DEFAULT_OUTPUT"] = aws_profile["output"]
+    env["AD_PASS"] = aws_config["password"]
     env["PATH"] = _path_with_runtime_venv_bins(env.get("PATH", ""))
     return env
 
@@ -665,55 +604,24 @@ def _path_with_runtime_venv_bins(path_value: str) -> str:
     return os.pathsep.join(prefix + parts)
 
 
-def _append_cli_arg(command: list[str], flag: str, value: Any) -> None:
-    text = _single_line(value)
-    if text:
-        command.extend([flag, text])
-
-
-def _first_aws_text(aws: dict[str, Any], *keys: str) -> str:
-    for key in keys:
-        text = _single_line(aws.get(key))
-        if text:
-            return text
-    return ""
-
-
-def _flag_enabled(value: Any, *, default: bool = False) -> bool:
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return value != 0
-    return str(value).strip().lower() in {"1", "true", "on", "yes", "y", "enabled"}
-
-
-def _shell_words(value: Any) -> list[str]:
-    if isinstance(value, list):
-        return [_single_line(item) for item in value if _single_line(item)]
-    text = _string_or_empty(value)
-    if not text:
-        return []
-    return shlex.split(text)
-
-
 def _restore_aws_profile(aws_meta: dict[str, Any]) -> None:
     profile_name = _string_or_empty(aws_meta.get("profile")) or "default"
     config_section = _string_or_empty(aws_meta.get("config_section")) or _aws_config_section_name(profile_name)
     credentials_section = _string_or_empty(aws_meta.get("credentials_section")) or profile_name
     previous = aws_meta.get("previous") if isinstance(aws_meta.get("previous"), dict) else {}
 
-    config_path = Path(str(aws_meta.get("config_path") or _aws_config_path()))
     credentials_path = Path(str(aws_meta.get("credentials_path") or _aws_credentials_path()))
 
     previous_config = previous.get("config") if isinstance(previous.get("config"), dict) else None
     previous_credentials = previous.get("credentials") if isinstance(previous.get("credentials"), dict) else None
 
-    if previous_config is None:
-        _remove_ini_section(config_path, config_section)
-    else:
-        _set_ini_section_exact(config_path, config_section, previous_config)
+    config_path_value = aws_meta.get("config_path")
+    if config_path_value or previous_config is not None:
+        config_path = Path(str(config_path_value or _aws_config_path()))
+        if previous_config is None:
+            _remove_ini_section(config_path, config_section)
+        else:
+            _set_ini_section_exact(config_path, config_section, previous_config)
 
     if previous_credentials is None:
         _remove_ini_section(credentials_path, credentials_section)
@@ -835,19 +743,8 @@ def _collect_profile_config_redaction_secrets(value: Any, secrets: list[str], ke
 
 def _is_profile_secret_key(key: str) -> bool:
     normalized = "".join(ch for ch in str(key or "").lower() if ch.isalnum())
-    return normalized in {
-        "apikey",
-        "accesskeyid",
-        "password",
-        "token",
-        "apitoken",
-        "accesstoken",
-        "secretaccesskey",
-        "sessiontoken",
-        "adfspassword",
-        "awspassword",
-        "secret",
-    } or str(key or "").lower() in _PROFILE_SECRET_KEY_NAMES
+    secret_markers = ("apikey", "password", "token", "apitoken", "accesstoken", "secret", "access")
+    return any(marker in normalized for marker in secret_markers) or str(key or "").lower() in _PROFILE_SECRET_KEY_NAMES
 
 
 def _profile_proxy_redaction_secrets(profile_config: dict[str, Any]) -> tuple[str, ...]:
@@ -918,14 +815,6 @@ def _aws_config_path() -> Path:
 
 def _aws_credentials_path() -> Path:
     return _home_path() / ".aws" / "credentials"
-
-
-def _aws_adfs_auth_path() -> Path:
-    return _home_path() / ".config" / "efp" / "runtime-profile-aws-adfs-auth.json"
-
-
-def _aws_adfs_helper_path() -> Path:
-    return _home_path() / ".config" / "efp" / "aws-adfs-credential-process.py"
 
 
 def _aws_config_section_name(profile_name: str) -> str:

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -27,7 +27,7 @@ _GIT_INCLUDE_END = "# END EFP_RUNTIME_PROFILE_GIT_INCLUDE"
 _REDACTED_SECRET = "[REDACTED_SECRET]"
 _PROXY_URL_ENV_KEYS = ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "all_proxy", "ALL_PROXY")
 _PROFILE_SECRET_KEY_NAMES = frozenset({"api_key", "password", "token", "api_token", "access_token", "secret"})
-_AWS_ADFS_DEFAULT_COMMAND = "adfs-assume"
+_AWS_AUTH_DEFAULT_COMMAND = "aws-auth"
 _RUNTIME_VENV_BIN_DIRS = ("/app/venv/bin", "/opt/venv/bin")
 _yaml = YAML()
 _yaml.default_flow_style = False
@@ -66,7 +66,7 @@ def apply_runtime_profile_external_config(
             cli_environment=cli_environment,
         )
         _apply_github(profile_config, metadata=metadata, cli_environment=cli_environment)
-        _apply_aws(profile_config, metadata=metadata)
+        _apply_aws(profile_config, metadata=metadata, cli_environment=cli_environment)
         _apply_git_user(profile_config, metadata=metadata, cli_environment=cli_environment)
     except Exception:
         if _metadata_has_managed_entries(metadata):
@@ -538,6 +538,7 @@ def _apply_aws(
     profile_config: dict[str, Any],
     *,
     metadata: dict[str, Any],
+    cli_environment: _CliEnvironment,
 ) -> None:
     aws_config = _build_aws_config(profile_config)
     if aws_config is None:
@@ -549,7 +550,7 @@ def _apply_aws(
     previous_credentials = _read_ini_section(credentials_path, credentials_section)
 
     metadata["aws"] = {
-        "auth_type": "adfs_assume_cli",
+        "auth_type": "aws_auth_cli",
         "credentials_path": str(credentials_path),
         "credentials_section": credentials_section,
         "command": _format_command(aws_config["command"], (aws_config["password"],)),
@@ -561,9 +562,9 @@ def _apply_aws(
     try:
         _run_cli(
             aws_config["command"],
-            env=_aws_env(aws_config),
+            env=_aws_env(cli_environment),
             secrets=(aws_config["password"],),
-            env_secrets=(aws_config["password"],),
+            env_secrets=cli_environment.secrets,
         )
     except Exception:
         _restore_aws_profile(metadata["aws"])
@@ -583,17 +584,18 @@ def _build_aws_config(profile_config: dict[str, Any]) -> dict[str, Any] | None:
         "domain": domain,
         "username": username,
         "password": password,
-        "command": _aws_command(domain=domain, username=username),
+        "command": _aws_command(),
     }
 
 
-def _aws_command(*, domain: str, username: str) -> list[str]:
-    return [_AWS_ADFS_DEFAULT_COMMAND, "--jenkins", "-n", "-d", domain, "-u", username]
+def _aws_command() -> list[str]:
+    return [_AWS_AUTH_DEFAULT_COMMAND, "login", "--json"]
 
 
-def _aws_env(aws_config: dict[str, Any]) -> dict[str, str]:
-    env = os.environ.copy()
-    env["AD_PASS"] = aws_config["password"]
+def _aws_env(cli_environment: _CliEnvironment) -> dict[str, str]:
+    env = dict(cli_environment.env)
+    for key in ("AD_PASS", "password"):
+        env.pop(key, None)
     env["PATH"] = _path_with_runtime_venv_bins(env.get("PATH", ""))
     return env
 

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -223,11 +223,16 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
     persisted = _read_yaml(config_path)
     assert "jira" not in persisted
     assert "confluence" not in persisted
-    assert "aws" not in persisted
+    assert persisted["aws"] == {
+        "enabled": True,
+        "domain": "HBEU",
+        "username": "aws-user",
+        "password": "aws-password",
+    }
     assert persisted["instruction_texts"]
     assert "jira-token" not in config_path.read_text(encoding="utf-8")
     assert "conf-token" not in config_path.read_text(encoding="utf-8")
-    assert "aws-password" not in config_path.read_text(encoding="utf-8")
+    assert "aws-password" in config_path.read_text(encoding="utf-8")
     assert applied[0]["jira"]["instances"][0]["token"] == "jira-token"
     assert applied[0]["confluence"]["instances"][0]["token"] == "conf-token"
     assert applied[0]["aws"]["domain"] == "HBEU"
@@ -240,12 +245,12 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
     ]
 
 
-def test_runtime_profile_aws_external_config_runs_adfs_assume_with_ad_pass_and_clears_files(tmp_path, monkeypatch):
+def test_runtime_profile_aws_external_config_runs_aws_auth_tool_and_clears_files(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("PATH", "/usr/local/bin")
-    for key in ("password", "ADFS_PASSWORD", "AWS_ADFS_PASSWORD"):
+    for key in ("password", "AD_PASS"):
         monkeypatch.delenv(key, raising=False)
     recorder = _CliRecorder(record_env=True)
     monkeypatch.setattr(profile_config_module.subprocess, "run", recorder.run)
@@ -271,25 +276,20 @@ def test_runtime_profile_aws_external_config_runs_adfs_assume_with_ad_pass_and_c
     assert not auth_path.exists()
     assert not helper_path.exists()
 
-    assume_call = next(call for call in recorder.calls if call["args"][0] == "adfs-assume")
+    assume_call = next(call for call in recorder.calls if call["args"][0] == "aws-auth")
     assume_args = assume_call["args"]
-    assert "--jenkins" in assume_args
-    assert "-n" in assume_args
-    assert assume_args[assume_args.index("-d") + 1] == "HBEU"
-    assert assume_args[assume_args.index("-u") + 1] == "aws-user"
+    assert assume_args == ["aws-auth", "login", "--json"]
     assert "aws-password" not in " ".join(assume_args)
     assume_env = assume_call["env"]
-    assert assume_env["AD_PASS"] == "aws-password"
+    assert "AD_PASS" not in assume_env
     assert "password" not in assume_env
-    assert "ADFS_PASSWORD" not in assume_env
-    assert "AWS_ADFS_PASSWORD" not in assume_env
     assert "/app/venv/bin" in assume_env["PATH"]
 
     metadata_path = home / ".config" / "efp" / "runtime-profile-external-config.json"
     metadata_text = metadata_path.read_text(encoding="utf-8")
     assert "aws-password" not in metadata_text
     metadata = json.loads(metadata_text)
-    assert metadata["aws"]["auth_type"] == "adfs_assume_cli"
+    assert metadata["aws"]["auth_type"] == "aws_auth_cli"
 
     profile_config_module.clear_runtime_profile_external_config()
     assert not aws_config.exists()
@@ -299,18 +299,18 @@ def test_runtime_profile_aws_external_config_runs_adfs_assume_with_ad_pass_and_c
     assert not metadata_path.exists()
 
 
-def test_runtime_profile_aws_adfs_assume_failure_redacts_ad_pass(tmp_path, monkeypatch):
+def test_runtime_profile_aws_auth_failure_redacts_password(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
     captured = {}
 
-    def fail_adfs(args, input=None, text=False, capture_output=False, check=False, env=None):
+    def fail_aws_auth(args, input=None, text=False, capture_output=False, check=False, env=None):
         captured["args"] = list(args)
         captured["env"] = dict(env or {})
         return _FakeCompleted(returncode=1, stderr="login failed for aws-password")
 
-    monkeypatch.setattr(profile_config_module.subprocess, "run", fail_adfs)
+    monkeypatch.setattr(profile_config_module.subprocess, "run", fail_aws_auth)
 
     with pytest.raises(RuntimeError) as exc:
         profile_config_module.apply_runtime_profile_external_config(
@@ -324,8 +324,8 @@ def test_runtime_profile_aws_adfs_assume_failure_redacts_ad_pass(tmp_path, monke
             }
         )
 
-    assert captured["args"][:1] == ["adfs-assume"]
-    assert captured["env"]["AD_PASS"] == "aws-password"
+    assert captured["args"] == ["aws-auth", "login", "--json"]
+    assert "AD_PASS" not in captured["env"]
     assert "aws-password" not in str(exc.value)
     assert "[REDACTED_SECRET]" in str(exc.value)
     assert not (home / ".aws" / "config").exists()

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -213,10 +213,8 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
             },
             "aws": {
                 "enabled": True,
-                "profile": "prod",
-                "region": "us-east-1",
-                "output": "json",
-                "username": "adfs-user",
+                "domain": "HBEU",
+                "username": "aws-user",
                 "password": "aws-password",
             },
         },
@@ -232,6 +230,7 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
     assert "aws-password" not in config_path.read_text(encoding="utf-8")
     assert applied[0]["jira"]["instances"][0]["token"] == "jira-token"
     assert applied[0]["confluence"]["instances"][0]["token"] == "conf-token"
+    assert applied[0]["aws"]["domain"] == "HBEU"
     assert applied[0]["aws"]["password"] == "aws-password"
     assert cfg.get_managed_overlay_meta()["managed_sections"] == [
         "aws",
@@ -255,29 +254,16 @@ def test_runtime_profile_aws_external_config_runs_adfs_assume_with_ad_pass_and_c
         {
             "aws": {
                 "enabled": True,
-                "profile": "prod",
-                "region": "us-east-1",
-                "output": "json",
-                "username": "adfs-user",
-                "password": "aws-password",
-                "account_no": "123456789012",
-                "role": "Engineer",
                 "domain": "HBEU",
-                "session_duration_minutes": "720",
+                "username": "aws-user",
+                "password": "aws-password",
             }
         }
     )
 
     aws_config = home / ".aws" / "config"
     aws_credentials = home / ".aws" / "credentials"
-    if os.name != "nt":
-        assert aws_config.stat().st_mode & 0o777 == 0o600
-
-    config_text = aws_config.read_text(encoding="utf-8")
-    assert "[profile prod]" in config_text
-    assert "region = us-east-1" in config_text
-    assert "output = json" in config_text
-    assert "credential_process =" not in config_text
+    assert not aws_config.exists()
     assert not aws_credentials.exists()
 
     auth_path = home / ".config" / "efp" / "runtime-profile-aws-adfs-auth.json"
@@ -289,13 +275,8 @@ def test_runtime_profile_aws_external_config_runs_adfs_assume_with_ad_pass_and_c
     assume_args = assume_call["args"]
     assert "--jenkins" in assume_args
     assert "-n" in assume_args
-    assert assume_args[assume_args.index("-u") + 1] == "adfs-user"
-    assert assume_args[assume_args.index("-p") + 1] == "prod"
-    assert assume_args[assume_args.index("-R") + 1] == "us-east-1"
-    assert assume_args[assume_args.index("-a") + 1] == "123456789012"
-    assert assume_args[assume_args.index("-r") + 1] == "Engineer"
     assert assume_args[assume_args.index("-d") + 1] == "HBEU"
-    assert assume_args[assume_args.index("--session-duration-minutes") + 1] == "720"
+    assert assume_args[assume_args.index("-u") + 1] == "aws-user"
     assert "aws-password" not in " ".join(assume_args)
     assume_env = assume_call["env"]
     assert assume_env["AD_PASS"] == "aws-password"
@@ -308,7 +289,6 @@ def test_runtime_profile_aws_external_config_runs_adfs_assume_with_ad_pass_and_c
     metadata_text = metadata_path.read_text(encoding="utf-8")
     assert "aws-password" not in metadata_text
     metadata = json.loads(metadata_text)
-    assert metadata["aws"]["profile"] == "prod"
     assert metadata["aws"]["auth_type"] == "adfs_assume_cli"
 
     profile_config_module.clear_runtime_profile_external_config()
@@ -337,16 +317,14 @@ def test_runtime_profile_aws_adfs_assume_failure_redacts_ad_pass(tmp_path, monke
             {
                 "aws": {
                     "enabled": True,
-                    "profile": "prod",
-                    "region": "us-east-1",
-                    "username": "adfs-user",
+                    "domain": "HBEU",
+                    "username": "aws-user",
                     "password": "aws-password",
-                    "assume_command": "custom-adfs-assume",
                 }
             }
         )
 
-    assert captured["args"][:1] == ["custom-adfs-assume"]
+    assert captured["args"][:1] == ["adfs-assume"]
     assert captured["env"]["AD_PASS"] == "aws-password"
     assert "aws-password" not in str(exc.value)
     assert "[REDACTED_SECRET]" in str(exc.value)


### PR DESCRIPTION
## Summary
- Keep the Portal-managed AWS profile in `config.yaml` so the shared tools config can be read by `aws-auth`.
- Replace native direct `adfs-assume` invocation with `aws-auth login --json` using `EFP_CONFIG`.
- Avoid passing `AD_PASS` from native runtime code; password handling is delegated to the tools CLI, while runtime metadata and errors remain redacted.

Depends on dvnuo/engineering-flow-platform-tools#42.

## Validation
- `pytest tests/test_runtime_profile_overlay.py --basetemp .pytest-tmp -p no:cacheprovider`
- Additional native profile/client/config subset: 50 passed; `tests/test_runtime_api_runtime_profile.py` still fails in the lightweight loader import path before exercising this change.