### PR TITLE
[codex] Configure AWS auth profile via CLI

### DIFF
--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -551,17 +551,18 @@ def _apply_aws(
 
     metadata["aws"] = {
         "auth_type": "aws_auth_cli",
-        "credentials_path": str(credentials_path),
-        "credentials_section": credentials_section,
         "command": _format_command(aws_config["command"], (aws_config["password"],)),
-        "previous": {
-            "credentials": previous_credentials,
-        },
+        "previous": {},
     }
+    if previous_credentials is not None:
+        metadata["aws"]["credentials_path"] = str(credentials_path)
+        metadata["aws"]["credentials_section"] = credentials_section
+        metadata["aws"]["previous"]["credentials"] = previous_credentials
 
     try:
         _run_cli(
             aws_config["command"],
+            input_text=aws_config["password"],
             env=_aws_env(cli_environment),
             secrets=(aws_config["password"],),
             env_secrets=cli_environment.secrets,
@@ -584,12 +585,22 @@ def _build_aws_config(profile_config: dict[str, Any]) -> dict[str, Any] | None:
         "domain": domain,
         "username": username,
         "password": password,
-        "command": _aws_command(),
+        "command": _aws_configure_command(domain=domain, username=username),
     }
 
 
-def _aws_command() -> list[str]:
-    return [_AWS_AUTH_DEFAULT_COMMAND, "login", "--json"]
+def _aws_configure_command(*, domain: str, username: str) -> list[str]:
+    return [
+        _AWS_AUTH_DEFAULT_COMMAND,
+        "auth",
+        "login",
+        "--domain",
+        domain,
+        "--username",
+        username,
+        "--password-stdin",
+        "--json",
+    ]
 
 
 def _aws_env(cli_environment: _CliEnvironment) -> dict[str, str]:
@@ -612,8 +623,6 @@ def _restore_aws_profile(aws_meta: dict[str, Any]) -> None:
     credentials_section = _string_or_empty(aws_meta.get("credentials_section")) or profile_name
     previous = aws_meta.get("previous") if isinstance(aws_meta.get("previous"), dict) else {}
 
-    credentials_path = Path(str(aws_meta.get("credentials_path") or _aws_credentials_path()))
-
     previous_config = previous.get("config") if isinstance(previous.get("config"), dict) else None
     previous_credentials = previous.get("credentials") if isinstance(previous.get("credentials"), dict) else None
 
@@ -625,10 +634,13 @@ def _restore_aws_profile(aws_meta: dict[str, Any]) -> None:
         else:
             _set_ini_section_exact(config_path, config_section, previous_config)
 
-    if previous_credentials is None:
-        _remove_ini_section(credentials_path, credentials_section)
-    else:
-        _set_ini_section_exact(credentials_path, credentials_section, previous_credentials)
+    credentials_path_value = aws_meta.get("credentials_path")
+    if credentials_path_value or previous_credentials is not None:
+        credentials_path = Path(str(credentials_path_value or _aws_credentials_path()))
+        if previous_credentials is None:
+            _remove_ini_section(credentials_path, credentials_section)
+        else:
+            _set_ini_section_exact(credentials_path, credentials_section, previous_credentials)
 
     for key in ("auth_path", "helper_path"):
         raw_path = aws_meta.get(key)

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -278,7 +278,18 @@ def test_runtime_profile_aws_external_config_runs_aws_auth_tool_and_clears_files
 
     assume_call = next(call for call in recorder.calls if call["args"][0] == "aws-auth")
     assume_args = assume_call["args"]
-    assert assume_args == ["aws-auth", "login", "--json"]
+    assert assume_args == [
+        "aws-auth",
+        "auth",
+        "login",
+        "--domain",
+        "HBEU",
+        "--username",
+        "aws-user",
+        "--password-stdin",
+        "--json",
+    ]
+    assert assume_call["input"] == "aws-password"
     assert "aws-password" not in " ".join(assume_args)
     assume_env = assume_call["env"]
     assert "AD_PASS" not in assume_env
@@ -307,6 +318,7 @@ def test_runtime_profile_aws_auth_failure_redacts_password(tmp_path, monkeypatch
 
     def fail_aws_auth(args, input=None, text=False, capture_output=False, check=False, env=None):
         captured["args"] = list(args)
+        captured["input"] = input
         captured["env"] = dict(env or {})
         return _FakeCompleted(returncode=1, stderr="login failed for aws-password")
 
@@ -324,7 +336,18 @@ def test_runtime_profile_aws_auth_failure_redacts_password(tmp_path, monkeypatch
             }
         )
 
-    assert captured["args"] == ["aws-auth", "login", "--json"]
+    assert captured["args"] == [
+        "aws-auth",
+        "auth",
+        "login",
+        "--domain",
+        "HBEU",
+        "--username",
+        "aws-user",
+        "--password-stdin",
+        "--json",
+    ]
+    assert captured["input"] == "aws-password"
     assert "AD_PASS" not in captured["env"]
     assert "aws-password" not in str(exc.value)
     assert "[REDACTED_SECRET]" in str(exc.value)


### PR DESCRIPTION
## Summary

Updates native runtime profile external config handling so AWS profile apply calls `aws-auth auth login --password-stdin` to save reusable ADFS auth settings. The flow no longer performs an immediate credential login from runtime profile apply, so account and role remain per-login inputs.

The metadata cleanup path was adjusted so profile clearing does not remove credentials generated later by a separate `aws-auth login --account --role` run unless previous credentials were actually captured.

## Validation

- `python -m pytest tests/test_runtime_profile_overlay.py -q`