### PR TITLE
[codex] Apply runtime profile proxy env globally

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -244,6 +244,16 @@ class Config:
         Path.home() / ".efp" / "config.yaml",  # User config directory
         Path(__file__).parent / "config.yaml",  # Project directory
     ]
+    PROXY_ENV_VARS = (
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+    )
 
     PROJECT_EXAMPLE = Path(__file__).parent.parent / 'config.yaml.example'
     MANAGED_OVERLAY_SECTIONS = {
@@ -549,7 +559,14 @@ class Config:
         changed_sections = sorted(previous_sections | new_sections)
         self.reload(changed_sections=changed_sections)
         if "proxy" in changed_sections:
-            self.apply_proxy()
+            if (
+                "proxy" in previous_sections
+                and "proxy" not in new_sections
+                and "proxy" not in self._config
+            ):
+                self._clear_proxy_env()
+            else:
+                self.apply_proxy()
         return changed_sections
 
     def clear_managed_overlay(self) -> None:
@@ -583,7 +600,10 @@ class Config:
         self._cleanup_legacy_runtime_profile_file()
         self.reload(changed_sections=previous_sections)
         if "proxy" in previous_sections:
-            self.apply_proxy()
+            if "proxy" in self._config:
+                self.apply_proxy()
+            else:
+                self._clear_proxy_env()
 
     def get_effective_config(self) -> Dict[str, Any]:
         return copy.deepcopy(self._config)
@@ -934,6 +954,10 @@ class Config:
     def proxy(self) -> Dict[str, Any]:
         """Get proxy configuration."""
         return self._config.get("proxy", {})
+
+    def _clear_proxy_env(self) -> None:
+        for var in self.PROXY_ENV_VARS:
+            os.environ.pop(var, None)
     
     def apply_proxy(self) -> None:
         """Apply proxy settings to os.environ."""
@@ -951,6 +975,8 @@ class Config:
             os.environ["https_proxy"] = url
             os.environ["HTTP_PROXY"] = url
             os.environ["HTTPS_PROXY"] = url
+            os.environ["all_proxy"] = url
+            os.environ["ALL_PROXY"] = url
             # Handle no_proxy for internal addresses
             no_proxy = no_proxy_value(proxy_config)
             os.environ["no_proxy"] = no_proxy
@@ -958,8 +984,7 @@ class Config:
         elif "proxy" in self._config:
             # Only clear if proxy section exists but is disabled
             # Don't clear inherited env vars when proxy section is absent
-            for var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]:
-                os.environ.pop(var, None)
+            self._clear_proxy_env()
     
     @property
     def heartbeat(self) -> Dict[str, Any]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,7 +153,16 @@ class TestConfigEdgeCases:
 class TestConfigProxy:
     """Tests for proxy configuration handling."""
 
-    PROXY_ENV_KEYS = ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]
+    PROXY_ENV_KEYS = [
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+    ]
 
     def _prepare_proxy_env(self, monkeypatch, clear: bool = True):
         """Ensure proxy env vars are tracked and optionally cleared for test isolation."""
@@ -182,6 +191,8 @@ class TestConfigProxy:
         assert os.environ["https_proxy"] == expected_url
         assert os.environ["HTTP_PROXY"] == expected_url
         assert os.environ["HTTPS_PROXY"] == expected_url
+        assert os.environ["all_proxy"] == expected_url
+        assert os.environ["ALL_PROXY"] == expected_url
 
     def test_apply_proxy_with_special_characters_in_credentials(self, tmp_path, monkeypatch):
         """Test apply_proxy() URL-encodes special characters in credentials."""
@@ -203,6 +214,8 @@ class TestConfigProxy:
         assert os.environ["https_proxy"] == expected_url
         assert os.environ["HTTP_PROXY"] == expected_url
         assert os.environ["HTTPS_PROXY"] == expected_url
+        assert os.environ["all_proxy"] == expected_url
+        assert os.environ["ALL_PROXY"] == expected_url
 
     def test_apply_proxy_disabled_clears_proxy_env_when_proxy_section_exists(self, tmp_path, monkeypatch):
         """Test disabled proxy clears proxy-related env vars when section exists."""

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -534,7 +534,16 @@ def test_runtime_profile_apply_filters_unmanaged_nested_fields_from_snapshot(tmp
 def test_runtime_profile_apply_prunes_stale_managed_proxy_fields(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
     _write_base_config(config_path)
-    for key in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]:
+    for key in [
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+    ]:
         monkeypatch.delenv(key, raising=False)
 
     cfg = Config(str(config_path))
@@ -544,18 +553,40 @@ def test_runtime_profile_apply_prunes_stale_managed_proxy_fields(tmp_path, monke
         {"proxy": {"enabled": True, "url": "http://overlay.proxy.local:8080", "password": "secret"}},
     )
     assert os.environ["http_proxy"] == "http://overlay.proxy.local:8080"
+    assert os.environ["all_proxy"] == "http://overlay.proxy.local:8080"
+    assert os.environ["ALL_PROXY"] == "http://overlay.proxy.local:8080"
 
     cfg.set_managed_overlay("rp_proxy", 2, {"llm": {"provider": "openai"}})
     cfg.load()
     assert cfg.proxy.get("enabled") is None
     assert cfg.proxy.get("url") is None
     assert cfg.proxy.get("password") is None
+    for key in [
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+    ]:
+        assert key not in os.environ
 
 
 def test_runtime_profile_apply_allows_proxy_no_proxy_fields(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
     _write_base_config(config_path)
-    for key in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]:
+    for key in [
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+    ]:
         monkeypatch.delenv(key, raising=False)
 
     cfg = Config(str(config_path))
@@ -622,7 +653,16 @@ def test_set_managed_overlay_external_cli_failure_is_non_fatal(tmp_path, monkeyp
     config_path = tmp_path / "config.yaml"
     runtime_profile_path = tmp_path / "runtime_profile.yaml"
     _write_base_config(config_path)
-    for key in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"]:
+    for key in [
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+    ]:
         monkeypatch.delenv(key, raising=False)
     token = "gh-secret-token"
     proxy_password = "proxy-url-secret"


### PR DESCRIPTION
## Summary

- Set `all_proxy` and `ALL_PROXY` alongside the existing HTTP/HTTPS proxy environment variables when native runtime profile proxy config is enabled.
- Clear the full proxy environment set when a Portal-managed proxy is disabled or removed, so stale runtime profile proxy values do not leak into later agent/tool CLI runs.
- Expand proxy tests to cover the additional env vars and managed profile removal behavior.

## Why

OpenCode already writes both HTTP/HTTPS and ALL proxy env vars into its runtime env file. Native runtime only applied HTTP/HTTPS globally, which meant some Linux CLI tools that prefer `ALL_PROXY` could miss the Portal runtime profile proxy.

## Validation

- `python -m pytest tests/test_config.py::TestConfigProxy tests/test_runtime_profile_overlay.py -q`