### PR TITLE
[codex] Add resumable chat run recovery

### DIFF
--- a/src/gateway/chat_run_registry.py
+++ b/src/gateway/chat_run_registry.py
@@ -1,0 +1,144 @@
+"""In-memory registry for resumable chat executions."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+
+TERMINAL_STATES = {"completed", "failed", "cancelled"}
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class ChatRunRecord:
+    request_id: str
+    session_id: str
+    engine: str = "native"
+    state: str = "running"
+    started_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
+    latest_event_at: str = ""
+    latest_event_seq: int = 0
+    replay_available: bool = True
+    detached_viewers: int = 0
+    final_payload: Optional[Dict[str, Any]] = None
+    error_payload: Optional[Dict[str, Any]] = None
+    task: Optional[asyncio.Task] = field(default=None, repr=False)
+
+    @property
+    def terminal(self) -> bool:
+        return self.state in TERMINAL_STATES
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "engine": self.engine,
+            "session_id": self.session_id,
+            "request_id": self.request_id,
+            "state": self.state,
+            "terminal": self.terminal,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "latest_event_at": self.latest_event_at,
+            "latest_event_seq": self.latest_event_seq,
+            "replay_available": self.replay_available,
+            "detached_viewers": self.detached_viewers,
+            "final_payload": self.final_payload,
+            "error_payload": self.error_payload,
+        }
+
+
+class ChatRunRegistry:
+    def __init__(self, *, max_records: int = 512) -> None:
+        self._records: Dict[str, ChatRunRecord] = {}
+        self._max_records = max_records
+
+    def start(self, *, session_id: str, request_id: str, engine: str = "native") -> ChatRunRecord:
+        existing = self.get(request_id, session_id=session_id)
+        if existing is not None:
+            return existing
+        record = ChatRunRecord(request_id=request_id, session_id=session_id, engine=engine)
+        self._records[request_id] = record
+        self._prune_terminal_records()
+        return record
+
+    def _prune_terminal_records(self) -> None:
+        if len(self._records) <= self._max_records:
+            return
+        overflow = len(self._records) - self._max_records
+        terminal_records = sorted(
+            (record for record in self._records.values() if record.terminal),
+            key=lambda record: record.updated_at,
+        )
+        for record in terminal_records[:overflow]:
+            self._records.pop(record.request_id, None)
+
+    def get(self, request_id: str, *, session_id: str | None = None) -> ChatRunRecord | None:
+        normalized_request_id = str(request_id or "").strip()
+        if not normalized_request_id:
+            return None
+        record = self._records.get(normalized_request_id)
+        if record is None:
+            return None
+        if session_id and record.session_id != session_id:
+            return None
+        return record
+
+    def attach_task(self, request_id: str, task: asyncio.Task) -> None:
+        record = self.get(request_id)
+        if record is not None:
+            record.task = task
+            record.updated_at = utc_now_iso()
+
+    def record_event(self, request_id: str, event: Dict[str, Any]) -> None:
+        record = self.get(request_id)
+        if record is None or record.terminal:
+            return
+        record.latest_event_seq += 1
+        created_at = event.get("created_at") if isinstance(event, dict) else None
+        record.latest_event_at = str(created_at or utc_now_iso())
+        record.updated_at = utc_now_iso()
+
+    def mark_detached(self, request_id: str) -> None:
+        record = self.get(request_id)
+        if record is None or record.terminal:
+            return
+        record.detached_viewers += 1
+        record.updated_at = utc_now_iso()
+
+    def complete(self, request_id: str, final_payload: Dict[str, Any]) -> None:
+        record = self.get(request_id)
+        if record is None:
+            return
+        record.state = "completed"
+        record.final_payload = dict(final_payload or {})
+        record.updated_at = utc_now_iso()
+
+    def fail(self, request_id: str, error_payload: Dict[str, Any]) -> None:
+        record = self.get(request_id)
+        if record is None:
+            return
+        if record.state == "cancelled":
+            return
+        record.state = "failed"
+        record.error_payload = dict(error_payload or {})
+        record.updated_at = utc_now_iso()
+
+    def cancel(self, request_id: str) -> bool:
+        record = self.get(request_id)
+        if record is None or record.terminal:
+            return False
+        record.state = "cancelled"
+        record.updated_at = utc_now_iso()
+        if record.task is not None and not record.task.done():
+            record.task.cancel()
+        return True
+
+
+chat_run_registry = ChatRunRegistry()

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -40,6 +40,7 @@ from src.gateway.chat_payloads import (
     build_runtime_response_payload,
     normalize_assistant_history_message,
 )
+from src.gateway.chat_run_registry import chat_run_registry
 from src.gateway.runtime_chat import (
     RuntimeChatError,
     run_runtime_chat,
@@ -698,6 +699,124 @@ def _sse_event_bytes(event_name: str, payload: Any) -> bytes:
     ).encode("utf-8")
 
 
+async def _try_write_sse_event(
+    response: web.StreamResponse,
+    event_name: str,
+    payload: Any,
+    *,
+    request_id: Optional[str] = None,
+) -> bool:
+    try:
+        await response.write(_sse_event_bytes(event_name, payload))
+        return True
+    except (ConnectionResetError, RuntimeError):
+        if request_id:
+            chat_run_registry.mark_detached(request_id)
+        return False
+
+
+async def _chat_run_status_from_session(session_id: str, request_id: str) -> Optional[Dict[str, Any]]:
+    if not session_id or not request_id:
+        return None
+    try:
+        session = await session_manager.get_existing_session(session_id)
+    except Exception:
+        logger.debug("Failed to inspect session while resolving chat run status", exc_info=True)
+        return None
+    if not isinstance(session, dict):
+        return None
+    metadata = session.get("metadata") if isinstance(session.get("metadata"), dict) else {}
+    if str(metadata.get("last_execution_id") or "").strip() != request_id:
+        return None
+    raw_status = str(metadata.get("last_runtime_status") or "").strip().lower()
+    if raw_status in {"success", "completed", "complete", "ok"}:
+        state = "completed"
+    elif raw_status in {"error", "failed", "failure"}:
+        state = "failed"
+    elif raw_status in {"cancelled", "canceled"}:
+        state = "cancelled"
+    else:
+        state = "completed" if raw_status else "unknown"
+    return {
+        "ok": True,
+        "engine": "native",
+        "session_id": session_id,
+        "request_id": request_id,
+        "state": state,
+        "terminal": state in {"completed", "failed", "cancelled"},
+        "started_at": "",
+        "updated_at": str(metadata.get("last_runtime_updated_at") or ""),
+        "latest_event_at": str(metadata.get("last_runtime_updated_at") or ""),
+        "latest_event_seq": 0,
+        "replay_available": False,
+        "final_payload": None,
+        "source_of_truth": "session_metadata",
+    }
+
+
+async def _chat_run_status_payload(session_id: str, request_id: str) -> Dict[str, Any]:
+    record = chat_run_registry.get(request_id, session_id=session_id or None)
+    if record is not None:
+        payload = record.to_payload()
+        payload["source_of_truth"] = "run_registry"
+        return payload
+    fallback = await _chat_run_status_from_session(session_id, request_id)
+    if fallback is not None:
+        return fallback
+    return {
+        "ok": False,
+        "engine": "native",
+        "session_id": session_id,
+        "request_id": request_id,
+        "state": "unknown",
+        "terminal": False,
+        "replay_available": False,
+        "error": "chat_run_not_found",
+    }
+
+
+async def _stream_existing_chat_run(
+    request: web.Request,
+    *,
+    session_id: str,
+    request_id: str,
+) -> web.StreamResponse:
+    response = web.StreamResponse(
+        status=200,
+        headers={
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+    await response.prepare(request)
+    connected = await _try_write_sse_event(
+        response,
+        "start",
+        {**build_stream_start_event_payload(session_id, request_id), "resumed": True},
+        request_id=request_id,
+    )
+    if not connected:
+        return response
+    while True:
+        payload = await _chat_run_status_payload(session_id, request_id)
+        connected = await _try_write_sse_event(response, "run_status", payload, request_id=request_id)
+        if not connected:
+            return response
+        if payload.get("terminal"):
+            final_payload = payload.get("final_payload")
+            if isinstance(final_payload, dict):
+                connected = await _try_write_sse_event(response, "final", final_payload, request_id=request_id)
+            if connected:
+                await _try_write_sse_event(response, "done", {"ok": True, "session_id": session_id, "request_id": request_id}, request_id=request_id)
+            return response
+        if payload.get("state") == "unknown":
+            await _try_write_sse_event(response, "done", {"ok": False, "session_id": session_id, "request_id": request_id}, request_id=request_id)
+            return response
+        await asyncio.sleep(0.5)
+
+
 def _json_compatible(value: Any) -> Any:
     try:
         json.dumps(value)
@@ -1252,6 +1371,9 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             request_id=request_id,
             session_id=session_id,
         )
+        existing_run = chat_run_registry.get(request_id, session_id=session_id)
+        if existing_run is not None:
+            return await _stream_existing_chat_run(request, session_id=session_id, request_id=request_id)
         effective_user_name = _resolve_chat_display_user_name(data, portal_user_name)
 
         attached_images = await _collect_attached_images(
@@ -1324,9 +1446,13 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         await response.prepare(request)
         response_prepared = True
 
-        # Send start event
-        await response.write(
-            _sse_event_bytes("start", build_stream_start_event_payload(session_id, request_id))
+        # Send start event. A later write failure only detaches this viewer; the
+        # agent run and gateway event publishing continue for refresh recovery.
+        client_connected = await _try_write_sse_event(
+            response,
+            "start",
+            build_stream_start_event_payload(session_id, request_id),
+            request_id=request_id,
         )
 
         event_queue = asyncio.Queue()
@@ -1344,6 +1470,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             agent_name=runtime_agent_name,
             model=model,
         )
+        chat_run_registry.start(session_id=session_id, request_id=request_id, engine="native")
         if runtime_agent_id and session_id:
             try:
                 await publish_session_metadata(
@@ -1378,6 +1505,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
                 transient_model_message=transient_model_message,
             )
         )
+        chat_run_registry.attach_task(request_id, run_task)
 
         while not run_task.done() or not event_queue.empty():
             try:
@@ -1388,7 +1516,14 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
                     event_payloads = runtime_event_projector.project(event)
                 for event_payload in event_payloads:
                     await _emit_gateway_runtime_event(event_payload)
-                    await response.write(_sse_event_bytes("runtime_event", event_payload))
+                    chat_run_registry.record_event(request_id, event_payload)
+                    if client_connected:
+                        client_connected = await _try_write_sse_event(
+                            response,
+                            "runtime_event",
+                            event_payload,
+                            request_id=request_id,
+                        )
             except asyncio.TimeoutError:
                 continue
 
@@ -1438,21 +1573,30 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             'session_id': session_id,
             'request_id': request_id,
         }
-        await response.write(_sse_event_bytes("usage", usage_data))
 
         response_data = build_runtime_response_payload(
             result if isinstance(result, dict) else None,
             session_id,
         )
         response_data.setdefault("request_id", request_id)
-        await response.write(_sse_event_bytes("final", response_data))
+        chat_run_registry.complete(request_id, response_data)
+        if client_connected:
+            client_connected = await _try_write_sse_event(response, "usage", usage_data, request_id=request_id)
+        if client_connected:
+            client_connected = await _try_write_sse_event(response, "final", response_data, request_id=request_id)
 
         # Send done event
-        await response.write(_sse_event_bytes("done", {
-            "ok": True,
-            "session_id": session_id,
-            "request_id": request_id,
-        }))
+        if client_connected:
+            await _try_write_sse_event(
+                response,
+                "done",
+                {
+                    "ok": True,
+                    "session_id": session_id,
+                    "request_id": request_id,
+                },
+                request_id=request_id,
+            )
 
         return response
 
@@ -1481,21 +1625,25 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             error_type=stream_error_type,
             metadata=execution_metadata,
         )
+        error_payload = {
+            "error": str(e),
+            "error_type": stream_error_type,
+            "details": stream_details,
+            "session_id": session_id,
+            "request_id": request_id,
+        }
+        if request_id:
+            chat_run_registry.fail(request_id, error_payload)
         if response is not None and response_prepared:
             try:
-                await response.write(
-                    _sse_event_bytes(
-                        "error",
-                        {
-                            "error": str(e),
-                            "error_type": stream_error_type,
-                            "details": stream_details,
-                            "session_id": session_id,
-                            "request_id": request_id,
-                        },
+                connected = await _try_write_sse_event(response, "error", error_payload, request_id=request_id)
+                if connected:
+                    await _try_write_sse_event(
+                        response,
+                        "done",
+                        {"ok": False, "session_id": session_id, "request_id": request_id},
+                        request_id=request_id,
                     )
-                )
-                await response.write(_sse_event_bytes("done", {"ok": False, "session_id": session_id, "request_id": request_id}))
             except Exception:
                 pass
             return response
@@ -1514,6 +1662,35 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
                 await _cleanup_one_shot_attachments(session_id, attachment_ids)
         finally:
             clear_log_context()
+
+
+async def api_chat_run_status(request: web.Request) -> web.Response:
+    request_id = str(request.match_info.get("request_id") or "").strip()
+    session_id = str(request.query.get("session_id") or "").strip()
+    if not request_id:
+        return web.json_response({"ok": False, "error": "request_id_required"}, status=400)
+    payload = await _chat_run_status_payload(session_id, request_id)
+    status_code = 404 if payload.get("error") == "chat_run_not_found" else 200
+    return web.json_response(payload, status=status_code)
+
+
+async def api_chat_run_cancel(request: web.Request) -> web.Response:
+    request_id = str(request.match_info.get("request_id") or "").strip()
+    session_id = str(request.query.get("session_id") or "").strip()
+    if not request_id:
+        return web.json_response({"ok": False, "error": "request_id_required"}, status=400)
+    record = chat_run_registry.get(request_id, session_id=session_id or None)
+    if record is None:
+        return web.json_response({"ok": False, "error": "chat_run_not_found", "request_id": request_id, "session_id": session_id}, status=404)
+    cancelled = chat_run_registry.cancel(request_id)
+    return web.json_response({
+        "ok": cancelled,
+        "engine": "native",
+        "request_id": request_id,
+        "session_id": record.session_id,
+        "state": "cancelled" if cancelled else record.state,
+        "terminal": True if cancelled else record.terminal,
+    })
 
 
 async def api_tasks_execute(request: web.Request) -> web.Response:
@@ -2893,6 +3070,8 @@ def setup_runtime_api_routes(app: web.Application):
 
     app.router.add_post('/api/chat', api_chat)
     app.router.add_post('/api/chat/stream', api_chat_stream)
+    app.router.add_get('/api/chat/runs/{request_id}', api_chat_run_status)
+    app.router.add_post('/api/chat/runs/{request_id}/cancel', api_chat_run_cancel)
     app.router.add_post('/api/tasks/execute', api_tasks_execute)
     app.router.add_get('/api/tasks/{task_id}', api_task_status)
     app.router.add_post('/api/tasks/{task_id}/cancel', api_task_cancel)

--- a/tests/test_chat_run_registry.py
+++ b/tests/test_chat_run_registry.py
@@ -1,0 +1,39 @@
+from src.gateway.chat_run_registry import ChatRunRegistry
+
+
+def test_chat_run_registry_tracks_events_and_completion():
+    registry = ChatRunRegistry()
+    record = registry.start(session_id="s1", request_id="r1")
+
+    registry.record_event("r1", {"created_at": "2026-06-17T00:00:00Z"})
+    registry.complete("r1", {"ok": True, "response": "done"})
+
+    payload = record.to_payload()
+    assert payload["state"] == "completed"
+    assert payload["terminal"] is True
+    assert payload["latest_event_seq"] == 1
+    assert payload["final_payload"]["response"] == "done"
+
+
+def test_chat_run_registry_cancel_is_not_overwritten_by_late_failure():
+    registry = ChatRunRegistry()
+    registry.start(session_id="s1", request_id="r1")
+
+    assert registry.cancel("r1") is True
+    registry.fail("r1", {"error": "late"})
+
+    payload = registry.get("r1").to_payload()
+    assert payload["state"] == "cancelled"
+    assert payload["terminal"] is True
+
+
+def test_chat_run_registry_prunes_only_terminal_records():
+    registry = ChatRunRegistry(max_records=2)
+    registry.start(session_id="s1", request_id="old")
+    registry.complete("old", {"ok": True})
+    registry.start(session_id="s1", request_id="running")
+    registry.start(session_id="s1", request_id="new")
+
+    assert registry.get("old") is None
+    assert registry.get("running") is not None
+    assert registry.get("new") is not None

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -34,6 +34,8 @@ class TestRuntimeApiRoutes:
 
         assert "/" not in routes
         assert '/api/chat' in routes
+        assert '/api/chat/runs/{request_id}' in routes
+        assert '/api/chat/runs/{request_id}/cancel' in routes
         assert '/api/sessions' in routes
         assert '/api/sessions/{session_id}/rename' in routes
         assert '/api/sessions/{session_id}' in routes


### PR DESCRIPTION
## Summary

Adds a lightweight in-memory chat run registry for native runtime streaming chat so a browser refresh can reconnect to the original agent execution by `request_id` and `session_id` instead of starting a duplicate run.

## What changed

- Track running, completed, failed, cancelled, and detached chat runs.
- Keep the runtime task alive after SSE viewer disconnects and continue publishing gateway runtime events.
- Add run status and cancel endpoints under `/api/chat/runs/{request_id}`.
- Reuse an existing run when `/api/chat/stream` receives the same `request_id`.
- Add bounded pruning for old terminal registry records.

## Validation

- `python -m py_compile src\gateway\chat_run_registry.py src\gateway\runtime_api.py`
- `python -m pytest tests\test_chat_run_registry.py tests\test_runtime_api.py::TestRuntimeApiRoutes::test_routes_registered tests\test_runtime_api.py::test_api_chat_stream_emits_runtime_event_json_before_done_while_task_running tests\test_runtime_api.py::test_api_chat_stream_emits_final_payload_before_done -q`
- `git diff --check`