### PR TITLE
[codex] Align native instruction loading with OpenCode

### DIFF
--- a/src/efp_runtime/config_loader.py
+++ b/src/efp_runtime/config_loader.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
+import glob
 import json
 import os
 from pathlib import Path
@@ -937,23 +938,23 @@ def _instruction_sources(
     value: Any,
     *,
     workspace_root: Path,
-) -> tuple[list[Path], list[str]]:
-    paths: list[Path] = []
+) -> tuple[list[str | Path], list[str]]:
+    paths: list[str | Path] = []
     texts: list[str] = []
 
     for entry in _coerce_sequence(value):
         if isinstance(entry, Mapping):
             if "path" in entry:
                 paths.extend(
-                    _resolve_path_values(workspace_root, entry["path"])
+                    _resolve_instruction_path_values(workspace_root, entry["path"])
                 )
             if "text" in entry:
                 texts.extend(_string_values(entry["text"]))
             continue
         if _path_has_value(entry):
-            paths.append(_resolve_workspace_path(workspace_root, entry))
+            paths.extend(_resolve_instruction_path_values(workspace_root, entry))
 
-    return _dedupe_paths(paths), _dedupe_strings(texts)
+    return _dedupe_instruction_paths(paths), _dedupe_strings(texts)
 
 
 def _merged_alias_mapping(
@@ -1014,6 +1015,21 @@ def _resolve_path_values(workspace_root: Path, value: Any) -> list[Path]:
         for path in _coerce_sequence(value)
         if _path_has_value(path)
     ]
+
+
+def _resolve_instruction_path_values(
+    workspace_root: Path,
+    value: Any,
+) -> list[str | Path]:
+    paths: list[str | Path] = []
+    for path in _coerce_sequence(value):
+        if not _path_has_value(path):
+            continue
+        if isinstance(path, (str, Path)) and glob.has_magic(str(path)):
+            paths.append(str(path))
+            continue
+        paths.append(_resolve_workspace_path(workspace_root, path))
+    return paths
 
 
 def _string_values(value: Any) -> list[str]:
@@ -1098,6 +1114,18 @@ def _dedupe_paths(paths: Iterable[Path]) -> list[Path]:
     for path in paths:
         marker = str(path)
         if marker in seen:
+            continue
+        seen.add(marker)
+        deduped.append(path)
+    return deduped
+
+
+def _dedupe_instruction_paths(paths: Iterable[str | Path]) -> list[str | Path]:
+    deduped: list[str | Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        marker = str(path)
+        if not marker.strip() or marker in seen:
             continue
         seen.add(marker)
         deduped.append(path)

--- a/src/efp_runtime/instructions/context.py
+++ b/src/efp_runtime/instructions/context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import glob
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,7 @@ from ..session.models import Message, MessagePart, MessageRole
 
 
 DEFAULT_INSTRUCTION_FILES = ("AGENTS.md",)
+DEFAULT_INSTRUCTION_GLOBS = (".efp/instructions/*.instructions.md",)
 _TRUNCATION_NOTICE = "[Instruction content truncated to {kept} of {original} chars.]"
 
 
@@ -24,6 +26,7 @@ class InstructionContextBuilder:
         instruction_texts: Iterable[str] = (),
         include_default_files: bool = True,
         default_file_names: Iterable[str] = DEFAULT_INSTRUCTION_FILES,
+        default_glob_patterns: Iterable[str] = DEFAULT_INSTRUCTION_GLOBS,
         max_instruction_chars: int = 20000,
     ) -> None:
         if max_instruction_chars < 0:
@@ -33,6 +36,9 @@ class InstructionContextBuilder:
         self.instruction_texts = list(instruction_texts)
         self.include_default_files = bool(include_default_files)
         self.default_file_names = [str(name) for name in default_file_names]
+        self.default_glob_patterns = [
+            str(pattern) for pattern in default_glob_patterns if str(pattern).strip()
+        ]
         self.max_instruction_chars = max_instruction_chars
 
     def build_messages(
@@ -70,19 +76,33 @@ class InstructionContextBuilder:
     ) -> list[Path]:
         paths: list[Path] = []
         root = _resolved_directory_path(self.workspace_root)
+        search_cwd = _metadata_cwd(metadata) if cwd is None else cwd
         if self.include_default_files and root is not None:
             default_path = _first_ancestor_instruction_path(
                 root,
-                cwd=_metadata_cwd(metadata) if cwd is None else cwd,
+                cwd=search_cwd,
                 default_file_names=self.default_file_names,
             )
             if default_path is not None:
                 paths.append(default_path)
+            for pattern in self.default_glob_patterns:
+                paths.extend(
+                    _expand_configured_paths(
+                        pattern,
+                        workspace_root=root,
+                        cwd=search_cwd,
+                        search_ancestors=True,
+                    )
+                )
 
         for raw_path in self.instruction_paths:
-            path = _resolve_configured_path(raw_path, workspace_root=root)
-            if path is not None:
-                paths.append(path)
+            paths.extend(
+                _configured_instruction_paths(
+                    raw_path,
+                    workspace_root=root,
+                    cwd=search_cwd,
+                )
+            )
 
         return paths
 
@@ -289,6 +309,66 @@ def _resolve_configured_path(
     return workspace_root / expanded
 
 
+def _configured_instruction_paths(
+    path: str | Path,
+    *,
+    workspace_root: Path | None,
+    cwd: str | Path | None,
+) -> list[Path]:
+    if isinstance(path, str) and not path.strip():
+        return []
+    if _has_glob_magic(path):
+        return _expand_configured_paths(
+            path,
+            workspace_root=workspace_root,
+            cwd=cwd,
+            search_ancestors=True,
+        )
+    resolved = _resolve_configured_path(path, workspace_root=workspace_root)
+    return [] if resolved is None else [resolved]
+
+
+def _has_glob_magic(path: str | Path) -> bool:
+    return glob.has_magic(str(path))
+
+
+def _expand_configured_paths(
+    pattern: str | Path,
+    *,
+    workspace_root: Path | None,
+    cwd: str | Path | None,
+    search_ancestors: bool,
+) -> list[Path]:
+    if isinstance(pattern, str) and not pattern.strip():
+        return []
+    raw_pattern = str(pattern)
+    expanded = Path(raw_pattern).expanduser()
+    matches: list[Path] = []
+    if expanded.is_absolute():
+        matches.extend(Path(match) for match in glob.glob(str(expanded), recursive=True))
+    elif workspace_root is not None:
+        bases = (
+            _ancestor_search_directories(workspace_root, cwd)
+            if search_ancestors
+            else [workspace_root]
+        )
+        for base in bases:
+            matches.extend(
+                Path(match)
+                for match in glob.glob(str(base / raw_pattern), recursive=True)
+            )
+
+    resolved_matches: list[Path] = []
+    seen: set[Path] = set()
+    for match in sorted(matches, key=lambda item: (str(item).casefold(), str(item))):
+        resolved = _resolved_file_path(match)
+        if resolved is None or resolved in seen:
+            continue
+        seen.add(resolved)
+        resolved_matches.append(resolved)
+    return resolved_matches
+
+
 def _resolved_file_path(path: Path) -> Path | None:
     try:
         resolved = path.resolve(strict=False)
@@ -344,6 +424,20 @@ def _is_relative_to(path: Path, root: Path) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _ancestor_search_directories(
+    workspace_root: Path,
+    cwd: str | Path | None,
+) -> list[Path]:
+    directories: list[Path] = []
+    current = _ancestor_search_start(workspace_root, cwd)
+    while _is_relative_to(current, workspace_root):
+        directories.append(current)
+        if current == workspace_root:
+            break
+        current = current.parent
+    return directories
 
 
 def _relative_posix(root: Path, path: Path) -> str:

--- a/src/efp_runtime/loop/runner.py
+++ b/src/efp_runtime/loop/runner.py
@@ -58,6 +58,9 @@ from .provider import LLMProvider, ProviderOutput, ProviderResult, RuntimeReques
 from .stream_events import bridge_llm_stream_events
 
 
+ContextMessageProvider = Callable[[Mapping[str, Any]], Iterable[Message]]
+
+
 class LoopStatus:
     COMPLETED = "completed"
     ERROR = "error"
@@ -257,6 +260,7 @@ class RuntimeLoopRunner:
         max_iterations: Optional[int] = None,
         metadata: Optional[dict[str, Any]] = None,
         context_messages: Optional[list[Message]] = None,
+        context_message_provider: Optional[ContextMessageProvider] = None,
         append_user_message: bool = True,
         user_parts: Optional[List[MessagePart]] = None,
         tools: Optional[Mapping[str, bool]] = None,
@@ -449,7 +453,6 @@ class RuntimeLoopRunner:
                 metadata=run_metadata,
             )
             history = compaction_outcome.history
-            request_history = [*(context_messages or []), *history]
             request_metadata = _request_metadata(
                 run_metadata,
                 session_id=resolved_session_id,
@@ -460,6 +463,13 @@ class RuntimeLoopRunner:
                 request_metadata,
                 compaction_outcome.replay,
             )
+            request_context_messages = _request_context_messages(
+                context_messages=context_messages,
+                context_message_provider=context_message_provider,
+                metadata=request_metadata,
+                run_metadata=run_metadata,
+            )
+            request_history = [*request_context_messages, *history]
             request = await self._prepare_runtime_request(
                 session_id=resolved_session_id,
                 history=history,
@@ -531,10 +541,12 @@ class RuntimeLoopRunner:
                 provider_output = await self._invoke_provider_with_retries(
                     request,
                     history=history,
-                    request_history=request_history,
                     tools=enabled_tools,
                     runtime_events=runtime_events,
                     run_id=run_id,
+                    run_metadata=run_metadata,
+                    context_messages=context_messages,
+                    context_message_provider=context_message_provider,
                     iteration=iteration,
                     max_iterations=iteration_limit,
                 )
@@ -1132,10 +1144,12 @@ class RuntimeLoopRunner:
         request: RuntimeRequest,
         *,
         history: list[Message],
-        request_history: list[Message],
         tools: list[Any],
         runtime_events: List[RuntimeEvent],
         run_id: str,
+        run_metadata: dict[str, Any],
+        context_messages: Optional[list[Message]],
+        context_message_provider: Optional[ContextMessageProvider],
         iteration: int,
         max_iterations: int,
     ) -> ProviderOutput:
@@ -1172,9 +1186,6 @@ class RuntimeLoopRunner:
                         budget=overflow_budget,
                     )
                 )
-                provider_context_messages = request_history[
-                    : max(0, len(request_history) - len(history))
-                ]
                 retry_history = history
                 replay_info: _CompactionReplayInfo | None = None
                 if self.compaction_auto:
@@ -1199,8 +1210,14 @@ class RuntimeLoopRunner:
                     overflow_metadata,
                     replay_info,
                 )
+                retry_context_messages = _request_context_messages(
+                    context_messages=context_messages,
+                    context_message_provider=context_message_provider,
+                    metadata=overflow_metadata,
+                    run_metadata=run_metadata,
+                )
                 retry_request_history = [
-                    *provider_context_messages,
+                    *retry_context_messages,
                     *retry_history,
                 ]
                 overflow_request = await self._prepare_runtime_request(
@@ -1783,6 +1800,7 @@ async def run_runtime_loop(
     context_reserve_tokens: int | None = None,
     metadata: Optional[dict[str, Any]] = None,
     context_messages: Optional[list[Message]] = None,
+    context_message_provider: Optional[ContextMessageProvider] = None,
     append_user_message: bool = True,
     user_parts: Optional[List[MessagePart]] = None,
     event_bus: Optional[RuntimeEventBus] = None,
@@ -1842,6 +1860,7 @@ async def run_runtime_loop(
         session=session,
         metadata=metadata,
         context_messages=context_messages,
+        context_message_provider=context_message_provider,
         append_user_message=append_user_message,
         user_parts=user_parts,
         tools=tools,
@@ -2386,6 +2405,46 @@ def _request_metadata(
     )
     request_metadata["loop"] = merged_loop_metadata
     return request_metadata
+
+
+def _request_context_messages(
+    *,
+    context_messages: Optional[list[Message]],
+    context_message_provider: Optional[ContextMessageProvider],
+    metadata: dict[str, Any],
+    run_metadata: dict[str, Any],
+) -> list[Message]:
+    messages = list(context_messages or [])
+    if context_message_provider is None:
+        return messages
+
+    dynamic_messages = list(context_message_provider(metadata) or [])
+    _record_dynamic_instruction_context_metadata(metadata, dynamic_messages)
+    _record_dynamic_instruction_context_metadata(run_metadata, dynamic_messages)
+    return [*messages, *dynamic_messages]
+
+
+def _record_dynamic_instruction_context_metadata(
+    metadata: dict[str, Any],
+    messages: Iterable[Message],
+) -> None:
+    instruction_messages = [
+        message
+        for message in messages
+        if message.metadata.get("kind") == "instruction_context"
+    ]
+    metadata["instruction_context_count"] = len(instruction_messages)
+    paths = [
+        str(path)
+        for message in instruction_messages
+        if message.metadata.get("source") == "file"
+        for path in [message.metadata.get("path")]
+        if path
+    ]
+    if paths:
+        metadata["system_instruction_paths"] = paths
+    else:
+        metadata.pop("system_instruction_paths", None)
 
 
 def _with_model_context_compaction_metadata(

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -584,13 +584,6 @@ class AgentRuntime:
                 if structured_output_active
                 else []
             )
-            instruction_context_messages = self._build_instruction_context_messages(
-                run_metadata
-            )
-            _record_system_instruction_paths(
-                run_metadata,
-                instruction_context_messages,
-            )
             available_skill_context_messages = (
                 self._build_available_skill_context_messages()
             )
@@ -599,7 +592,8 @@ class AgentRuntime:
                 *system_prompt_messages,
                 *structured_output_messages,
                 *agent_profile_messages,
-                *instruction_context_messages,
+            ]
+            post_instruction_context_messages = [
                 *available_skill_context_messages,
                 *skill_context_messages,
             ]
@@ -614,7 +608,7 @@ class AgentRuntime:
             run_metadata["structured_output_context_count"] = len(
                 structured_output_messages
             )
-            run_metadata["instruction_context_count"] = len(instruction_context_messages)
+            run_metadata["instruction_context_count"] = 0
             run_metadata["available_skill_context_count"] = len(
                 available_skill_context_messages
             )
@@ -678,6 +672,10 @@ class AgentRuntime:
                 session_id=resolved_session_id,
                 metadata=run_metadata,
                 context_messages=context_messages,
+                context_message_provider=lambda metadata: [
+                    *self._build_instruction_context_messages(metadata),
+                    *post_instruction_context_messages,
+                ],
                 tools=run_tools,
                 structured_output_required=structured_output_active,
                 structured_output_tool_id=structured_output_tool_id,
@@ -813,13 +811,6 @@ class AgentRuntime:
                 if structured_output_active
                 else []
             )
-            instruction_context_messages = self._build_instruction_context_messages(
-                run_metadata
-            )
-            _record_system_instruction_paths(
-                run_metadata,
-                instruction_context_messages,
-            )
             available_skill_context_messages = (
                 self._build_available_skill_context_messages()
             )
@@ -828,7 +819,8 @@ class AgentRuntime:
                 *system_prompt_messages,
                 *structured_output_messages,
                 *agent_profile_messages,
-                *instruction_context_messages,
+            ]
+            post_instruction_context_messages = [
                 *available_skill_context_messages,
                 *skill_context_messages,
             ]
@@ -840,7 +832,7 @@ class AgentRuntime:
             run_metadata["structured_output_context_count"] = len(
                 structured_output_messages
             )
-            run_metadata["instruction_context_count"] = len(instruction_context_messages)
+            run_metadata["instruction_context_count"] = 0
             run_metadata["available_skill_context_count"] = len(
                 available_skill_context_messages
             )
@@ -902,6 +894,10 @@ class AgentRuntime:
                 session_id=session_id,
                 metadata=run_metadata,
                 context_messages=context_messages,
+                context_message_provider=lambda metadata: [
+                    *self._build_instruction_context_messages(metadata),
+                    *post_instruction_context_messages,
+                ],
                 append_user_message=False,
                 tools=run_tools,
                 structured_output_required=structured_output_active,
@@ -2805,23 +2801,6 @@ def _tool_enabled_for_run(
         overrides=run_tools,
     )
     return tool_id in enabled_tool_ids
-
-
-def _record_system_instruction_paths(
-    metadata: dict[str, Any],
-    messages: Iterable[Message],
-) -> None:
-    paths = [
-        str(path)
-        for message in messages
-        if message.metadata.get("source") == "file"
-        for path in [message.metadata.get("path")]
-        if path
-    ]
-    if paths:
-        metadata["system_instruction_paths"] = paths
-    else:
-        metadata.pop("system_instruction_paths", None)
 
 
 def _resolve_skill_discovery(

--- a/tests/runtime/test_config_loader.py
+++ b/tests/runtime/test_config_loader.py
@@ -428,6 +428,28 @@ def test_runtime_config_field_mapping(tmp_path: Path):
     assert config.runtime_mode == "plan"
 
 
+def test_runtime_config_instruction_globs_are_preserved_for_runtime(
+    tmp_path: Path,
+):
+    _write_json(
+        tmp_path / "opencode.json",
+        {
+            "instructions": [
+                "docs/*.instructions.md",
+                {"path": ["rules/*.md", "docs/AGENTS.md"]},
+            ],
+        },
+    )
+
+    result = load_runtime_config(tmp_path)
+
+    assert result.config.instruction_paths == [
+        "docs/*.instructions.md",
+        "rules/*.md",
+        (tmp_path / "docs/AGENTS.md").resolve(),
+    ]
+
+
 @pytest.mark.parametrize(
     "alias",
     ["includeEnvironmentContext", "include_environment_context"],

--- a/tests/runtime/test_instruction_context.py
+++ b/tests/runtime/test_instruction_context.py
@@ -13,6 +13,8 @@ from efp_runtime.loop import ScriptedLLMProvider
 from efp_runtime.models import MessagePart, MessageRole
 from efp_runtime.runtime import AgentRuntime, RuntimeConfig
 from efp_runtime.session.store import InMemorySessionStore
+from efp_runtime.tools.definition import ToolDef
+from efp_runtime.tools.registry import ToolRegistry
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -42,6 +44,32 @@ def test_builder_loads_agents_as_only_workspace_default_file(tmp_path: Path):
     assert messages[0].parts[0].metadata == messages[0].metadata
     assert "Claude instructions." not in messages[0].parts[0].text
     assert "Context instructions." not in messages[0].parts[0].text
+
+
+def test_builder_loads_workspace_instruction_glob_after_agents(tmp_path: Path):
+    nested = tmp_path / "src" / "pkg"
+    nested.mkdir(parents=True)
+    (tmp_path / "AGENTS.md").write_text("Agent instructions.", encoding="utf-8")
+    instructions = tmp_path / ".efp" / "instructions"
+    instructions.mkdir(parents=True)
+    (instructions / "b.instructions.md").write_text("B rules.", encoding="utf-8")
+    (instructions / "a.instructions.md").write_text("A rules.", encoding="utf-8")
+    (instructions / "ignored.md").write_text("Ignored.", encoding="utf-8")
+
+    messages = InstructionContextBuilder(workspace_root=tmp_path).build_messages(
+        metadata={"cwd": nested}
+    )
+
+    assert [message.metadata["path"] for message in messages] == [
+        str((tmp_path / "AGENTS.md").resolve()),
+        str((instructions / "a.instructions.md").resolve()),
+        str((instructions / "b.instructions.md").resolve()),
+    ]
+    text = "\n".join(message.parts[0].text for message in messages)
+    assert "Agent instructions." in text
+    assert "A rules." in text
+    assert "B rules." in text
+    assert "Ignored." not in text
 
 
 def test_nested_cwd_ignores_claude_and_context_by_default(tmp_path: Path):
@@ -78,6 +106,7 @@ def test_explicit_instruction_paths_support_relative_absolute_and_home(
     home_file = home / "home.md"
     home_file.write_text("Home instructions.", encoding="utf-8")
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
 
     messages = InstructionContextBuilder(
         workspace_root=tmp_path,
@@ -102,6 +131,43 @@ def test_explicit_instruction_paths_support_relative_absolute_and_home(
         "Absolute instructions.",
         "Home instructions.",
     ]
+
+
+def test_explicit_instruction_paths_support_globs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "b.instructions.md").write_text("B explicit.", encoding="utf-8")
+    (rules / "a.instructions.md").write_text("A explicit.", encoding="utf-8")
+    (rules / "ignored.md").write_text("Ignored explicit.", encoding="utf-8")
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "home.instructions.md").write_text("Home explicit.", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    messages = InstructionContextBuilder(
+        workspace_root=tmp_path,
+        include_default_files=False,
+        instruction_paths=[
+            "rules/*.instructions.md",
+            str(rules / "*.instructions.md"),
+            "~/*.instructions.md",
+        ],
+    ).build_messages()
+
+    assert [message.metadata["path"] for message in messages] == [
+        str((rules / "a.instructions.md").resolve()),
+        str((rules / "b.instructions.md").resolve()),
+        str((home / "home.instructions.md").resolve()),
+    ]
+    text = "\n".join(message.parts[0].text for message in messages)
+    assert "A explicit." in text
+    assert "B explicit." in text
+    assert "Home explicit." in text
+    assert "Ignored explicit." not in text
 
 
 def test_inline_instruction_text_generates_system_message():
@@ -174,6 +240,64 @@ async def test_agent_runtime_run_injects_instruction_context_without_persisting_
         MessageRole.ASSISTANT,
     ]
     assert all(message.role is not MessageRole.SYSTEM for message in history)
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_refreshes_instruction_context_each_provider_request(
+    tmp_path: Path,
+):
+    instructions = tmp_path / ".efp" / "instructions"
+    instructions.mkdir(parents=True)
+    rule_file = instructions / "rules.instructions.md"
+    rule_file.write_text("Initial rules.", encoding="utf-8")
+
+    async def refresh_rules(_args, _context):
+        rule_file.write_text("Updated rules.", encoding="utf-8")
+        return "updated"
+
+    provider = ScriptedLLMProvider(
+        [
+            {"tool_calls": [_tool_call("call-refresh", "refresh_rules")]},
+            {"content": "Done."},
+        ]
+    )
+    runtime = AgentRuntime(
+        provider=provider,
+        tool_registry=ToolRegistry(
+            [
+                ToolDef(
+                    id="refresh_rules",
+                    description="Refresh instruction rules.",
+                    input_schema={"type": "object", "properties": {}},
+                    execute=refresh_rules,
+                )
+            ]
+        ),
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            max_iterations=2,
+            include_default_system_prompt=False,
+            include_environment_context=False,
+            include_runtime_reminders=False,
+        ),
+    )
+
+    await runtime.run("Refresh instructions.", session_id="session-refresh-rules")
+
+    assert len(provider.requests) == 2
+    first_text = "\n".join(
+        message.text for message in provider.requests[0].provider_request.messages
+    )
+    second_text = "\n".join(
+        message.text for message in provider.requests[1].provider_request.messages
+    )
+    assert "Initial rules." in first_text
+    assert "Updated rules." not in first_text
+    assert "Updated rules." in second_text
+    assert provider.requests[1].metadata["instruction_context_count"] == 1
+    assert provider.requests[1].metadata["system_instruction_paths"] == [
+        str(rule_file.resolve())
+    ]
 
 
 @pytest.mark.asyncio
@@ -309,3 +433,14 @@ def _write_skill(
         encoding="utf-8",
     )
     return skill_dir
+
+
+def _tool_call(call_id: str, tool_name: str) -> dict[str, object]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": tool_name,
+            "arguments": "{}",
+        },
+    }


### PR DESCRIPTION
## Summary

- Load `AGENTS.md` plus `.efp/instructions/*.instructions.md` as native default instruction context.
- Preserve glob patterns from `config.instructions` so the runtime expands them at request time.
- Refresh instruction context before every provider request, including retries, while keeping instruction metadata available for read-tool duplicate suppression.

## Validation

- `python -m pytest tests\runtime\test_instruction_context.py tests\runtime\test_config_loader.py::test_default_file_lookup_and_merge_order tests\runtime\test_config_loader.py::test_load_runtime_config_resolves_parent_opencode_json_from_nested_dir tests\runtime\test_config_loader.py::test_runtime_config_field_mapping tests\runtime\test_config_loader.py::test_runtime_config_instruction_globs_are_preserved_for_runtime tests\runtime\test_system_prompt_stack.py -q`
- `python -m py_compile src\efp_runtime\instructions\context.py src\efp_runtime\config_loader.py src\efp_runtime\runtime\agent.py src\efp_runtime\loop\runner.py`
- `git diff --check`