### PR TITLE
[codex] Persist running native chat state

### DIFF
--- a/src/efp_runtime/session/gateway_facade.py
+++ b/src/efp_runtime/session/gateway_facade.py
@@ -300,6 +300,21 @@ class RuntimeSessionManager:
             return
         await self.merge_metadata(session_id, {"last_execution_id": request_id})
 
+    async def mark_runtime_running(self, session_id: str, *, request_id: str) -> None:
+        if not session_id or not request_id:
+            return
+        await self.merge_metadata(
+            session_id,
+            {
+                "last_execution_id": request_id,
+                "last_runtime_status": "running",
+                "last_runtime_updated_at": _now_iso(),
+                "latest_event_type": "chat.started",
+                "latest_event_state": "running",
+                "completion_state": "running",
+            },
+        )
+
     async def get_context_state(self, session_id: str) -> Optional[dict[str, Any]]:
         session = await self.get_session(session_id)
         context_state = session.get("metadata", {}).get("context_state")
@@ -427,8 +442,22 @@ class RuntimeSessionManager:
         metadata = deepcopy(session.metadata)
         if request_id:
             metadata["last_execution_id"] = request_id
-        metadata["last_runtime_status"] = getattr(result, "status", None)
+        runtime_status = getattr(result, "status", None)
+        metadata["last_runtime_status"] = runtime_status
         metadata["last_runtime_updated_at"] = _now_iso()
+        normalized_status = str(runtime_status or "").strip().lower()
+        if normalized_status in {"success", "completed", "complete", "ok"}:
+            metadata["latest_event_type"] = "chat.completed"
+            metadata["latest_event_state"] = "success"
+            metadata["completion_state"] = "completed"
+        elif normalized_status in {"error", "failed", "failure"}:
+            metadata["latest_event_type"] = "chat.failed"
+            metadata["latest_event_state"] = "error"
+            metadata["completion_state"] = "error"
+        elif normalized_status in {"cancelled", "canceled"}:
+            metadata["latest_event_type"] = "chat.cancelled"
+            metadata["latest_event_state"] = "cancelled"
+            metadata["completion_state"] = "cancelled"
         pending_permission = getattr(result, "pending_permission_request", None)
         pending_question = getattr(result, "pending_question_request", None)
         if pending_permission is not None:

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -731,6 +731,8 @@ async def _chat_run_status_from_session(session_id: str, request_id: str) -> Opt
     raw_status = str(metadata.get("last_runtime_status") or "").strip().lower()
     if raw_status in {"success", "completed", "complete", "ok"}:
         state = "completed"
+    elif raw_status in {"running", "accepted", "queued", "in_progress"}:
+        state = "running"
     elif raw_status in {"error", "failed", "failure"}:
         state = "failed"
     elif raw_status in {"cancelled", "canceled"}:
@@ -1135,6 +1137,7 @@ async def api_chat(request: web.Request) -> web.Response:
         # Run EFP runtime; session_manager remains the gateway-side history mirror.
         runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
         set_log_context(agent_id=runtime_agent_id)
+        await session_manager.mark_runtime_running(session_id, request_id=request_id)
         if runtime_agent_id and session_id:
             try:
                 await publish_session_metadata(
@@ -1362,6 +1365,8 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
         original_user_text = (data.get('message') or '').strip()
         message = original_user_text
         session_id = _resolve_runtime_session_id(data)
+        if not session_manager._initialized:
+            await session_manager.initialize()
         attachment_ids = _normalize_attachment_ids(data.get("attachments", []))
         portal_user_id, portal_user_name = _extract_portal_identity(request, data)
         execution_metadata = _extract_trusted_control_plane_metadata(request, data)
@@ -1372,7 +1377,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             session_id=session_id,
         )
         existing_run = chat_run_registry.get(request_id, session_id=session_id)
-        if existing_run is not None:
+        if existing_run is not None or data.get("reconnect") is True:
             return await _stream_existing_chat_run(request, session_id=session_id, request_id=request_id)
         effective_user_name = _resolve_chat_display_user_name(data, portal_user_name)
 
@@ -1471,6 +1476,7 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
             model=model,
         )
         chat_run_registry.start(session_id=session_id, request_id=request_id, engine="native")
+        await session_manager.mark_runtime_running(session_id, request_id=request_id)
         if runtime_agent_id and session_id:
             try:
                 await publish_session_metadata(

--- a/tests/runtime/test_gateway_session_facade_contract.py
+++ b/tests/runtime/test_gateway_session_facade_contract.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -22,6 +23,34 @@ from efp_runtime.tools.runtime import ToolRuntime
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.asyncio
+async def test_gateway_facade_marks_running_chat_and_terminal_result(tmp_path: Path):
+    store = FileSessionStore(tmp_path / "store")
+    manager = RuntimeSessionManager(store=store)
+
+    await manager.mark_runtime_running("running-session", request_id="req-running")
+
+    running_metadata = store.get_session("running-session").metadata
+    assert running_metadata["last_execution_id"] == "req-running"
+    assert running_metadata["last_runtime_status"] == "running"
+    assert running_metadata["latest_event_type"] == "chat.started"
+    assert running_metadata["latest_event_state"] == "running"
+    assert running_metadata["completion_state"] == "running"
+
+    await manager.record_runtime_result(
+        "running-session",
+        SimpleNamespace(status="completed", pending_permission_request=None, pending_question_request=None),
+        request_id="req-running",
+    )
+
+    terminal_metadata = store.get_session("running-session").metadata
+    assert terminal_metadata["last_execution_id"] == "req-running"
+    assert terminal_metadata["last_runtime_status"] == "completed"
+    assert terminal_metadata["latest_event_type"] == "chat.completed"
+    assert terminal_metadata["latest_event_state"] == "success"
+    assert terminal_metadata["completion_state"] == "completed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist native chat running metadata at request start so refresh recovery can find the active request id
- map running session metadata to a non-terminal chat run status
- make reconnect stream requests status-only so they do not start duplicate native chat work
- update terminal runtime metadata when a result is recorded

## Validation
- python -m py_compile src\gateway\runtime_api.py src\efp_runtime\session\gateway_facade.py
- python -m pytest tests\runtime\test_gateway_session_facade_contract.py -q
- git diff --check