### PR TITLE
Apply Jenkins runtime profile via CLI

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -95,17 +95,17 @@ PORTAL_MANAGED_RUNTIME_FIELDS = frozenset(
 RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS = [
     (
         "Use bash for external CLI tools configured by the runtime profile: "
-        "jira, confluence, gh, aws, and git."
+        "jira, confluence, gh, aws, jenkins, and git."
     ),
     (
-        "For jira and confluence, always pass --json. Before complex commands, "
+        "For jira, confluence, and jenkins, always pass --json. Before complex commands, "
         "inspect commands/schema/help llm; prefer --dry-run for writes, and use "
         "--yes only when a destructive action was explicitly confirmed."
     ),
-    "Use gh for GitHub issues, pull requests, and api calls; use aws for AWS operations; use git for clone, fetch, push, and status.",
+    "Use gh for GitHub issues, pull requests, and api calls; use aws for AWS operations; use jenkins for Jenkins controller operations; use git for clone, fetch, push, and status.",
     (
         "Credentials were applied by the runtime profile through the real CLIs; "
-        "if jira or confluence returns auth_failed, aws returns an auth error, or gh/git authentication fails, "
+        "if jira, confluence, or jenkins returns auth_failed, aws returns an auth error, or gh/git authentication fails, "
         "report a runtime profile configuration problem."
     ),
 ]
@@ -190,6 +190,7 @@ def _should_inject_runtime_profile_external_cli_instructions(overlay: Dict[str, 
     return (
         _has_atlassian_profile_instances(overlay.get("jira"))
         or _has_atlassian_profile_instances(overlay.get("confluence"))
+        or _has_atlassian_profile_instances(overlay.get("jenkins"))
         or _has_github_profile_token(overlay.get("github"))
         or _has_aws_profile_config(overlay.get("aws"))
         or _has_git_profile_user(overlay.get("git"))
@@ -263,6 +264,7 @@ class Config:
         "confluence",
         "github",
         "aws",
+        "jenkins",
         "git",
         "debug",
         *PORTAL_MANAGED_RUNTIME_FIELDS,
@@ -321,6 +323,12 @@ class Config:
             "domain": True,
             "username": True,
             "password": True,
+        },
+        "jenkins": {
+            "enabled": True,
+            "instances": True,
+            "default_instance": True,
+            "defaultInstance": True,
         },
         "git": {
             "user": {
@@ -521,6 +529,7 @@ class Config:
         persisted_overlay = copy.deepcopy(external_cli_overlay)
         persisted_overlay.pop("jira", None)
         persisted_overlay.pop("confluence", None)
+        persisted_overlay.pop("jenkins", None)
         new_sections = set(external_cli_overlay.keys())
 
         config_document = self._load_yaml_document(self.config_path)

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -67,6 +67,7 @@ def apply_runtime_profile_external_config(
         )
         _apply_github(profile_config, metadata=metadata, cli_environment=cli_environment)
         _apply_aws(profile_config, metadata=metadata, cli_environment=cli_environment)
+        _apply_jenkins(profile_config, metadata=metadata, cli_environment=cli_environment)
         _apply_git_user(profile_config, metadata=metadata, cli_environment=cli_environment)
     except Exception:
         if _metadata_has_managed_entries(metadata):
@@ -195,6 +196,79 @@ def _remove_atlassian_instance_if_exists(product: str, name: str, *, cli_environ
         return
 
 
+def _apply_jenkins(
+    profile_config: dict[str, Any],
+    *,
+    metadata: dict[str, Any],
+    cli_environment: _CliEnvironment,
+) -> None:
+    instances = _build_jenkins_instances(profile_config.get("jenkins") if isinstance(profile_config, dict) else None)
+    if not instances:
+        return
+
+    default_name = _default_instance_name(profile_config.get("jenkins"), instances)
+    jenkins_meta: dict[str, Any] = {"instances": []}
+    metadata["jenkins"] = jenkins_meta
+    for instance in instances:
+        _remove_jenkins_instance_if_exists(instance["name"], cli_environment=cli_environment)
+        _add_jenkins_instance(
+            instance,
+            default=instance["name"] == default_name,
+            cli_environment=cli_environment,
+        )
+        jenkins_meta["instances"].append({"name": instance["name"]})
+
+
+def _add_jenkins_instance(
+    instance: dict[str, Any],
+    *,
+    default: bool,
+    cli_environment: _CliEnvironment,
+) -> None:
+    args = [
+        "jenkins",
+        "instance",
+        "add",
+        instance["name"],
+        "--base-url",
+        instance["base_url"],
+        "--username",
+        instance["username"],
+        "--password-stdin",
+        "--json",
+    ]
+    if default:
+        args.insert(-1, "--default")
+    _run_cli(
+        args,
+        input_text=instance["password"],
+        secrets=(instance["password"],),
+        env=cli_environment.env,
+        env_secrets=cli_environment.secrets,
+    )
+
+
+def _remove_jenkins_instance(name: str, *, cli_environment: _CliEnvironment) -> None:
+    _run_cli(
+        ["jenkins", "instance", "remove", name, "--yes", "--json"],
+        allowed_returncodes=tuple(range(256)),
+        env=cli_environment.env,
+        env_secrets=cli_environment.secrets,
+    )
+
+
+def _remove_jenkins_instance_if_exists(name: str, *, cli_environment: _CliEnvironment) -> None:
+    try:
+        _run_cli(
+            ["jenkins", "instance", "remove", name, "--yes", "--json"],
+            allowed_returncodes=tuple(range(256)),
+            env=cli_environment.env,
+            env_secrets=cli_environment.secrets,
+        )
+    except RuntimeError:
+        return
+
+
 def _apply_github(
     profile_config: dict[str, Any],
     *,
@@ -306,6 +380,10 @@ def _clear_new_metadata(meta: dict[str, Any], *, cli_environment: _CliEnvironmen
         for name in _metadata_instance_names(product_meta):
             _remove_atlassian_instance(product, name, cli_environment=cli_environment)
 
+    jenkins_meta = meta.get("jenkins") if isinstance(meta.get("jenkins"), dict) else {}
+    for name in _metadata_instance_names(jenkins_meta):
+        _remove_jenkins_instance(name, cli_environment=cli_environment)
+
     gh = meta.get("gh") if isinstance(meta.get("gh"), dict) else {}
     if "path" not in gh:
         for host in _metadata_gh_hosts(gh):
@@ -355,7 +433,7 @@ def _clear_legacy_metadata(meta: dict[str, Any]) -> None:
 
 
 def _metadata_has_managed_entries(metadata: dict[str, Any]) -> bool:
-    return any(key in metadata for key in ("jira", "confluence", "gh", "aws", "git"))
+    return any(key in metadata for key in ("jira", "confluence", "gh", "aws", "jenkins", "git"))
 
 
 def _metadata_instance_names(product_meta: dict[str, Any]) -> list[str]:
@@ -467,6 +545,36 @@ def _build_product_instances(product_config: Any, *, product: str) -> list[dict[
                 "auth": auth,
             }
         instances.append(instance)
+    return instances
+
+
+def _build_jenkins_instances(jenkins_config: Any) -> list[dict[str, Any]]:
+    if not isinstance(jenkins_config, dict):
+        return []
+    if jenkins_config.get("enabled") is False:
+        return []
+    raw_instances = jenkins_config.get("instances")
+    if not isinstance(raw_instances, list):
+        return []
+    instances: list[dict[str, Any]] = []
+    used_names: set[str] = set()
+    for index, raw in enumerate(raw_instances, 1):
+        if not isinstance(raw, dict) or raw.get("enabled") is False:
+            continue
+        base_url = _profile_instance_base_url(raw)
+        username = _single_line(raw.get("username") or raw.get("email"))
+        password = _string_or_empty(raw.get("password"))
+        if not (base_url and username and password):
+            continue
+        name = _unique_instance_name(str(raw.get("name") or f"jenkins-{index}").strip(), used_names, "jenkins", index)
+        instances.append(
+            {
+                "name": name,
+                "base_url": base_url,
+                "username": username,
+                "password": password,
+            }
+        )
     return instances
 
 

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -214,12 +214,24 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
                 "username": "aws-user",
                 "password": "aws-password",
             },
+            "jenkins": {
+                "enabled": True,
+                "instances": [
+                    {
+                        "name": "ci",
+                        "url": "https://jenkins.example.test",
+                        "username": "jenkins-user",
+                        "password": "jenkins-password",
+                    }
+                ],
+            },
         },
     )
 
     persisted = _read_yaml(config_path)
     assert "jira" not in persisted
     assert "confluence" not in persisted
+    assert "jenkins" not in persisted
     assert persisted["aws"] == {
         "enabled": True,
         "domain": "HBEU",
@@ -229,15 +241,18 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
     assert persisted["instruction_texts"]
     assert "jira-token" not in config_path.read_text(encoding="utf-8")
     assert "conf-token" not in config_path.read_text(encoding="utf-8")
+    assert "jenkins-password" not in config_path.read_text(encoding="utf-8")
     assert "aws-password" in config_path.read_text(encoding="utf-8")
     assert applied[0]["jira"]["instances"][0]["token"] == "jira-token"
     assert applied[0]["confluence"]["instances"][0]["token"] == "conf-token"
     assert applied[0]["aws"]["domain"] == "HBEU"
     assert applied[0]["aws"]["password"] == "aws-password"
+    assert applied[0]["jenkins"]["instances"][0]["password"] == "jenkins-password"
     assert cfg.get_managed_overlay_meta()["managed_sections"] == [
         "aws",
         "confluence",
         "instruction_texts",
+        "jenkins",
         "jira",
     ]
 
@@ -818,6 +833,17 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
                 "access_token": "gh-token",
                 "api_base_url": "https://github.example.test/api/v3",
             },
+            "jenkins": {
+                "enabled": True,
+                "instances": [
+                    {
+                        "name": "ci",
+                        "url": "https://jenkins.example.test/",
+                        "username": "jenkins-user",
+                        "password": "jenkins-password",
+                    }
+                ],
+            },
             "git": {"user": {"name": "Runtime Bot", "email": "runtime@example.test"}},
         },
     )
@@ -920,6 +946,38 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
             "check": False,
         }
     ]
+    jenkins_remove = _command_calls(recorder, ["jenkins", "instance", "remove"])
+    assert jenkins_remove == [
+        {
+            "args": ["jenkins", "instance", "remove", "ci", "--yes", "--json"],
+            "input": None,
+            "text": True,
+            "capture_output": True,
+            "check": False,
+        }
+    ]
+    jenkins_add = _command_calls(recorder, ["jenkins", "instance", "add"])
+    assert jenkins_add == [
+        {
+            "args": [
+                "jenkins",
+                "instance",
+                "add",
+                "ci",
+                "--base-url",
+                "https://jenkins.example.test",
+                "--username",
+                "jenkins-user",
+                "--password-stdin",
+                "--default",
+                "--json",
+            ],
+            "input": "jenkins-password",
+            "text": True,
+            "capture_output": True,
+            "check": False,
+        }
+    ]
     assert _command_calls(recorder, ["git", "config", "--global", "user.name"]) == [
         {
             "args": ["git", "config", "--global", "user.name", "Runtime Bot"],
@@ -954,6 +1012,7 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
         "jira": {"instances": [{"name": "jira-main"}]},
         "confluence": {"instances": [{"name": "docs"}]},
         "gh": {"hosts": ["github.example.test"]},
+        "jenkins": {"instances": [{"name": "ci"}]},
         "git": {
             "managed": {
                 "user.name": "Runtime Bot",
@@ -968,7 +1027,7 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
 
     metadata_text = json.dumps(metadata)
     all_argv = json.dumps([call["args"] for call in recorder.calls])
-    for secret in ("jira-token", "conf-token", "gh-token"):
+    for secret in ("jira-token", "conf-token", "gh-token", "jenkins-password"):
         assert secret not in all_argv
         assert secret not in metadata_text
 
@@ -999,6 +1058,22 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
         },
         {
             "args": ["confluence", "--json", "instance", "remove", "docs", "--yes"],
+            "input": None,
+            "text": True,
+            "capture_output": True,
+            "check": False,
+        },
+    ]
+    assert _command_calls(recorder, ["jenkins", "instance", "remove"]) == [
+        {
+            "args": ["jenkins", "instance", "remove", "ci", "--yes", "--json"],
+            "input": None,
+            "text": True,
+            "capture_output": True,
+            "check": False,
+        },
+        {
+            "args": ["jenkins", "instance", "remove", "ci", "--yes", "--json"],
             "input": None,
             "text": True,
             "capture_output": True,
@@ -1537,12 +1612,13 @@ def test_runtime_profile_external_cli_instructions_are_injected(tmp_path, monkey
     instructions = cfg.get_effective_config()["instruction_texts"]
     joined = "\n".join(instructions)
     assert "Use bash" in joined
-    assert "jira, confluence, gh, aws, and git" in joined
+    assert "jira, confluence, gh, aws, jenkins, and git" in joined
     assert "always pass --json" in joined
     assert "commands/schema/help llm" in joined
     assert "--dry-run" in joined
     assert "--yes" in joined
     assert "gh for GitHub issues, pull requests, and api calls" in joined
+    assert "jenkins for Jenkins controller operations" in joined
     assert "git for clone, fetch, push, and status" in joined
     assert "Credentials were applied by the runtime profile through the real CLIs" in joined
     assert "auth_failed" in joined


### PR DESCRIPTION
## Summary
- Add Jenkins runtime profile support to native external CLI apply/clear
- Configure Jenkins instances with username/password via stdin and record metadata without secrets
- Include Jenkins in native CLI instructions and tests

## Tests
- python -m pytest tests\\test_runtime_profile_overlay.py -q
- python -m py_compile src\\config.py src\\external_cli\\profile_config.py
- git diff --check