### PR TITLE
[codex] Apply Jenkins profile credentials via env

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -104,7 +104,11 @@ RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS = [
     ),
     "Use gh for GitHub issues, pull requests, and api calls; use aws for AWS operations; use jenkins for Jenkins controller operations; use git for clone, fetch, push, and status.",
     (
-        "Credentials were applied by the runtime profile through the real CLIs; "
+        "Jenkins runtime profile credentials are available as EFP_JENKINS_USERNAME and EFP_JENKINS_PASSWORD. "
+        "When the user provides a Jenkins controller URL or pipeline/job, configure or log in to that controller at that time and pass the password through stdin."
+    ),
+    (
+        "Credentials were applied by the runtime profile through real CLIs or environment variables; "
         "if jira, confluence, or jenkins returns auth_failed, aws returns an auth error, or gh/git authentication fails, "
         "report a runtime profile configuration problem."
     ),
@@ -190,7 +194,7 @@ def _should_inject_runtime_profile_external_cli_instructions(overlay: Dict[str, 
     return (
         _has_atlassian_profile_instances(overlay.get("jira"))
         or _has_atlassian_profile_instances(overlay.get("confluence"))
-        or _has_atlassian_profile_instances(overlay.get("jenkins"))
+        or _has_jenkins_profile_credentials(overlay.get("jenkins"))
         or _has_github_profile_token(overlay.get("github"))
         or _has_aws_profile_config(overlay.get("aws"))
         or _has_git_profile_user(overlay.get("git"))
@@ -226,6 +230,14 @@ def _has_aws_profile_config(section: Any) -> bool:
     return bool(domain and username and password)
 
 
+def _has_jenkins_profile_credentials(section: Any) -> bool:
+    if not isinstance(section, dict) or section.get("enabled") is False:
+        return False
+    username = str(section.get("username") or "").strip()
+    password = str(section.get("password") or "").strip()
+    return bool(username and password)
+
+
 def _has_git_profile_user(section: Any) -> bool:
     user = section.get("user") if isinstance(section, dict) else None
     if not isinstance(user, dict):
@@ -254,6 +266,12 @@ class Config:
         "ALL_PROXY",
         "no_proxy",
         "NO_PROXY",
+    )
+    JENKINS_ENV_VARS = (
+        "EFP_JENKINS_USERNAME",
+        "EFP_JENKINS_PASSWORD",
+        "JENKINS_USERNAME",
+        "JENKINS_PASSWORD",
     )
 
     PROJECT_EXAMPLE = Path(__file__).parent.parent / 'config.yaml.example'
@@ -326,9 +344,8 @@ class Config:
         },
         "jenkins": {
             "enabled": True,
-            "instances": True,
-            "default_instance": True,
-            "defaultInstance": True,
+            "username": True,
+            "password": True,
         },
         "git": {
             "user": {
@@ -529,7 +546,6 @@ class Config:
         persisted_overlay = copy.deepcopy(external_cli_overlay)
         persisted_overlay.pop("jira", None)
         persisted_overlay.pop("confluence", None)
-        persisted_overlay.pop("jenkins", None)
         new_sections = set(external_cli_overlay.keys())
 
         config_document = self._load_yaml_document(self.config_path)
@@ -793,6 +809,8 @@ class Config:
                             logger.warning(f"Service reload failed: {service}")
                     if "proxy" in changed_sections:
                         self.apply_proxy()
+                    if "jenkins" in changed_sections:
+                        self.apply_jenkins_env()
                 return True
         except Exception:
             pass
@@ -994,6 +1012,26 @@ class Config:
             # Only clear if proxy section exists but is disabled
             # Don't clear inherited env vars when proxy section is absent
             self._clear_proxy_env()
+
+    @property
+    def jenkins(self) -> Dict[str, Any]:
+        return self._config.get("jenkins", {})
+
+    def _clear_jenkins_env(self) -> None:
+        for var in self.JENKINS_ENV_VARS:
+            os.environ.pop(var, None)
+
+    def apply_jenkins_env(self) -> None:
+        jenkins_config = self.jenkins
+        username = str(jenkins_config.get("username") or "").strip() if isinstance(jenkins_config, dict) else ""
+        password = str(jenkins_config.get("password") or "").strip() if isinstance(jenkins_config, dict) else ""
+        if isinstance(jenkins_config, dict) and jenkins_config.get("enabled") and username and password:
+            os.environ["EFP_JENKINS_USERNAME"] = username
+            os.environ["EFP_JENKINS_PASSWORD"] = password
+            os.environ["JENKINS_USERNAME"] = username
+            os.environ["JENKINS_PASSWORD"] = password
+        else:
+            self._clear_jenkins_env()
     
     @property
     def heartbeat(self) -> Dict[str, Any]:

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -67,7 +67,6 @@ def apply_runtime_profile_external_config(
         )
         _apply_github(profile_config, metadata=metadata, cli_environment=cli_environment)
         _apply_aws(profile_config, metadata=metadata, cli_environment=cli_environment)
-        _apply_jenkins(profile_config, metadata=metadata, cli_environment=cli_environment)
         _apply_git_user(profile_config, metadata=metadata, cli_environment=cli_environment)
     except Exception:
         if _metadata_has_managed_entries(metadata):
@@ -196,58 +195,6 @@ def _remove_atlassian_instance_if_exists(product: str, name: str, *, cli_environ
         return
 
 
-def _apply_jenkins(
-    profile_config: dict[str, Any],
-    *,
-    metadata: dict[str, Any],
-    cli_environment: _CliEnvironment,
-) -> None:
-    instances = _build_jenkins_instances(profile_config.get("jenkins") if isinstance(profile_config, dict) else None)
-    if not instances:
-        return
-
-    default_name = _default_instance_name(profile_config.get("jenkins"), instances)
-    jenkins_meta: dict[str, Any] = {"instances": []}
-    metadata["jenkins"] = jenkins_meta
-    for instance in instances:
-        _remove_jenkins_instance_if_exists(instance["name"], cli_environment=cli_environment)
-        _add_jenkins_instance(
-            instance,
-            default=instance["name"] == default_name,
-            cli_environment=cli_environment,
-        )
-        jenkins_meta["instances"].append({"name": instance["name"]})
-
-
-def _add_jenkins_instance(
-    instance: dict[str, Any],
-    *,
-    default: bool,
-    cli_environment: _CliEnvironment,
-) -> None:
-    args = [
-        "jenkins",
-        "instance",
-        "add",
-        instance["name"],
-        "--base-url",
-        instance["base_url"],
-        "--username",
-        instance["username"],
-        "--password-stdin",
-        "--json",
-    ]
-    if default:
-        args.insert(-1, "--default")
-    _run_cli(
-        args,
-        input_text=instance["password"],
-        secrets=(instance["password"],),
-        env=cli_environment.env,
-        env_secrets=cli_environment.secrets,
-    )
-
-
 def _remove_jenkins_instance(name: str, *, cli_environment: _CliEnvironment) -> None:
     _run_cli(
         ["jenkins", "instance", "remove", name, "--yes", "--json"],
@@ -255,18 +202,6 @@ def _remove_jenkins_instance(name: str, *, cli_environment: _CliEnvironment) -> 
         env=cli_environment.env,
         env_secrets=cli_environment.secrets,
     )
-
-
-def _remove_jenkins_instance_if_exists(name: str, *, cli_environment: _CliEnvironment) -> None:
-    try:
-        _run_cli(
-            ["jenkins", "instance", "remove", name, "--yes", "--json"],
-            allowed_returncodes=tuple(range(256)),
-            env=cli_environment.env,
-            env_secrets=cli_environment.secrets,
-        )
-    except RuntimeError:
-        return
 
 
 def _apply_github(
@@ -545,36 +480,6 @@ def _build_product_instances(product_config: Any, *, product: str) -> list[dict[
                 "auth": auth,
             }
         instances.append(instance)
-    return instances
-
-
-def _build_jenkins_instances(jenkins_config: Any) -> list[dict[str, Any]]:
-    if not isinstance(jenkins_config, dict):
-        return []
-    if jenkins_config.get("enabled") is False:
-        return []
-    raw_instances = jenkins_config.get("instances")
-    if not isinstance(raw_instances, list):
-        return []
-    instances: list[dict[str, Any]] = []
-    used_names: set[str] = set()
-    for index, raw in enumerate(raw_instances, 1):
-        if not isinstance(raw, dict) or raw.get("enabled") is False:
-            continue
-        base_url = _profile_instance_base_url(raw)
-        username = _single_line(raw.get("username") or raw.get("email"))
-        password = _string_or_empty(raw.get("password"))
-        if not (base_url and username and password):
-            continue
-        name = _unique_instance_name(str(raw.get("name") or f"jenkins-{index}").strip(), used_names, "jenkins", index)
-        instances.append(
-            {
-                "name": name,
-                "base_url": base_url,
-                "username": username,
-                "password": password,
-            }
-        )
     return instances
 
 

--- a/src/utils/redaction.py
+++ b/src/utils/redaction.py
@@ -21,6 +21,7 @@ _SENSITIVE_KEYS = {
     "github_token", "github_api_token",
     "openai_api_key", "llm_api_key",
     "proxy_password",
+    "jenkins_password", "efp_jenkins_password",
 }
 _COMPACT_SENSITIVE_KEYS = {key.replace("_", "") for key in _SENSITIVE_KEYS}
 

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -68,6 +68,13 @@ def test_camelcase_sensitive_keys_are_redacted():
     assert out["accessToken"] == "***REDACTED***"
 
 
+def test_jenkins_password_env_keys_are_redacted():
+    data = {"EFP_JENKINS_PASSWORD": "jenkins-secret", "JENKINS_USERNAME": "builder"}
+    out = redact_value(data)
+    assert out["EFP_JENKINS_PASSWORD"] == "***REDACTED***"
+    assert out["JENKINS_USERNAME"] == "builder"
+
+
 def test_assignment_style_patterns_are_redacted():
     text = "access_token=abc refresh_token=xyz secret_key=qwe"
     out = redact_text(text)

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -170,9 +170,11 @@ def test_runtime_profile_apply_writes_config_yaml_without_sidecar(tmp_path):
     assert meta["managed_sections"] == ["jira", "llm"]
 
 
-def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persisted(tmp_path, monkeypatch):
+def test_runtime_profile_external_overlay_keeps_jenkins_credentials_in_config(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
     _write_base_config(config_path)
+    for key in ("EFP_JENKINS_USERNAME", "EFP_JENKINS_PASSWORD", "JENKINS_USERNAME", "JENKINS_PASSWORD"):
+        monkeypatch.delenv(key, raising=False)
     applied = []
 
     monkeypatch.setattr(
@@ -216,14 +218,8 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
             },
             "jenkins": {
                 "enabled": True,
-                "instances": [
-                    {
-                        "name": "ci",
-                        "url": "https://jenkins.example.test",
-                        "username": "jenkins-user",
-                        "password": "jenkins-password",
-                    }
-                ],
+                "username": "jenkins-user",
+                "password": "jenkins-password",
             },
         },
     )
@@ -231,23 +227,30 @@ def test_runtime_profile_atlassian_overlay_is_external_only_and_not_portal_persi
     persisted = _read_yaml(config_path)
     assert "jira" not in persisted
     assert "confluence" not in persisted
-    assert "jenkins" not in persisted
     assert persisted["aws"] == {
         "enabled": True,
         "domain": "HBEU",
         "username": "aws-user",
         "password": "aws-password",
     }
+    assert persisted["jenkins"] == {
+        "enabled": True,
+        "username": "jenkins-user",
+        "password": "jenkins-password",
+    }
     assert persisted["instruction_texts"]
     assert "jira-token" not in config_path.read_text(encoding="utf-8")
     assert "conf-token" not in config_path.read_text(encoding="utf-8")
-    assert "jenkins-password" not in config_path.read_text(encoding="utf-8")
     assert "aws-password" in config_path.read_text(encoding="utf-8")
     assert applied[0]["jira"]["instances"][0]["token"] == "jira-token"
     assert applied[0]["confluence"]["instances"][0]["token"] == "conf-token"
     assert applied[0]["aws"]["domain"] == "HBEU"
     assert applied[0]["aws"]["password"] == "aws-password"
-    assert applied[0]["jenkins"]["instances"][0]["password"] == "jenkins-password"
+    assert applied[0]["jenkins"]["password"] == "jenkins-password"
+    assert os.environ["EFP_JENKINS_USERNAME"] == "jenkins-user"
+    assert os.environ["EFP_JENKINS_PASSWORD"] == "jenkins-password"
+    assert os.environ["JENKINS_USERNAME"] == "jenkins-user"
+    assert os.environ["JENKINS_PASSWORD"] == "jenkins-password"
     assert cfg.get_managed_overlay_meta()["managed_sections"] == [
         "aws",
         "confluence",
@@ -628,15 +631,20 @@ def test_runtime_profile_apply_encrypts_sensitive_fields_in_config_yaml(tmp_path
     cfg.set_managed_overlay(
         "rp_3",
         7,
-        {"proxy": {"enabled": True, "url": "http://proxy:8080", "password": "secret"}},
+        {
+            "proxy": {"enabled": True, "url": "http://proxy:8080", "password": "secret"},
+            "jenkins": {"enabled": True, "username": "build", "password": "jenkins-secret"},
+        },
     )
 
     raw_content = config_path.read_text(encoding="utf-8")
     assert "ENC:" in raw_content
     assert "secret" not in raw_content
+    assert "jenkins-secret" not in raw_content
 
     cfg.load()
     assert cfg.proxy.get("password") == "secret"
+    assert cfg.jenkins.get("password") == "jenkins-secret"
 
 
 def test_runtime_profile_clear_removes_managed_subtree_and_metadata(tmp_path):
@@ -787,6 +795,8 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.delenv("ATLASSIAN_CONFIG", raising=False)
     monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+    for key in ("EFP_JENKINS_USERNAME", "EFP_JENKINS_PASSWORD", "JENKINS_USERNAME", "JENKINS_PASSWORD"):
+        monkeypatch.delenv(key, raising=False)
     recorder = _CliRecorder()
     recorder.git_values = {
         "user.name": "Existing User",
@@ -835,14 +845,8 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
             },
             "jenkins": {
                 "enabled": True,
-                "instances": [
-                    {
-                        "name": "ci",
-                        "url": "https://jenkins.example.test/",
-                        "username": "jenkins-user",
-                        "password": "jenkins-password",
-                    }
-                ],
+                "username": "jenkins-user",
+                "password": "jenkins-password",
             },
             "git": {"user": {"name": "Runtime Bot", "email": "runtime@example.test"}},
         },
@@ -946,38 +950,11 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
             "check": False,
         }
     ]
-    jenkins_remove = _command_calls(recorder, ["jenkins", "instance", "remove"])
-    assert jenkins_remove == [
-        {
-            "args": ["jenkins", "instance", "remove", "ci", "--yes", "--json"],
-            "input": None,
-            "text": True,
-            "capture_output": True,
-            "check": False,
-        }
-    ]
-    jenkins_add = _command_calls(recorder, ["jenkins", "instance", "add"])
-    assert jenkins_add == [
-        {
-            "args": [
-                "jenkins",
-                "instance",
-                "add",
-                "ci",
-                "--base-url",
-                "https://jenkins.example.test",
-                "--username",
-                "jenkins-user",
-                "--password-stdin",
-                "--default",
-                "--json",
-            ],
-            "input": "jenkins-password",
-            "text": True,
-            "capture_output": True,
-            "check": False,
-        }
-    ]
+    assert _command_calls(recorder, ["jenkins"]) == []
+    assert os.environ["EFP_JENKINS_USERNAME"] == "jenkins-user"
+    assert os.environ["EFP_JENKINS_PASSWORD"] == "jenkins-password"
+    assert os.environ["JENKINS_USERNAME"] == "jenkins-user"
+    assert os.environ["JENKINS_PASSWORD"] == "jenkins-password"
     assert _command_calls(recorder, ["git", "config", "--global", "user.name"]) == [
         {
             "args": ["git", "config", "--global", "user.name", "Runtime Bot"],
@@ -1012,7 +989,6 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
         "jira": {"instances": [{"name": "jira-main"}]},
         "confluence": {"instances": [{"name": "docs"}]},
         "gh": {"hosts": ["github.example.test"]},
-        "jenkins": {"instances": [{"name": "ci"}]},
         "git": {
             "managed": {
                 "user.name": "Runtime Bot",
@@ -1064,22 +1040,11 @@ def test_runtime_profile_apply_calls_external_clis_and_clear(tmp_path, monkeypat
             "check": False,
         },
     ]
-    assert _command_calls(recorder, ["jenkins", "instance", "remove"]) == [
-        {
-            "args": ["jenkins", "instance", "remove", "ci", "--yes", "--json"],
-            "input": None,
-            "text": True,
-            "capture_output": True,
-            "check": False,
-        },
-        {
-            "args": ["jenkins", "instance", "remove", "ci", "--yes", "--json"],
-            "input": None,
-            "text": True,
-            "capture_output": True,
-            "check": False,
-        },
-    ]
+    assert _command_calls(recorder, ["jenkins"]) == []
+    assert "EFP_JENKINS_USERNAME" not in os.environ
+    assert "EFP_JENKINS_PASSWORD" not in os.environ
+    assert "JENKINS_USERNAME" not in os.environ
+    assert "JENKINS_PASSWORD" not in os.environ
     assert _command_calls(recorder, ["gh", "auth", "logout"]) == [
         {
             "args": ["gh", "auth", "logout", "--hostname", "github.example.test"],
@@ -1619,8 +1584,10 @@ def test_runtime_profile_external_cli_instructions_are_injected(tmp_path, monkey
     assert "--yes" in joined
     assert "gh for GitHub issues, pull requests, and api calls" in joined
     assert "jenkins for Jenkins controller operations" in joined
+    assert "EFP_JENKINS_USERNAME" in joined
+    assert "EFP_JENKINS_PASSWORD" in joined
     assert "git for clone, fetch, push, and status" in joined
-    assert "Credentials were applied by the runtime profile through the real CLIs" in joined
+    assert "Credentials were applied by the runtime profile through real CLIs or environment variables" in joined
     assert "auth_failed" in joined
     assert "include_default_system_prompt" not in cfg.get_effective_config()
     assert applied[0]["instruction_texts"] == instructions


### PR DESCRIPTION
## What changed
- Persist Jenkins runtime profile config as enabled/username/password instead of instances.
- Apply Jenkins credentials to agent process environment variables and clear them with the managed overlay.
- Removed Jenkins instance add/remove from the new runtime profile apply path while preserving legacy metadata cleanup.
- Added redaction and encryption test coverage for Jenkins password keys.

## Why
The native agent should receive reusable Jenkins credentials only; actual controller login/configuration happens when a pipeline/job is executed.

## Validation
- python -m pytest tests\test_runtime_profile_overlay.py tests\test_redaction.py -q
- python -m py_compile src\config.py src\external_cli\profile_config.py src\utils\redaction.py
- git diff --check