### PR TITLE
[codex] Load mounted skills in native runtime

### DIFF
--- a/src/efp_runtime/skills/discovery.py
+++ b/src/efp_runtime/skills/discovery.py
@@ -23,6 +23,8 @@ DEFAULT_PROJECT_SKILL_DIRECTORIES = (
     ".efp/skill",
     ".efp/skills",
 )
+RUNTIME_SKILLS_DIR_ENV = "EFP_SKILLS_DIR"
+RUNTIME_APP_SKILLS_DIR = "/app/skills"
 
 
 class SkillDiscovery:
@@ -84,6 +86,14 @@ def default_skill_directories(
     root = _expand_user_path(workspace_root).resolve(strict=False)
     start = _ancestor_search_start(root, cwd)
     directories: list[Path] = []
+    env_dir = os.getenv(RUNTIME_SKILLS_DIR_ENV)
+    if env_dir and env_dir.strip():
+        path = _expand_user_path(env_dir).resolve(strict=False)
+        if path.is_dir():
+            directories.append(path)
+    app_skills = Path(RUNTIME_APP_SKILLS_DIR).resolve(strict=False)
+    if app_skills.is_dir():
+        directories.append(app_skills)
     for directory in DEFAULT_GLOBAL_SKILL_DIRECTORIES:
         path = _expand_user_path(directory).resolve(strict=False)
         if path.is_dir():

--- a/src/gateway/runtime_chat.py
+++ b/src/gateway/runtime_chat.py
@@ -31,6 +31,7 @@ from src.efp_runtime.session.gateway_facade import (
     runtime_session_root,
 )
 from src.efp_runtime.session.models import MessagePartType
+from src.efp_runtime.skills.discovery import default_skill_directories
 from src.utils.redaction import sanitize_exception_message
 
 
@@ -374,6 +375,13 @@ def _runtime_config(
     kwargs["workspace_root"] = _runtime_workspace_root()
     kwargs["default_provider_id"] = "github-copilot"
     kwargs["default_model"] = model
+    if not (
+        _mapping_has_key(managed_overlay_config, "skill_directories")
+        or _mapping_has_key(profile_config, "skill_directories")
+    ):
+        default_dirs = default_skill_directories(kwargs["workspace_root"])
+        if default_dirs:
+            kwargs["skill_directories"] = default_dirs
     if not (
         _mapping_has_key(managed_overlay_config, "track_usage")
         or _mapping_has_key(profile_config, "track_usage")

--- a/tests/runtime/test_runtime_chat_gateway.py
+++ b/tests/runtime/test_runtime_chat_gateway.py
@@ -465,6 +465,33 @@ def test_runtime_chat_uses_persisted_runtime_config_fields(monkeypatch):
     assert not hasattr(runtime_config, "compaction_preserve_recent_turns")
 
 
+def test_runtime_chat_adds_default_skill_directories(monkeypatch, tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+
+    class _FakeConfig:
+        @property
+        def session(self):
+            return {"max_iterations": 2}
+
+        def get_effective_config(self):
+            return {}
+
+    monkeypatch.setattr(runtime_chat, "config", _FakeConfig())
+    monkeypatch.setattr(
+        runtime_chat,
+        "default_skill_directories",
+        lambda workspace_root: [skills_dir],
+    )
+
+    runtime_config = runtime_chat._runtime_config(
+        "request-model",
+        track_usage=False,
+    )
+
+    assert runtime_config.skill_directories == [skills_dir]
+
+
 def test_runtime_chat_profile_track_usage_overrides_only_when_present(monkeypatch):
     monkeypatch.setattr(
         runtime_chat.config,

--- a/tests/runtime/test_skill_tool.py
+++ b/tests/runtime/test_skill_tool.py
@@ -1,5 +1,6 @@
 import pytest
 
+import efp_runtime.skills.discovery as discovery_module
 from efp_runtime.context import render_tool_schemas
 from efp_runtime.loop import LoopStatus, ScriptedLLMProvider
 from efp_runtime.models import ToolCall
@@ -110,6 +111,30 @@ def test_default_skill_directories_include_efp_skill_before_plural(
         efp_skills.resolve(),
     ]
     assert default_skill_directories(tmp_path, include_defaults=False) == []
+
+
+def test_default_skill_directories_include_runtime_mounts_before_defaults(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    env_skills = tmp_path / "mounted-skills"
+    app_skills = tmp_path / "app-skills"
+    global_skills = home / ".efp" / "skills"
+    project_skills = tmp_path / ".efp" / "skills"
+    for directory in (env_skills, app_skills, global_skills, project_skills):
+        directory.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("EFP_SKILLS_DIR", str(env_skills))
+    monkeypatch.setattr(discovery_module, "RUNTIME_APP_SKILLS_DIR", str(app_skills))
+
+    assert default_skill_directories(tmp_path) == [
+        env_skills.resolve(),
+        app_skills.resolve(),
+        global_skills.resolve(),
+        project_skills.resolve(),
+    ]
 
 
 def test_default_skill_directories_discover_cwd_ancestors(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Add runtime skill mount discovery through `EFP_SKILLS_DIR` and `/app/skills` before global/project defaults.
- Populate native runtime chat gateway `skill_directories` from those defaults when the profile does not explicitly configure skills.
- Add focused coverage for native skill directory discovery and runtime chat config wiring.

## Root cause
Delegated `agent_async_task` jobs could ask native runtime to use a selected skill, but the runtime config did not include the mounted skills repository by default. As a result, skill activation could fail even though Portal had mounted the skills repo into the pod.

## Validation
- `python -m pytest tests/runtime/test_skill_tool.py::test_default_skill_directories_include_runtime_mounts_before_defaults tests/runtime/test_runtime_chat_gateway.py::test_runtime_chat_adds_default_skill_directories`
- `python -m py_compile src/efp_runtime/skills/discovery.py src/gateway/runtime_chat.py`

## Notes
A wider local Windows run of `tests/runtime/test_skill_tool.py tests/runtime/test_runtime_chat_gateway.py` showed one pre-existing path-separator expectation unrelated to this patch: `references/guide.md` vs `references\\guide.md`.