### PR TITLE
[codex] Align native max steps with opencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Sessions are automatically persisted to `/workspace/sessions/` by default.
 ```yaml
 session:
   max_history: 5        # Turns to keep in context
-  max_iterations: 30    # Max tool calls per turn
+  # max_iterations: 30  # Optional max agentic steps; omit for no limit
   persistence:
     enabled: true
     storage_dir: "/workspace/sessions"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -141,9 +141,9 @@ session:
   max_history: 5  # Keep last 5 conversation turns
   auto_save: true  # Automatically save sessions to disk
 
-  # Maximum iterations for tool execution loop
-  # Prevents infinite loops when LLM keeps requesting tools
-  max_iterations: 30
+  # Optional maximum agentic steps; omit to keep the loop unbounded until the model stops
+  # Alias-compatible with opencode-style `steps`.
+  # max_iterations: 30
 
   # Persistence layer settings (per-session files)
   persistence:

--- a/src/efp_runtime/agents/task_runner.py
+++ b/src/efp_runtime/agents/task_runner.py
@@ -336,7 +336,7 @@ def _child_config(
     max_iterations = (
         profile.max_iterations
         if profile.max_iterations is not None
-        else (base_config.max_iterations if base_config is not None else 4)
+        else (base_config.max_iterations if base_config is not None else None)
     )
     profile_permission_overlay = normalize_agent_permission_overlay(profile.metadata)
     base_tool_permissions = (

--- a/src/efp_runtime/config_loader.py
+++ b/src/efp_runtime/config_loader.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 import glob
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -71,6 +72,10 @@ _RUNTIME_CONFIG_KEYS = {
     "model",
     "defaultModel",
     "default_model",
+    "steps",
+    "maxSteps",
+    "maxIterations",
+    "max_iterations",
     "maxContextTokens",
     "max_context_tokens",
     "contextReserveTokens",
@@ -498,6 +503,8 @@ def _runtime_config_from_raw(
 
     kwargs.update(_model_context_fields(raw))
 
+    kwargs.update(_iteration_limit_fields(raw))
+
     kwargs.update(_compaction_policy_fields(raw))
 
     instruction_paths, instruction_texts = _instruction_sources(
@@ -750,6 +757,11 @@ _COMPACTION_TOP_LEVEL_FIELDS = {
     "compaction_prune_protect_chars",
 }
 
+_INTEGER_PATTERN = re.compile(r"^[+-]?\d+$")
+
+
+_ITERATION_LIMIT_ALIASES = ("steps", "maxSteps", "maxIterations", "max_iterations")
+
 
 def _model_context_fields(raw: Mapping[str, Any]) -> dict[str, Any]:
     fields: dict[str, Any] = {}
@@ -775,6 +787,13 @@ def _model_context_fields(raw: Mapping[str, Any]) -> dict[str, Any]:
     if context_reserve_tokens is not None:
         fields["context_reserve_tokens"] = context_reserve_tokens
     return fields
+
+
+def _iteration_limit_fields(raw: Mapping[str, Any]) -> dict[str, Any]:
+    value = _first_alias_value(raw, _ITERATION_LIMIT_ALIASES)
+    if value is None:
+        return {}
+    return {"max_iterations": _positive_int(value, field_name="max_iterations")}
 
 
 def _compaction_policy_fields(raw: Mapping[str, Any]) -> dict[str, Any]:
@@ -1045,6 +1064,20 @@ def _first_alias_value(raw: Mapping[str, Any], aliases: Iterable[str]) -> Any:
         if alias in alias_set and alias_value is not None:
             value = alias_value
     return value
+
+
+def _positive_int(value: Any, *, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a positive integer")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str) and _INTEGER_PATTERN.match(value.strip()):
+        parsed = int(value.strip())
+    else:
+        raise ValueError(f"{field_name} must be a positive integer")
+    if parsed < 1:
+        raise ValueError(f"{field_name} must be a positive integer")
+    return parsed
 
 
 def _first_runtime_context_alias_value(

--- a/src/efp_runtime/loop/provider.py
+++ b/src/efp_runtime/loop/provider.py
@@ -27,7 +27,7 @@ class RuntimeRequest:
     session_id: str
     messages: List[Message]
     iteration: int
-    max_iterations: int
+    max_iterations: int | None
     metadata: dict[str, Any] = field(default_factory=dict)
     provider_request: ProviderRequest = field(
         default_factory=lambda: ProviderRequest(messages=[])

--- a/src/efp_runtime/loop/runner.py
+++ b/src/efp_runtime/loop/runner.py
@@ -117,6 +117,23 @@ _COMPACTION_REPLAY_CONTINUE_TEXT = (
     "unsure how to proceed."
 )
 
+MAX_STEPS_REACHED_PROMPT = """CRITICAL - MAXIMUM STEPS REACHED
+
+The maximum number of steps allowed for this task has been reached. Tools are disabled until next user input. Respond with text only.
+
+STRICT REQUIREMENTS:
+1. Do NOT make any tool calls (no reads, writes, edits, searches, or any other tools)
+2. MUST provide a text response summarizing work done so far
+3. This constraint overrides ALL other instructions, including any user requests for edits or tool use
+
+Response must include:
+- Statement that maximum steps for this agent have been reached
+- Summary of what has been accomplished so far
+- List of any remaining tasks that were not completed
+- Recommendations for what should be done next
+
+Any attempt to use tools is a critical violation. Respond with text ONLY."""
+
 
 class _RuntimeEventLog(list):
     def __init__(self, event_bus: Optional[RuntimeEventBus] = None):
@@ -143,7 +160,7 @@ class RuntimeLoopRunner:
         provider: Union[LLMProvider, ProviderCallable],
         adapter: Optional[LLMEventAdapter] = None,
         tool_runtime: ToolRuntime,
-        max_iterations: int = 4,
+        max_iterations: int | None = None,
         doom_loop_threshold: Optional[int] = 3,
         default_provider_id: str = DEFAULT_PROVIDER_ID,
         default_model: str = DEFAULT_MODEL_ID,
@@ -169,7 +186,7 @@ class RuntimeLoopRunner:
         track_usage: bool = True,
         usage_pricing: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        if max_iterations < 1:
+        if max_iterations is not None and max_iterations < 1:
             raise ValueError("max_iterations must be at least 1")
         if doom_loop_threshold is not None and doom_loop_threshold < 2:
             raise ValueError("doom_loop_threshold must be at least 2 or None")
@@ -268,7 +285,7 @@ class RuntimeLoopRunner:
         structured_output_tool_id: str = "StructuredOutput",
     ) -> RuntimeLoopResult:
         iteration_limit = max_iterations if max_iterations is not None else self.max_iterations
-        if iteration_limit < 1:
+        if iteration_limit is not None and iteration_limit < 1:
             raise ValueError("max_iterations must be at least 1")
 
         run_metadata = dict(metadata or {})
@@ -368,28 +385,32 @@ class RuntimeLoopRunner:
                 )
             )
 
+        run_start_payload = {
+            "run_id": run_id,
+            "enabled_tool_ids": list(enabled_tool_ids),
+            "disabled_tool_ids": list(disabled_tool_ids),
+            "model_aware_tool_selection": deepcopy(
+                run_metadata["model_aware_tool_selection"]
+            ),
+            "emit_llm_stream_events": self.emit_llm_stream_events,
+            "track_usage": self.track_usage,
+            "usage_pricing_enabled": bool(
+                self.track_usage and self.usage_pricing
+            ),
+        }
+        _record_iteration_limit_metadata(
+            run_start_payload,
+            max_iterations=iteration_limit,
+        )
         runtime_events.append(
             RuntimeEvent(
                 type="run_start",
                 session_id=resolved_session_id,
-                payload={
-                    "run_id": run_id,
-                    "max_iterations": iteration_limit,
-                    "enabled_tool_ids": list(enabled_tool_ids),
-                    "disabled_tool_ids": list(disabled_tool_ids),
-                    "model_aware_tool_selection": deepcopy(
-                        run_metadata["model_aware_tool_selection"]
-                    ),
-                    "emit_llm_stream_events": self.emit_llm_stream_events,
-                    "track_usage": self.track_usage,
-                    "usage_pricing_enabled": bool(
-                        self.track_usage and self.usage_pricing
-                    ),
-                },
+                payload=run_start_payload,
             )
         )
 
-        while iterations < iteration_limit:
+        while iteration_limit is None or iterations < iteration_limit:
             if await self._cancel_requested(resolved_session_id):
                 status = LoopStatus.CANCELLED
                 publish_cancelled("before_iteration")
@@ -459,6 +480,16 @@ class RuntimeLoopRunner:
                 iteration=iteration,
                 max_iterations=iteration_limit,
             )
+            max_steps_final_iteration = (
+                iteration_limit is not None and iteration >= iteration_limit
+            )
+            request_tools = [] if max_steps_final_iteration else enabled_tools
+            if max_steps_final_iteration:
+                _record_max_steps_metadata(
+                    request_metadata,
+                    iteration=iteration,
+                    max_iterations=iteration_limit,
+                )
             _apply_compaction_replay_request_metadata(
                 request_metadata,
                 compaction_outcome.replay,
@@ -470,6 +501,13 @@ class RuntimeLoopRunner:
                 run_metadata=run_metadata,
             )
             request_history = [*request_context_messages, *history]
+            if max_steps_final_iteration:
+                request_history.append(
+                    _max_steps_reached_message(
+                        iteration=iteration,
+                        max_iterations=iteration_limit,
+                    )
+                )
             request = await self._prepare_runtime_request(
                 session_id=resolved_session_id,
                 history=history,
@@ -477,7 +515,7 @@ class RuntimeLoopRunner:
                 iteration=iteration,
                 max_iterations=iteration_limit,
                 metadata=request_metadata,
-                tools=enabled_tools,
+                tools=request_tools,
                 budget=self._context_budget(request_metadata),
             )
             _apply_compaction_replay_metadata_to_request(
@@ -541,7 +579,7 @@ class RuntimeLoopRunner:
                 provider_output = await self._invoke_provider_with_retries(
                     request,
                     history=history,
-                    tools=enabled_tools,
+                    tools=request_tools,
                     runtime_events=runtime_events,
                     run_id=run_id,
                     run_metadata=run_metadata,
@@ -635,6 +673,28 @@ class RuntimeLoopRunner:
                 status = LoopStatus.CANCELLED
                 publish_cancelled("after_iteration")
                 break
+            if max_steps_final_iteration:
+                terminal_reason = "max_steps_reached"
+                runtime_events.append(
+                    RuntimeEvent(
+                        type="loop.max_iterations",
+                        message="Maximum steps reached; agent was asked to respond with text only.",
+                        session_id=resolved_session_id,
+                        message_id=final_assistant_message.message_id,
+                        payload={
+                            "run_id": run_id,
+                            "max_iterations": iteration_limit,
+                            "iteration": iteration,
+                            "tool_call_count": len(tool_calls),
+                            "tools_disabled": True,
+                        },
+                    )
+                )
+                if tool_calls:
+                    status = LoopStatus.MAX_ITERATIONS
+                else:
+                    status = LoopStatus.COMPLETED
+                break
             if not tool_calls:
                 status = LoopStatus.COMPLETED
                 break
@@ -667,23 +727,6 @@ class RuntimeLoopRunner:
                 status = LoopStatus.COMPLETED
                 terminal_reason = tool_execution_outcome.terminal_reason
                 structured_output = tool_execution_outcome.structured_output
-                break
-
-            if iterations >= iteration_limit:
-                status = LoopStatus.MAX_ITERATIONS
-                runtime_events.append(
-                    RuntimeEvent(
-                        type="loop.max_iterations",
-                        message="Maximum loop iterations reached.",
-                        session_id=resolved_session_id,
-                        message_id=final_assistant_message.message_id,
-                        payload={
-                            "run_id": run_id,
-                            "max_iterations": iteration_limit,
-                            "pending_tool_call_count": len(tool_calls),
-                        },
-                    )
-                )
                 break
 
         if status == LoopStatus.CANCELLED:
@@ -1044,7 +1087,7 @@ class RuntimeLoopRunner:
         history: list[Message],
         request_history: list[Message],
         iteration: int,
-        max_iterations: int,
+        max_iterations: int | None,
         metadata: Mapping[str, Any],
         tools: list[Any],
         budget: ContextBudget,
@@ -1151,7 +1194,7 @@ class RuntimeLoopRunner:
         context_messages: Optional[list[Message]],
         context_message_provider: Optional[ContextMessageProvider],
         iteration: int,
-        max_iterations: int,
+        max_iterations: int | None,
     ) -> ProviderOutput:
         current_request = request
         retry_count = 0
@@ -1220,6 +1263,13 @@ class RuntimeLoopRunner:
                     *retry_context_messages,
                     *retry_history,
                 ]
+                if max_iterations is not None and iteration >= max_iterations:
+                    retry_request_history.append(
+                        _max_steps_reached_message(
+                            iteration=iteration,
+                            max_iterations=max_iterations,
+                        )
+                    )
                 overflow_request = await self._prepare_runtime_request(
                     session_id=current_request.session_id,
                     history=retry_history,
@@ -1789,7 +1839,7 @@ async def run_runtime_loop(
     provider: Union[LLMProvider, ProviderCallable],
     adapter: Optional[LLMEventAdapter] = None,
     tool_runtime: ToolRuntime,
-    max_iterations: int = 4,
+    max_iterations: int | None = None,
     doom_loop_threshold: Optional[int] = 3,
     default_provider_id: str = DEFAULT_PROVIDER_ID,
     default_model: str = DEFAULT_MODEL_ID,
@@ -2066,6 +2116,63 @@ def _record_usage_metadata(
         }
     )
     metadata["usage_telemetry"] = merged_usage_metadata
+
+
+def _record_iteration_limit_metadata(
+    metadata: dict[str, Any],
+    *,
+    max_iterations: int | None,
+) -> None:
+    if max_iterations is None:
+        metadata.pop("max_iterations", None)
+        metadata["max_iterations_unbounded"] = True
+        return
+    metadata["max_iterations"] = max_iterations
+    metadata.pop("max_iterations_unbounded", None)
+
+
+def _record_max_steps_metadata(
+    metadata: dict[str, Any],
+    *,
+    iteration: int,
+    max_iterations: int,
+) -> None:
+    metadata["max_steps_reached"] = True
+    metadata["tools_disabled_reason"] = "max_steps"
+    metadata["max_steps_iteration"] = iteration
+    metadata["max_steps_limit"] = max_iterations
+    loop_metadata = metadata.get("loop")
+    if isinstance(loop_metadata, Mapping):
+        loop = dict(loop_metadata)
+    else:
+        loop = {}
+        if loop_metadata is not None:
+            loop["caller_value"] = loop_metadata
+    loop.update(
+        {
+            "max_steps_reached": True,
+            "tools_disabled_reason": "max_steps",
+            "max_steps_iteration": iteration,
+            "max_steps_limit": max_iterations,
+        }
+    )
+    metadata["loop"] = loop
+
+
+def _max_steps_reached_message(*, iteration: int, max_iterations: int) -> Message:
+    metadata = {
+        "source": "loop.max_steps",
+        "synthetic": True,
+        "max_steps_reached": True,
+        "iteration": iteration,
+        "max_iterations": max_iterations,
+    }
+    return Message(
+        role=MessageRole.ASSISTANT,
+        parts=[MessagePart.text_part(MAX_STEPS_REACHED_PROMPT, metadata=metadata)],
+        metadata=metadata,
+        status="complete",
+    )
 
 
 async def _observe_usage_events(
@@ -2383,12 +2490,15 @@ def _request_metadata(
     *,
     session_id: str,
     iteration: int,
-    max_iterations: int,
+    max_iterations: int | None,
 ) -> dict[str, Any]:
     request_metadata = dict(metadata or {})
     request_metadata["session_id"] = session_id
     request_metadata["iteration"] = iteration
-    request_metadata["max_iterations"] = max_iterations
+    _record_iteration_limit_metadata(
+        request_metadata,
+        max_iterations=max_iterations,
+    )
     loop_metadata = request_metadata.get("loop")
     if isinstance(loop_metadata, Mapping):
         merged_loop_metadata = dict(loop_metadata)
@@ -2396,12 +2506,10 @@ def _request_metadata(
         merged_loop_metadata = {}
         if loop_metadata is not None:
             merged_loop_metadata["caller_value"] = loop_metadata
-    merged_loop_metadata.update(
-        {
-            "session_id": session_id,
-            "iteration": iteration,
-            "max_iterations": max_iterations,
-        }
+    merged_loop_metadata.update({"session_id": session_id, "iteration": iteration})
+    _record_iteration_limit_metadata(
+        merged_loop_metadata,
+        max_iterations=max_iterations,
     )
     request_metadata["loop"] = merged_loop_metadata
     return request_metadata

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -545,7 +545,10 @@ class AgentRuntime:
                 source="run",
             )
             self._inject_pending_background_task_results(resolved_session_id)
-            run_metadata["max_iterations"] = iteration_limit
+            _record_run_iteration_limit_metadata(
+                run_metadata,
+                max_iterations=iteration_limit,
+            )
             run_metadata["run_id"] = run_id
             command_subtask_events: list[RuntimeEvent] = []
             if selected_agent_source is not None:
@@ -787,7 +790,10 @@ class AgentRuntime:
             run_metadata = self._base_run_metadata(metadata)
             self._apply_session_model_default(run_metadata, session)
             run_metadata["run_id"] = run_id
-            run_metadata["max_iterations"] = iteration_limit
+            _record_run_iteration_limit_metadata(
+                run_metadata,
+                max_iterations=iteration_limit,
+            )
             if selected_agent_source is not None:
                 run_metadata["selected_agent_source"] = selected_agent_source
             if structured_output_active:
@@ -1519,7 +1525,10 @@ class AgentRuntime:
     def _base_run_metadata(self, metadata: Mapping[str, Any] | None) -> dict[str, Any]:
         run_metadata = dict(self.config.metadata)
         run_metadata.update(metadata or {})
-        run_metadata["max_iterations"] = self.config.max_iterations
+        _record_run_iteration_limit_metadata(
+            run_metadata,
+            max_iterations=self.config.max_iterations,
+        )
         run_metadata["runtime_mode"] = self.config.runtime_mode
         run_metadata["plan_mode_read_only"] = self.config.plan_mode_read_only
         run_metadata["enable_question_tool"] = self.config.enable_question_tool
@@ -2322,10 +2331,24 @@ def _profile_configured_max_iterations(profile: Any) -> int | None:
     return max_iterations
 
 
-def _profile_max_iterations(profile: Any | None, default: int) -> int:
+def _record_run_iteration_limit_metadata(
+    metadata: dict[str, Any],
+    *,
+    max_iterations: int | None,
+) -> None:
+    if max_iterations is None:
+        metadata.pop("max_iterations", None)
+        metadata["max_iterations_unbounded"] = True
+        return
+    metadata["max_iterations"] = max_iterations
+    metadata.pop("max_iterations_unbounded", None)
+
+
+def _profile_max_iterations(profile: Any | None, default: int | None) -> int | None:
     if profile is None:
         return default
-    return _profile_configured_max_iterations(profile) or default
+    configured = _profile_configured_max_iterations(profile)
+    return configured if configured is not None else default
 
 
 def _profile_active_skills(profile: Any) -> list[str]:
@@ -2490,7 +2513,7 @@ def _resolve_config(
     if config is None:
         return RuntimeConfig(
             workspace_root=workspace_root,
-            max_iterations=max_iterations if max_iterations is not None else 4,
+            max_iterations=max_iterations,
             doom_loop_threshold=3,
             max_context_parts=max_context_parts,
             max_context_chars=max_context_chars,

--- a/src/efp_runtime/runtime/config.py
+++ b/src/efp_runtime/runtime/config.py
@@ -17,7 +17,7 @@ class RuntimeConfig:
     """Static settings for an AgentRuntime instance."""
 
     workspace_root: str | Path | None = None
-    max_iterations: int = 4
+    max_iterations: int | None = None
     doom_loop_threshold: int | None = 3
     default_provider_id: str = "github-copilot"
     default_model: str = "gpt-5.4"
@@ -84,7 +84,7 @@ class RuntimeConfig:
     tool_output_dir: str | Path | None = None
 
     def __post_init__(self) -> None:
-        if self.max_iterations < 1:
+        if self.max_iterations is not None and self.max_iterations < 1:
             raise ValueError("max_iterations must be at least 1")
         if self.doom_loop_threshold is not None and self.doom_loop_threshold < 2:
             raise ValueError("doom_loop_threshold must be at least 2 or None")

--- a/src/gateway/runtime_chat.py
+++ b/src/gateway/runtime_chat.py
@@ -466,13 +466,15 @@ def _runtime_config_profile_kwargs(
     }
 
 
-def _resolve_max_iterations() -> int:
-    value = config.session.get("max_iterations", 30)
+def _resolve_max_iterations() -> int | None:
+    value = config.session.get("max_iterations")
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return None
     try:
         parsed = int(value)
     except (TypeError, ValueError):
-        return 30
-    return parsed if parsed > 0 else 30
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _resolve_model(model: str | None = None) -> str:

--- a/tests/runtime/test_active_skills.py
+++ b/tests/runtime/test_active_skills.py
@@ -27,7 +27,7 @@ async def test_config_active_skills_are_injected_before_user_history(tmp_path: P
         config=RuntimeConfig(
             skill_directories=[tmp_path],
             active_skills=["review-pr"],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -60,7 +60,7 @@ async def test_injected_skill_context_builder_is_used_without_config_directories
         provider=provider,
         config=RuntimeConfig(
             active_skills=["review-pr"],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -83,7 +83,7 @@ async def test_skill_command_adds_active_skill_and_cleans_user_text(tmp_path: Pa
         provider=provider,
         config=RuntimeConfig(
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -114,7 +114,7 @@ async def test_skill_command_only_still_sends_context(tmp_path: Path):
         provider=provider,
         config=RuntimeConfig(
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -143,7 +143,7 @@ async def test_skill_clear_removes_active_skills_and_stops_injection(tmp_path: P
         config=RuntimeConfig(
             skill_directories=[tmp_path],
             active_skills=["review-pr"],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -181,7 +181,7 @@ async def test_skill_context_is_not_persisted_or_duplicated_between_runs(tmp_pat
         config=RuntimeConfig(
             skill_directories=[tmp_path],
             active_skills=["review-pr"],
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -223,7 +223,7 @@ async def test_unknown_active_skill_error_includes_available_names(tmp_path: Pat
     provider = ScriptedLLMProvider([{"content": "Unused."}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(skill_directories=[tmp_path], max_iterations=1),
+        config=RuntimeConfig(skill_directories=[tmp_path], max_iterations=2),
     )
 
     with pytest.raises(KeyError) as error:

--- a/tests/runtime/test_agent_profiles_subagent_runner.py
+++ b/tests/runtime/test_agent_profiles_subagent_runner.py
@@ -346,7 +346,7 @@ async def test_subagent_runner_selects_profile_and_builds_child_prompt():
                 metadata={"tier": "specialist"},
             ),
         ],
-        base_config=RuntimeConfig(max_iterations=1),
+        base_config=RuntimeConfig(max_iterations=2),
     )
 
     result = await runner(
@@ -398,7 +398,7 @@ async def test_create_agent_task_tool_foreground_execution_still_selects_profile
                 prompt="Use the debugger profile.",
             ),
         ],
-        base_config=RuntimeConfig(max_iterations=1),
+        base_config=RuntimeConfig(max_iterations=2),
     )
     runtime = ToolRuntime(ToolRegistry([tool]))
 
@@ -441,7 +441,7 @@ async def test_profile_tools_are_applied_as_per_run_overrides():
             )
         ],
         base_config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             enabled_tools=["alpha", "beta"],
         ),
         tool_runtime_factory=tool_runtime_factory,
@@ -729,7 +729,7 @@ async def test_profile_active_skills_enter_child_context_without_base_pollution(
     base_config = RuntimeConfig(
         skill_directories=[tmp_path],
         active_skills=["base-skill"],
-        max_iterations=1,
+        max_iterations=2,
         include_default_system_prompt=False,
         include_environment_context=False,
         include_runtime_reminders=False,
@@ -908,7 +908,7 @@ async def test_create_task_tool_with_subagent_runner_returns_output_to_parent_lo
             AgentProfile(name="general"),
             AgentProfile(name="debugger", prompt="Debug the task."),
         ],
-        base_config=RuntimeConfig(max_iterations=1),
+        base_config=RuntimeConfig(max_iterations=2),
     )
     runner = RuntimeLoopRunner(
         store=_store(),
@@ -986,7 +986,7 @@ async def _visible_child_tool_ids(profile: AgentProfile) -> list[str]:
     runner = create_subagent_task_runner(
         provider=provider,
         profiles=[profile],
-        base_config=RuntimeConfig(max_iterations=1),
+        base_config=RuntimeConfig(max_iterations=2),
         tool_runtime_factory=tool_runtime_factory,
     )
     result = await runner(

--- a/tests/runtime/test_agent_runtime_profiles.py
+++ b/tests/runtime/test_agent_runtime_profiles.py
@@ -47,7 +47,7 @@ async def test_named_agent_injects_profile_prompt_into_provider_system_context()
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -88,7 +88,7 @@ async def test_builtin_read_only_agent_records_metadata_and_applies_prompt():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -133,7 +133,7 @@ async def test_profile_prompt_is_not_written_to_session_history():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -161,7 +161,7 @@ async def test_default_agent_is_used_when_run_omits_agent():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -193,7 +193,7 @@ async def test_switch_agent_persists_event_and_run_resume_use_session_profile():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -259,7 +259,7 @@ async def test_caller_command_and_mention_agents_override_session_agent():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -310,7 +310,7 @@ async def test_agent_mention_selects_profile_and_strips_token():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -340,7 +340,7 @@ async def test_agent_mention_alone_selects_profile_and_sends_clean_prompt():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -372,7 +372,7 @@ async def test_caller_agent_wins_over_agent_mention_without_stripping():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -416,7 +416,7 @@ async def test_command_agent_wins_over_agent_mention_without_stripping():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -448,7 +448,7 @@ async def test_unknown_agent_mention_is_left_as_prompt_text():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -478,7 +478,7 @@ async def test_file_reference_at_first_token_is_not_consumed_as_agent_mention(
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -494,7 +494,7 @@ async def test_file_reference_at_first_token_is_not_consumed_as_agent_mention(
     assert "agent_mention" not in request.metadata
     assert message.parts[0].text == "@README.md"
     assert message.attachments[0].text_ref == "README.md"
-    assert message.attachments[0].metadata["content"] == "read me\n"
+    assert message.attachments[0].metadata["content"].replace("\r\n", "\n") == "read me\n"
 
 
 @pytest.mark.asyncio
@@ -503,7 +503,7 @@ async def test_direct_agent_profile_does_not_require_registry():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -539,7 +539,7 @@ async def test_profile_active_skills_are_base_and_skill_commands_are_temporary(
         config=RuntimeConfig(
             skill_directories=[tmp_path],
             active_skills=["runtime-skill"],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -588,7 +588,7 @@ async def test_profile_active_skills_do_not_leak_to_next_plain_run(tmp_path: Pat
         provider=provider,
         config=RuntimeConfig(
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -636,7 +636,7 @@ async def test_profile_active_skills_apply_when_profile_selected_by_command(
         provider=provider,
         config=RuntimeConfig(
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -672,7 +672,7 @@ async def test_profile_tools_apply_and_caller_tools_override_profile_tools():
     )
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1),
+        config=RuntimeConfig(max_iterations=2),
         tool_registry=ToolRegistry([_tool("alpha"), _tool("beta")]),
         agent_registry=registry,
     )
@@ -789,7 +789,7 @@ async def test_invalid_profile_permission_metadata_raises_before_provider_call()
     )
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1),
+        config=RuntimeConfig(max_iterations=2),
         tool_registry=ToolRegistry([_tool("alpha")]),
     )
 
@@ -889,7 +889,7 @@ async def test_profile_metadata_is_run_metadata_without_top_level_model_switch()
         name="review",
         metadata={"model": "profile-model", "mode": "review", "temperature": 0.2},
     )
-    runtime = AgentRuntime(provider=provider, config=RuntimeConfig(max_iterations=1))
+    runtime = AgentRuntime(provider=provider, config=RuntimeConfig(max_iterations=2))
 
     await runtime.run("Record metadata.", session_id="session-profile-metadata", agent=profile)
 

--- a/tests/runtime/test_auto_session_compaction.py
+++ b/tests/runtime/test_auto_session_compaction.py
@@ -520,7 +520,7 @@ async def test_resume_path_uses_auto_session_compaction():
         provider=provider,
         store=store,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             max_context_parts=3,
             compaction_tail_turns=1,
             include_default_system_prompt=False,

--- a/tests/runtime/test_compaction_summarizer_controller.py
+++ b/tests/runtime/test_compaction_summarizer_controller.py
@@ -322,7 +322,7 @@ async def test_agent_runtime_passes_enabled_compaction_summarizer_to_runner():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             max_context_parts=2,
             enable_compaction_summarizer=True,
         ),
@@ -363,7 +363,7 @@ async def test_agent_runtime_does_not_call_summarizer_when_config_disabled():
     provider = ScriptedLLMProvider([{"content": "Done."}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1, max_context_parts=2),
+        config=RuntimeConfig(max_iterations=2, max_context_parts=2),
         compaction_summarizer=fake,
     )
     runtime.store.create_session(session_id="session-disabled-summary")

--- a/tests/runtime/test_config_loader.py
+++ b/tests/runtime/test_config_loader.py
@@ -1446,6 +1446,31 @@ def test_max_step_aliases_map_to_agent_max_iterations(tmp_path: Path):
     assert registry.resolve("max-iterations-agent").max_iterations == 4
 
 
+@pytest.mark.parametrize(
+    ("alias", "value"),
+    [
+        ("steps", 2),
+        ("maxSteps", "3"),
+        ("maxIterations", 4),
+        ("max_iterations", "5"),
+    ],
+)
+def test_runtime_iteration_limit_aliases_map_to_max_iterations(
+    tmp_path: Path,
+    alias: str,
+    value: int | str,
+):
+    _write_json(tmp_path / ".efp/config.json", {alias: value})
+
+    result = load_runtime_config(
+        tmp_path,
+        paths=[".efp/config.json"],
+        include_defaults=False,
+    )
+
+    assert result.config.max_iterations == int(value)
+
+
 def test_agent_unknown_fields_are_preserved_in_profile_raw_config(tmp_path: Path):
     _write_json(
         tmp_path / "agents.json",

--- a/tests/runtime/test_context_budget_compaction.py
+++ b/tests/runtime/test_context_budget_compaction.py
@@ -206,7 +206,7 @@ async def test_agent_runtime_passes_config_max_context_chars_to_provider_request
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             max_context_chars=420,
             context_reserve_chars=20,
         ),

--- a/tests/runtime/test_custom_commands.py
+++ b/tests/runtime/test_custom_commands.py
@@ -454,7 +454,7 @@ async def test_slash_command_expands_into_provider_user_message(tmp_path: Path):
         provider=provider,
         config=RuntimeConfig(
             command_directories=[command_dir],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -491,7 +491,7 @@ async def test_skill_backed_slash_command_expands_into_provider_user_message(
         provider=provider,
         config=RuntimeConfig(
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -533,7 +533,7 @@ async def test_run_command_matches_slash_invocation_prompt_and_metadata(
     arguments = 'ticket-1 --flag "two words"'
     config = RuntimeConfig(
         command_directories=[command_dir],
-        max_iterations=1,
+        max_iterations=2,
         include_default_system_prompt=False,
         include_environment_context=False,
         include_runtime_reminders=False,
@@ -585,7 +585,7 @@ async def test_run_command_accepts_leading_slash_in_command_name(tmp_path: Path)
         provider=provider,
         config=RuntimeConfig(
             command_directories=[command_dir],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -645,7 +645,7 @@ async def test_run_command_invokes_skill_backed_command(tmp_path: Path):
         provider=provider,
         config=RuntimeConfig(
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -688,7 +688,7 @@ async def test_run_command_emits_command_executed_event_once(tmp_path: Path):
         provider=provider,
         config=RuntimeConfig(
             command_directories=[command_dir],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -731,7 +731,7 @@ async def test_slash_command_emits_command_executed_event(tmp_path: Path):
         provider=provider,
         config=RuntimeConfig(
             command_directories=[command_dir],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -879,7 +879,7 @@ async def test_builtin_init_available_without_config_or_command_directory(
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -908,7 +908,7 @@ async def test_builtin_review_available_without_config_or_command_directory(
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1012,7 +1012,7 @@ async def test_injected_command_registry_expands_without_config_directories():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1071,7 +1071,7 @@ async def test_command_subtask_true_executes_task_tool_before_parent_provider():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1194,7 +1194,7 @@ async def test_command_agent_subagent_profile_executes_task_when_subtask_omitted
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1245,7 +1245,7 @@ async def test_command_subtask_false_overrides_subagent_profile_mode():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1292,7 +1292,7 @@ async def test_command_subtask_respects_disabled_task_tool():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             disabled_tools=["task"],
             include_default_system_prompt=False,
             include_environment_context=False,
@@ -1338,7 +1338,7 @@ async def test_command_subtask_respects_per_run_task_disable():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1392,7 +1392,7 @@ async def test_command_subtask_error_falls_back_to_ordinary_command_prompt():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1485,7 +1485,7 @@ async def test_command_agent_selects_profile_when_caller_omits_agent():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1528,7 +1528,7 @@ async def test_caller_agent_wins_over_command_agent():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1599,7 +1599,7 @@ async def test_command_model_records_requested_model_without_provider_model_swit
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1652,7 +1652,7 @@ async def test_command_model_sets_openai_payload_model_without_provider_model_sw
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1707,7 +1707,7 @@ async def test_command_tools_merge_profile_command_and_caller_overrides():
     )
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1, model_aware_tool_selection=False),
+        config=RuntimeConfig(max_iterations=2, model_aware_tool_selection=False),
         command_registry=registry,
         tool_registry=ToolRegistry(
             [_tool("read"), _tool("edit"), _tool("bash")]
@@ -1779,7 +1779,7 @@ async def test_slash_command_preserves_remaining_body(tmp_path: Path):
         provider=provider,
         config=RuntimeConfig(
             command_directories=[command_dir],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1806,7 +1806,7 @@ async def test_unknown_slash_command_is_left_as_user_text(tmp_path: Path):
         config=RuntimeConfig(
             command_directories=[command_dir],
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1839,7 +1839,7 @@ async def test_skill_slash_fallback_activates_discovered_skill_when_unhandled(
         provider=provider,
         config=RuntimeConfig(
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1878,7 +1878,7 @@ async def test_skill_slash_fallback_handles_multiline_form(tmp_path: Path):
         provider=provider,
         config=RuntimeConfig(
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1908,7 +1908,7 @@ async def test_custom_command_wins_over_same_named_skill(tmp_path: Path):
         config=RuntimeConfig(
             command_directories=[command_dir],
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1938,7 +1938,7 @@ async def test_skill_command_does_not_trigger_custom_command(tmp_path: Path):
         config=RuntimeConfig(
             command_directories=[command_dir],
             skill_directories=[tmp_path],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -1977,7 +1977,7 @@ async def test_command_content_is_truncated_by_configured_limit(tmp_path: Path):
         config=RuntimeConfig(
             command_directories=[command_dir],
             max_command_chars=3,
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -2018,7 +2018,7 @@ async def test_command_shell_interpolation_renders_tool_results(tmp_path: Path):
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             tool_permissions={"bash": "allow"},
             include_default_system_prompt=False,
             include_environment_context=False,
@@ -2067,7 +2067,7 @@ async def test_command_shell_interpolation_permission_denial_is_visible(
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             tool_permissions={"bash": "deny"},
             include_default_system_prompt=False,
             include_environment_context=False,
@@ -2104,7 +2104,7 @@ async def test_command_arguments_and_body_shell_syntax_are_not_interpolated(
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             tool_permissions={"bash": "allow"},
             include_default_system_prompt=False,
             include_environment_context=False,
@@ -2145,7 +2145,7 @@ async def test_command_file_references_are_resolved_after_expansion(tmp_path: Pa
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,

--- a/tests/runtime/test_file_session_store.py
+++ b/tests/runtime/test_file_session_store.py
@@ -365,7 +365,7 @@ async def test_agent_runtime_with_file_store_persists_text_only_run(tmp_path: Pa
     runtime = AgentRuntime(
         provider=provider,
         workspace_root=tmp_path,
-        max_iterations=1,
+        max_iterations=2,
         store=store,
     )
 

--- a/tests/runtime/test_instruction_context.py
+++ b/tests/runtime/test_instruction_context.py
@@ -214,7 +214,7 @@ async def test_agent_runtime_run_injects_instruction_context_without_persisting_
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -324,7 +324,7 @@ async def test_resume_injects_instruction_context_without_empty_user_message(
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,
@@ -364,7 +364,7 @@ async def test_instruction_context_precedes_active_skill_context(tmp_path: Path)
             workspace_root=tmp_path,
             skill_directories=[skills_root],
             active_skills=["review-pr"],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,

--- a/tests/runtime/test_loop_runner.py
+++ b/tests/runtime/test_loop_runner.py
@@ -47,7 +47,9 @@ async def test_text_only_provider_response_creates_final_assistant_text():
     assert request.provider_request.messages[0].text == "Say done."
     assert request.prepared_request.request is request.provider_request
     assert request.metadata["loop"]["iteration"] == 1
-    assert request.metadata["loop"]["max_iterations"] == 4
+    assert request.max_iterations is None
+    assert "max_iterations" not in request.metadata["loop"]
+    assert request.metadata["loop"]["max_iterations_unbounded"] is True
 
 
 @pytest.mark.asyncio
@@ -173,24 +175,12 @@ async def test_max_context_parts_compacts_provider_request_metadata():
 
 
 @pytest.mark.asyncio
-async def test_max_iterations_stops_with_explicit_status_after_tool_results():
+async def test_max_iterations_requests_text_only_summary_on_final_step():
     async def execute(args, context):
         return "ok"
 
     store = InMemorySessionStore()
-    provider = ScriptedLLMProvider(
-        [
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_again",
-                        "type": "function",
-                        "function": {"name": "again", "arguments": "{}"},
-                    }
-                ]
-            }
-        ]
-    )
+    provider = ScriptedLLMProvider([{"content": "Maximum steps reached. Summary."}])
     runner = RuntimeLoopRunner(
         store=store,
         provider=provider,
@@ -211,19 +201,80 @@ async def test_max_iterations_stops_with_explicit_status_after_tool_results():
 
     result = await runner.run(session_id="session-max", user_text="Loop once.")
 
-    assert result.status == LoopStatus.MAX_ITERATIONS
+    assert result.status == LoopStatus.COMPLETED
     assert result.iterations == 1
     assert result.final_assistant_message is not None
-    assert result.final_assistant_message.parts[0].type is MessagePartType.TOOL_CALL
+    assert result.final_assistant_message.parts[0].text == "Maximum steps reached. Summary."
     assert any(event.type == "loop.max_iterations" for event in result.runtime_events)
+    request = provider.requests[0]
+    assert request.max_iterations == 1
+    assert request.provider_request.tools == []
+    assert request.provider_request.messages[-1].role == "assistant"
+    assert "CRITICAL - MAXIMUM STEPS REACHED" in request.provider_request.messages[-1].text
+    finish = result.runtime_events[-1]
+    assert finish.type == "run_finish"
+    assert finish.payload["status"] == LoopStatus.COMPLETED
+    assert finish.payload["terminal_reason"] == "max_steps_reached"
 
     history = store.read_history(result.session_id)
     assert [message.role for message in history] == [
         MessageRole.USER,
         MessageRole.ASSISTANT,
-        MessageRole.TOOL,
     ]
-    assert history[2].parts[0].type is MessagePartType.TOOL_RESULT
+
+
+@pytest.mark.asyncio
+async def test_default_loop_is_unbounded_until_model_stops():
+    async def execute(args, context):
+        return "ok"
+
+    store = InMemorySessionStore()
+    provider = ScriptedLLMProvider(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": f"call_again_{index}",
+                        "type": "function",
+                        "function": {"name": "again", "arguments": "{}"},
+                    }
+                ]
+            }
+            for index in range(5)
+        ]
+        + [{"content": "Done after repeated tools."}]
+    )
+    runner = RuntimeLoopRunner(
+        store=store,
+        provider=provider,
+        tool_runtime=ToolRuntime(
+            ToolRegistry(
+                [
+                    ToolDef(
+                        id="again",
+                        description="Return ok",
+                        input_schema={"type": "object", "properties": {}},
+                        execute=execute,
+                    )
+                ]
+            )
+        ),
+        doom_loop_threshold=None,
+    )
+
+    result = await runner.run(session_id="session-unbounded", user_text="Keep going.")
+
+    assert result.status == LoopStatus.COMPLETED
+    assert result.iterations == 6
+    assert result.final_assistant_message is not None
+    assert result.final_assistant_message.parts[0].text == "Done after repeated tools."
+    assert len(provider.requests) == 6
+    assert all(request.max_iterations is None for request in provider.requests)
+    assert not any(event.type == "loop.max_iterations" for event in result.runtime_events)
+    assert not any(
+        "CRITICAL - MAXIMUM STEPS REACHED" in message.text
+        for message in provider.requests[-1].provider_request.messages
+    )
 
 
 def test_loop_package_imports_standalone_with_pythonpath_src():

--- a/tests/runtime/test_lsp_tool.py
+++ b/tests/runtime/test_lsp_tool.py
@@ -218,7 +218,7 @@ async def test_agent_runtime_can_expose_lsp_provider_schema(tmp_path: Path):
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             enable_lsp_tool=True,
         ),
         lsp_client=RecordingLSPClient(),

--- a/tests/runtime/test_opencode_tool_surface.py
+++ b/tests/runtime/test_opencode_tool_surface.py
@@ -39,7 +39,7 @@ async def test_agent_runtime_default_request_uses_efp_core_tools(tmp_path: Path)
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=1),
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=2),
     )
 
     result = await runtime.run("List tools.", session_id="session-default-surface")
@@ -62,7 +62,7 @@ async def test_model_aware_selection_uses_only_registered_file_tools_by_default(
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=1),
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=2),
     )
 
     result = await runtime.run(

--- a/tests/runtime/test_permission_config.py
+++ b/tests/runtime/test_permission_config.py
@@ -602,7 +602,7 @@ async def test_permission_config_does_not_control_tool_schema_visibility(
         provider=visible_provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
                 model_aware_tool_selection=False,
                 tool_permissions={"edit": "deny"},
         ),
@@ -630,7 +630,7 @@ async def test_permission_config_does_not_control_tool_schema_visibility(
         provider=disabled_provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             model_aware_tool_selection=False,
             disabled_tools=["edit"],
             tool_permissions={"edit": "deny"},

--- a/tests/runtime/test_plan_mode.py
+++ b/tests/runtime/test_plan_mode.py
@@ -40,7 +40,7 @@ async def test_build_mode_defaults_do_not_register_or_expose_plan_exit(tmp_path:
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=1),
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=2),
     )
 
     result = await runtime.run("Run normally.", session_id="session-build-mode")
@@ -62,7 +62,7 @@ async def test_plan_mode_exposes_plan_exit_and_hides_mutating_tools(tmp_path: Pa
         config=RuntimeConfig(
             workspace_root=tmp_path,
             runtime_mode="plan",
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -89,7 +89,7 @@ async def test_plan_mode_custom_alias_registry_hides_mutating_aliases(tmp_path: 
         config=RuntimeConfig(
             workspace_root=tmp_path,
             runtime_mode="plan",
-            max_iterations=1,
+            max_iterations=2,
         ),
         tool_registry=ToolRegistry(
             [
@@ -278,7 +278,7 @@ async def test_enable_plan_tool_registers_plan_exit_in_build_mode(tmp_path: Path
         config=RuntimeConfig(
             workspace_root=tmp_path,
             enable_plan_tool=True,
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -302,7 +302,7 @@ async def test_plan_mode_read_only_false_does_not_force_hide_mutating_tools(
             workspace_root=tmp_path,
             runtime_mode="plan",
             plan_mode_read_only=False,
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -326,7 +326,7 @@ async def test_plan_mode_enabled_tools_cannot_bypass_read_only_policy(
             runtime_mode="plan",
             enabled_tools=["apply_patch", "plan_exit", "read"],
             disabled_tools=["read"],
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -359,7 +359,7 @@ async def test_plan_mode_reminder_is_provider_only_context(tmp_path: Path):
         config=RuntimeConfig(
             workspace_root=tmp_path,
             runtime_mode="plan",
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 

--- a/tests/runtime/test_prompt_reference_resolver.py
+++ b/tests/runtime/test_prompt_reference_resolver.py
@@ -133,7 +133,7 @@ async def test_agent_runtime_writes_prompt_reference_parts_to_history_and_reques
     provider = ScriptedLLMProvider([{"content": "Done."}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=1),
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=2),
     )
 
     result = await runtime.run("Use @notes.txt", session_id="session-prompt-ref")
@@ -169,7 +169,7 @@ async def test_agent_runtime_can_keep_prompt_references_as_plain_text(tmp_path: 
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             resolve_prompt_references=False,
         ),
     )

--- a/tests/runtime/test_provider_retry_overflow.py
+++ b/tests/runtime/test_provider_retry_overflow.py
@@ -19,6 +19,7 @@ from efp_runtime.loop import LoopStatus, RuntimeLoopRunner, RuntimeRequest
 from efp_runtime.models import Message, MessagePart, ToolCall
 from efp_runtime.session.models import Session
 from efp_runtime.session.store import InMemorySessionStore
+from efp_runtime.tools.definition import ToolDef
 from efp_runtime.tools.registry import ToolRegistry
 from efp_runtime.tools.runtime import ToolRuntime
 
@@ -232,6 +233,52 @@ async def test_context_overflow_triggers_compacted_retry_and_succeeds():
     assert overflow_events[0].payload["attempt"] == 1
     assert overflow_events[0].payload["compaction"]["overflow_retry"] is True
     assert provider.message_snapshots[1][-1] == ("user", "latest request")
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_retry_preserves_max_steps_text_only_request():
+    async def execute(args, context):
+        return "unused"
+
+    provider = SequenceProvider(
+        [
+            ProviderContextOverflowError("context too long"),
+            {"content": "Stopped after max steps."},
+        ]
+    )
+    runner = RuntimeLoopRunner(
+        store=InMemorySessionStore(),
+        provider=provider,
+        tool_runtime=ToolRuntime(
+            ToolRegistry(
+                [
+                    ToolDef(
+                        id="again",
+                        description="Return unused",
+                        input_schema={"type": "object", "properties": {}},
+                        execute=execute,
+                    )
+                ]
+            )
+        ),
+        max_iterations=1,
+        max_context_parts=5,
+    )
+
+    result = await runner.run(
+        session=_old_session("old 1", "old 2", "old 3", "old 4"),
+        user_text="latest request",
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    assert len(provider.requests) == 2
+    assert provider.requests[0].provider_request.tools == []
+    assert provider.requests[1].provider_request.tools == []
+    assert provider.metadata_snapshots[1]["max_steps_reached"] is True
+    assert provider.metadata_snapshots[1]["overflow_retry"] is True
+    assert provider.message_snapshots[1][-1][0] == "assistant"
+    assert "CRITICAL - MAXIMUM STEPS REACHED" in provider.message_snapshots[1][-1][1]
+    assert any(event.type == "loop.max_iterations" for event in result.runtime_events)
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_provider_transport.py
+++ b/tests/runtime/test_provider_transport.py
@@ -1345,7 +1345,7 @@ def _runtime_request_with_tool_history(
         session_id="session-history",
         messages=[],
         iteration=1,
-        max_iterations=1,
+        max_iterations=2,
         provider_request=ProviderRequest(
             messages=[
                 RequestMessage(
@@ -1375,7 +1375,7 @@ def _runtime_request_with_tool_call_and_result_history(
         session_id="session-tool-history",
         messages=[],
         iteration=1,
-        max_iterations=1,
+        max_iterations=2,
         provider_request=ProviderRequest(
             messages=[
                 RequestMessage(
@@ -1427,7 +1427,7 @@ def _runtime_request_with_metadata(metadata: dict[str, object]) -> RuntimeReques
         session_id="session-metadata",
         messages=[],
         iteration=1,
-        max_iterations=1,
+        max_iterations=2,
         provider_request=ProviderRequest(
             messages=[
                 RequestMessage(

--- a/tests/runtime/test_read_instruction_attachment.py
+++ b/tests/runtime/test_read_instruction_attachment.py
@@ -120,7 +120,7 @@ async def test_agent_runtime_default_registry_attaches_read_instructions(tmp_pat
         provider=ScriptedLLMProvider([{"content": "unused"}]),
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -161,7 +161,7 @@ async def test_agent_runtime_can_disable_read_instruction_attachment(tmp_path: P
         provider=ScriptedLLMProvider([{"content": "unused"}]),
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             attach_read_instructions=False,
         ),
     )

--- a/tests/runtime/test_runtime_chat_gateway.py
+++ b/tests/runtime/test_runtime_chat_gateway.py
@@ -465,6 +465,25 @@ def test_runtime_chat_uses_persisted_runtime_config_fields(monkeypatch):
     assert not hasattr(runtime_config, "compaction_preserve_recent_turns")
 
 
+def test_runtime_chat_leaves_max_iterations_unbounded_when_unconfigured(monkeypatch):
+    class _FakeConfig:
+        @property
+        def session(self):
+            return {}
+
+        def get_effective_config(self):
+            return {}
+
+    monkeypatch.setattr(runtime_chat, "config", _FakeConfig())
+
+    runtime_config = runtime_chat._runtime_config(
+        "request-model",
+        track_usage=True,
+    )
+
+    assert runtime_config.max_iterations is None
+
+
 def test_runtime_chat_adds_default_skill_directories(monkeypatch, tmp_path):
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()

--- a/tests/runtime/test_runtime_facade.py
+++ b/tests/runtime/test_runtime_facade.py
@@ -24,7 +24,7 @@ async def test_agent_runtime_defaults_to_builtin_tools_for_workspace(tmp_path: P
         provider=provider,
         config=RuntimeConfig(
             workspace_root=tmp_path,
-            max_iterations=1,
+            max_iterations=2,
             metadata={"suite": "facade"},
         ),
     )
@@ -77,7 +77,7 @@ async def test_agent_runtime_defaults_to_builtin_tools_for_workspace(tmp_path: P
     assert request.metadata["instruction_context_count"] == 0
     assert request.metadata["skill_context_count"] == 0
     assert request.metadata["loop"]["iteration"] == 1
-    assert request.provider_request.metadata["loop"]["max_iterations"] == 1
+    assert request.provider_request.metadata["loop"]["max_iterations"] == 2
 
 
 @pytest.mark.asyncio
@@ -91,7 +91,7 @@ async def test_agent_runtime_session_management_facade_with_default_store(tmp_pa
     )
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=1),
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=2),
     )
 
     created = runtime.create_session(
@@ -176,7 +176,7 @@ async def test_agent_runtime_switch_model_sets_session_default_for_run_and_resum
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_runtime_reminders=False,
         ),
@@ -218,7 +218,7 @@ async def test_agent_runtime_switch_model_mapping_sets_session_model_without_str
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_runtime_reminders=False,
         ),

--- a/tests/runtime/test_skill_tool.py
+++ b/tests/runtime/test_skill_tool.py
@@ -590,7 +590,7 @@ async def test_agent_runtime_default_provider_request_tools_include_skill(tmp_pa
         config=RuntimeConfig(
             workspace_root=tmp_path,
             skill_directories=[skills_dir],
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -674,7 +674,7 @@ async def test_agent_runtime_skill_metadata_counts_only_visible_skills(tmp_path)
             workspace_root=tmp_path,
             skill_directories=[skills_dir],
             tool_permissions={"skill": {"*": "allow", "internal-*": "deny"}},
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -705,7 +705,7 @@ async def test_agent_runtime_filters_denied_active_skill_context(tmp_path):
             skill_directories=[skills_dir],
             active_skills=["internal-docs", "public-docs"],
             tool_permissions={"skill": {"*": "allow", "internal-*": "deny"}},
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=False,
             include_environment_context=False,
             include_runtime_reminders=False,

--- a/tests/runtime/test_structured_output_tool.py
+++ b/tests/runtime/test_structured_output_tool.py
@@ -9,7 +9,7 @@ import pytest
 from efp_runtime.loop import LoopStatus, ScriptedLLMProvider
 from efp_runtime.permissions import ASK, PermissionMetadata
 from efp_runtime.runtime import AgentRuntime, RuntimeConfig
-from efp_runtime.session.models import MessagePart, MessageRole
+from efp_runtime.session.models import MessagePart, MessagePartType, MessageRole
 from efp_runtime.tools.builtin import create_structured_output_tool
 from efp_runtime.tools.definition import ToolContext, ToolDef
 from efp_runtime.tools.registry import ToolRegistry
@@ -194,7 +194,7 @@ async def test_plain_text_with_output_schema_returns_missing_structured_output_e
     provider = ScriptedLLMProvider([{"content": "plain text"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=1),
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=2),
     )
 
     result = await runtime.run(
@@ -265,10 +265,16 @@ async def test_invalid_structured_output_at_max_iterations_becomes_error(
     assert missing_event.payload["iterations"] == 1
     assert missing_event.payload["prior_status"] == LoopStatus.MAX_ITERATIONS
 
+    request = provider.requests[0]
+    assert request.provider_request.tools == []
+    assert "CRITICAL - MAXIMUM STEPS REACHED" in request.provider_request.messages[-1].text
+
     history = runtime.store.read_history("session-structured-invalid")
-    tool_result = history[2].parts[0].tool_result
-    assert tool_result is not None
-    assert tool_result.status == "validation_error"
+    assert [message.role for message in history] == [
+        MessageRole.USER,
+        MessageRole.ASSISTANT,
+    ]
+    assert history[1].parts[0].type is MessagePartType.TOOL_CALL
 
 
 @pytest.mark.asyncio
@@ -278,7 +284,7 @@ async def test_waiting_for_permission_is_not_structured_output_error(tmp_path: P
     )
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=1),
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=2),
         tool_registry=ToolRegistry([_permission_tool("approval_required")]),
     )
 
@@ -301,7 +307,7 @@ async def test_structured_output_not_visible_without_schema(tmp_path: Path):
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=1),
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=2),
     )
 
     result = await runtime.run("Run normally.", session_id="session-no-structured")
@@ -319,7 +325,7 @@ async def test_structured_output_can_be_explicitly_disabled_for_run(tmp_path: Pa
     provider = ScriptedLLMProvider([{"content": "plain text"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=1),
+        config=RuntimeConfig(workspace_root=tmp_path, max_iterations=2),
     )
 
     result = await runtime.run(

--- a/tests/runtime/test_system_prompt_stack.py
+++ b/tests/runtime/test_system_prompt_stack.py
@@ -56,7 +56,7 @@ async def test_default_runtime_injects_only_agents_instruction_before_skills(
             workspace_root=tmp_path,
             skill_directories=[skills_root],
             active_skills=["review-pr"],
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -102,7 +102,7 @@ async def test_opt_in_runtime_prepends_system_prompt_before_instructions_and_ski
             workspace_root=tmp_path,
             skill_directories=[skills_root],
             active_skills=["review-pr"],
-            max_iterations=1,
+            max_iterations=2,
             include_default_system_prompt=True,
             include_environment_context=True,
             include_runtime_reminders=True,
@@ -171,7 +171,7 @@ async def test_available_skills_context_is_injected_without_active_skill(
             skill_directories=[skills_root],
             include_default_system_prompt=False,
             include_runtime_reminders=False,
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -229,7 +229,7 @@ async def test_available_skills_context_hides_denied_skills(tmp_path: Path):
             tool_permissions={"skill": {"internal-*": "deny"}},
             include_default_system_prompt=False,
             include_runtime_reminders=False,
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -260,7 +260,7 @@ async def test_available_skills_context_is_omitted_when_no_skills(tmp_path: Path
             skill_directories=[skills_root],
             include_default_system_prompt=False,
             include_runtime_reminders=False,
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -289,7 +289,7 @@ async def test_default_system_prompt_can_be_disabled_but_explicit_texts_remain(
             include_environment_context=False,
             include_runtime_reminders=False,
             system_prompt_texts=["Custom system layer."],
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -409,6 +409,21 @@ def test_runtime_reminders_can_be_enabled_and_disabled():
     assert "saved output metadata" in reminder.parts[0].text
     assert "ranged read or grep" in reminder.parts[0].text
 
+    unbounded = SystemPromptBuilder(
+        workspace_root=None,
+        include_default_system_prompt=False,
+        include_environment_context=False,
+        include_runtime_reminders=True,
+    ).build_messages(
+        metadata={
+            "max_iterations_unbounded": True,
+            "enable_question_tool": True,
+        }
+    )
+    assert len(unbounded) == 1
+    assert "close-bounded by max_iterations" not in unbounded[0].parts[0].text
+    assert "only when truly blocked after reading relevant context" in unbounded[0].parts[0].text
+
     disabled = SystemPromptBuilder(
         workspace_root=None,
         include_default_system_prompt=False,
@@ -452,7 +467,7 @@ async def test_system_prompt_context_is_not_persisted_or_duplicated_between_runs
             include_default_system_prompt=True,
             include_environment_context=True,
             include_runtime_reminders=False,
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -545,7 +560,7 @@ async def test_environment_context_uses_requested_model(
             include_default_system_prompt=False,
             include_environment_context=True,
             include_runtime_reminders=False,
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 
@@ -574,7 +589,7 @@ async def test_environment_context_can_be_disabled(tmp_path: Path):
             workspace_root=tmp_path,
             include_environment_context=False,
             include_runtime_reminders=False,
-            max_iterations=1,
+            max_iterations=2,
         ),
     )
 

--- a/tests/runtime/test_tool_selection_controls.py
+++ b/tests/runtime/test_tool_selection_controls.py
@@ -57,7 +57,7 @@ async def test_model_hint_gpt_5_prefers_apply_patch_tool():
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1),
+        config=RuntimeConfig(max_iterations=2),
         tool_registry=_file_tool_registry(),
     )
 
@@ -87,7 +87,7 @@ async def test_model_hint_gpt_4_prefers_direct_file_tools():
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1),
+        config=RuntimeConfig(max_iterations=2),
         tool_registry=_file_tool_registry(),
     )
 
@@ -116,7 +116,7 @@ async def test_model_hint_gpt_oss_prefers_direct_file_tools():
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1),
+        config=RuntimeConfig(max_iterations=2),
         tool_registry=_file_tool_registry(),
     )
 
@@ -138,7 +138,7 @@ async def test_without_model_hint_keeps_default_file_tool_selection():
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1),
+        config=RuntimeConfig(max_iterations=2),
         tool_registry=_file_tool_registry(),
     )
 
@@ -161,7 +161,7 @@ async def test_model_aware_tool_selection_can_be_disabled_by_config():
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
-            max_iterations=1,
+            max_iterations=2,
             model_aware_tool_selection=False,
         ),
         tool_registry=_file_tool_registry(),
@@ -193,7 +193,7 @@ async def test_per_run_override_cannot_reenable_model_disabled_tool():
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1),
+        config=RuntimeConfig(max_iterations=2),
         tool_registry=_file_tool_registry(),
     )
 
@@ -214,7 +214,7 @@ async def test_structured_output_tool_remains_available_with_model_selection():
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1),
+        config=RuntimeConfig(max_iterations=2),
         tool_registry=_file_tool_registry(),
     )
 
@@ -264,7 +264,7 @@ async def test_config_disabled_tool_is_not_shown_to_provider():
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1, disabled_tools=["beta"]),
+        config=RuntimeConfig(max_iterations=2, disabled_tools=["beta"]),
         tool_registry=ToolRegistry([_tool("alpha"), _tool("beta")]),
     )
 
@@ -283,7 +283,7 @@ async def test_per_run_override_disables_config_enabled_tool():
     provider = ScriptedLLMProvider([{"content": "done"}])
     runtime = AgentRuntime(
         provider=provider,
-        config=RuntimeConfig(max_iterations=1, enabled_tools=["alpha", "beta"]),
+        config=RuntimeConfig(max_iterations=2, enabled_tools=["alpha", "beta"]),
         tool_registry=ToolRegistry([_tool("alpha"), _tool("beta")]),
     )
 

--- a/tests/runtime/test_workspace_bootstrap.py
+++ b/tests/runtime/test_workspace_bootstrap.py
@@ -214,7 +214,7 @@ async def test_workspace_metadata_merges_through_agent_runtime_behavior(
         workspace_root=tmp_path,
         paths=["runtime.json"],
         include_defaults=False,
-        max_iterations=1,
+        max_iterations=2,
         metadata={"suite": "workspace"},
     )
     await runtime.run(
@@ -226,7 +226,7 @@ async def test_workspace_metadata_merges_through_agent_runtime_behavior(
     request = provider.requests[0]
     assert request.metadata["suite"] == "workspace"
     assert request.metadata["request_id"] == "run-1"
-    assert request.metadata["max_iterations"] == 1
+    assert request.metadata["max_iterations"] == 2
     assert request.metadata["raw_config"] == {"project": "alpha"}
     assert request.metadata["unconsumed_config"] == {"project": "alpha"}
 

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -4478,13 +4478,15 @@ def test_core_max_iterations_response_text_is_consistent():
     repo_root = Path(__file__).parent.parent
     runner_py = (repo_root / "src" / "efp_runtime" / "loop" / "runner.py").read_text(encoding="utf-8")
 
-    max_iter_anchor = "Maximum loop iterations reached."
+    max_iter_anchor = "CRITICAL - MAXIMUM STEPS REACHED"
     start = runner_py.find(max_iter_anchor)
     assert start != -1
     chunk = runner_py[start: start + 400]
 
     assert "LoopStatus.MAX_ITERATIONS" in runner_py
     assert "type=\"loop.max_iterations\"" in runner_py
+    assert "Maximum loop iterations reached." not in runner_py
+    assert "Tools are disabled until next user input" in chunk
     assert "Task completed after maximum iterations." not in runner_py
     assert "Task completed (max iterations reached)" not in runner_py
 


### PR DESCRIPTION
## Summary
- Align native runtime max-step handling with anomalyco/opencode behavior.
- Make max iterations optional/unbounded by default and support `steps`, `maxSteps`, `maxIterations`, and `max_iterations` aliases.
- On the final configured step, disable tools and inject an opencode-style max-steps text-only prompt instead of executing tools and returning the legacy hard error.
- Update gateway defaults, docs, and tests for the new explicit-limit semantics.

## Root Cause
EFP native runtime had its own fixed default iteration ceilings and stopped with `Maximum loop iterations reached.` after tool execution. opencode treats `steps` as optional: unset means unbounded, and a configured final step asks the model to summarize with tools disabled.

## Validation
- `python -m pytest tests\\runtime\\test_loop_runner.py tests\\runtime\\test_runtime_facade.py tests\\runtime\\test_agent_runtime_profiles.py tests\\runtime\\test_agent_profiles_subagent_runner.py tests\\runtime\\test_structured_output_tool.py tests\\runtime\\test_config_loader.py tests\\runtime\\test_runtime_chat_gateway.py tests\\runtime\\test_system_prompt_stack.py tests\\runtime\\test_provider_retry_overflow.py tests\\runtime\\test_plan_mode.py tests\\runtime\\test_doom_loop_guard.py tests\\runtime\\test_tool_selection_controls.py tests\\runtime\\test_opencode_tool_surface.py tests\\test_runtime_api.py`
- `python -m py_compile src\\efp_runtime\\agents\\task_runner.py src\\efp_runtime\\config_loader.py src\\efp_runtime\\loop\\provider.py src\\efp_runtime\\loop\\runner.py src\\efp_runtime\\runtime\\agent.py src\\efp_runtime\\runtime\\config.py src\\gateway\\runtime_chat.py`
- `git diff --check`

Note: a full `tests/runtime` run on Windows had unrelated existing platform-sensitive failures around CRLF/path separators/shell command behavior; the max-step related suite above passed.
