### PR TITLE
[codex] Hide task sessions from sessions API

### DIFF
--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -441,6 +441,28 @@ def _safe_runtime_task_session_id(value: str) -> str:
     return cleaned or f"task-session-{hashlib.sha256(str(value).encode('utf-8')).hexdigest()[:16]}"
 
 
+TASK_SESSION_ID_PREFIXES = (
+    "agent-task:",
+    "agent-task-",
+    "generic-task:",
+    "generic-task-",
+    "delegation:",
+    "delegation-",
+    "task-",
+)
+
+
+def _runtime_session_id_is_task_session(session_id: Any) -> bool:
+    if not isinstance(session_id, str):
+        return False
+    return session_id.strip().startswith(TASK_SESSION_ID_PREFIXES)
+
+
+def _request_includes_task_sessions(request: web.Request) -> bool:
+    raw = str(request.query.get("include_task_sessions", "") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
 def _resolve_runtime_task_delivery(input_payload: Dict[str, Any], metadata: Dict[str, Any]) -> str:
     for value in (
         input_payload.get("delivery"),
@@ -2894,12 +2916,16 @@ async def api_sessions(request: web.Request) -> web.Response:
             await session_manager.initialize()
         
         limit = int(request.query.get('limit', 10))
+        include_task_sessions = _request_includes_task_sessions(request)
         session_ids = await session_manager.list_sessions()
         logger.info(f"[api_sessions] Found {len(session_ids)} sessions: {session_ids[:5]}")
         
         # Format sessions with details, filter out empty sessions
         detailed_sessions = []
-        for session_id in session_ids[:limit]:
+        for session_id in session_ids:
+            if not include_task_sessions and _runtime_session_id_is_task_session(session_id):
+                logger.info(f"[api_sessions] Skipping task session: {session_id}")
+                continue
             # Get session info
             session_info = await session_manager.get_session_info(session_id)
             
@@ -2932,6 +2958,8 @@ async def api_sessions(request: web.Request) -> web.Response:
                 'message_count': len(user_messages),
             })
             logger.info(f"[api_sessions] Added session: {session_id} -> name='{session_name}'")
+            if len(detailed_sessions) >= limit:
+                break
         
         logger.info(f"[api_sessions] Returning {len(detailed_sessions)} sessions")
         return web.json_response({'sessions': detailed_sessions})

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -133,6 +133,69 @@ def test_resolve_runtime_session_id_avoids_same_second_collisions_without_client
 
 
 @pytest.mark.asyncio
+async def test_api_sessions_hides_task_sessions_by_default(monkeypatch):
+    from src.gateway import runtime_api
+
+    class _FakeSessionManager:
+        _initialized = True
+
+        async def initialize(self):
+            raise AssertionError("already initialized")
+
+        async def list_sessions(self):
+            return [
+                "agent-task-task-1",
+                "generic-task-task-2",
+                "delegation-rule-1-event-1",
+                "s-human",
+            ]
+
+        async def get_session_info(self, session_id):
+            return {
+                "title": session_id,
+                "history": [{"role": "user", "content": f"hello from {session_id}"}],
+                "updated_at": "2026-06-21T00:00:00Z",
+            }
+
+    monkeypatch.setattr(runtime_api, "session_manager", _FakeSessionManager())
+
+    response = await runtime_api.api_sessions(type("Request", (), {"query": {"limit": "10"}})())
+    payload = json.loads(response.body)
+
+    assert [item["session_id"] for item in payload["sessions"]] == ["s-human"]
+
+
+@pytest.mark.asyncio
+async def test_api_sessions_can_include_task_sessions_for_debug(monkeypatch):
+    from src.gateway import runtime_api
+
+    class _FakeSessionManager:
+        _initialized = True
+
+        async def initialize(self):
+            raise AssertionError("already initialized")
+
+        async def list_sessions(self):
+            return ["agent-task-task-1", "s-human"]
+
+        async def get_session_info(self, session_id):
+            return {
+                "title": session_id,
+                "history": [{"role": "user", "content": f"hello from {session_id}"}],
+                "updated_at": "2026-06-21T00:00:00Z",
+            }
+
+    monkeypatch.setattr(runtime_api, "session_manager", _FakeSessionManager())
+
+    response = await runtime_api.api_sessions(
+        type("Request", (), {"query": {"limit": "10", "include_task_sessions": "1"}})()
+    )
+    payload = json.loads(response.body)
+
+    assert [item["session_id"] for item in payload["sessions"]] == ["agent-task-task-1", "s-human"]
+
+
+@pytest.mark.asyncio
 async def test_chat_execution_bus_adapter_non_stream(monkeypatch):
     from src.gateway import runtime_api
 


### PR DESCRIPTION
﻿## Summary
- Hide task-backed native runtime sessions from GET /api/sessions by default.
- Add include_task_sessions=1 as an explicit debug escape hatch.
- Continue scanning past hidden task sessions so chat sessions are not starved by the limit window.

## Root Cause
Native task execution writes task progress into dedicated runtime sessions such as agent-task-<id> and generic-task-<id>. The sessions listing endpoint returned every non-empty session, so assistant chat session pickers could show task execution records.

## Validation
- python -m pytest tests/test_runtime_api.py -k "api_sessions_hides_task_sessions_by_default or api_sessions_can_include_task_sessions_for_debug or generic_agent_task_uses_file_safe_task_session"
