### PR TITLE
[codex] Add workspace fallback for runtime session root

### DIFF
--- a/docs/runtime-design.md
+++ b/docs/runtime-design.md
@@ -122,8 +122,10 @@ The runtime facade backs gateway history, session list/delete/rename, metadata,
 pending permissions/questions, todos, fork/revert/summary/query helpers, and
 recovery metadata with `FileSessionStore`.
 
-The default runtime session root is `~/.efp/runtime`; it can be overridden with
-`EFP_RUNTIME_SESSION_ROOT`.
+The default runtime session root is `~/.efp/runtime`. `EFP_RUNTIME_SESSION_ROOT`
+overrides it explicitly. When that override is absent and `EFP_WORKSPACE_DIR` is
+set, the runtime uses `$EFP_WORKSPACE_DIR/.efp/runtime` so Portal-managed native
+agents persist sessions on the workspace mount.
 
 ## Skills And Commands
 

--- a/src/efp_runtime/session/gateway_facade.py
+++ b/src/efp_runtime/session/gateway_facade.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 JIRA_SESSION_PREFIX = "jira:"
 RUNTIME_SESSION_ROOT_ENV = "EFP_RUNTIME_SESSION_ROOT"
+RUNTIME_WORKSPACE_DIR_ENV = "EFP_WORKSPACE_DIR"
 DEFAULT_MAX_HISTORY = 999999
 DEFAULT_AUTO_SAVE = True
 
@@ -39,9 +40,12 @@ _manager_singletons: dict[Path, "RuntimeSessionManager"] = {}
 def runtime_session_root(root: str | Path | None = None) -> Path:
     if root is not None:
         return Path(root).expanduser().resolve()
-    configured = os.environ.get(RUNTIME_SESSION_ROOT_ENV)
+    configured = str(os.environ.get(RUNTIME_SESSION_ROOT_ENV) or "").strip()
     if configured:
         return Path(configured).expanduser().resolve()
+    workspace = str(os.environ.get(RUNTIME_WORKSPACE_DIR_ENV) or "").strip()
+    if workspace:
+        return (Path(workspace).expanduser() / ".efp" / "runtime").resolve()
     return (Path.home() / ".efp" / "runtime").resolve()
 
 

--- a/tests/test_runtime_session_root.py
+++ b/tests/test_runtime_session_root.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from src.efp_runtime.session.gateway_facade import runtime_session_root
+
+
+def test_runtime_session_root_prefers_explicit_argument(monkeypatch, tmp_path):
+    explicit_root = tmp_path / "explicit-root"
+    env_root = tmp_path / "env-root"
+    workspace = tmp_path / "workspace"
+    monkeypatch.setenv("EFP_RUNTIME_SESSION_ROOT", str(env_root))
+    monkeypatch.setenv("EFP_WORKSPACE_DIR", str(workspace))
+
+    assert runtime_session_root(explicit_root) == explicit_root.resolve()
+
+
+def test_runtime_session_root_prefers_env_root_over_workspace(monkeypatch, tmp_path):
+    env_root = tmp_path / "env-root"
+    workspace = tmp_path / "workspace"
+    monkeypatch.setenv("EFP_RUNTIME_SESSION_ROOT", str(env_root))
+    monkeypatch.setenv("EFP_WORKSPACE_DIR", str(workspace))
+
+    assert runtime_session_root() == env_root.resolve()
+
+
+def test_runtime_session_root_falls_back_to_workspace_dir(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    monkeypatch.delenv("EFP_RUNTIME_SESSION_ROOT", raising=False)
+    monkeypatch.setenv("EFP_WORKSPACE_DIR", str(workspace))
+
+    assert runtime_session_root() == (workspace / ".efp" / "runtime").resolve()
+
+
+def test_runtime_session_root_ignores_blank_env_values(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("EFP_RUNTIME_SESSION_ROOT", "   ")
+    monkeypatch.setenv("EFP_WORKSPACE_DIR", "   ")
+    monkeypatch.setenv("HOME", str(home))
+
+    assert runtime_session_root() == (Path.home() / ".efp" / "runtime").resolve()


### PR DESCRIPTION
﻿## Summary

- Add a runtime-side fallback so `runtime_session_root()` uses `$EFP_WORKSPACE_DIR/.efp/runtime` when `EFP_RUNTIME_SESSION_ROOT` is not explicitly set.
- Preserve the existing priority order: explicit function argument, then `EFP_RUNTIME_SESSION_ROOT`, then workspace fallback, then `~/.efp/runtime`.
- Document the fallback and add focused unit tests for the resolution order.

## Why

Portal now injects `EFP_RUNTIME_SESSION_ROOT` for native K8s agents, but direct runtime launches or older Portal deployments may still provide only `EFP_WORKSPACE_DIR`. This fallback keeps native runtime sessions on the workspace mount in those environments instead of falling back to container-local `~/.efp/runtime`.

## Validation

- `python -m pytest tests/test_runtime_session_root.py`
- `python -m pytest tests/test_p3_docs_contract.py`
- `python -m py_compile src/efp_runtime/session/gateway_facade.py`
- `git diff --check`
