### PR TITLE
Limit runtime task recovery persistence

### DIFF
--- a/docs/runtime-design.md
+++ b/docs/runtime-design.md
@@ -138,6 +138,8 @@ Startup recovery is intentionally bounded:
 
 - `EFP_RUNTIME_TASKS_LOAD_MAX_RECORDS` limits how many persisted records are
   loaded at startup. The default is `256`.
+- `EFP_RUNTIME_TASKS_SCAN_MAX_RECORDS` limits how many candidate task files are
+  parsed while looking for records to load. The default is `512`.
 - `EFP_RUNTIME_TASKS_LOAD_MAX_FILE_BYTES` skips individual persisted task files
   larger than the configured byte limit. The default is `2000000`.
 - `EFP_RUNTIME_TASKS_RESUME_MAX_ACTIVE` limits how many active tasks are resumed

--- a/docs/runtime-design.md
+++ b/docs/runtime-design.md
@@ -127,6 +127,26 @@ overrides it explicitly. When that override is absent and `EFP_WORKSPACE_DIR` is
 set, the runtime uses `$EFP_WORKSPACE_DIR/.efp/runtime` so Portal-managed native
 agents persist sessions on the workspace mount.
 
+## Runtime Task Recovery
+
+The gateway persists runtime task tracker records under
+`$EFP_WORKSPACE_DIR/.efp/runtime_tasks` by default. This lets a restarted native
+runtime reconcile accepted Portal tasks instead of leaving them permanently
+running in Portal.
+
+Startup recovery is intentionally bounded:
+
+- `EFP_RUNTIME_TASKS_LOAD_MAX_RECORDS` limits how many persisted records are
+  loaded at startup. The default is `256`.
+- `EFP_RUNTIME_TASKS_LOAD_MAX_FILE_BYTES` skips individual persisted task files
+  larger than the configured byte limit. The default is `2000000`.
+- `EFP_RUNTIME_TASKS_RESUME_MAX_ACTIVE` limits how many active tasks are resumed
+  concurrently during startup. The default is `8`; additional active records are
+  marked stale.
+- `EFP_RUNTIME_TASKS_PERSIST_MAX_FILE_BYTES` caps each persisted record. Large
+  result payloads are omitted from the persisted tracker file while the task
+  status and identifiers remain available. The default is `2000000`.
+
 ## Skills And Commands
 
 The runtime discovers skills from configured roots, `EFP_SKILLS_DIR`, or
@@ -169,7 +189,7 @@ The runtime intentionally does not implement:
 - Old Python local/external tool loaders.
 - Embedded browser UI.
 - Provider fallback to OpenAI, Anthropic, or Ollama.
-- Cross-process background task persistence or shell job restoration.
+- Shell job restoration.
 
 The current tool and capability contract is tracked in
 `docs/runtime-tool-surface.md` and guarded by runtime tests.

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -71,6 +71,7 @@ runtime_session_artifacts = RuntimeSessionArtifacts()
 
 MAX_PORTAL_IDENTITY_LENGTH = 256
 RUNTIME_TASK_LOAD_MAX_RECORDS_DEFAULT = 256
+RUNTIME_TASK_SCAN_MAX_RECORDS_DEFAULT = 512
 RUNTIME_TASK_LOAD_MAX_FILE_BYTES_DEFAULT = 2_000_000
 RUNTIME_TASK_RESUME_MAX_ACTIVE_DEFAULT = 8
 RUNTIME_TASK_PERSIST_MAX_FILE_BYTES_DEFAULT = 2_000_000
@@ -2808,6 +2809,10 @@ def _runtime_task_persistence_limits() -> Dict[str, int]:
             "EFP_RUNTIME_TASKS_LOAD_MAX_RECORDS",
             RUNTIME_TASK_LOAD_MAX_RECORDS_DEFAULT,
         ),
+        "scan_max_records": _runtime_task_non_negative_env(
+            "EFP_RUNTIME_TASKS_SCAN_MAX_RECORDS",
+            RUNTIME_TASK_SCAN_MAX_RECORDS_DEFAULT,
+        ),
         "load_max_file_bytes": _runtime_task_non_negative_env(
             "EFP_RUNTIME_TASKS_LOAD_MAX_FILE_BYTES",
             RUNTIME_TASK_LOAD_MAX_FILE_BYTES_DEFAULT,
@@ -2837,6 +2842,7 @@ async def resume_persisted_runtime_tasks() -> int:
     )
     loaded_count = runtime_task_tracker.load_persisted_records(
         max_records=limits["load_max_records"],
+        max_scan_records=limits["scan_max_records"],
         max_file_bytes=limits["load_max_file_bytes"],
     )
     rehydrated_waiting_count = _rehydrate_waiting_runtime_task_session_lanes()
@@ -2905,13 +2911,15 @@ async def resume_persisted_runtime_tasks() -> int:
         logger.info(
             "Runtime task recovery initialized | storage_dir=%s loaded=%s resumed=%s "
             "skipped_resume_limit=%s waiting_lanes=%s load_max_records=%s "
-            "load_max_file_bytes=%s resume_max_active=%s persist_max_file_bytes=%s",
+            "scan_max_records=%s load_max_file_bytes=%s resume_max_active=%s "
+            "persist_max_file_bytes=%s",
             storage_dir,
             loaded_count,
             resumed_count,
             skipped_resume_count,
             rehydrated_waiting_count,
             limits["load_max_records"],
+            limits["scan_max_records"],
             limits["load_max_file_bytes"],
             limits["resume_max_active"],
             limits["persist_max_file_bytes"],

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -70,6 +70,10 @@ runtime_session_artifacts = RuntimeSessionArtifacts()
 
 
 MAX_PORTAL_IDENTITY_LENGTH = 256
+RUNTIME_TASK_LOAD_MAX_RECORDS_DEFAULT = 256
+RUNTIME_TASK_LOAD_MAX_FILE_BYTES_DEFAULT = 2_000_000
+RUNTIME_TASK_RESUME_MAX_ACTIVE_DEFAULT = 8
+RUNTIME_TASK_PERSIST_MAX_FILE_BYTES_DEFAULT = 2_000_000
 TASK_STATUS_EVENT_TAIL_ITEMS = 10
 TASK_STATUS_MAX_TEXT_CHARS = 20_000
 TASK_STATUS_MAX_LIST_ITEMS = 50
@@ -2776,19 +2780,89 @@ def _runtime_task_persistence_storage_dir() -> Optional[Path]:
     return resolve_runtime_workspace(config_data) / ".efp" / "runtime_tasks"
 
 
+def _runtime_task_non_negative_env(name: str, default: int) -> int:
+    raw = str(os.getenv(name, "")).strip()
+    if not raw:
+        return max(0, default)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return max(0, default)
+    return max(0, value)
+
+
+def _runtime_task_positive_env(name: str, default: int) -> int:
+    raw = str(os.getenv(name, "")).strip()
+    if not raw:
+        return max(1, default)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return max(1, default)
+    return max(1, value)
+
+
+def _runtime_task_persistence_limits() -> Dict[str, int]:
+    return {
+        "load_max_records": _runtime_task_non_negative_env(
+            "EFP_RUNTIME_TASKS_LOAD_MAX_RECORDS",
+            RUNTIME_TASK_LOAD_MAX_RECORDS_DEFAULT,
+        ),
+        "load_max_file_bytes": _runtime_task_non_negative_env(
+            "EFP_RUNTIME_TASKS_LOAD_MAX_FILE_BYTES",
+            RUNTIME_TASK_LOAD_MAX_FILE_BYTES_DEFAULT,
+        ),
+        "resume_max_active": _runtime_task_non_negative_env(
+            "EFP_RUNTIME_TASKS_RESUME_MAX_ACTIVE",
+            RUNTIME_TASK_RESUME_MAX_ACTIVE_DEFAULT,
+        ),
+        "persist_max_file_bytes": _runtime_task_positive_env(
+            "EFP_RUNTIME_TASKS_PERSIST_MAX_FILE_BYTES",
+            RUNTIME_TASK_PERSIST_MAX_FILE_BYTES_DEFAULT,
+        ),
+    }
+
+
 async def resume_persisted_runtime_tasks() -> int:
     storage_dir = _runtime_task_persistence_storage_dir()
     if storage_dir is None:
         runtime_task_tracker.configure_storage(None)
+        runtime_task_tracker.configure_limits(max_persisted_record_bytes=None)
         return 0
 
+    limits = _runtime_task_persistence_limits()
     runtime_task_tracker.configure_storage(storage_dir)
-    loaded_count = runtime_task_tracker.load_persisted_records()
+    runtime_task_tracker.configure_limits(
+        max_persisted_record_bytes=limits["persist_max_file_bytes"],
+    )
+    loaded_count = runtime_task_tracker.load_persisted_records(
+        max_records=limits["load_max_records"],
+        max_file_bytes=limits["load_max_file_bytes"],
+    )
     rehydrated_waiting_count = _rehydrate_waiting_runtime_task_session_lanes()
     resumed_count = 0
+    skipped_resume_count = 0
     for record in runtime_task_tracker.list_active():
         background_task = getattr(record, "background_task", None)
         if background_task is not None and not background_task.done():
+            continue
+        if resumed_count >= limits["resume_max_active"]:
+            skipped_resume_count += 1
+            runtime_task_tracker.mark_stale(
+                record.task_id,
+                reason="Runtime task recovery resume limit exceeded",
+                payload={
+                    "ok": False,
+                    "task_id": record.task_id,
+                    "execution_type": "task",
+                    "request_id": record.request_id,
+                    "status": "stale",
+                    "trace_id": record.trace_id,
+                    "portal_dispatch_id": record.portal_dispatch_id,
+                    "error": "Runtime task recovery resume limit exceeded",
+                    "resume_max_active": limits["resume_max_active"],
+                },
+            )
             continue
         resumed_record = runtime_task_tracker.mark_resuming(record.task_id) or record
         try:
@@ -2829,11 +2903,18 @@ async def resume_persisted_runtime_tasks() -> int:
         )
     if loaded_count or resumed_count:
         logger.info(
-            "Runtime task recovery initialized | storage_dir=%s loaded=%s resumed=%s waiting_lanes=%s",
+            "Runtime task recovery initialized | storage_dir=%s loaded=%s resumed=%s "
+            "skipped_resume_limit=%s waiting_lanes=%s load_max_records=%s "
+            "load_max_file_bytes=%s resume_max_active=%s persist_max_file_bytes=%s",
             storage_dir,
             loaded_count,
             resumed_count,
+            skipped_resume_count,
             rehydrated_waiting_count,
+            limits["load_max_records"],
+            limits["load_max_file_bytes"],
+            limits["resume_max_active"],
+            limits["persist_max_file_bytes"],
         )
     return resumed_count
 

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -19,6 +19,10 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _json_dumps_compact(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
 def _coerce_positive_int(value: Any) -> int | None:
     if value is None:
         return None
@@ -411,11 +415,12 @@ class RuntimeTaskTracker:
         if self._storage_dir is None or not self._storage_dir.exists():
             return 0
         record_limit = _coerce_non_negative_int(max_records)
+        if record_limit == 0:
+            return 0
         file_size_limit = _coerce_non_negative_int(max_file_bytes)
-        loaded: list[RuntimeTaskRecord] = []
+        active_records: list[RuntimeTaskRecord] = []
+        terminal_records: list[RuntimeTaskRecord] = []
         for path in sorted(self._storage_dir.glob("*.json")):
-            if record_limit is not None and len(loaded) >= record_limit:
-                break
             if file_size_limit is not None:
                 try:
                     if path.stat().st_size > file_size_limit:
@@ -427,8 +432,19 @@ class RuntimeTaskTracker:
                 record = _record_from_json(raw)
             except Exception:
                 continue
-            loaded.append(record)
+            if record.status in _TASK_TERMINAL_STATUSES:
+                if record_limit is None or len(active_records) + len(terminal_records) < record_limit:
+                    terminal_records.append(record)
+                continue
+            if record_limit is not None and len(active_records) >= record_limit:
+                continue
+            active_records.append(record)
+            while record_limit is not None and len(active_records) + len(terminal_records) > record_limit:
+                if not terminal_records:
+                    break
+                terminal_records.pop(0)
 
+        loaded = active_records + terminal_records
         loaded.sort(key=lambda record: record.accepted_at or "")
         max_admitted_seq = max([record.admitted_seq for record in self._records.values()] or [0])
         for record in loaded:
@@ -478,6 +494,8 @@ class RuntimeTaskTracker:
             tmp_path = path.with_suffix(path.suffix + ".tmp")
             encoded = self._encode_record_for_persistence(record)
             if encoded is None:
+                tmp_path.unlink(missing_ok=True)
+                self._delete_record_file(record.task_id)
                 return
             tmp_path.write_text(encoded, encoding="utf-8")
             tmp_path.replace(path)
@@ -486,7 +504,7 @@ class RuntimeTaskTracker:
 
     def _encode_record_for_persistence(self, record: RuntimeTaskRecord) -> str | None:
         record_payload = _record_to_json(record)
-        encoded = json.dumps(record_payload, ensure_ascii=False, sort_keys=True)
+        encoded = _json_dumps_compact(record_payload)
         max_bytes = self._max_persisted_record_bytes
         if max_bytes is None or len(encoded.encode("utf-8")) <= max_bytes:
             return encoded
@@ -496,7 +514,11 @@ class RuntimeTaskTracker:
             "payload_omitted_from_persistence": True,
             "reason": "runtime_task_record_exceeded_persistence_limit",
         }
-        encoded = json.dumps(record_payload, ensure_ascii=False, sort_keys=True)
+        encoded = _json_dumps_compact(record_payload)
+        if len(encoded.encode("utf-8")) <= max_bytes:
+            return encoded
+        minimal_record_payload = _minimal_record_for_persistence(record)
+        encoded = _json_dumps_compact(minimal_record_payload)
         if len(encoded.encode("utf-8")) <= max_bytes:
             return encoded
         return None
@@ -687,6 +709,47 @@ def _record_to_json(record: RuntimeTaskRecord) -> Dict[str, Any]:
             "last_progress_at": record.last_progress_at,
             "pending_permission_request": record.pending_permission_request,
             "pending_question_request": record.pending_question_request,
+            "completion_source": record.completion_source,
+            "cancel_requested": record.cancel_requested,
+        }
+    )
+
+
+def _minimal_record_for_persistence(record: RuntimeTaskRecord) -> Dict[str, Any]:
+    return _json_safe(
+        {
+            "task_id": record.task_id,
+            "request_id": record.request_id,
+            "task_type": record.task_type,
+            "source": record.source,
+            "session_id": record.session_id,
+            "agent_id": record.agent_id,
+            "status": record.status,
+            "accepted_at": record.accepted_at,
+            "started_at": record.started_at,
+            "finished_at": record.finished_at,
+            "trace_id": record.trace_id,
+            "portal_dispatch_id": record.portal_dispatch_id,
+            "portal_task_id": record.portal_task_id,
+            "payload": {
+                "ok": record.status == "success",
+                "status": record.status,
+                "payload_omitted_from_persistence": True,
+                "record_minimized_from_persistence": True,
+                "reason": "runtime_task_record_exceeded_persistence_limit",
+            },
+            "error_message": record.error_message,
+            "resume_count": record.resume_count,
+            "last_resumed_at": record.last_resumed_at,
+            "admission_id": record.admission_id,
+            "admitted_seq": record.admitted_seq,
+            "admitted_at": record.admitted_at,
+            "input_delivery": record.input_delivery,
+            "input_hash": record.input_hash,
+            "task_session_id": record.task_session_id,
+            "attempt_count": record.attempt_count,
+            "last_attempt_started_at": record.last_attempt_started_at,
+            "last_progress_at": record.last_progress_at,
             "completion_source": record.completion_source,
             "cancel_requested": record.cancel_requested,
         }

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -19,6 +19,26 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _coerce_positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return None
+    return normalized if normalized > 0 else None
+
+
+def _coerce_non_negative_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return None
+    return normalized if normalized >= 0 else None
+
+
 @dataclass
 class RuntimeTaskRecord:
     task_id: str
@@ -66,11 +86,18 @@ class RuntimeTaskTracker:
     the in-memory behavior, while the runtime server can opt in during startup.
     """
 
-    def __init__(self, *, max_records: int = 512, storage_dir: Optional[str | Path] = None):
+    def __init__(
+        self,
+        *,
+        max_records: int = 512,
+        storage_dir: Optional[str | Path] = None,
+        max_persisted_record_bytes: int | None = None,
+    ):
         self._records: "OrderedDict[str, RuntimeTaskRecord]" = OrderedDict()
         self._max_records = max(1, int(max_records))
         self._next_admitted_seq = 1
         self._storage_dir: Optional[Path] = None
+        self._max_persisted_record_bytes = _coerce_positive_int(max_persisted_record_bytes)
         self.configure_storage(storage_dir)
 
     @property
@@ -82,6 +109,9 @@ class RuntimeTaskTracker:
             self._storage_dir = None
             return
         self._storage_dir = Path(storage_dir).expanduser()
+
+    def configure_limits(self, *, max_persisted_record_bytes: int | None = None) -> None:
+        self._max_persisted_record_bytes = _coerce_positive_int(max_persisted_record_bytes)
 
     def create_pending(
         self,
@@ -372,11 +402,26 @@ class RuntimeTaskTracker:
         )
         return bool(record.input_hash and record.input_hash == expected)
 
-    def load_persisted_records(self) -> int:
+    def load_persisted_records(
+        self,
+        *,
+        max_records: int | None = None,
+        max_file_bytes: int | None = None,
+    ) -> int:
         if self._storage_dir is None or not self._storage_dir.exists():
             return 0
+        record_limit = _coerce_non_negative_int(max_records)
+        file_size_limit = _coerce_non_negative_int(max_file_bytes)
         loaded: list[RuntimeTaskRecord] = []
         for path in sorted(self._storage_dir.glob("*.json")):
+            if record_limit is not None and len(loaded) >= record_limit:
+                break
+            if file_size_limit is not None:
+                try:
+                    if path.stat().st_size > file_size_limit:
+                        continue
+                except OSError:
+                    continue
             try:
                 raw = json.loads(path.read_text(encoding="utf-8"))
                 record = _record_from_json(raw)
@@ -431,10 +476,30 @@ class RuntimeTaskTracker:
             self._storage_dir.mkdir(parents=True, exist_ok=True)
             path = self._record_path(record.task_id)
             tmp_path = path.with_suffix(path.suffix + ".tmp")
-            tmp_path.write_text(json.dumps(_record_to_json(record), ensure_ascii=False, sort_keys=True), encoding="utf-8")
+            encoded = self._encode_record_for_persistence(record)
+            if encoded is None:
+                return
+            tmp_path.write_text(encoded, encoding="utf-8")
             tmp_path.replace(path)
         except (OSError, TypeError, ValueError):
             return
+
+    def _encode_record_for_persistence(self, record: RuntimeTaskRecord) -> str | None:
+        record_payload = _record_to_json(record)
+        encoded = json.dumps(record_payload, ensure_ascii=False, sort_keys=True)
+        max_bytes = self._max_persisted_record_bytes
+        if max_bytes is None or len(encoded.encode("utf-8")) <= max_bytes:
+            return encoded
+        record_payload["payload"] = {
+            "ok": record.status == "success",
+            "status": record.status,
+            "payload_omitted_from_persistence": True,
+            "reason": "runtime_task_record_exceeded_persistence_limit",
+        }
+        encoded = json.dumps(record_payload, ensure_ascii=False, sort_keys=True)
+        if len(encoded.encode("utf-8")) <= max_bytes:
+            return encoded
+        return None
 
     def _delete_record_file(self, task_id: str) -> None:
         if self._storage_dir is None:

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -505,7 +505,8 @@ class RuntimeTaskTracker:
             encoded = self._encode_record_for_persistence(record)
             if encoded is None:
                 tmp_path.unlink(missing_ok=True)
-                self._delete_record_file(record.task_id)
+                if record.status in _TASK_TERMINAL_STATUSES:
+                    self._delete_record_file(record.task_id)
                 return
             tmp_path.write_text(encoded, encoding="utf-8")
             tmp_path.replace(path)

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -761,6 +761,8 @@ def _minimal_record_for_persistence(record: RuntimeTaskRecord) -> Dict[str, Any]
             "attempt_count": record.attempt_count,
             "last_attempt_started_at": record.last_attempt_started_at,
             "last_progress_at": record.last_progress_at,
+            "pending_permission_request": record.pending_permission_request,
+            "pending_question_request": record.pending_question_request,
             "completion_source": record.completion_source,
             "cancel_requested": record.cancel_requested,
         }

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -411,6 +411,7 @@ class RuntimeTaskTracker:
         *,
         max_records: int | None = None,
         max_file_bytes: int | None = None,
+        max_scan_records: int | None = None,
     ) -> int:
         if self._storage_dir is None or not self._storage_dir.exists():
             return 0
@@ -418,10 +419,16 @@ class RuntimeTaskTracker:
         if record_limit == 0:
             return 0
         file_size_limit = _coerce_non_negative_int(max_file_bytes)
+        scan_limit = _coerce_non_negative_int(max_scan_records)
+        if scan_limit is None and record_limit is not None:
+            scan_limit = record_limit * 2
         active_records: list[RuntimeTaskRecord] = []
         terminal_records: list[RuntimeTaskRecord] = []
+        scanned_count = 0
         for path in sorted(self._storage_dir.glob("*.json")):
             if record_limit is not None and len(active_records) >= record_limit:
+                break
+            if scan_limit is not None and scanned_count >= scan_limit:
                 break
             if file_size_limit is not None:
                 try:
@@ -429,6 +436,7 @@ class RuntimeTaskTracker:
                         continue
                 except OSError:
                     continue
+            scanned_count += 1
             try:
                 raw = json.loads(path.read_text(encoding="utf-8"))
                 record = _record_from_json(raw)
@@ -447,7 +455,7 @@ class RuntimeTaskTracker:
                 terminal_records.pop(0)
 
         loaded = active_records + terminal_records
-        loaded.sort(key=lambda record: record.accepted_at or "")
+        loaded.sort(key=lambda record: (record.accepted_at or "", record.task_id))
         max_admitted_seq = max([record.admitted_seq for record in self._records.values()] or [0])
         for record in loaded:
             if record.admitted_seq <= 0:

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -40,7 +40,7 @@ def _coerce_non_negative_int(value: Any) -> int | None:
         normalized = int(value)
     except (TypeError, ValueError):
         return None
-    return normalized if normalized >= 0 else None
+    return max(0, normalized)
 
 
 @dataclass

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -421,6 +421,8 @@ class RuntimeTaskTracker:
         active_records: list[RuntimeTaskRecord] = []
         terminal_records: list[RuntimeTaskRecord] = []
         for path in sorted(self._storage_dir.glob("*.json")):
+            if record_limit is not None and len(active_records) >= record_limit:
+                break
             if file_size_limit is not None:
                 try:
                     if path.stat().st_size > file_size_limit:

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3261,6 +3261,44 @@ def test_runtime_task_tracker_load_limits_skip_oversized_and_excess_records(tmp_
     assert len(count_guard.list_active()) == 1
 
 
+def test_runtime_task_tracker_load_limit_prioritizes_active_records(tmp_path):
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    (tmp_path / "000-terminal.json").write_text(
+        json.dumps(
+            {
+                "task_id": "task-terminal",
+                "request_id": "task-task-terminal",
+                "task_type": "adapter_action_task",
+                "source": "portal",
+                "status": "success",
+                "accepted_at": "2026-06-22T00:00:00Z",
+                "payload": {"ok": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "001-active.json").write_text(
+        json.dumps(
+            {
+                "task_id": "task-active",
+                "request_id": "task-task-active",
+                "task_type": "adapter_action_task",
+                "source": "portal",
+                "status": "running",
+                "accepted_at": "2026-06-22T00:01:00Z",
+                "payload": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    assert tracker.load_persisted_records(max_records=1, max_file_bytes=100_000) == 1
+    assert tracker.get("task-active") is not None
+    assert tracker.get("task-terminal") is None
+
+
 def test_runtime_task_tracker_omits_large_payload_from_persistence(tmp_path):
     from src.runtime.runtime_task_tracker import RuntimeTaskTracker
 
@@ -3289,6 +3327,35 @@ def test_runtime_task_tracker_omits_large_payload_from_persistence(tmp_path):
     assert persisted["status"] == "success"
     assert persisted["payload"]["payload_omitted_from_persistence"] is True
     assert persisted["payload"]["reason"] == "runtime_task_record_exceeded_persistence_limit"
+
+
+def test_runtime_task_tracker_removes_stale_file_when_persistence_cap_cannot_write(tmp_path):
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    tracker.create_pending(
+        task_id="task-too-small-cap",
+        request_id="task-task-too-small-cap",
+        task_type="adapter_action_task",
+        source="portal",
+        session_id="session-1",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="task-too-small-cap",
+        merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
+        metadata={"task_id": "task-too-small-cap"},
+    )
+    [record_path] = list(tmp_path.glob("*.json"))
+    tracker.configure_limits(max_persisted_record_bytes=1)
+
+    tracker.mark_terminal(
+        "task-too-small-cap",
+        status="success",
+        payload={"ok": True, "status": "success", "result": "x" * 20_000},
+    )
+
+    assert not record_path.exists()
 
 
 def test_runtime_task_tracker_ignores_stale_attempt_terminal_write():

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3438,6 +3438,35 @@ def test_runtime_task_tracker_removes_stale_file_when_persistence_cap_cannot_wri
     assert not record_path.exists()
 
 
+def test_runtime_task_tracker_keeps_active_file_when_persistence_cap_cannot_update(tmp_path):
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    tracker.create_pending(
+        task_id="task-active-too-small-cap",
+        request_id="task-task-active-too-small-cap",
+        task_type="adapter_action_task",
+        source="portal",
+        session_id="session-1",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="task-active-too-small-cap",
+        merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
+        metadata={"task_id": "task-active-too-small-cap"},
+    )
+    [record_path] = list(tmp_path.glob("*.json"))
+    before = json.loads(record_path.read_text(encoding="utf-8"))
+    tracker.configure_limits(max_persisted_record_bytes=1)
+
+    tracker.mark_running("task-active-too-small-cap")
+
+    assert record_path.exists()
+    after = json.loads(record_path.read_text(encoding="utf-8"))
+    assert after == before
+    assert after["status"] == "accepted"
+
+
 def test_runtime_task_tracker_ignores_stale_attempt_terminal_write():
     from src.runtime.runtime_task_tracker import RuntimeTaskTracker
 

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3467,6 +3467,42 @@ def test_runtime_task_tracker_keeps_active_file_when_persistence_cap_cannot_upda
     assert after["status"] == "accepted"
 
 
+def test_runtime_task_tracker_minimal_persistence_keeps_pending_permission(tmp_path):
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    tracker.create_pending(
+        task_id="task-blocked-minimal",
+        request_id="task-task-blocked-minimal",
+        task_type="adapter_action_task",
+        source="portal",
+        session_id="session-1",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="task-blocked-minimal",
+        merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
+        metadata={"task_id": "task-blocked-minimal", "large": "x" * 5000},
+    )
+    tracker.configure_limits(max_persisted_record_bytes=2000)
+
+    tracker.mark_terminal(
+        "task-blocked-minimal",
+        status="blocked",
+        payload={
+            "ok": False,
+            "status": "blocked",
+            "pending_permission_request": {"id": "perm-1", "tool": "bash"},
+        },
+    )
+
+    [record_path] = list(tmp_path.glob("*.json"))
+    persisted = json.loads(record_path.read_text(encoding="utf-8"))
+    assert persisted["status"] == "blocked"
+    assert persisted["payload"]["record_minimized_from_persistence"] is True
+    assert persisted["pending_permission_request"] == {"id": "perm-1", "tool": "bash"}
+
+
 def test_runtime_task_tracker_ignores_stale_attempt_terminal_write():
     from src.runtime.runtime_task_tracker import RuntimeTaskTracker
 

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3317,6 +3317,68 @@ def test_runtime_task_tracker_load_limit_prioritizes_active_records(tmp_path):
     assert tracker.get("task-terminal") is None
 
 
+def test_runtime_task_tracker_load_scan_limit_bounds_candidate_parsing(tmp_path):
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    for index in range(3):
+        (tmp_path / f"{index:03d}-terminal.json").write_text(
+            json.dumps(
+                {
+                    "task_id": f"task-terminal-{index}",
+                    "request_id": f"task-task-terminal-{index}",
+                    "task_type": "adapter_action_task",
+                    "source": "portal",
+                    "status": "success",
+                    "accepted_at": f"2026-06-22T00:0{index}:00Z",
+                    "payload": {"ok": True},
+                }
+            ),
+            encoding="utf-8",
+        )
+    (tmp_path / "999-active.json").write_text(
+        json.dumps(
+            {
+                "task_id": "task-active-after-scan-limit",
+                "request_id": "task-task-active-after-scan-limit",
+                "task_type": "adapter_action_task",
+                "source": "portal",
+                "status": "running",
+                "accepted_at": "2026-06-22T00:10:00Z",
+                "payload": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    assert tracker.load_persisted_records(max_records=2, max_scan_records=2, max_file_bytes=100_000) == 2
+    assert tracker.get("task-active-after-scan-limit") is None
+
+
+def test_runtime_task_tracker_load_order_uses_task_id_tie_breaker(tmp_path):
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    for filename, task_id in (("000-z.json", "task-z"), ("001-a.json", "task-a")):
+        (tmp_path / filename).write_text(
+            json.dumps(
+                {
+                    "task_id": task_id,
+                    "request_id": f"task-{task_id}",
+                    "task_type": "adapter_action_task",
+                    "source": "portal",
+                    "status": "running",
+                    "accepted_at": "2026-06-22T00:00:00Z",
+                    "payload": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    assert tracker.load_persisted_records(max_file_bytes=100_000) == 2
+    assert [record.task_id for record in tracker.list_active()] == ["task-a", "task-z"]
+
+
 def test_runtime_task_tracker_omits_large_payload_from_persistence(tmp_path):
     from src.runtime.runtime_task_tracker import RuntimeTaskTracker
 

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3233,6 +3233,64 @@ def test_runtime_task_tracker_persists_and_loads_active_records(tmp_path):
     assert [item.task_id for item in loaded.list_active()] == ["task-persist"]
 
 
+def test_runtime_task_tracker_load_limits_skip_oversized_and_excess_records(tmp_path):
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    for task_id in ("task-load-1", "task-load-2"):
+        tracker.create_pending(
+            task_id=task_id,
+            request_id=f"task-{task_id}",
+            task_type="adapter_action_task",
+            source="portal",
+            session_id="session-1",
+            agent_id="agent-1",
+            trace_id="trace-1",
+            portal_dispatch_id="dispatch-1",
+            portal_task_id=task_id,
+            merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
+            metadata={"task_id": task_id},
+        )
+    (tmp_path / "oversized.json").write_text(json.dumps({"task_id": "huge", "payload": "x" * 5000}), encoding="utf-8")
+
+    oversized_guard = RuntimeTaskTracker(storage_dir=tmp_path)
+    assert oversized_guard.load_persisted_records(max_records=10, max_file_bytes=100) == 0
+
+    count_guard = RuntimeTaskTracker(storage_dir=tmp_path)
+    assert count_guard.load_persisted_records(max_records=1, max_file_bytes=100_000) == 1
+    assert len(count_guard.list_active()) == 1
+
+
+def test_runtime_task_tracker_omits_large_payload_from_persistence(tmp_path):
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path, max_persisted_record_bytes=4000)
+    tracker.create_pending(
+        task_id="task-big-payload",
+        request_id="task-task-big-payload",
+        task_type="adapter_action_task",
+        source="portal",
+        session_id="session-1",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        portal_dispatch_id="dispatch-1",
+        portal_task_id="task-big-payload",
+        merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
+        metadata={"task_id": "task-big-payload"},
+    )
+    tracker.mark_terminal(
+        "task-big-payload",
+        status="success",
+        payload={"ok": True, "status": "success", "result": "x" * 20_000},
+    )
+
+    [record_path] = list(tmp_path.glob("*.json"))
+    persisted = json.loads(record_path.read_text(encoding="utf-8"))
+    assert persisted["status"] == "success"
+    assert persisted["payload"]["payload_omitted_from_persistence"] is True
+    assert persisted["payload"]["reason"] == "runtime_task_record_exceeded_persistence_limit"
+
+
 def test_runtime_task_tracker_ignores_stale_attempt_terminal_write():
     from src.runtime.runtime_task_tracker import RuntimeTaskTracker
 
@@ -3516,6 +3574,70 @@ async def test_resume_persisted_runtime_tasks_replays_active_record(tmp_path, mo
     assert captured["metadata"]["runtime_task_attempt_id"]
     assert captured["metadata"]["runtime_task_attempt_count"] == 2
     assert "task.resumed" in emitted
+
+
+@pytest.mark.asyncio
+async def test_resume_persisted_runtime_tasks_limits_active_resumes(tmp_path, monkeypatch):
+    from src.gateway import runtime_api
+    from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+    initial = RuntimeTaskTracker(storage_dir=tmp_path)
+    for task_id in ("task-resume-limit-1", "task-resume-limit-2"):
+        initial.create_pending(
+            task_id=task_id,
+            request_id=f"task-{task_id}",
+            task_type="adapter_action_task",
+            source="portal",
+            session_id=f"session-{task_id}",
+            agent_id="agent-1",
+            trace_id="trace-1",
+            portal_dispatch_id="dispatch-1",
+            portal_task_id=task_id,
+            merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
+            metadata={"task_id": task_id, "portal_task_id": task_id},
+            trace_headers={"trace_id": "trace-1", "portal_dispatch_id": "dispatch-1"},
+        )
+        initial.mark_running(task_id)
+
+    runtime_api.runtime_task_tracker.reset()
+    tracker = RuntimeTaskTracker()
+    monkeypatch.setattr(runtime_api, "runtime_task_tracker", tracker)
+    monkeypatch.setenv("EFP_RUNTIME_TASKS_DIR", str(tmp_path))
+    monkeypatch.setenv("EFP_RUNTIME_TASKS_LOAD_MAX_RECORDS", "10")
+    monkeypatch.setenv("EFP_RUNTIME_TASKS_LOAD_MAX_FILE_BYTES", "1000000")
+    monkeypatch.setenv("EFP_RUNTIME_TASKS_RESUME_MAX_ACTIVE", "1")
+    monkeypatch.setenv("EFP_RUNTIME_TASKS_PERSIST_MAX_FILE_BYTES", "1000000")
+    spawned = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_emit_task_lifecycle_event", lambda *_args, **_kwargs: asyncio.sleep(0))
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    resumed = await runtime_api.resume_persisted_runtime_tasks()
+
+    assert resumed == 1
+    assert len(spawned) == 1
+    await spawned[0]
+
+    statuses = {task_id: tracker.get(task_id).status for task_id in ("task-resume-limit-1", "task-resume-limit-2")}
+    assert sorted(statuses.values()) == ["stale", "success"]
+    stale_task_id = next(task_id for task_id, status in statuses.items() if status == "stale")
+    assert tracker.get(stale_task_id).payload["error"] == "Runtime task recovery resume limit exceeded"
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3251,7 +3251,19 @@ def test_runtime_task_tracker_load_limits_skip_oversized_and_excess_records(tmp_
             merged_input_payload={"task_type": "adapter_action_task", "action_id": "jira.transition"},
             metadata={"task_id": task_id},
         )
-    (tmp_path / "oversized.json").write_text(json.dumps({"task_id": "huge", "payload": "x" * 5000}), encoding="utf-8")
+    (tmp_path / "oversized.json").write_text(
+        json.dumps(
+            {
+                "task_id": "huge",
+                "request_id": "task-huge",
+                "task_type": "adapter_action_task",
+                "source": "portal",
+                "status": "running",
+                "payload": {"result": "x" * 5000},
+            }
+        ),
+        encoding="utf-8",
+    )
 
     oversized_guard = RuntimeTaskTracker(storage_dir=tmp_path)
     assert oversized_guard.load_persisted_records(max_records=10, max_file_bytes=100) == 0
@@ -3259,6 +3271,12 @@ def test_runtime_task_tracker_load_limits_skip_oversized_and_excess_records(tmp_
     count_guard = RuntimeTaskTracker(storage_dir=tmp_path)
     assert count_guard.load_persisted_records(max_records=1, max_file_bytes=100_000) == 1
     assert len(count_guard.list_active()) == 1
+
+    negative_record_guard = RuntimeTaskTracker(storage_dir=tmp_path)
+    assert negative_record_guard.load_persisted_records(max_records=-1, max_file_bytes=100_000) == 0
+
+    negative_file_guard = RuntimeTaskTracker(storage_dir=tmp_path)
+    assert negative_file_guard.load_persisted_records(max_records=10, max_file_bytes=-1) == 0
 
 
 def test_runtime_task_tracker_load_limit_prioritizes_active_records(tmp_path):


### PR DESCRIPTION
## Summary
- Bound runtime task startup recovery by record count, individual file size, and active resume count
- Cap persisted task tracker files and omit oversized result payloads from tracker persistence
- Document the runtime task recovery environment limits

## Tests
- python -m pytest tests/test_runtime_api.py