### PR TITLE
[codex] Align native task recovery with opencode

### DIFF
--- a/docs/runtime-design.md
+++ b/docs/runtime-design.md
@@ -132,9 +132,9 @@ agents persist sessions on the workspace mount.
 The gateway persists runtime task tracker records under
 `$EFP_WORKSPACE_DIR/.efp/runtime_tasks` by default. This lets a restarted native
 runtime reconcile accepted Portal tasks instead of leaving them permanently
-running in Portal. Startup reconciliation follows the upstream opencode safety
-boundary: completed and blocked task metadata can be reloaded, but an in-flight
-provider/tool activity is not automatically replayed after process loss.
+running in Portal. Startup reconciliation follows the upstream OpenCode safety
+boundary: completed and blocked task metadata can be reloaded, but in-flight
+provider/tool activity is never automatically replayed after process loss.
 
 Startup recovery is intentionally bounded:
 

--- a/docs/runtime-design.md
+++ b/docs/runtime-design.md
@@ -132,7 +132,9 @@ agents persist sessions on the workspace mount.
 The gateway persists runtime task tracker records under
 `$EFP_WORKSPACE_DIR/.efp/runtime_tasks` by default. This lets a restarted native
 runtime reconcile accepted Portal tasks instead of leaving them permanently
-running in Portal.
+running in Portal. Startup reconciliation follows the upstream opencode safety
+boundary: completed and blocked task metadata can be reloaded, but an in-flight
+provider/tool activity is not automatically replayed after process loss.
 
 Startup recovery is intentionally bounded:
 
@@ -142,9 +144,9 @@ Startup recovery is intentionally bounded:
   parsed while looking for records to load. The default is `512`.
 - `EFP_RUNTIME_TASKS_LOAD_MAX_FILE_BYTES` skips individual persisted task files
   larger than the configured byte limit. The default is `2000000`.
-- `EFP_RUNTIME_TASKS_RESUME_MAX_ACTIVE` limits how many active tasks are resumed
-  concurrently during startup. The default is `8`; additional active records are
-  marked stale.
+- Active records from a previous process are marked stale with
+  `runtime_restart_task_replay_disabled` and should be re-dispatched if the work
+  is still required.
 - `EFP_RUNTIME_TASKS_PERSIST_MAX_FILE_BYTES` caps each persisted record. Large
   result payloads are omitted from the persisted tracker file while the task
   status and identifiers remain available. The default is `2000000`.

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -73,8 +73,10 @@ MAX_PORTAL_IDENTITY_LENGTH = 256
 RUNTIME_TASK_LOAD_MAX_RECORDS_DEFAULT = 256
 RUNTIME_TASK_SCAN_MAX_RECORDS_DEFAULT = 512
 RUNTIME_TASK_LOAD_MAX_FILE_BYTES_DEFAULT = 2_000_000
-RUNTIME_TASK_RESUME_MAX_ACTIVE_DEFAULT = 8
 RUNTIME_TASK_PERSIST_MAX_FILE_BYTES_DEFAULT = 2_000_000
+RUNTIME_TASK_RESTART_REPLAY_DISABLED_MESSAGE = (
+    "Runtime restarted before task completion; automatic task replay is disabled"
+)
 TASK_STATUS_EVENT_TAIL_ITEMS = 10
 TASK_STATUS_MAX_TEXT_CHARS = 20_000
 TASK_STATUS_MAX_LIST_ITEMS = 50
@@ -2817,10 +2819,6 @@ def _runtime_task_persistence_limits() -> Dict[str, int]:
             "EFP_RUNTIME_TASKS_LOAD_MAX_FILE_BYTES",
             RUNTIME_TASK_LOAD_MAX_FILE_BYTES_DEFAULT,
         ),
-        "resume_max_active": _runtime_task_non_negative_env(
-            "EFP_RUNTIME_TASKS_RESUME_MAX_ACTIVE",
-            RUNTIME_TASK_RESUME_MAX_ACTIVE_DEFAULT,
-        ),
         "persist_max_file_bytes": _runtime_task_positive_env(
             "EFP_RUNTIME_TASKS_PERSIST_MAX_FILE_BYTES",
             RUNTIME_TASK_PERSIST_MAX_FILE_BYTES_DEFAULT,
@@ -2846,85 +2844,44 @@ async def resume_persisted_runtime_tasks() -> int:
         max_file_bytes=limits["load_max_file_bytes"],
     )
     rehydrated_waiting_count = _rehydrate_waiting_runtime_task_session_lanes()
-    resumed_count = 0
-    skipped_resume_count = 0
+    stale_active_count = 0
     for record in runtime_task_tracker.list_active():
         background_task = getattr(record, "background_task", None)
         if background_task is not None and not background_task.done():
             continue
-        if resumed_count >= limits["resume_max_active"]:
-            skipped_resume_count += 1
-            runtime_task_tracker.mark_stale(
-                record.task_id,
-                reason="Runtime task recovery resume limit exceeded",
-                payload={
-                    "ok": False,
-                    "task_id": record.task_id,
-                    "execution_type": "task",
-                    "request_id": record.request_id,
-                    "status": "stale",
-                    "trace_id": record.trace_id,
-                    "portal_dispatch_id": record.portal_dispatch_id,
-                    "error": "Runtime task recovery resume limit exceeded",
-                    "resume_max_active": limits["resume_max_active"],
-                },
-            )
-            continue
-        resumed_record = runtime_task_tracker.mark_resuming(record.task_id) or record
-        try:
-            scheduled = _schedule_runtime_task_record(resumed_record, resumed=True)
-        except Exception as exc:
-            sanitized_message = sanitize_exception_message(exc)
-            logger.error("Persisted runtime task resume failed | task_id=%s", record.task_id, exc_info=True)
-            failure_payload = {
+        stale_active_count += 1
+        runtime_task_tracker.mark_stale(
+            record.task_id,
+            reason=RUNTIME_TASK_RESTART_REPLAY_DISABLED_MESSAGE,
+            payload={
                 "ok": False,
                 "task_id": record.task_id,
                 "execution_type": "task",
                 "request_id": record.request_id,
-                "status": "error",
+                "status": "stale",
+                "state_code": "runtime_restart_task_replay_disabled",
                 "trace_id": record.trace_id,
                 "portal_dispatch_id": record.portal_dispatch_id,
-                "error": sanitized_message,
-            }
-            current = runtime_task_tracker.get(record.task_id)
-            if current is not None:
-                failure_payload.update(_runtime_task_observability_fields(current))
-            runtime_task_tracker.mark_internal_failure(
-                record.task_id,
-                payload=failure_payload,
-                error_message=sanitized_message,
-            )
-            continue
-        if not scheduled:
-            continue
-        resumed_count += 1
-        await _emit_task_lifecycle_event(
-            "task.resumed",
-            task_id=record.task_id,
-            portal_task_id=record.portal_task_id,
-            agent_id=record.agent_id,
-            session_id=record.session_id,
-            trace_id=record.trace_id,
-            portal_dispatch_id=record.portal_dispatch_id,
+                "error": RUNTIME_TASK_RESTART_REPLAY_DISABLED_MESSAGE,
+                "next_recommendation": "Re-dispatch the task if it is still required.",
+            },
         )
-    if loaded_count or resumed_count:
+    if loaded_count or stale_active_count:
         logger.info(
-            "Runtime task recovery initialized | storage_dir=%s loaded=%s resumed=%s "
-            "skipped_resume_limit=%s waiting_lanes=%s load_max_records=%s "
-            "scan_max_records=%s load_max_file_bytes=%s resume_max_active=%s "
+            "Runtime task recovery initialized | storage_dir=%s loaded=%s active_marked_stale=%s "
+            "waiting_lanes=%s load_max_records=%s "
+            "scan_max_records=%s load_max_file_bytes=%s "
             "persist_max_file_bytes=%s",
             storage_dir,
             loaded_count,
-            resumed_count,
-            skipped_resume_count,
+            stale_active_count,
             rehydrated_waiting_count,
             limits["load_max_records"],
             limits["scan_max_records"],
             limits["load_max_file_bytes"],
-            limits["resume_max_active"],
             limits["persist_max_file_bytes"],
         )
-    return resumed_count
+    return 0
 
 
 async def _resume_runtime_tasks_on_startup(_app: web.Application) -> None:

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -2442,6 +2442,9 @@ async def _run_task_execution_in_background(
         )
     except asyncio.CancelledError:
         current = runtime_task_tracker.get(task_id)
+        if current is None:
+            logger.info("Task cancellation ignored because task record no longer exists | task_id=%s attempt_id=%s", task_id, attempt_id or "-")
+            return
         if current is not None and attempt_id is not None and getattr(current, "active_attempt_id", None) != attempt_id:
             logger.info("Stale task cancellation ignored because attempt is no longer current | task_id=%s attempt_id=%s", task_id, attempt_id)
             return

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -2445,10 +2445,10 @@ async def _run_task_execution_in_background(
         if current is None:
             logger.info("Task cancellation ignored because task record no longer exists | task_id=%s attempt_id=%s", task_id, attempt_id or "-")
             return
-        if current is not None and attempt_id is not None and getattr(current, "active_attempt_id", None) != attempt_id:
+        if attempt_id is not None and getattr(current, "active_attempt_id", None) != attempt_id:
             logger.info("Stale task cancellation ignored because attempt is no longer current | task_id=%s attempt_id=%s", task_id, attempt_id)
             return
-        if current is None or current.status != "cancelled":
+        if current.status != "cancelled":
             cancelled_payload = {
                 "ok": False,
                 "task_id": task_id,

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -1923,30 +1923,34 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
                     },
                     status=409,
                 )
-            if existing_record.status in {"accepted", "running"}:
-                try:
-                    _schedule_runtime_task_record(existing_record)
-                except Exception as exc:
-                    sanitized_message = sanitize_exception_message(exc)
-                    logger.error("Task execute duplicate scheduling failed | task_id=%s", parsed["task_id"], exc_info=True)
-                    logger.debug("Task execute duplicate scheduling error detail: %s", sanitized_message)
-                    failure_payload = {
-                        "ok": False,
-                        "task_id": parsed["task_id"],
-                        "execution_type": "task",
-                        "request_id": existing_record.request_id,
-                        "status": "error",
-                        "trace_id": existing_record.trace_id,
-                        "portal_dispatch_id": existing_record.portal_dispatch_id,
-                        "error": sanitized_message,
-                    }
-                    runtime_task_tracker.mark_internal_failure(
-                        parsed["task_id"],
-                        payload=failure_payload,
-                        error_message=sanitized_message,
-                    )
-                    return web.json_response(failure_payload, status=500)
-            return web.json_response(_runtime_task_status_payload(existing_record), status=200)
+            if _is_restart_stale_runtime_task_record(existing_record):
+                runtime_task_tracker.remove(parsed["task_id"])
+                existing_record = None
+            else:
+                if existing_record.status in {"accepted", "running"}:
+                    try:
+                        _schedule_runtime_task_record(existing_record)
+                    except Exception as exc:
+                        sanitized_message = sanitize_exception_message(exc)
+                        logger.error("Task execute duplicate scheduling failed | task_id=%s", parsed["task_id"], exc_info=True)
+                        logger.debug("Task execute duplicate scheduling error detail: %s", sanitized_message)
+                        failure_payload = {
+                            "ok": False,
+                            "task_id": parsed["task_id"],
+                            "execution_type": "task",
+                            "request_id": existing_record.request_id,
+                            "status": "error",
+                            "trace_id": existing_record.trace_id,
+                            "portal_dispatch_id": existing_record.portal_dispatch_id,
+                            "error": sanitized_message,
+                        }
+                        runtime_task_tracker.mark_internal_failure(
+                            parsed["task_id"],
+                            payload=failure_payload,
+                            error_message=sanitized_message,
+                        )
+                        return web.json_response(failure_payload, status=500)
+                return web.json_response(_runtime_task_status_payload(existing_record), status=200)
 
         record = runtime_task_tracker.create_pending(
             task_id=parsed["task_id"],
@@ -2148,6 +2152,15 @@ def _runtime_task_status_payload(record: Any) -> Dict[str, Any]:
             **_runtime_task_observability_fields(record),
         }
     return _compact_runtime_task_status_payload(_runtime_task_payload_with_observability(record))
+
+
+def _is_restart_stale_runtime_task_record(record: Any) -> bool:
+    payload = getattr(record, "payload", None)
+    return (
+        getattr(record, "status", None) == "stale"
+        and isinstance(payload, dict)
+        and payload.get("state_code") == "runtime_restart_task_replay_disabled"
+    )
 
 
 def _has_runtime_task_resume_payload(record: Any) -> bool:
@@ -2881,7 +2894,7 @@ async def resume_persisted_runtime_tasks() -> int:
             limits["load_max_file_bytes"],
             limits["persist_max_file_bytes"],
         )
-    return 0
+    return stale_active_count
 
 
 async def _resume_runtime_tasks_on_startup(_app: web.Application) -> None:

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -1924,6 +1924,9 @@ async def api_tasks_execute(request: web.Request) -> web.Response:
                     status=409,
                 )
             if _is_restart_stale_runtime_task_record(existing_record):
+                background_task = getattr(existing_record, "background_task", None)
+                if background_task is not None and not background_task.done():
+                    background_task.cancel()
                 runtime_task_tracker.remove(parsed["task_id"])
                 existing_record = None
             else:
@@ -2439,6 +2442,9 @@ async def _run_task_execution_in_background(
         )
     except asyncio.CancelledError:
         current = runtime_task_tracker.get(task_id)
+        if current is not None and attempt_id is not None and getattr(current, "active_attempt_id", None) != attempt_id:
+            logger.info("Stale task cancellation ignored because attempt is no longer current | task_id=%s attempt_id=%s", task_id, attempt_id)
+            return
         if current is None or current.status != "cancelled":
             cancelled_payload = {
                 "ok": False,

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3726,9 +3726,12 @@ async def test_api_tasks_execute_restart_stale_matching_admission_redelivers(mon
     assert second_body["status"] == "accepted"
     assert second_body["task_id"] == "task-restart-stale-redelivery"
     assert len(spawned) == 2
+    await asyncio.sleep(0)
+    assert spawned[0].done()
 
     release.set()
-    await asyncio.gather(*spawned)
+    await asyncio.gather(*spawned, return_exceptions=True)
+    assert runtime_api.runtime_task_tracker.get("task-restart-stale-redelivery").status == "success"
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3665,6 +3665,73 @@ async def test_api_tasks_execute_duplicate_conflicting_admission_returns_409(mon
 
 
 @pytest.mark.asyncio
+async def test_api_tasks_execute_restart_stale_matching_admission_redelivers(monkeypatch):
+    from src.gateway import runtime_api
+
+    runtime_api.runtime_task_tracker.reset()
+    release = asyncio.Event()
+    spawned = []
+
+    async def _fake_execute_runtime_task_request(**kwargs):
+        await release.wait()
+        return type(
+            "R",
+            (),
+            {
+                "request_id": kwargs["request_id"],
+                "status": "success",
+                "output_payload": {"ok": True},
+                "artifacts": [],
+                "runtime_events": [],
+                "next_action_hint": None,
+                "audit_ref": None,
+            },
+        )()
+
+    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
+    monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+
+    class _Request:
+        headers = INTERNAL_HEADERS
+
+        async def json(self):
+            return {
+                "task_id": "task-restart-stale-redelivery",
+                "task_type": "adapter_action_task",
+                "input_payload": {"action_id": "jira.transition"},
+            }
+
+    first_response = await runtime_api.api_tasks_execute(_Request())
+    await asyncio.sleep(0)
+    stale_record = runtime_api.runtime_task_tracker.mark_stale(
+        "task-restart-stale-redelivery",
+        reason=runtime_api.RUNTIME_TASK_RESTART_REPLAY_DISABLED_MESSAGE,
+        payload={
+            "ok": False,
+            "task_id": "task-restart-stale-redelivery",
+            "execution_type": "task",
+            "request_id": "task-task-restart-stale-redelivery",
+            "status": "stale",
+            "state_code": "runtime_restart_task_replay_disabled",
+            "error": runtime_api.RUNTIME_TASK_RESTART_REPLAY_DISABLED_MESSAGE,
+        },
+    )
+
+    second_response = await runtime_api.api_tasks_execute(_Request())
+    second_body = json.loads(second_response.body)
+
+    assert first_response.status == 202
+    assert stale_record is not None and stale_record.status == "stale"
+    assert second_response.status == 202
+    assert second_body["status"] == "accepted"
+    assert second_body["task_id"] == "task-restart-stale-redelivery"
+    assert len(spawned) == 2
+
+    release.set()
+    await asyncio.gather(*spawned)
+
+
+@pytest.mark.asyncio
 async def test_api_tasks_execute_generic_agent_task_uses_file_safe_task_session(monkeypatch):
     from src.gateway import runtime_api
 
@@ -3746,9 +3813,9 @@ async def test_resume_persisted_runtime_tasks_marks_active_record_stale_by_defau
     spawned = []
     monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
-    resumed = await runtime_api.resume_persisted_runtime_tasks()
+    stale_count = await runtime_api.resume_persisted_runtime_tasks()
 
-    assert resumed == 0
+    assert stale_count == 1
     assert spawned == []
 
     record = tracker.get("task-resume-1")
@@ -3756,7 +3823,7 @@ async def test_resume_persisted_runtime_tasks_marks_active_record_stale_by_defau
     assert record.status == "stale"
     assert record.resume_count == 0
     assert record.payload["state_code"] == "runtime_restart_task_replay_disabled"
-    assert record.payload["error"] == "Runtime restarted before task completion; automatic task replay is disabled"
+    assert record.payload["error"] == runtime_api.RUNTIME_TASK_RESTART_REPLAY_DISABLED_MESSAGE
 
 @pytest.mark.asyncio
 async def test_resume_persisted_runtime_tasks_marks_all_active_records_stale(tmp_path, monkeypatch):
@@ -3791,9 +3858,9 @@ async def test_resume_persisted_runtime_tasks_marks_all_active_records_stale(tmp
     spawned = []
     monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
-    resumed = await runtime_api.resume_persisted_runtime_tasks()
+    stale_count = await runtime_api.resume_persisted_runtime_tasks()
 
-    assert resumed == 0
+    assert stale_count == 2
     assert spawned == []
 
     statuses = {task_id: tracker.get(task_id).status for task_id in ("task-resume-limit-1", "task-resume-limit-2")}

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3726,11 +3726,11 @@ async def test_api_tasks_execute_restart_stale_matching_admission_redelivers(mon
     assert second_body["status"] == "accepted"
     assert second_body["task_id"] == "task-restart-stale-redelivery"
     assert len(spawned) == 2
-    await asyncio.sleep(0)
+    await asyncio.wait_for(asyncio.gather(spawned[0], return_exceptions=True), timeout=1)
     assert spawned[0].done()
 
     release.set()
-    await asyncio.gather(*spawned, return_exceptions=True)
+    await asyncio.gather(spawned[1], return_exceptions=True)
     assert runtime_api.runtime_task_tracker.get("task-restart-stale-redelivery").status == "success"
 
 
@@ -3812,7 +3812,6 @@ async def test_resume_persisted_runtime_tasks_marks_active_record_stale_by_defau
     tracker = RuntimeTaskTracker()
     monkeypatch.setattr(runtime_api, "runtime_task_tracker", tracker)
     monkeypatch.setenv("EFP_RUNTIME_TASKS_DIR", str(tmp_path))
-    monkeypatch.delenv("EFP_RUNTIME_TASKS_RESUME_MAX_ACTIVE", raising=False)
     spawned = []
     monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3671,6 +3671,7 @@ async def test_api_tasks_execute_restart_stale_matching_admission_redelivers(mon
     runtime_api.runtime_task_tracker.reset()
     release = asyncio.Event()
     spawned = []
+    emitted = []
 
     async def _fake_execute_runtime_task_request(**kwargs):
         await release.wait()
@@ -3690,6 +3691,7 @@ async def test_api_tasks_execute_restart_stale_matching_admission_redelivers(mon
 
     monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
     monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
+    monkeypatch.setattr(runtime_api, "_emit_task_lifecycle_event", lambda event_type, **_kwargs: emitted.append(event_type) or asyncio.sleep(0))
 
     class _Request:
         headers = INTERNAL_HEADERS
@@ -3728,6 +3730,7 @@ async def test_api_tasks_execute_restart_stale_matching_admission_redelivers(mon
     assert len(spawned) == 2
     await asyncio.wait_for(asyncio.gather(spawned[0], return_exceptions=True), timeout=1)
     assert spawned[0].done()
+    assert "task.cancelled" not in emitted
 
     release.set()
     await asyncio.gather(spawned[1], return_exceptions=True)

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -3716,7 +3716,7 @@ async def test_api_tasks_execute_generic_agent_task_uses_file_safe_task_session(
 
 
 @pytest.mark.asyncio
-async def test_resume_persisted_runtime_tasks_replays_active_record(tmp_path, monkeypatch):
+async def test_resume_persisted_runtime_tasks_marks_active_record_stale_by_default(tmp_path, monkeypatch):
     from src.gateway import runtime_api
     from src.runtime.runtime_task_tracker import RuntimeTaskTracker
 
@@ -3742,54 +3742,24 @@ async def test_resume_persisted_runtime_tasks_replays_active_record(tmp_path, mo
     tracker = RuntimeTaskTracker()
     monkeypatch.setattr(runtime_api, "runtime_task_tracker", tracker)
     monkeypatch.setenv("EFP_RUNTIME_TASKS_DIR", str(tmp_path))
+    monkeypatch.delenv("EFP_RUNTIME_TASKS_RESUME_MAX_ACTIVE", raising=False)
     spawned = []
-    captured = {}
-    emitted = []
-
-    async def _fake_execute_runtime_task_request(**kwargs):
-        captured.update(kwargs)
-        return type(
-            "R",
-            (),
-            {
-                "request_id": kwargs["request_id"],
-                "status": "success",
-                "output_payload": {"ok": True},
-                "artifacts": [],
-                "runtime_events": [],
-                "next_action_hint": None,
-                "audit_ref": None,
-            },
-        )()
-
-    async def _fake_emit_task_lifecycle_event(event_type, **kwargs):
-        emitted.append(event_type)
-
-    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
-    monkeypatch.setattr(runtime_api, "_emit_task_lifecycle_event", _fake_emit_task_lifecycle_event)
     monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
     resumed = await runtime_api.resume_persisted_runtime_tasks()
 
-    assert resumed == 1
-    assert len(spawned) == 1
-    await spawned[0]
+    assert resumed == 0
+    assert spawned == []
 
     record = tracker.get("task-resume-1")
     assert record is not None
-    assert record.status == "success"
-    assert record.resume_count == 1
-    assert captured["metadata"]["runtime_task_resumed"] is True
-    assert captured["metadata"]["runtime_task_resume_count"] == 1
-    assert captured["metadata"]["runtime_task_admission_id"] == record.admission_id
-    assert captured["metadata"]["runtime_task_input_hash"] == record.input_hash
-    assert captured["metadata"]["runtime_task_attempt_id"]
-    assert captured["metadata"]["runtime_task_attempt_count"] == 2
-    assert "task.resumed" in emitted
-
+    assert record.status == "stale"
+    assert record.resume_count == 0
+    assert record.payload["state_code"] == "runtime_restart_task_replay_disabled"
+    assert record.payload["error"] == "Runtime restarted before task completion; automatic task replay is disabled"
 
 @pytest.mark.asyncio
-async def test_resume_persisted_runtime_tasks_limits_active_resumes(tmp_path, monkeypatch):
+async def test_resume_persisted_runtime_tasks_marks_all_active_records_stale(tmp_path, monkeypatch):
     from src.gateway import runtime_api
     from src.runtime.runtime_task_tracker import RuntimeTaskTracker
 
@@ -3817,39 +3787,19 @@ async def test_resume_persisted_runtime_tasks_limits_active_resumes(tmp_path, mo
     monkeypatch.setenv("EFP_RUNTIME_TASKS_DIR", str(tmp_path))
     monkeypatch.setenv("EFP_RUNTIME_TASKS_LOAD_MAX_RECORDS", "10")
     monkeypatch.setenv("EFP_RUNTIME_TASKS_LOAD_MAX_FILE_BYTES", "1000000")
-    monkeypatch.setenv("EFP_RUNTIME_TASKS_RESUME_MAX_ACTIVE", "1")
     monkeypatch.setenv("EFP_RUNTIME_TASKS_PERSIST_MAX_FILE_BYTES", "1000000")
     spawned = []
-
-    async def _fake_execute_runtime_task_request(**kwargs):
-        return type(
-            "R",
-            (),
-            {
-                "request_id": kwargs["request_id"],
-                "status": "success",
-                "output_payload": {"ok": True},
-                "artifacts": [],
-                "runtime_events": [],
-                "next_action_hint": None,
-                "audit_ref": None,
-            },
-        )()
-
-    monkeypatch.setattr(runtime_api, "execute_runtime_task_request", _fake_execute_runtime_task_request)
-    monkeypatch.setattr(runtime_api, "_emit_task_lifecycle_event", lambda *_args, **_kwargs: asyncio.sleep(0))
     monkeypatch.setattr(runtime_api, "_spawn_runtime_background_task", lambda coro: spawned.append(asyncio.create_task(coro)) or spawned[-1])
 
     resumed = await runtime_api.resume_persisted_runtime_tasks()
 
-    assert resumed == 1
-    assert len(spawned) == 1
-    await spawned[0]
+    assert resumed == 0
+    assert spawned == []
 
     statuses = {task_id: tracker.get(task_id).status for task_id in ("task-resume-limit-1", "task-resume-limit-2")}
-    assert sorted(statuses.values()) == ["stale", "success"]
-    stale_task_id = next(task_id for task_id, status in statuses.items() if status == "stale")
-    assert tracker.get(stale_task_id).payload["error"] == "Runtime task recovery resume limit exceeded"
+    assert sorted(statuses.values()) == ["stale", "stale"]
+    for task_id in statuses:
+        assert tracker.get(task_id).payload["state_code"] == "runtime_restart_task_replay_disabled"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿## Summary

Align native runtime task restart handling with upstream OpenCode's recovery boundary. Runtime startup still reloads bounded task metadata and rehydrates blocked/waiting lanes, but in-flight provider/tool activity from a previous process is no longer replayed automatically. Active records from an older process are marked stale with `runtime_restart_task_replay_disabled` so Portal can surface a clear re-dispatch path.

## Root Cause

The previous native recovery path could schedule persisted active tasks during runtime startup. That exceeds upstream OpenCode's current capability boundary, where durable session/history is retained but post-crash activity recovery is intentionally deferred because provider/tool side effects may be ambiguous.

## Validation

- `python -m pytest tests/test_runtime_api.py::test_resume_persisted_runtime_tasks_marks_active_record_stale_by_default tests/test_runtime_api.py::test_resume_persisted_runtime_tasks_marks_all_active_records_stale tests/test_runtime_api.py::test_persisted_blocked_runtime_task_rehydrates_session_lane_before_new_input -q`
- `python -m pytest tests/test_runtime_api.py -q`
