### PR TITLE
Add mobile CLI support to native runtime images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ RUN apt-get update \
     && "$VIRTUAL_ENV/bin/python" -m pip install --no-cache-dir --upgrade pip setuptools wheel \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/opt/venv/bin:/usr/local/bin:$PATH"
+ENV PATH="/opt/venv/bin:/usr/local/bin:$PATH" \
+    BROWSERSTACK_LOCAL_BINARY="/usr/local/bin/BrowserStackLocal"
 
 # Install Python dependencies into the virtual environment.
 COPY requirements.txt .
@@ -78,7 +79,10 @@ RUN set -eux; \
     && confluence schema page.create --json >/dev/null \
     && browser version --json >/dev/null \
     && browser commands --json >/dev/null \
-    && browser schema probe --json >/dev/null
+    && browser schema probe --json >/dev/null \
+    && mobile version --json >/dev/null \
+    && mobile commands --json >/dev/null \
+    && mobile schema run.start --json >/dev/null
 
 # Create the runtime workspace and external skills directories.
 RUN mkdir -p /app/skills /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,9 +80,9 @@ RUN set -eux; \
     && browser version --json >/dev/null \
     && browser commands --json >/dev/null \
     && browser schema probe --json >/dev/null \
-    && mobile version --json >/dev/null \
-    && mobile commands --json >/dev/null \
-    && mobile schema run.start --json >/dev/null
+    && mobile-auto version --json >/dev/null \
+    && mobile-auto commands --json >/dev/null \
+    && mobile-auto schema run.start --json >/dev/null
 
 # Create the runtime workspace and external skills directories.
 RUN mkdir -p /app/skills /workspace

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ EFP native runtime exposes only EFP-owned built-in LLM tools
 `apply_patch`, plus other EFP runtime built-ins). Legacy Python tool packages,
 including `src/bash_tools`, are not part of the production LLM tool surface.
 Runtime image builds can also place prebuilt `engineering-flow-platform-tools`
-CLI binaries such as `jira`, `confluence`, and `browser` on `PATH` in
+CLI binaries such as `jira`, `confluence`, `browser`, and `mobile` on `PATH` in
 `/usr/local/bin`. Agents invoke those CLIs through the EFP `bash` built-in from
 the workspace; they are not registered as separate model-facing function tools
 and are not loaded through `EFP_TOOLS_DIR` or `EFP_EXTERNAL_TOOLS_*`.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ EFP native runtime exposes only EFP-owned built-in LLM tools
 `apply_patch`, plus other EFP runtime built-ins). Legacy Python tool packages,
 including `src/bash_tools`, are not part of the production LLM tool surface.
 Runtime image builds can also place prebuilt `engineering-flow-platform-tools`
-CLI binaries such as `jira`, `confluence`, `browser`, and `mobile` on `PATH` in
+CLI binaries such as `jira`, `confluence`, `browser`, and `mobile-auto` on `PATH` in
 `/usr/local/bin`. Agents invoke those CLIs through the EFP `bash` built-in from
 the workspace; they are not registered as separate model-facing function tools
 and are not loaded through `EFP_TOOLS_DIR` or `EFP_EXTERNAL_TOOLS_*`.

--- a/docs/runtime-design.md
+++ b/docs/runtime-design.md
@@ -77,7 +77,7 @@ The runtime image can also provide prebuilt `engineering-flow-platform-tools`
 CLI binaries on `PATH` under `/usr/local/bin`. `scripts/prepare-runtime-tools.sh`
 discovers every `cmd/<tool>/main.go` from that repository and writes generated
 binaries to `runtime-tools/` for Docker/CI to copy into the image. Current tools
-include `jira`, `confluence`, `browser`, and `mobile`; future `cmd/<tool>` binaries should
+include `jira`, `confluence`, `browser`, and `mobile-auto`; future `cmd/<tool>` binaries should
 enter the image the same way. Agents reach these CLIs by invoking the model-facing
 `bash` built-in in the workspace-full-access workspace. They should inspect
 `<tool> commands --json` and `<tool> schema <command> --json`, prefer JSON

--- a/docs/runtime-design.md
+++ b/docs/runtime-design.md
@@ -77,16 +77,20 @@ The runtime image can also provide prebuilt `engineering-flow-platform-tools`
 CLI binaries on `PATH` under `/usr/local/bin`. `scripts/prepare-runtime-tools.sh`
 discovers every `cmd/<tool>/main.go` from that repository and writes generated
 binaries to `runtime-tools/` for Docker/CI to copy into the image. Current tools
-include `jira`, `confluence`, and `browser`; future `cmd/<tool>` binaries should
+include `jira`, `confluence`, `browser`, and `mobile`; future `cmd/<tool>` binaries should
 enter the image the same way. Agents reach these CLIs by invoking the model-facing
 `bash` built-in in the workspace-full-access workspace. They should inspect
 `<tool> commands --json` and `<tool> schema <command> --json`, prefer JSON
 output, use `--dry-run` before writes, and reserve `--yes` for destructive
 operations. These CLIs are not projected as separate model-facing function tools.
 
+Private managed mobile sessions additionally require the BrowserStackLocal
+binary staged as `runtime-tools/BrowserStackLocal` or configured through
+`BROWSERSTACK_LOCAL_BINARY`.
+
 Runtime profile application still writes the config files those CLIs and system
 tools expect: Atlassian config for Jira/Confluence, `gh` hosts config for
-GitHub, and Git user include config. The old `EFP_TOOLS_DIR` and
+GitHub, mobile BrowserStack config, and Git user include config. The old `EFP_TOOLS_DIR` and
 `EFP_EXTERNAL_TOOLS_*` Python loader settings remain ignored; `runtime-tools/*`
 is only a build input for PATH binaries.
 

--- a/docs/runtime_contract.md
+++ b/docs/runtime_contract.md
@@ -37,7 +37,7 @@ Native runtime must support:
 - Runtime tool surface comes from the EFP-owned runtime built-in registry only (`src.__init__.get_tools_schema()`).
 - Model-visible tool ids include `bash`, `read`, `write`, `edit`, `grep`, `glob`, `webfetch`, `todowrite`, and `apply_patch`.
 - Legacy Python tool packages such as `src.bash_tools` are not present, and Jira/GitHub/Confluence/Git Python tools are not exposed as LLM tools.
-- The runtime image may include prebuilt `engineering-flow-platform-tools` CLI binaries on `PATH` in `/usr/local/bin`. Current binaries include `jira`, `confluence`, `browser`, and `mobile`; future binaries are discovered from `cmd/<tool>` in that repo.
+- The runtime image may include prebuilt `engineering-flow-platform-tools` CLI binaries on `PATH` in `/usr/local/bin`. Current binaries include `jira`, `confluence`, `browser`, and `mobile-auto`; future binaries are discovered from `cmd/<tool>` in that repo.
 - Agents use those CLIs through the model-visible `bash` built-in in the workspace-full-access runtime workspace. They should run `<tool> commands --json`, then `<tool> schema <command> --json`, prefer `--json`, use `--dry-run` before writes, and pass `--yes` for destructive operations.
 - Runtime profile application still projects Jira, Confluence, GitHub, Git, and mobile BrowserStack configuration to the corresponding CLI config files.
 - Private managed mobile runs require BrowserStackLocal at `/usr/local/bin/BrowserStackLocal` or a configured `BROWSERSTACK_LOCAL_BINARY`; CI may stage that third-party binary into `runtime-tools/BrowserStackLocal`.

--- a/docs/runtime_contract.md
+++ b/docs/runtime_contract.md
@@ -37,9 +37,10 @@ Native runtime must support:
 - Runtime tool surface comes from the EFP-owned runtime built-in registry only (`src.__init__.get_tools_schema()`).
 - Model-visible tool ids include `bash`, `read`, `write`, `edit`, `grep`, `glob`, `webfetch`, `todowrite`, and `apply_patch`.
 - Legacy Python tool packages such as `src.bash_tools` are not present, and Jira/GitHub/Confluence/Git Python tools are not exposed as LLM tools.
-- The runtime image may include prebuilt `engineering-flow-platform-tools` CLI binaries on `PATH` in `/usr/local/bin`. Current binaries include `jira`, `confluence`, and `browser`; future binaries are discovered from `cmd/<tool>` in that repo.
+- The runtime image may include prebuilt `engineering-flow-platform-tools` CLI binaries on `PATH` in `/usr/local/bin`. Current binaries include `jira`, `confluence`, `browser`, and `mobile`; future binaries are discovered from `cmd/<tool>` in that repo.
 - Agents use those CLIs through the model-visible `bash` built-in in the workspace-full-access runtime workspace. They should run `<tool> commands --json`, then `<tool> schema <command> --json`, prefer `--json`, use `--dry-run` before writes, and pass `--yes` for destructive operations.
-- Runtime profile application still projects Jira, Confluence, GitHub, and Git configuration to the corresponding CLI config files.
+- Runtime profile application still projects Jira, Confluence, GitHub, Git, and mobile BrowserStack configuration to the corresponding CLI config files.
+- Private managed mobile runs require BrowserStackLocal at `/usr/local/bin/BrowserStackLocal` or a configured `BROWSERSTACK_LOCAL_BINARY`; CI may stage that third-party binary into `runtime-tools/BrowserStackLocal`.
 - Legacy `EFP_TOOLS_DIR` / `EFP_EXTERNAL_TOOLS_*` Python external tool loaders are ignored by native runtime. `runtime-tools/*` is a Docker/CI build input for prebuilt CLI binaries and is copied into `PATH`; it is not a Python loader.
 - MCP servers and external protocol tool providers are intentionally excluded.
 

--- a/runtime-tools/README.md
+++ b/runtime-tools/README.md
@@ -3,8 +3,13 @@ script discovers every `cmd/<tool>/main.go` in the adjacent, checked-out, or
 cloned `engineering-flow-platform-tools` repository and writes Linux amd64
 runtime binaries here by default.
 
-Current generated binaries include `jira`, `confluence`, and `browser`. Future
+Current generated binaries include `jira`, `confluence`, `browser`, and `mobile`. Future
 tools added under `cmd/<tool>` are prepared the same way.
+
+For private managed mobile sessions, CI may also stage the BrowserStack-provided
+`BrowserStackLocal` binary here by setting `BROWSERSTACK_LOCAL_SOURCE` or
+`BROWSERSTACK_LOCAL_BINARY` before running the prepare script. That binary is
+copied to `/usr/local/bin/BrowserStackLocal` by the runtime image build.
 
 The runtime image copies generated binaries into `/usr/local/bin` so agents can
 call them through the EFP `bash` built-in from the workspace. The final runtime

--- a/runtime-tools/README.md
+++ b/runtime-tools/README.md
@@ -3,7 +3,7 @@ script discovers every `cmd/<tool>/main.go` in the adjacent, checked-out, or
 cloned `engineering-flow-platform-tools` repository and writes Linux amd64
 runtime binaries here by default.
 
-Current generated binaries include `jira`, `confluence`, `browser`, and `mobile`. Future
+Current generated binaries include `jira`, `confluence`, `browser`, and `mobile-auto`. Future
 tools added under `cmd/<tool>` are prepared the same way.
 
 For private managed mobile sessions, CI may also stage the BrowserStack-provided

--- a/scripts/prepare-runtime-tools.sh
+++ b/scripts/prepare-runtime-tools.sh
@@ -9,6 +9,7 @@ TOOLS_REPO_DIR=""
 TARGET_GOOS="${GOOS:-linux}"
 TARGET_GOARCH="${GOARCH:-amd64}"
 TARGET_CGO_ENABLED="${CGO_ENABLED:-0}"
+BROWSERSTACK_LOCAL_SOURCE="${BROWSERSTACK_LOCAL_SOURCE:-${BROWSERSTACK_LOCAL_BINARY:-}}"
 
 log() {
   printf '[prepare-runtime-tools] %s\n' "$*" >&2
@@ -51,6 +52,20 @@ resolve_tools_repo_dir() {
   TOOLS_REPO_DIR="$TEMP_DIR/engineering-flow-platform-tools"
 }
 
+stage_browserstack_local() {
+  local source="$BROWSERSTACK_LOCAL_SOURCE"
+  if [[ -z "$source" ]]; then
+    log "BrowserStackLocal source not set; private-managed mobile runs require staging runtime-tools/BrowserStackLocal separately"
+    return
+  fi
+  if [[ "$source" != /* ]]; then
+    source="$ROOT/$source"
+  fi
+  [[ -f "$source" ]] || die "BrowserStackLocal source does not exist: $source"
+  install -m 0755 "$source" "$OUTPUT_DIR/BrowserStackLocal"
+  log "Staged BrowserStackLocal binary from $source"
+}
+
 command -v go >/dev/null 2>&1 || die "go is required to build runtime tools"
 mkdir -p "$OUTPUT_DIR"
 
@@ -89,5 +104,6 @@ for tool_name in "${tool_names[@]}"; do
 done
 
 chmod 0755 "${built_outputs[@]}"
+stage_browserstack_local
 log "Built runtime tools: ${tool_names[*]}"
 log "Prepared runtime tool binaries in $OUTPUT_DIR"

--- a/src/config.py
+++ b/src/config.py
@@ -95,20 +95,20 @@ PORTAL_MANAGED_RUNTIME_FIELDS = frozenset(
 RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS = [
     (
         "Use bash for external CLI tools configured by the runtime profile: "
-        "jira, confluence, gh, aws, jenkins, mobile, and git."
+        "jira, confluence, gh, aws, jenkins, mobile-auto, and git."
     ),
     (
-        "For jira, confluence, jenkins, and mobile, always pass --json. Before complex commands, "
+        "For jira, confluence, jenkins, and mobile-auto, always pass --json. Before complex commands, "
         "inspect commands/schema/help llm; prefer --dry-run for writes, and use "
         "--yes only when a destructive action was explicitly confirmed."
     ),
     (
         "Use gh for GitHub issues, pull requests, and api calls; use aws for AWS operations; "
-        "use jenkins for Jenkins controller operations; use mobile for BrowserStack/Appium device automation; "
+        "use jenkins for Jenkins controller operations; use mobile-auto for BrowserStack/Appium device automation; "
         "use git for clone, fetch, push, and status."
     ),
     (
-        "For mobile automation, start with `mobile doctor --json` and `mobile auth test --json`. "
+        "For mobile automation, start with `mobile-auto doctor --json` and `mobile-auto auth test --json`. "
         "Use `private-external` with an existing BrowserStackLocal identifier, or `private-managed` only when "
         "the runtime image provides `/usr/local/bin/BrowserStackLocal`."
     ),
@@ -118,7 +118,7 @@ RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS = [
     ),
     (
         "Credentials were applied by the runtime profile through real CLIs or environment variables; "
-        "if jira, confluence, jenkins, or mobile returns auth_failed, aws returns an auth error, or gh/git authentication fails, "
+        "if jira, confluence, jenkins, or mobile-auto returns auth_failed, aws returns an auth error, or gh/git authentication fails, "
         "report a runtime profile configuration problem."
     ),
 ]
@@ -204,7 +204,7 @@ def _should_inject_runtime_profile_external_cli_instructions(overlay: Dict[str, 
         _has_atlassian_profile_instances(overlay.get("jira"))
         or _has_atlassian_profile_instances(overlay.get("confluence"))
         or _has_jenkins_profile_credentials(overlay.get("jenkins"))
-        or _has_mobile_profile_config(overlay.get("mobile"))
+        or _has_mobile_profile_config(overlay.get("mobile-auto"))
         or _has_github_profile_token(overlay.get("github"))
         or _has_aws_profile_config(overlay.get("aws"))
         or _has_git_profile_user(overlay.get("git"))
@@ -310,7 +310,7 @@ class Config:
         "github",
         "aws",
         "jenkins",
-        "mobile",
+        "mobile-auto",
         "git",
         "debug",
         *PORTAL_MANAGED_RUNTIME_FIELDS,
@@ -375,7 +375,7 @@ class Config:
             "username": True,
             "password": True,
         },
-        "mobile": {
+        "mobile-auto": {
             "enabled": True,
             "default_provider": True,
             "state_dir": True,
@@ -867,7 +867,7 @@ class Config:
                         self.apply_proxy()
                     if "jenkins" in changed_sections:
                         self.apply_jenkins_env()
-                    if "mobile" in changed_sections:
+                    if "mobile-auto" in changed_sections:
                         self.apply_mobile_env()
                 return True
         except Exception:
@@ -1093,7 +1093,7 @@ class Config:
 
     @property
     def mobile(self) -> Dict[str, Any]:
-        return self._config.get("mobile", {})
+        return self._config.get("mobile-auto", {})
 
     def _clear_mobile_env(self) -> None:
         for var in set(self.MOBILE_ENV_VARS) | set(self._mobile_env_vars):

--- a/src/config.py
+++ b/src/config.py
@@ -95,21 +95,30 @@ PORTAL_MANAGED_RUNTIME_FIELDS = frozenset(
 RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS = [
     (
         "Use bash for external CLI tools configured by the runtime profile: "
-        "jira, confluence, gh, aws, jenkins, and git."
+        "jira, confluence, gh, aws, jenkins, mobile, and git."
     ),
     (
-        "For jira, confluence, and jenkins, always pass --json. Before complex commands, "
+        "For jira, confluence, jenkins, and mobile, always pass --json. Before complex commands, "
         "inspect commands/schema/help llm; prefer --dry-run for writes, and use "
         "--yes only when a destructive action was explicitly confirmed."
     ),
-    "Use gh for GitHub issues, pull requests, and api calls; use aws for AWS operations; use jenkins for Jenkins controller operations; use git for clone, fetch, push, and status.",
+    (
+        "Use gh for GitHub issues, pull requests, and api calls; use aws for AWS operations; "
+        "use jenkins for Jenkins controller operations; use mobile for BrowserStack/Appium device automation; "
+        "use git for clone, fetch, push, and status."
+    ),
+    (
+        "For mobile automation, start with `mobile doctor --json` and `mobile auth test --json`. "
+        "Use `private-external` with an existing BrowserStackLocal identifier, or `private-managed` only when "
+        "the runtime image provides `/usr/local/bin/BrowserStackLocal`."
+    ),
     (
         "Jenkins runtime profile credentials are available as EFP_JENKINS_USERNAME and EFP_JENKINS_PASSWORD. "
         "When the user provides a Jenkins controller URL or pipeline/job, configure or log in to that controller at that time and pass the password through stdin."
     ),
     (
         "Credentials were applied by the runtime profile through real CLIs or environment variables; "
-        "if jira, confluence, or jenkins returns auth_failed, aws returns an auth error, or gh/git authentication fails, "
+        "if jira, confluence, jenkins, or mobile returns auth_failed, aws returns an auth error, or gh/git authentication fails, "
         "report a runtime profile configuration problem."
     ),
 ]
@@ -195,6 +204,7 @@ def _should_inject_runtime_profile_external_cli_instructions(overlay: Dict[str, 
         _has_atlassian_profile_instances(overlay.get("jira"))
         or _has_atlassian_profile_instances(overlay.get("confluence"))
         or _has_jenkins_profile_credentials(overlay.get("jenkins"))
+        or _has_mobile_profile_config(overlay.get("mobile"))
         or _has_github_profile_token(overlay.get("github"))
         or _has_aws_profile_config(overlay.get("aws"))
         or _has_git_profile_user(overlay.get("git"))
@@ -236,6 +246,19 @@ def _has_jenkins_profile_credentials(section: Any) -> bool:
     username = str(section.get("username") or "").strip()
     password = str(section.get("password") or "").strip()
     return bool(username and password)
+
+
+def _has_mobile_profile_config(section: Any) -> bool:
+    if not isinstance(section, dict) or section.get("enabled") is False:
+        return False
+    browserstack = section.get("browserstack")
+    if not isinstance(browserstack, dict):
+        return False
+    return bool(
+        str(browserstack.get("username") or browserstack.get("username_env") or "").strip()
+        or str(browserstack.get("access_key") or browserstack.get("access_key_env") or "").strip()
+        or str(browserstack.get("api_base_url") or browserstack.get("appium_base_url") or "").strip()
+    )
 
 
 def _has_git_profile_user(section: Any) -> bool:
@@ -283,6 +306,7 @@ class Config:
         "github",
         "aws",
         "jenkins",
+        "mobile",
         "git",
         "debug",
         *PORTAL_MANAGED_RUNTIME_FIELDS,
@@ -346,6 +370,33 @@ class Config:
             "enabled": True,
             "username": True,
             "password": True,
+        },
+        "mobile": {
+            "enabled": True,
+            "default_provider": True,
+            "state_dir": True,
+            "artifacts_dir": True,
+            "retention_hours": True,
+            "defaults": {
+                "platform": True,
+                "network_mode": True,
+                "idle_timeout_seconds": True,
+                "new_command_timeout_seconds": True,
+                "interactive_debugging": True,
+                "video": True,
+            },
+            "browserstack": {
+                "api_base_url": True,
+                "appium_base_url": True,
+                "username_env": True,
+                "access_key_env": True,
+                "username": True,
+                "access_key": True,
+                "verify_ssl": True,
+                "ca_cert": True,
+                "http_proxy": True,
+                "local": True,
+            },
         },
         "git": {
             "user": {
@@ -740,7 +791,7 @@ class Config:
                 "Ensure EFP_CONFIG_KEY is correct and the configuration file contains valid encrypted values."
             ) from e
     
-    SENSITIVE_FIELDS = {"api_key", "password", "token", "api_token", "access_token", "secret"}
+    SENSITIVE_FIELDS = {"api_key", "password", "token", "api_token", "access_token", "access_key", "secret"}
     
     def _encrypt_sensitive_fields(self, obj: Any, path: tuple[str, ...] = ()) -> None:
         """Recursively encrypt sensitive fields in config."""

--- a/src/config.py
+++ b/src/config.py
@@ -296,6 +296,10 @@ class Config:
         "JENKINS_USERNAME",
         "JENKINS_PASSWORD",
     )
+    MOBILE_ENV_VARS = (
+        "BROWSERSTACK_USERNAME",
+        "BROWSERSTACK_ACCESS_KEY",
+    )
 
     PROJECT_EXAMPLE = Path(__file__).parent.parent / 'config.yaml.example'
     MANAGED_OVERLAY_SECTIONS = {
@@ -424,6 +428,7 @@ class Config:
             "revision": None,
         }
         self._managed_sections: List[str] = []
+        self._mobile_env_vars: set[str] = set()
         self._external_config_status: Dict[str, Any] = {
             "success": True,
             "error": None,
@@ -862,6 +867,8 @@ class Config:
                         self.apply_proxy()
                     if "jenkins" in changed_sections:
                         self.apply_jenkins_env()
+                    if "mobile" in changed_sections:
+                        self.apply_mobile_env()
                 return True
         except Exception:
             pass
@@ -1083,6 +1090,39 @@ class Config:
             os.environ["JENKINS_PASSWORD"] = password
         else:
             self._clear_jenkins_env()
+
+    @property
+    def mobile(self) -> Dict[str, Any]:
+        return self._config.get("mobile", {})
+
+    def _clear_mobile_env(self) -> None:
+        for var in set(self.MOBILE_ENV_VARS) | set(self._mobile_env_vars):
+            os.environ.pop(var, None)
+        self._mobile_env_vars = set()
+
+    def apply_mobile_env(self) -> None:
+        mobile_config = self.mobile
+        browserstack = (
+            mobile_config.get("browserstack")
+            if isinstance(mobile_config, dict) and isinstance(mobile_config.get("browserstack"), dict)
+            else {}
+        )
+        username = str(browserstack.get("username") or "").strip()
+        access_key = str(browserstack.get("access_key") or "").strip()
+        username_env = str(browserstack.get("username_env") or "BROWSERSTACK_USERNAME").strip()
+        access_key_env = str(browserstack.get("access_key_env") or "BROWSERSTACK_ACCESS_KEY").strip()
+
+        self._clear_mobile_env()
+        if not (isinstance(mobile_config, dict) and mobile_config.get("enabled") and isinstance(browserstack, dict)):
+            return
+        if username and username_env:
+            os.environ[username_env] = username
+            os.environ["BROWSERSTACK_USERNAME"] = username
+            self._mobile_env_vars.update({username_env, "BROWSERSTACK_USERNAME"})
+        if access_key and access_key_env:
+            os.environ[access_key_env] = access_key
+            os.environ["BROWSERSTACK_ACCESS_KEY"] = access_key
+            self._mobile_env_vars.update({access_key_env, "BROWSERSTACK_ACCESS_KEY"})
     
     @property
     def heartbeat(self) -> Dict[str, Any]:

--- a/src/efp_runtime/system_prompt.py
+++ b/src/efp_runtime/system_prompt.py
@@ -27,11 +27,11 @@ Core operating rules:
 - When citing code, prefer path:line references.
 
 Runtime CLI tools:
-- The runtime image may place engineering-flow-platform-tools binaries on PATH, such as `jira`, `confluence`, `browser`, `mobile`, and future binaries built from `cmd/<tool>`.
+- The runtime image may place engineering-flow-platform-tools binaries on PATH, such as `jira`, `confluence`, `browser`, `mobile-auto`, and future binaries built from `cmd/<tool>`.
 - Use these CLIs through the EFP `bash` built-in from the workspace. The default runtime environment is workspace-full-access.
 - Before using a CLI command, inspect `<tool> commands --json`, then inspect `<tool> schema <command> --json`.
 - Prefer `--json` output. For writes, run `--dry-run` first. For destructive or deletion operations, require explicit `--yes`.
-- For mobile BrowserStack/Appium automation, start with `mobile doctor --json` and `mobile auth test --json`; use `private-external` with a supplied BrowserStackLocal identifier, or `private-managed` only when BrowserStackLocal exists in the runtime image.
+- For mobile BrowserStack/Appium automation, start with `mobile-auto doctor --json` and `mobile-auto auth test --json`; use `private-external` with a supplied BrowserStackLocal identifier, or `private-managed` only when BrowserStackLocal exists in the runtime image.
 - These CLIs are shell commands, not model-facing function tools.
 """
 

--- a/src/efp_runtime/system_prompt.py
+++ b/src/efp_runtime/system_prompt.py
@@ -27,10 +27,11 @@ Core operating rules:
 - When citing code, prefer path:line references.
 
 Runtime CLI tools:
-- The runtime image may place engineering-flow-platform-tools binaries on PATH, such as `jira`, `confluence`, `browser`, and future binaries built from `cmd/<tool>`.
+- The runtime image may place engineering-flow-platform-tools binaries on PATH, such as `jira`, `confluence`, `browser`, `mobile`, and future binaries built from `cmd/<tool>`.
 - Use these CLIs through the EFP `bash` built-in from the workspace. The default runtime environment is workspace-full-access.
 - Before using a CLI command, inspect `<tool> commands --json`, then inspect `<tool> schema <command> --json`.
 - Prefer `--json` output. For writes, run `--dry-run` first. For destructive or deletion operations, require explicit `--yes`.
+- For mobile BrowserStack/Appium automation, start with `mobile doctor --json` and `mobile auth test --json`; use `private-external` with a supplied BrowserStackLocal identifier, or `private-managed` only when BrowserStackLocal exists in the runtime image.
 - These CLIs are shell commands, not model-facing function tools.
 """
 

--- a/tests/test_docker_runtime_contract.py
+++ b/tests/test_docker_runtime_contract.py
@@ -64,9 +64,9 @@ def test_dockerfile_installs_gh_and_copies_runtime_tools_binaries():
         "browser version --json",
         "browser commands --json",
         "browser schema probe --json",
-        "mobile version --json",
-        "mobile commands --json",
-        "mobile schema run.start --json",
+        "mobile-auto version --json",
+        "mobile-auto commands --json",
+        "mobile-auto schema run.start --json",
     ]:
         assert command in text
 
@@ -86,7 +86,7 @@ def test_prepare_runtime_tools_script_discovers_all_cmd_tools(tmp_path):
     script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
 
     tools_repo = tmp_path / "engineering-flow-platform-tools"
-    for tool_name in ["jira", "confluence", "browser", "mobile"]:
+    for tool_name in ["jira", "confluence", "browser", "mobile-auto"]:
         command_dir = tools_repo / "cmd" / tool_name
         command_dir.mkdir(parents=True)
         (command_dir / "main.go").write_text("package main\nfunc main() {}\n", encoding="utf-8")
@@ -142,10 +142,10 @@ printf '#!/usr/bin/env bash\\necho "%s"\\n' "$tool" > "$out"
         text=True,
     )
 
-    assert "Discovered runtime tools: browser confluence jira mobile" in result.stderr
-    assert "Built runtime tools: browser confluence jira mobile" in result.stderr
+    assert "Discovered runtime tools: browser confluence jira mobile-auto" in result.stderr
+    assert "Built runtime tools: browser confluence jira mobile-auto" in result.stderr
     assert (runtime_tools / "README.md").read_text(encoding="utf-8") == "kept\n"
-    for tool_name in ["jira", "confluence", "browser", "mobile"]:
+    for tool_name in ["jira", "confluence", "browser", "mobile-auto"]:
         tool_path = runtime_tools / tool_name
         assert tool_path.exists()
         assert tool_path.stat().st_mode & 0o111
@@ -153,7 +153,7 @@ printf '#!/usr/bin/env bash\\necho "%s"\\n' "$tool" > "$out"
         "browser linux amd64 0",
         "confluence linux amd64 0",
         "jira linux amd64 0",
-        "mobile linux amd64 0",
+        "mobile-auto linux amd64 0",
     ]
 
 
@@ -182,7 +182,7 @@ def test_runtime_tools_gitignore_and_readme_cover_dynamic_binaries():
     assert "jira" in readme
     assert "confluence" in readme
     assert "browser" in readme
-    assert "mobile" in readme
+    assert "mobile-auto" in readme
     assert "BrowserStackLocal" in readme
 
 

--- a/tests/test_docker_runtime_contract.py
+++ b/tests/test_docker_runtime_contract.py
@@ -64,6 +64,9 @@ def test_dockerfile_installs_gh_and_copies_runtime_tools_binaries():
         "browser version --json",
         "browser commands --json",
         "browser schema probe --json",
+        "mobile version --json",
+        "mobile commands --json",
+        "mobile schema run.start --json",
     ]:
         assert command in text
 
@@ -83,7 +86,7 @@ def test_prepare_runtime_tools_script_discovers_all_cmd_tools(tmp_path):
     script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
 
     tools_repo = tmp_path / "engineering-flow-platform-tools"
-    for tool_name in ["jira", "confluence", "browser"]:
+    for tool_name in ["jira", "confluence", "browser", "mobile"]:
         command_dir = tools_repo / "cmd" / tool_name
         command_dir.mkdir(parents=True)
         (command_dir / "main.go").write_text("package main\nfunc main() {}\n", encoding="utf-8")
@@ -139,10 +142,10 @@ printf '#!/usr/bin/env bash\\necho "%s"\\n' "$tool" > "$out"
         text=True,
     )
 
-    assert "Discovered runtime tools: browser confluence jira" in result.stderr
-    assert "Built runtime tools: browser confluence jira" in result.stderr
+    assert "Discovered runtime tools: browser confluence jira mobile" in result.stderr
+    assert "Built runtime tools: browser confluence jira mobile" in result.stderr
     assert (runtime_tools / "README.md").read_text(encoding="utf-8") == "kept\n"
-    for tool_name in ["jira", "confluence", "browser"]:
+    for tool_name in ["jira", "confluence", "browser", "mobile"]:
         tool_path = runtime_tools / tool_name
         assert tool_path.exists()
         assert tool_path.stat().st_mode & 0o111
@@ -150,6 +153,7 @@ printf '#!/usr/bin/env bash\\necho "%s"\\n' "$tool" > "$out"
         "browser linux amd64 0",
         "confluence linux amd64 0",
         "jira linux amd64 0",
+        "mobile linux amd64 0",
     ]
 
 
@@ -162,6 +166,8 @@ def test_prepare_runtime_tools_script_uses_dynamic_cmd_discovery():
     assert "find \"$TOOLS_REPO_DIR/cmd\"" in text
     assert "go build" in text
     assert "\"./cmd/$tool_name\"" in text
+    assert "BROWSERSTACK_LOCAL_SOURCE" in text
+    assert "BrowserStackLocal" in text
     assert "./cmd/jira" not in text
     assert "./cmd/confluence" not in text
     assert "./cmd/browser" not in text
@@ -176,6 +182,8 @@ def test_runtime_tools_gitignore_and_readme_cover_dynamic_binaries():
     assert "jira" in readme
     assert "confluence" in readme
     assert "browser" in readme
+    assert "mobile" in readme
+    assert "BrowserStackLocal" in readme
 
 
 def test_workflows_prepare_runtime_tools_before_docker_builds():

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -647,6 +647,43 @@ def test_runtime_profile_apply_encrypts_sensitive_fields_in_config_yaml(tmp_path
     assert cfg.jenkins.get("password") == "jenkins-secret"
 
 
+def test_runtime_profile_apply_persists_mobile_config_and_encrypts_access_key(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    _write_base_config(config_path)
+    monkeypatch.setenv("EFP_CONFIG_KEY", "test-key")
+
+    cfg = Config(str(config_path))
+    updated = cfg.set_managed_overlay(
+        "rp_mobile",
+        4,
+        {
+            "mobile": {
+                "enabled": True,
+                "default_provider": "browserstack",
+                "state_dir": "/workspace/.efp/mobile/runs",
+                "artifacts_dir": "/workspace/.efp/mobile/artifacts",
+                "defaults": {"platform": "android", "network_mode": "private-external"},
+                "browserstack": {
+                    "username": "bs-user",
+                    "access_key": "bs-access-key",
+                    "local": {"mode": "external", "binary": "/usr/local/bin/BrowserStackLocal"},
+                },
+            }
+        },
+    )
+
+    raw_content = config_path.read_text(encoding="utf-8")
+    assert "ENC:" in raw_content
+    assert "bs-access-key" not in raw_content
+
+    cfg.load()
+    effective = cfg.get_effective_config()
+    assert effective["mobile"]["enabled"] is True
+    assert effective["mobile"]["browserstack"]["access_key"] == "bs-access-key"
+    assert "mobile" in updated
+    assert cfg.get_managed_overlay_meta()["managed_sections"] == ["instruction_texts", "mobile"]
+
+
 def test_runtime_profile_clear_removes_managed_subtree_and_metadata(tmp_path):
     config_path = tmp_path / "config.yaml"
     runtime_profile_path = tmp_path / "runtime_profile.yaml"
@@ -1577,7 +1614,7 @@ def test_runtime_profile_external_cli_instructions_are_injected(tmp_path, monkey
     instructions = cfg.get_effective_config()["instruction_texts"]
     joined = "\n".join(instructions)
     assert "Use bash" in joined
-    assert "jira, confluence, gh, aws, jenkins, and git" in joined
+    assert "jira, confluence, gh, aws, jenkins, mobile, and git" in joined
     assert "always pass --json" in joined
     assert "commands/schema/help llm" in joined
     assert "--dry-run" in joined

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -651,6 +651,8 @@ def test_runtime_profile_apply_persists_mobile_config_and_encrypts_access_key(tm
     config_path = tmp_path / "config.yaml"
     _write_base_config(config_path)
     monkeypatch.setenv("EFP_CONFIG_KEY", "test-key")
+    monkeypatch.delenv("BROWSERSTACK_USERNAME", raising=False)
+    monkeypatch.delenv("BROWSERSTACK_ACCESS_KEY", raising=False)
 
     cfg = Config(str(config_path))
     updated = cfg.set_managed_overlay(
@@ -680,8 +682,56 @@ def test_runtime_profile_apply_persists_mobile_config_and_encrypts_access_key(tm
     effective = cfg.get_effective_config()
     assert effective["mobile"]["enabled"] is True
     assert effective["mobile"]["browserstack"]["access_key"] == "bs-access-key"
+    assert os.environ["BROWSERSTACK_USERNAME"] == "bs-user"
+    assert os.environ["BROWSERSTACK_ACCESS_KEY"] == "bs-access-key"
     assert "mobile" in updated
     assert cfg.get_managed_overlay_meta()["managed_sections"] == ["instruction_texts", "mobile"]
+
+
+def test_runtime_profile_mobile_env_supports_custom_names_and_clears_on_remove(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    _write_base_config(config_path)
+    monkeypatch.setenv("EFP_CONFIG_KEY", "test-key")
+    for key in [
+        "BROWSERSTACK_USERNAME",
+        "BROWSERSTACK_ACCESS_KEY",
+        "CUSTOM_BS_USERNAME",
+        "CUSTOM_BS_ACCESS_KEY",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    cfg = Config(str(config_path))
+    cfg.set_managed_overlay(
+        "rp_mobile",
+        4,
+        {
+            "mobile": {
+                "enabled": True,
+                "default_provider": "browserstack",
+                "browserstack": {
+                    "username": "bs-user",
+                    "access_key": "bs-access-key",
+                    "username_env": "CUSTOM_BS_USERNAME",
+                    "access_key_env": "CUSTOM_BS_ACCESS_KEY",
+                },
+            }
+        },
+    )
+
+    assert os.environ["CUSTOM_BS_USERNAME"] == "bs-user"
+    assert os.environ["CUSTOM_BS_ACCESS_KEY"] == "bs-access-key"
+    assert os.environ["BROWSERSTACK_USERNAME"] == "bs-user"
+    assert os.environ["BROWSERSTACK_ACCESS_KEY"] == "bs-access-key"
+
+    cfg.set_managed_overlay("rp_mobile", 5, {"llm": {"provider": "openai"}})
+
+    for key in [
+        "BROWSERSTACK_USERNAME",
+        "BROWSERSTACK_ACCESS_KEY",
+        "CUSTOM_BS_USERNAME",
+        "CUSTOM_BS_ACCESS_KEY",
+    ]:
+        assert key not in os.environ
 
 
 def test_runtime_profile_clear_removes_managed_subtree_and_metadata(tmp_path):

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -659,11 +659,11 @@ def test_runtime_profile_apply_persists_mobile_config_and_encrypts_access_key(tm
         "rp_mobile",
         4,
         {
-            "mobile": {
+            "mobile-auto": {
                 "enabled": True,
                 "default_provider": "browserstack",
-                "state_dir": "/workspace/.efp/mobile/runs",
-                "artifacts_dir": "/workspace/.efp/mobile/artifacts",
+                "state_dir": "/workspace/.efp/mobile-auto/runs",
+                "artifacts_dir": "/workspace/.efp/mobile-auto/artifacts",
                 "defaults": {"platform": "android", "network_mode": "private-external"},
                 "browserstack": {
                     "username": "bs-user",
@@ -680,12 +680,12 @@ def test_runtime_profile_apply_persists_mobile_config_and_encrypts_access_key(tm
 
     cfg.load()
     effective = cfg.get_effective_config()
-    assert effective["mobile"]["enabled"] is True
-    assert effective["mobile"]["browserstack"]["access_key"] == "bs-access-key"
+    assert effective["mobile-auto"]["enabled"] is True
+    assert effective["mobile-auto"]["browserstack"]["access_key"] == "bs-access-key"
     assert os.environ["BROWSERSTACK_USERNAME"] == "bs-user"
     assert os.environ["BROWSERSTACK_ACCESS_KEY"] == "bs-access-key"
-    assert "mobile" in updated
-    assert cfg.get_managed_overlay_meta()["managed_sections"] == ["instruction_texts", "mobile"]
+    assert "mobile-auto" in updated
+    assert cfg.get_managed_overlay_meta()["managed_sections"] == ["instruction_texts", "mobile-auto"]
 
 
 def test_runtime_profile_mobile_env_supports_custom_names_and_clears_on_remove(tmp_path, monkeypatch):
@@ -705,7 +705,7 @@ def test_runtime_profile_mobile_env_supports_custom_names_and_clears_on_remove(t
         "rp_mobile",
         4,
         {
-            "mobile": {
+            "mobile-auto": {
                 "enabled": True,
                 "default_provider": "browserstack",
                 "browserstack": {
@@ -1664,7 +1664,7 @@ def test_runtime_profile_external_cli_instructions_are_injected(tmp_path, monkey
     instructions = cfg.get_effective_config()["instruction_texts"]
     joined = "\n".join(instructions)
     assert "Use bash" in joined
-    assert "jira, confluence, gh, aws, jenkins, mobile, and git" in joined
+    assert "jira, confluence, gh, aws, jenkins, mobile-auto, and git" in joined
     assert "always pass --json" in joined
     assert "commands/schema/help llm" in joined
     assert "--dry-run" in joined


### PR DESCRIPTION
## Summary
- Include the `mobile` CLI in native runtime smoke checks, runtime docs, and agent prompt guidance.
- Stage BrowserStackLocal from CI-provided input when available.
- Persist mobile BrowserStack profile config through managed overlays, including encrypted access keys.

## Testing
- `python -m pytest -q -p no:cacheprovider --basetemp .tmp-pytest tests/test_runtime_profile_overlay.py tests/test_docker_runtime_contract.py`