### PR TITLE
Fix unbounded gateway memory retention for chat runs and tasks

### DIFF
--- a/src/gateway/chat_run_registry.py
+++ b/src/gateway/chat_run_registry.py
@@ -18,6 +18,17 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _parse_iso_timestamp(value: Any) -> Optional[datetime]:
+    """Parse an ISO timestamp ('Z' or offset suffix); None when unparseable."""
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
 def compact_final_payload(payload: Dict[str, Any] | None) -> Dict[str, Any]:
     """Drop full event streams from a retained terminal payload.
 
@@ -106,11 +117,12 @@ class ChatRunRegistry:
         """
         if self._stale_running_seconds <= 0:
             return
-        cutoff = (
-            datetime.now(timezone.utc) - timedelta(seconds=self._stale_running_seconds)
-        ).isoformat().replace("+00:00", "Z")
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=self._stale_running_seconds)
         for record in self._records.values():
-            if record.terminal or record.updated_at >= cutoff:
+            if record.terminal:
+                continue
+            updated_at = _parse_iso_timestamp(record.updated_at)
+            if updated_at is None or updated_at >= cutoff:
                 continue
             record.state = "failed"
             record.error_payload = {

--- a/src/gateway/chat_run_registry.py
+++ b/src/gateway/chat_run_registry.py
@@ -4,15 +4,36 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 
 TERMINAL_STATES = {"completed", "failed", "cancelled"}
+RETAINED_EVENT_LIST_KEYS = ("events", "runtime_events", "thinking_events")
+RETAINED_EVENT_TAIL_ITEMS = 100
+DEFAULT_STALE_RUNNING_SECONDS = 6 * 3600
 
 
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def compact_final_payload(payload: Dict[str, Any] | None) -> Dict[str, Any]:
+    """Drop full event streams from a retained terminal payload.
+
+    Live viewers already received the complete stream over SSE. The registry
+    only serves late reconnects, and the chat UI merges at most the last 100
+    events from a final payload, so retaining the full per-delta event list
+    for up to ``max_records`` runs only accumulates memory.
+    """
+    compact = dict(payload or {})
+    for key in RETAINED_EVENT_LIST_KEYS:
+        value = compact.get(key)
+        if isinstance(value, list) and len(value) > RETAINED_EVENT_TAIL_ITEMS:
+            compact[key] = value[-RETAINED_EVENT_TAIL_ITEMS:]
+            compact[f"{key}_count"] = len(value)
+            compact[f"{key}_truncated"] = True
+    return compact
 
 
 @dataclass
@@ -55,9 +76,15 @@ class ChatRunRecord:
 
 
 class ChatRunRegistry:
-    def __init__(self, *, max_records: int = 512) -> None:
+    def __init__(
+        self,
+        *,
+        max_records: int = 512,
+        stale_running_seconds: float = DEFAULT_STALE_RUNNING_SECONDS,
+    ) -> None:
         self._records: Dict[str, ChatRunRecord] = {}
         self._max_records = max_records
+        self._stale_running_seconds = max(0.0, float(stale_running_seconds))
 
     def start(self, *, session_id: str, request_id: str, engine: str = "native") -> ChatRunRecord:
         existing = self.get(request_id, session_id=session_id)
@@ -65,8 +92,35 @@ class ChatRunRegistry:
             return existing
         record = ChatRunRecord(request_id=request_id, session_id=session_id, engine=engine)
         self._records[request_id] = record
+        self._fail_stale_running_records()
         self._prune_terminal_records()
         return record
+
+    def _fail_stale_running_records(self) -> None:
+        """Mark long-inactive non-terminal records failed so they become prunable.
+
+        A record left in ``running`` this long means the producing run died
+        before ``complete()``/``fail()`` (for example the request handler was
+        cancelled by a client disconnect); otherwise ``record_event`` would
+        have refreshed ``updated_at``.
+        """
+        if self._stale_running_seconds <= 0:
+            return
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(seconds=self._stale_running_seconds)
+        ).isoformat().replace("+00:00", "Z")
+        for record in self._records.values():
+            if record.terminal or record.updated_at >= cutoff:
+                continue
+            record.state = "failed"
+            record.error_payload = {
+                "error": "chat_run_stale",
+                "detail": "No run activity before the stale timeout; a terminal outcome was never recorded.",
+                "session_id": record.session_id,
+                "request_id": record.request_id,
+            }
+            record.updated_at = utc_now_iso()
+            record.task = None
 
     def _prune_terminal_records(self) -> None:
         if len(self._records) <= self._max_records:
@@ -117,8 +171,9 @@ class ChatRunRegistry:
         if record is None:
             return
         record.state = "completed"
-        record.final_payload = dict(final_payload or {})
+        record.final_payload = compact_final_payload(final_payload)
         record.updated_at = utc_now_iso()
+        record.task = None
 
     def fail(self, request_id: str, error_payload: Dict[str, Any]) -> None:
         record = self.get(request_id)
@@ -127,8 +182,9 @@ class ChatRunRegistry:
         if record.state == "cancelled":
             return
         record.state = "failed"
-        record.error_payload = dict(error_payload or {})
+        record.error_payload = compact_final_payload(error_payload)
         record.updated_at = utc_now_iso()
+        record.task = None
 
     def cancel(self, request_id: str) -> bool:
         record = self.get(request_id)
@@ -136,8 +192,10 @@ class ChatRunRegistry:
             return False
         record.state = "cancelled"
         record.updated_at = utc_now_iso()
-        if record.task is not None and not record.task.done():
-            record.task.cancel()
+        task = record.task
+        record.task = None
+        if task is not None and not task.done():
+            task.cancel()
         return True
 
 

--- a/src/gateway/event_bus.py
+++ b/src/gateway/event_bus.py
@@ -110,10 +110,20 @@ class EventBus:
         for listener in listeners:
             if not self._event_matches_filters(event_type, data, listener.filters):
                 continue
-            try:
-                listener.queue.put_nowait(event)
-            except Exception as e:
-                logger.error(f"Error sending event to listener: {e}")
+            self._offer(listener.queue, event)
+
+    @staticmethod
+    def _offer(queue: asyncio.Queue, event: str) -> None:
+        """Enqueue without blocking; drop the oldest event when the viewer is not draining."""
+        try:
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            queue.put_nowait(event)
+        except Exception as e:
+            logger.error(f"Error sending event to listener: {e}")
 
     def emit_sync(self, event_type: str, data: Dict[str, Any]):
         """Synchronous emit for use in callbacks.
@@ -131,11 +141,7 @@ class EventBus:
         for listener in listeners:
             if not self._event_matches_filters(event_type, data, listener.filters):
                 continue
-            try:
-                listener.queue.put_nowait(event)
-                logger.info("[EventBus] Event sent to listener")
-            except Exception as e:
-                logger.error(f"[EventBus] Error: {e}")
+            self._offer(listener.queue, event)
 
     async def replay_events(
         self,

--- a/src/gateway/events.py
+++ b/src/gateway/events.py
@@ -19,9 +19,10 @@ async def handle_websocket(request: web.Request) -> WebSocketResponse:
     """
     ws = web.WebSocketResponse()
     await ws.prepare(request)
-    
-    # Create a queue for this connection
-    queue = asyncio.Queue()
+
+    # Create a bounded queue for this connection; the bus drops the oldest
+    # event when a viewer stops draining (e.g. half-open connection).
+    queue = asyncio.Queue(maxsize=200)
 
     query = request.rel_url.query
     filter_keys = ("session_id", "task_id", "group_id", "coordination_run_id", "agent_id", "request_id")

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -157,8 +157,12 @@ def _compact_runtime_task_status_payload(payload: Dict[str, Any]) -> Dict[str, A
     return compact
 
 
-def _runtime_task_payload_with_observability(record: Any) -> Dict[str, Any]:
-    payload = dict(record.payload)
+def _runtime_task_payload_with_observability(
+    record: Any,
+    *,
+    payload_override: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    payload = dict(payload_override if isinstance(payload_override, dict) else record.payload)
     payload["accepted_at"] = record.accepted_at
     payload["started_at"] = record.started_at
     payload["finished_at"] = record.finished_at
@@ -1451,6 +1455,42 @@ async def api_chat(request: web.Request) -> web.Response:
             clear_log_context()
 
 
+def _finalize_chat_run_record(task: asyncio.Task, *, request_id: str, session_id: str) -> None:
+    """Record a terminal registry outcome for a chat run whose handler died.
+
+    Without this, a record left in ``running`` is never prunable and its
+    payload/task references stay in memory until process restart.
+    """
+    record = chat_run_registry.get(request_id)
+    if record is None or record.terminal:
+        return
+    if task.cancelled():
+        chat_run_registry.fail(
+            request_id,
+            {"error": "chat_run_cancelled", "session_id": session_id, "request_id": request_id},
+        )
+        return
+    exc = task.exception()
+    if exc is not None:
+        chat_run_registry.fail(
+            request_id,
+            {
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+                "session_id": session_id,
+                "request_id": request_id,
+            },
+        )
+        return
+    result_value = task.result()
+    outcome = build_runtime_response_payload(
+        result_value if isinstance(result_value, dict) else None,
+        session_id,
+    )
+    outcome.setdefault("request_id", request_id)
+    chat_run_registry.complete(request_id, outcome)
+
+
 async def api_chat_stream(request: web.Request) -> web.StreamResponse:
     """Handle streaming chat API requests (Server-Sent Events).
 
@@ -1730,6 +1770,29 @@ async def api_chat_stream(request: web.Request) -> web.StreamResponse:
     except ValueError as e:
         response = web.json_response({'error': str(e)}, status=400)
         return response
+    except asyncio.CancelledError:
+        # Client disconnected: the run continues detached for refresh recovery,
+        # but this handler can no longer record the terminal outcome inline.
+        # Defer it to the run task so the registry record cannot stay
+        # "running" (and therefore unprunable) forever.
+        if request_id and session_id and run_task is not None:
+            finalize_session_id = session_id
+            finalize_request_id = request_id
+            if run_task.done():
+                _finalize_chat_run_record(
+                    run_task,
+                    request_id=finalize_request_id,
+                    session_id=finalize_session_id,
+                )
+            else:
+                run_task.add_done_callback(
+                    lambda task: _finalize_chat_run_record(
+                        task,
+                        request_id=finalize_request_id,
+                        session_id=finalize_session_id,
+                    )
+                )
+        raise
     except web.HTTPException:
         raise
     except Exception as e:
@@ -2565,8 +2628,11 @@ async def api_task_status_full(request: web.Request) -> web.Response:
         if record is None:
             return web.json_response({"error": "Task not found"}, status=404)
         filename = _safe_task_result_filename(task_id)
+        # The in-memory terminal payload may be compacted; the persisted record
+        # keeps the full payload for this download endpoint.
+        persisted_payload = runtime_task_tracker.read_persisted_payload(task_id)
         return web.json_response(
-            _runtime_task_payload_with_observability(record),
+            _runtime_task_payload_with_observability(record, payload_override=persisted_payload),
             headers={"Content-Disposition": f'attachment; filename="{filename}"'},
         )
     finally:
@@ -2849,6 +2915,7 @@ def _runtime_task_persistence_limits() -> Dict[str, int]:
 
 
 async def resume_persisted_runtime_tasks() -> int:
+    runtime_task_tracker.configure_compaction(_compact_runtime_task_status_payload)
     storage_dir = _runtime_task_persistence_storage_dir()
     if storage_dir is None:
         runtime_task_tracker.configure_storage(None)

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 
 _TASK_TERMINAL_STATUSES = {"success", "error", "blocked", "cancelled", "stale"}
@@ -81,6 +81,10 @@ class RuntimeTaskRecord:
     completion_source: Optional[str] = None
     cancel_requested: bool = False
     background_task: Optional[asyncio.Task[Any]] = None
+    # True when the in-memory payload was compacted after the full terminal
+    # payload was persisted; guards the persisted full payload from being
+    # overwritten by the compacted copy.
+    payload_compacted: bool = False
 
 
 class RuntimeTaskTracker:
@@ -102,6 +106,7 @@ class RuntimeTaskTracker:
         self._next_admitted_seq = 1
         self._storage_dir: Optional[Path] = None
         self._max_persisted_record_bytes = _coerce_positive_int(max_persisted_record_bytes)
+        self._compact_terminal_payload: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None
         self.configure_storage(storage_dir)
 
     @property
@@ -116,6 +121,43 @@ class RuntimeTaskTracker:
 
     def configure_limits(self, *, max_persisted_record_bytes: int | None = None) -> None:
         self._max_persisted_record_bytes = _coerce_positive_int(max_persisted_record_bytes)
+
+    def configure_compaction(
+        self,
+        compact_terminal_payload: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]],
+    ) -> None:
+        """Install a compactor applied to in-memory terminal payloads.
+
+        Only active when persistence is configured: the full payload is written
+        to disk first and stays available via ``read_persisted_payload``, so
+        memory does not need to retain full event streams for up to
+        ``max_records`` terminal tasks.
+        """
+        self._compact_terminal_payload = compact_terminal_payload
+
+    def _compact_record_payload_in_memory(self, record: RuntimeTaskRecord) -> None:
+        if self._compact_terminal_payload is None or self._storage_dir is None:
+            return
+        try:
+            compacted = self._compact_terminal_payload(dict(record.payload))
+        except Exception:
+            return
+        if isinstance(compacted, dict):
+            record.payload = compacted
+            record.payload_compacted = True
+
+    def read_persisted_payload(self, task_id: str) -> Optional[Dict[str, Any]]:
+        """Return the full persisted payload for a task, if available on disk."""
+        if self._storage_dir is None:
+            return None
+        try:
+            raw = json.loads(self._record_path(task_id).read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        payload = raw.get("payload") if isinstance(raw, dict) else None
+        if not isinstance(payload, dict) or payload.get("payload_omitted_from_persistence"):
+            return None
+        return payload
 
     def create_pending(
         self,
@@ -239,6 +281,7 @@ class RuntimeTaskTracker:
             record.completion_source = completion_source
         _apply_observation_from_payload(record, payload)
         self._persist_record(record)
+        self._compact_record_payload_in_memory(record)
         self.prune()
         return record
 
@@ -275,10 +318,12 @@ class RuntimeTaskTracker:
         record.finished_at = _utc_now_iso()
         record.error_message = reason
         record.payload = dict(payload or {"ok": False, "task_id": task_id, "execution_type": "task", "request_id": record.request_id, "status": "cancelled", "error": reason})
+        record.payload_compacted = False
         record.cancel_requested = True
         record.active_attempt_id = None
         record.completion_source = "cancel"
         self._persist_record(record)
+        self._compact_record_payload_in_memory(record)
         return record
 
     def mark_stale(self, task_id: str, *, reason: str = "Task stale", payload: Optional[Dict[str, Any]] = None) -> Optional[RuntimeTaskRecord]:
@@ -368,6 +413,7 @@ class RuntimeTaskTracker:
         record.finished_at = None
         record.error_message = None
         record.payload = {}
+        record.payload_compacted = False
         record.active_attempt_id = None
         record.background_task = None
         record.cancel_requested = False
@@ -468,6 +514,8 @@ class RuntimeTaskTracker:
             existing = self._records.get(record.task_id)
             if existing is not None and existing.background_task is not None and not existing.background_task.done():
                 continue
+            if record.status in _TASK_TERMINAL_STATUSES:
+                self._compact_record_payload_in_memory(record)
             self._records[record.task_id] = record
             self._records.move_to_end(record.task_id)
         self.prune()
@@ -497,6 +545,10 @@ class RuntimeTaskTracker:
 
     def _persist_record(self, record: RuntimeTaskRecord) -> None:
         if self._storage_dir is None:
+            return
+        if record.payload_compacted:
+            # The persisted file still holds the full terminal payload; do not
+            # overwrite it with the compacted in-memory copy.
             return
         try:
             self._storage_dir.mkdir(parents=True, exist_ok=True)

--- a/src/runtime/runtime_task_tracker.py
+++ b/src/runtime/runtime_task_tracker.py
@@ -280,8 +280,11 @@ class RuntimeTaskTracker:
         if completion_source:
             record.completion_source = completion_source
         _apply_observation_from_payload(record, payload)
-        self._persist_record(record)
-        self._compact_record_payload_in_memory(record)
+        # Compact the in-memory copy only when disk holds the full payload;
+        # otherwise (size limit, write failure) memory keeps the only full
+        # copy so /api/tasks/{id}/full stays lossless while the process lives.
+        if self._persist_record(record):
+            self._compact_record_payload_in_memory(record)
         self.prune()
         return record
 
@@ -322,8 +325,8 @@ class RuntimeTaskTracker:
         record.cancel_requested = True
         record.active_attempt_id = None
         record.completion_source = "cancel"
-        self._persist_record(record)
-        self._compact_record_payload_in_memory(record)
+        if self._persist_record(record):
+            self._compact_record_payload_in_memory(record)
         return record
 
     def mark_stale(self, task_id: str, *, reason: str = "Task stale", payload: Optional[Dict[str, Any]] = None) -> Optional[RuntimeTaskRecord]:
@@ -543,34 +546,41 @@ class RuntimeTaskTracker:
                 except OSError:
                     pass
 
-    def _persist_record(self, record: RuntimeTaskRecord) -> None:
+    def _persist_record(self, record: RuntimeTaskRecord) -> bool:
+        """Persist the record; return True only when the full payload was written.
+
+        Callers use the return value to decide whether the in-memory payload
+        may be compacted: when persistence omitted or dropped the payload
+        (size limit, write failure), memory holds the only full copy.
+        """
         if self._storage_dir is None:
-            return
+            return False
         if record.payload_compacted:
             # The persisted file still holds the full terminal payload; do not
             # overwrite it with the compacted in-memory copy.
-            return
+            return False
         try:
             self._storage_dir.mkdir(parents=True, exist_ok=True)
             path = self._record_path(record.task_id)
             tmp_path = path.with_suffix(path.suffix + ".tmp")
-            encoded = self._encode_record_for_persistence(record)
+            encoded, full_payload_included = self._encode_record_for_persistence(record)
             if encoded is None:
                 tmp_path.unlink(missing_ok=True)
                 if record.status in _TASK_TERMINAL_STATUSES:
                     self._delete_record_file(record.task_id)
-                return
+                return False
             tmp_path.write_text(encoded, encoding="utf-8")
             tmp_path.replace(path)
+            return full_payload_included
         except (OSError, TypeError, ValueError):
-            return
+            return False
 
-    def _encode_record_for_persistence(self, record: RuntimeTaskRecord) -> str | None:
+    def _encode_record_for_persistence(self, record: RuntimeTaskRecord) -> tuple[str | None, bool]:
         record_payload = _record_to_json(record)
         encoded = _json_dumps_compact(record_payload)
         max_bytes = self._max_persisted_record_bytes
         if max_bytes is None or len(encoded.encode("utf-8")) <= max_bytes:
-            return encoded
+            return encoded, True
         record_payload["payload"] = {
             "ok": record.status == "success",
             "status": record.status,
@@ -579,12 +589,12 @@ class RuntimeTaskTracker:
         }
         encoded = _json_dumps_compact(record_payload)
         if len(encoded.encode("utf-8")) <= max_bytes:
-            return encoded
+            return encoded, False
         minimal_record_payload = _minimal_record_for_persistence(record)
         encoded = _json_dumps_compact(minimal_record_payload)
         if len(encoded.encode("utf-8")) <= max_bytes:
-            return encoded
-        return None
+            return encoded, False
+        return None, False
 
     def _delete_record_file(self, task_id: str) -> None:
         if self._storage_dir is None:

--- a/tests/test_chat_run_registry.py
+++ b/tests/test_chat_run_registry.py
@@ -1,4 +1,9 @@
-from src.gateway.chat_run_registry import ChatRunRegistry
+import asyncio
+
+from src.gateway.chat_run_registry import (
+    RETAINED_EVENT_TAIL_ITEMS,
+    ChatRunRegistry,
+)
 
 
 def test_chat_run_registry_tracks_events_and_completion():
@@ -37,3 +42,72 @@ def test_chat_run_registry_prunes_only_terminal_records():
     assert registry.get("old") is None
     assert registry.get("running") is not None
     assert registry.get("new") is not None
+
+
+def test_chat_run_registry_compacts_retained_event_streams():
+    registry = ChatRunRegistry()
+    registry.start(session_id="s1", request_id="r1")
+    events = [{"type": "llm.text_delta", "payload": {"delta": str(i)}} for i in range(500)]
+
+    registry.complete(
+        "r1",
+        {"ok": True, "response": "done", "events": events, "runtime_events": events},
+    )
+
+    final = registry.get("r1").to_payload()["final_payload"]
+    assert final["response"] == "done"
+    assert len(final["runtime_events"]) == RETAINED_EVENT_TAIL_ITEMS
+    assert final["runtime_events"][-1] == events[-1]
+    assert final["runtime_events_count"] == 500
+    assert final["runtime_events_truncated"] is True
+    assert len(final["events"]) == RETAINED_EVENT_TAIL_ITEMS
+
+
+def test_chat_run_registry_keeps_small_event_lists_intact():
+    registry = ChatRunRegistry()
+    registry.start(session_id="s1", request_id="r1")
+    events = [{"type": "llm.text_delta", "payload": {"delta": "x"}}]
+
+    registry.complete("r1", {"ok": True, "response": "done", "runtime_events": events})
+
+    final = registry.get("r1").to_payload()["final_payload"]
+    assert final["runtime_events"] == events
+    assert "runtime_events_count" not in final
+    assert "runtime_events_truncated" not in final
+
+
+def test_chat_run_registry_releases_task_reference_on_terminal():
+    async def scenario():
+        registry = ChatRunRegistry()
+        record = registry.start(session_id="s1", request_id="r1")
+
+        async def _noop():
+            return {"ok": True}
+
+        task = asyncio.create_task(_noop())
+        registry.attach_task("r1", task)
+        await task
+        assert record.task is task
+
+        registry.complete("r1", {"ok": True, "response": "done"})
+        assert record.task is None
+
+    asyncio.run(scenario())
+
+
+def test_chat_run_registry_marks_stale_running_records_failed_and_prunable():
+    registry = ChatRunRegistry(max_records=2, stale_running_seconds=3600)
+    stuck = registry.start(session_id="s1", request_id="stuck")
+    stuck.updated_at = "2000-01-01T00:00:00Z"
+
+    registry.start(session_id="s1", request_id="new1")
+
+    stuck_record = registry.get("stuck")
+    assert stuck_record.state == "failed"
+    assert stuck_record.terminal is True
+    assert stuck_record.error_payload["error"] == "chat_run_stale"
+
+    registry.start(session_id="s1", request_id="new2")
+    assert registry.get("stuck") is None
+    assert registry.get("new1") is not None
+    assert registry.get("new2") is not None

--- a/tests/test_chat_run_registry.py
+++ b/tests/test_chat_run_registry.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timezone
 
 from src.gateway.chat_run_registry import (
     RETAINED_EVENT_TAIL_ITEMS,
@@ -111,3 +112,20 @@ def test_chat_run_registry_marks_stale_running_records_failed_and_prunable():
     assert registry.get("stuck") is None
     assert registry.get("new1") is not None
     assert registry.get("new2") is not None
+
+
+def test_chat_run_registry_stale_check_handles_mixed_timestamp_formats():
+    registry = ChatRunRegistry(max_records=10, stale_running_seconds=3600)
+    fresh = registry.start(session_id="s1", request_id="fresh")
+    fresh.updated_at = datetime.now(timezone.utc).isoformat()  # offset suffix, no 'Z'
+    stale = registry.start(session_id="s1", request_id="stale")
+    stale.updated_at = "2000-01-01T00:00:00+00:00"
+    unparseable = registry.start(session_id="s1", request_id="weird")
+    unparseable.updated_at = "not-a-timestamp"
+
+    registry.start(session_id="s1", request_id="trigger")
+
+    assert registry.get("fresh").state == "running"
+    assert registry.get("stale").state == "failed"
+    # Unparseable timestamps must not get a run killed.
+    assert registry.get("weird").state == "running"

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -134,6 +134,23 @@ async def test_event_bus_request_id_filter_does_not_match_parent_request_id():
 
 
 @pytest.mark.asyncio
+async def test_event_bus_drops_oldest_event_when_listener_queue_is_full():
+    bus = EventBus()
+    queue = asyncio.Queue(maxsize=2)
+    await bus.add_listener(queue)
+
+    await bus.emit("task.progress", {"session_id": "s1", "step": 1})
+    await bus.emit("task.progress", {"session_id": "s1", "step": 2})
+    await bus.emit("task.progress", {"session_id": "s1", "step": 3})
+
+    first = json.loads(queue.get_nowait())
+    second = json.loads(queue.get_nowait())
+    assert first["data"]["step"] == 2
+    assert second["data"]["step"] == 3
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
 async def test_event_bus_replay_returns_recent_matching_session_and_request_events():
     bus = EventBus()
 

--- a/tests/test_runtime_task_tracker_compaction.py
+++ b/tests/test_runtime_task_tracker_compaction.py
@@ -95,6 +95,22 @@ def test_load_persisted_records_compacts_terminal_payloads_in_memory(tmp_path):
     assert len(reader.read_persisted_payload("t1")["runtime_events"]) == 50
 
 
+def test_oversized_payload_keeps_full_copy_in_memory(tmp_path):
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path, max_persisted_record_bytes=500)
+    tracker.configure_compaction(_compact)
+    _create_pending(tracker)
+    tracker.mark_running("t1")
+
+    tracker.mark_terminal("t1", status="success", payload=_terminal_payload())
+
+    record = tracker.get("t1")
+    # Persistence omitted the payload (size limit), so memory holds the only
+    # full copy and must not be compacted.
+    assert record.payload_compacted is False
+    assert len(record.payload["runtime_events"]) == 50
+    assert tracker.read_persisted_payload("t1") is None
+
+
 def test_force_cancel_after_compaction_persists_new_terminal_payload(tmp_path):
     tracker = RuntimeTaskTracker(storage_dir=tmp_path)
     tracker.configure_compaction(_compact)

--- a/tests/test_runtime_task_tracker_compaction.py
+++ b/tests/test_runtime_task_tracker_compaction.py
@@ -1,0 +1,112 @@
+from src.runtime.runtime_task_tracker import RuntimeTaskTracker
+
+
+def _compact(payload):
+    compact = dict(payload)
+    events = compact.get("runtime_events")
+    if isinstance(events, list) and len(events) > 10:
+        compact["runtime_events"] = events[-10:]
+        compact["runtime_events_count"] = len(events)
+        compact["runtime_events_truncated"] = True
+    return compact
+
+
+def _create_pending(tracker, task_id="t1"):
+    return tracker.create_pending(
+        task_id=task_id,
+        request_id=f"req-{task_id}",
+        task_type="chat",
+        source="portal",
+        session_id="s1",
+        agent_id="a1",
+        trace_id=None,
+        portal_dispatch_id=None,
+        portal_task_id=task_id,
+    )
+
+
+def _terminal_payload():
+    events = [{"type": "llm.text_delta", "payload": {"delta": str(i)}} for i in range(50)]
+    return {"ok": True, "status": "success", "runtime_events": events}
+
+
+def test_mark_terminal_compacts_memory_and_keeps_full_payload_on_disk(tmp_path):
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    tracker.configure_compaction(_compact)
+    _create_pending(tracker)
+    tracker.mark_running("t1")
+
+    tracker.mark_terminal("t1", status="success", payload=_terminal_payload())
+
+    record = tracker.get("t1")
+    assert record.payload_compacted is True
+    assert len(record.payload["runtime_events"]) == 10
+    assert record.payload["runtime_events_count"] == 50
+    assert record.payload["runtime_events_truncated"] is True
+
+    persisted = tracker.read_persisted_payload("t1")
+    assert persisted is not None
+    assert len(persisted["runtime_events"]) == 50
+
+
+def test_mark_terminal_keeps_full_payload_in_memory_without_persistence():
+    tracker = RuntimeTaskTracker()
+    tracker.configure_compaction(_compact)
+    _create_pending(tracker)
+    tracker.mark_running("t1")
+
+    tracker.mark_terminal("t1", status="success", payload=_terminal_payload())
+
+    record = tracker.get("t1")
+    assert record.payload_compacted is False
+    assert len(record.payload["runtime_events"]) == 50
+    assert tracker.read_persisted_payload("t1") is None
+
+
+def test_compacted_record_does_not_overwrite_persisted_full_payload(tmp_path):
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    tracker.configure_compaction(_compact)
+    _create_pending(tracker)
+    tracker.mark_running("t1")
+    tracker.mark_terminal("t1", status="success", payload=_terminal_payload())
+
+    tracker.update_observation("t1", progress={"step": 1})
+
+    persisted = tracker.read_persisted_payload("t1")
+    assert persisted is not None
+    assert len(persisted["runtime_events"]) == 50
+    assert "progress" not in persisted
+
+
+def test_load_persisted_records_compacts_terminal_payloads_in_memory(tmp_path):
+    writer = RuntimeTaskTracker(storage_dir=tmp_path)
+    _create_pending(writer)
+    writer.mark_running("t1")
+    writer.mark_terminal("t1", status="success", payload=_terminal_payload())
+
+    reader = RuntimeTaskTracker(storage_dir=tmp_path)
+    reader.configure_compaction(_compact)
+    loaded = reader.load_persisted_records()
+
+    assert loaded == 1
+    record = reader.get("t1")
+    assert record.payload_compacted is True
+    assert len(record.payload["runtime_events"]) == 10
+    assert len(reader.read_persisted_payload("t1")["runtime_events"]) == 50
+
+
+def test_force_cancel_after_compaction_persists_new_terminal_payload(tmp_path):
+    tracker = RuntimeTaskTracker(storage_dir=tmp_path)
+    tracker.configure_compaction(_compact)
+    _create_pending(tracker)
+    tracker.mark_running("t1")
+    tracker.mark_terminal("t1", status="blocked", payload=_terminal_payload())
+    assert tracker.get("t1").payload_compacted is True
+
+    tracker.cancel("t1", reason="forced", force=True)
+
+    record = tracker.get("t1")
+    assert record.status == "cancelled"
+    persisted = tracker.read_persisted_payload("t1")
+    assert persisted is not None
+    assert persisted["status"] == "cancelled"


### PR DESCRIPTION
## Problem

Native agent pods show high, never-decreasing memory in K8s. Root cause: the gateway retains full per-delta runtime event streams in long-lived in-memory registries.

- `ChatRunRegistry` kept the complete `runtime_events` list (one dict per LLM stream delta; `emit_llm_stream_events` defaults to true) plus the `asyncio.Task` reference for up to 512 terminal runs, with no TTL. Measured ~5.7MB retained per medium chat turn (24KB text, 12 tool calls), ~1.8GB RSS at the 512-record cap.
- Records whose stream handler was cancelled by a client disconnect stayed `running` forever: `complete()`/`fail()` were only called inline in the HTTP handler, and `_prune_terminal_records` never removes non-terminal records, so these leaked unboundedly.
- `RuntimeTaskTracker` kept uncompacted terminal task payloads (full `runtime_events`) in memory for up to 512 tasks; the `TASK_STATUS_*` compaction only applied when serving the status API.
- Gateway WebSocket listener queues were unbounded and could grow on half-open connections.

## Changes

- `ChatRunRegistry.complete()/fail()` retain only the last 100 events per stream key, with `<key>_count` / `<key>_truncated` markers. The chat UI merges at most the last 100 events from a final payload on reconnect (`mergeThinkingEvents(...).slice(-100)`), and live viewers already received the full stream over SSE, so the reconnect contract is preserved. Task references are released on terminal states.
- Non-terminal records with no activity for 6h are marked `failed` during registry growth so they become prunable.
- `api_chat_stream` catches `asyncio.CancelledError` (client disconnect) and defers terminal outcome recording to the run task via a done-callback — only on the disconnect path, so happy-path semantics (`detached_viewers`, `latest_event_seq` during tail drain) are unchanged.
- `RuntimeTaskTracker.mark_terminal` persists the full payload to disk first, then compacts the in-memory copy (only when persistence is configured). A `payload_compacted` guard prevents later writes from clobbering the persisted full payload. `GET /api/tasks/{id}/full` now serves the persisted full payload, keeping the download contract intact. Behavior is unchanged when persistence is disabled.
- WebSocket listener queues are bounded (maxsize 200, drop-oldest), matching the opencode adapter pattern.

## Verification

- 11 new regression tests; targeted suites pass (157 passed in `test_runtime_api.py` / `test_adapter_boundaries.py` / `test_chat_run_registry.py`).
- Full suite: 2341 passed; the 39 failures are identical on clean `master` (pre-existing Windows environment issues, unrelated).
- Measured with the real registry code on Linux (512 medium runs): RSS growth drops from **+1787MB to +55MB (-97%)**; memory is returned to the OS on eviction.

Companion PR for the OpenCode runtime (same retention pattern plus an unbounded EventBus replay-bucket leak): dvnuo/engineering-flow-platform-opencode-runtime#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)