### PR TITLE
Follow-up: /api/chat registry lifecycle and session-scoped idempotency

### DIFF
--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -1193,7 +1193,11 @@ async def api_chat(request: web.Request) -> web.Response:
             # Idempotency guard: stream fallbacks may re-submit the same
             # request_id after a transport break while the original run is
             # still executing detached. Never execute the same request twice.
-            existing_run = chat_run_registry.get(client_request_id)
+            # Scope by the client-provided session id (the resolved session id
+            # generates fresh defaults) so a request_id reused across sessions
+            # can never replay another session's payload.
+            raw_session_id = str(data.get("session_id") or "").strip()
+            existing_run = chat_run_registry.get(client_request_id, session_id=raw_session_id or None)
             if existing_run is not None:
                 if existing_run.terminal and isinstance(existing_run.final_payload, dict):
                     return web.json_response(existing_run.final_payload)
@@ -1307,6 +1311,9 @@ async def api_chat(request: web.Request) -> web.Response:
         # Run EFP runtime; session_manager remains the gateway-side history mirror.
         runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
         set_log_context(agent_id=runtime_agent_id)
+        # Register the run so the request_id idempotency guard covers
+        # non-stream retries and /api/chat/runs/{id} can report this run.
+        chat_run_registry.start(session_id=session_id, request_id=request_id, engine="native")
         await session_manager.mark_runtime_running(session_id, request_id=request_id)
         if runtime_agent_id and session_id:
             try:
@@ -1369,8 +1376,10 @@ async def api_chat(request: web.Request) -> web.Response:
             result if isinstance(result, dict) else None,
             session_id,
         )
+        response_data.setdefault("request_id", request_id)
+        chat_run_registry.complete(request_id, response_data)
         usage = response_data.get("usage", {}) or {}
-        
+
         # Record usage if available
         if usage:
             provider = global_config.llm.get('provider') or 'github_copilot'
@@ -1439,6 +1448,15 @@ async def api_chat(request: web.Request) -> web.Response:
         return web.json_response({'error': 'Invalid JSON'}, status=400)
     except ValueError as e:
         return web.json_response({'error': str(e)}, status=400)
+    except asyncio.CancelledError:
+        # Non-stream execution is inline: handler cancellation kills the run,
+        # so the registry record must not stay "running".
+        if request_id:
+            chat_run_registry.fail(
+                request_id,
+                {"error": "chat_run_cancelled", "session_id": session_id, "request_id": request_id},
+            )
+        raise
     except web.HTTPException:
         raise
     except Exception as e:
@@ -1494,6 +1512,7 @@ async def api_chat(request: web.Request) -> web.Response:
             error_response['session_id'] = session_id
         if request_id:
             error_response['request_id'] = request_id
+            chat_run_registry.fail(request_id, error_response)
         return web.json_response(error_response, status=status_code)
     finally:
         try:

--- a/tests/test_chat_stream_resilience.py
+++ b/tests/test_chat_stream_resilience.py
@@ -201,6 +201,79 @@ async def test_chat_run_status_reports_interrupted_session_as_terminal(monkeypat
     assert payload["terminal"] is True
 
 
+def _patch_nonstream_harness(monkeypatch, fake_run, tmp_path):
+    monkeypatch.setattr(runtime_api, "_run_chat_via_execution_bus", fake_run)
+    monkeypatch.setattr(runtime_api, "inject_context", lambda **kwargs: (kwargs["message"], "ok", []))
+    monkeypatch.setattr(
+        runtime_api.global_config,
+        "_config",
+        {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}},
+        raising=False,
+    )
+    monkeypatch.setattr(runtime_api.session_manager, "_initialized", True)
+    monkeypatch.setattr(runtime_api.session_manager, "mark_runtime_running", lambda *_a, **_k: asyncio.sleep(0, result=None))
+    monkeypatch.setattr(runtime_api.session_manager, "get_session", lambda _sid: asyncio.sleep(0, result={"history": [{}], "channel": "", "metadata": {}}))
+    monkeypatch.setattr(runtime_api.runtime_session_artifacts, "save_session", lambda **_k: asyncio.sleep(0, result=True))
+    monkeypatch.setattr(runtime_api.runtime_session_artifacts, "storage_dir", str(tmp_path), raising=False)
+
+
+@pytest.mark.asyncio
+async def test_api_chat_registers_run_and_replays_completed_duplicate(monkeypatch, tmp_path):
+    request_id = "portal-chat-full-idem-1"
+    session_id = "s-chat-full-idem"
+    runtime_api.chat_run_registry._records.pop(request_id, None)
+    calls = []
+
+    async def _fake_run(**kwargs):
+        calls.append(kwargs)
+        return {"response": "fresh answer", "usage": {}}
+
+    _patch_nonstream_harness(monkeypatch, _fake_run, tmp_path)
+    payload = {"message": "hello", "session_id": session_id, "client_request_id": request_id}
+    try:
+        first = await runtime_api.api_chat(_PortalRequest(dict(payload)))
+        record = runtime_api.chat_run_registry.get(request_id)
+        assert record is not None
+        assert record.state == "completed"
+        second = await runtime_api.api_chat(_PortalRequest(dict(payload)))
+    finally:
+        runtime_api.chat_run_registry._records.pop(request_id, None)
+
+    assert first.status == 200
+    assert second.status == 200
+    # The duplicate is replayed from the registry, never executed again.
+    assert len(calls) == 1
+    assert b"fresh answer" in second.body
+
+
+@pytest.mark.asyncio
+async def test_api_chat_duplicate_request_id_in_other_session_executes_fresh(monkeypatch, tmp_path):
+    request_id = "portal-chat-cross-session-1"
+    runtime_api.chat_run_registry._records.pop(request_id, None)
+    runtime_api.chat_run_registry.start(session_id="s-other", request_id=request_id)
+    runtime_api.chat_run_registry.complete(
+        request_id,
+        {"response": "other session answer", "session_id": "s-other", "request_id": request_id},
+    )
+
+    async def _fake_run(**kwargs):
+        return {"response": "fresh in this session", "usage": {}}
+
+    _patch_nonstream_harness(monkeypatch, _fake_run, tmp_path)
+    try:
+        resp = await runtime_api.api_chat(
+            _PortalRequest({"message": "hi", "session_id": "s-mine", "client_request_id": request_id})
+        )
+    finally:
+        runtime_api.chat_run_registry._records.pop(request_id, None)
+
+    # A request_id reused in a different session is a different logical
+    # request: it must execute fresh, never replay another session's payload.
+    assert resp.status == 200
+    assert b"other session answer" not in resp.body
+    assert b"fresh in this session" in resp.body
+
+
 @pytest.mark.asyncio
 async def test_api_chat_conflicts_on_active_duplicate_request_id(monkeypatch):
     request_id = "portal-chat-dedupe-req-1"


### PR DESCRIPTION
Follow-ups for the review comments on #558 (merged before they could land there).

- **Full /api/chat registry lifecycle** (Codex P2 + Copilot): the non-stream endpoint now registers its run in `chat_run_registry` (start before execution, complete with the response payload, fail on errors/cancellation), so the request_id idempotency guard covers direct non-stream retries too and `/api/chat/runs/{id}` reports these runs.
- **Session-scoped idempotency** (Copilot): the duplicate lookup is scoped by the client-provided session_id, so a request_id reused across sessions executes as the distinct logical request it is and can never replay another session payload. Same-session and new-session (no session_id) retries still dedupe.

Tests: 2 new regressions (full lifecycle replay with single execution; cross-session freshness). Full suite: 2351 passed, 39 pre-existing environment failures unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)