### PR TITLE
Set BROWSERSTACK_LOCAL_BINARY from the runtime profile on native

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -300,6 +300,11 @@ class Config:
         "BROWSERSTACK_USERNAME",
         "BROWSERSTACK_ACCESS_KEY",
     )
+    # Where the runtime image installs the BrowserStack Local binary (matches
+    # the opencode runtime's bundled path). Used as the default so mobile-auto
+    # resolves BROWSERSTACK_LOCAL_BINARY directly instead of relying on a bare
+    # PATH lookup of "BrowserStackLocal".
+    DEFAULT_BROWSERSTACK_LOCAL_BINARY_PATH = "/usr/local/bin/BrowserStackLocal"
 
     PROJECT_EXAMPLE = Path(__file__).parent.parent / 'config.yaml.example'
     MANAGED_OVERLAY_SECTIONS = {
@@ -1123,6 +1128,21 @@ class Config:
             os.environ[access_key_env] = access_key
             os.environ["BROWSERSTACK_ACCESS_KEY"] = access_key
             self._mobile_env_vars.update({access_key_env, "BROWSERSTACK_ACCESS_KEY"})
+
+        # Expose the BrowserStack Local binary path so the mobile-auto CLI
+        # resolves it directly (parity with the opencode runtime, which sets
+        # BROWSERSTACK_LOCAL_BINARY from the bundled path). Honor an explicit
+        # profile-configured path unconditionally; otherwise fall back to the
+        # bundled default only when it actually exists, so a missing binary
+        # leaves mobile-auto's PATH lookup of "BrowserStackLocal" intact
+        # instead of pinning BROWSERSTACK_LOCAL_BINARY at a phantom path.
+        local = browserstack.get("local") if isinstance(browserstack.get("local"), dict) else {}
+        binary_path = str(local.get("binary") or "").strip() if isinstance(local, dict) else ""
+        if not binary_path and os.path.exists(self.DEFAULT_BROWSERSTACK_LOCAL_BINARY_PATH):
+            binary_path = self.DEFAULT_BROWSERSTACK_LOCAL_BINARY_PATH
+        if binary_path:
+            os.environ["BROWSERSTACK_LOCAL_BINARY"] = binary_path
+            self._mobile_env_vars.add("BROWSERSTACK_LOCAL_BINARY")
     
     @property
     def heartbeat(self) -> Dict[str, Any]:

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -653,6 +653,7 @@ def test_runtime_profile_apply_persists_mobile_config_and_encrypts_access_key(tm
     monkeypatch.setenv("EFP_CONFIG_KEY", "test-key")
     monkeypatch.delenv("BROWSERSTACK_USERNAME", raising=False)
     monkeypatch.delenv("BROWSERSTACK_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("BROWSERSTACK_LOCAL_BINARY", raising=False)
 
     cfg = Config(str(config_path))
     updated = cfg.set_managed_overlay(
@@ -684,8 +685,57 @@ def test_runtime_profile_apply_persists_mobile_config_and_encrypts_access_key(tm
     assert effective["mobile-auto"]["browserstack"]["access_key"] == "bs-access-key"
     assert os.environ["BROWSERSTACK_USERNAME"] == "bs-user"
     assert os.environ["BROWSERSTACK_ACCESS_KEY"] == "bs-access-key"
+    # An explicit profile local.binary is exposed verbatim for the mobile-auto CLI.
+    assert os.environ["BROWSERSTACK_LOCAL_BINARY"] == "/usr/local/bin/BrowserStackLocal"
     assert "mobile-auto" in updated
     assert cfg.get_managed_overlay_meta()["managed_sections"] == ["instruction_texts", "mobile-auto"]
+
+
+def test_apply_mobile_env_sets_local_binary_from_default_or_leaves_path_fallback(monkeypatch):
+    monkeypatch.delenv("BROWSERSTACK_LOCAL_BINARY", raising=False)
+    cfg = Config.__new__(Config)
+    cfg._config = {}
+    cfg._mobile_env_vars = set()
+    enabled_bs = {
+        "mobile-auto": {
+            "enabled": True,
+            "browserstack": {"username": "u", "access_key": "k"},
+        }
+    }
+
+    # No explicit local.binary, bundled default present -> default is exposed.
+    monkeypatch.setattr(
+        "src.config.os.path.exists",
+        lambda p: p == Config.DEFAULT_BROWSERSTACK_LOCAL_BINARY_PATH,
+    )
+    cfg._config = enabled_bs
+    cfg.apply_mobile_env()
+    assert os.environ["BROWSERSTACK_LOCAL_BINARY"] == Config.DEFAULT_BROWSERSTACK_LOCAL_BINARY_PATH
+
+    # Bundled default missing -> env is left unset so mobile-auto's PATH lookup
+    # of "BrowserStackLocal" stays in effect instead of pinning a phantom path.
+    monkeypatch.setattr("src.config.os.path.exists", lambda p: False)
+    cfg.apply_mobile_env()
+    assert "BROWSERSTACK_LOCAL_BINARY" not in os.environ
+
+    # Explicit profile path is honored even when it does not exist on disk.
+    cfg._config = {
+        "mobile-auto": {
+            "enabled": True,
+            "browserstack": {
+                "username": "u",
+                "access_key": "k",
+                "local": {"binary": "/opt/custom/BrowserStackLocal"},
+            },
+        }
+    }
+    cfg.apply_mobile_env()
+    assert os.environ["BROWSERSTACK_LOCAL_BINARY"] == "/opt/custom/BrowserStackLocal"
+
+    # Disabling mobile-auto clears the managed binary env var.
+    cfg._config = {"mobile-auto": {"enabled": False}}
+    cfg.apply_mobile_env()
+    assert "BROWSERSTACK_LOCAL_BINARY" not in os.environ
 
 
 def test_runtime_profile_mobile_env_supports_custom_names_and_clears_on_remove(tmp_path, monkeypatch):
@@ -695,6 +745,7 @@ def test_runtime_profile_mobile_env_supports_custom_names_and_clears_on_remove(t
     for key in [
         "BROWSERSTACK_USERNAME",
         "BROWSERSTACK_ACCESS_KEY",
+        "BROWSERSTACK_LOCAL_BINARY",
         "CUSTOM_BS_USERNAME",
         "CUSTOM_BS_ACCESS_KEY",
     ]:
@@ -728,6 +779,7 @@ def test_runtime_profile_mobile_env_supports_custom_names_and_clears_on_remove(t
     for key in [
         "BROWSERSTACK_USERNAME",
         "BROWSERSTACK_ACCESS_KEY",
+        "BROWSERSTACK_LOCAL_BINARY",
         "CUSTOM_BS_USERNAME",
         "CUSTOM_BS_ACCESS_KEY",
     ]:


### PR DESCRIPTION
## Why

Align the native runtime with the opencode runtime for the BrowserStack Local binary path, so a `private-managed` tunnel with a custom binary works on native too.

`apply_mobile_env` previously set only the credential env vars (`BROWSERSTACK_USERNAME`/`BROWSERSTACK_ACCESS_KEY`), never `BROWSERSTACK_LOCAL_BINARY`. The image Dockerfile sets `BROWSERSTACK_LOCAL_BINARY` to the bundled default, but that static value **shadows a profile-configured binary**: mobile-auto resolves the binary as `firstNonEmpty(os.Getenv("BROWSERSTACK_LOCAL_BINARY"), config.Binary)`, so the env var wins over the `mobile-auto.browserstack.local.binary` value in the persisted config file. Without promoting the profile's path to the env var, an operator's explicit `local.binary` override never takes effect.

(Credentials and tunnel startup were already wired on both runtimes; this closes the binary-path parity gap. The tunnel needs only the access key — env — plus a resolvable binary; the common public-network flow needs no tunnel at all.)

## Change

`apply_mobile_env`, when mobile-auto is enabled with browserstack:
- sets `BROWSERSTACK_LOCAL_BINARY` to an explicit `mobile-auto.browserstack.local.binary` from the profile (honored verbatim so the override applies), else
- falls back to the bundled default path **only when that binary is actually present**, so a missing binary leaves mobile-auto's PATH lookup of `BrowserStackLocal` intact instead of pinning a phantom path.

The var is tracked in `_mobile_env_vars` so it is cleared when mobile-auto is disabled, matching the credential env lifecycle.

## Tests

`test_runtime_profile_overlay.py` (32 passed): a new focused test covers the explicit-path / default-present / default-missing / disabled-clear branches by exercising `apply_mobile_env` in isolation with a patched `os.path.exists`; the existing persist test asserts the explicit path is exposed, and the clear test asserts the var is removed on disable. The 8 pre-existing `test_config.py` failures are identical on clean `master` (Windows environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)