### PR TITLE
Restore native message edit and delete-from-here endpoints (fix Retry/Edit 404)

### DIFF
--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -43,6 +43,7 @@ from src.gateway.chat_payloads import (
 from src.gateway.chat_run_registry import chat_run_registry
 from src.gateway.runtime_chat import (
     RuntimeChatError,
+    resume_runtime_chat,
     run_runtime_chat,
 )
 from src.gateway.runtime_event_projection import (
@@ -3376,6 +3377,239 @@ async def api_delete_session(request: web.Request) -> web.Response:
         return web.json_response({'error': str(e)}, status=500)
 
 
+async def api_delete_conversation_from(request: web.Request) -> web.Response:
+    """Delete a message and every message after it (truncate the conversation).
+
+    POST /api/sessions/{session_id}/messages/{message_id}/delete-from-here
+
+    Used by the chat UI "Retry" action: it removes the target message onward,
+    then re-sends the original user text as a fresh chat turn.
+    """
+    message_id = request.match_info.get('message_id')
+    try:
+        session_id = request.match_info.get('session_id')
+        if not session_id or not message_id:
+            return web.json_response(
+                {'error': 'Missing session_id or message_id', 'user_message_id': message_id},
+                status=400,
+            )
+        if not session_manager._initialized:
+            await session_manager.initialize()
+
+        history = await session_manager.get_history(session_id)
+        if not any(msg.get('id') == message_id for msg in history):
+            return web.json_response(
+                {'error': 'Message not found', 'user_message_id': message_id},
+                status=404,
+            )
+
+        deleted_count = await session_manager.delete_messages_from(
+            session_id,
+            message_id,
+            wait_for_save=True,
+        )
+        return web.json_response({'success': True, 'deleted_count': deleted_count})
+    except Exception as e:
+        logger.error(f"[api_delete_conversation_from] ERROR: {e}", exc_info=True)
+        return web.json_response({'error': str(e), 'user_message_id': message_id}, status=500)
+
+
+async def api_edit_message(request: web.Request) -> web.Response:
+    """Edit a message in place and delete every message after it (synchronous).
+
+    POST /api/sessions/{session_id}/messages/{message_id}/edit
+    Body: {"new_content": "edited message content"}
+
+    Kept for compatibility; the chat UI uses the async variant below.
+    """
+    try:
+        session_id = request.match_info.get('session_id')
+        message_id = request.match_info.get('message_id')
+        if not session_id or not message_id:
+            return web.json_response({'error': 'Missing session_id or message_id'}, status=400)
+        if not session_manager._initialized:
+            await session_manager.initialize()
+
+        try:
+            data = await request.json()
+        except (json.JSONDecodeError, ContentTypeError):
+            return web.json_response({'error': 'Invalid JSON in request body'}, status=400)
+
+        new_content = data.get('new_content')
+        if new_content is None:
+            new_content = data.get('content')
+        if new_content is None:
+            return web.json_response({'error': "Missing 'new_content' in request body"}, status=400)
+        if not isinstance(new_content, str):
+            return web.json_response({'error': "'new_content' must be a string"}, status=400)
+
+        edited = await session_manager.edit_message(session_id, message_id, new_content)
+        if not edited:
+            return web.json_response({'error': 'Message not found', 'user_message_id': message_id}, status=404)
+
+        deleted_count = await session_manager.delete_messages_after(session_id, message_id)
+        history = await session_manager.get_history(session_id)
+        return web.json_response({'success': True, 'deleted_count': deleted_count, 'messages': history})
+    except Exception as e:
+        logger.error(f"[api_edit_message] ERROR: {e}", exc_info=True)
+        return web.json_response({'error': str(e)}, status=500)
+
+
+async def _run_edit_resend_in_background(
+    *,
+    session_id: str,
+    content: str,
+    request_id: str,
+    replacement_user_message_id: str,
+    agent_id: Optional[str],
+    agent_name: Optional[str],
+    model: Optional[str],
+    execution_metadata: Dict[str, Any],
+) -> None:
+    """Append the edited content as a fresh user turn and regenerate the reply.
+
+    Runs detached from the request so ``/edit/async`` can return 202 while the
+    runtime regenerates. The chat UI polls ``GET /api/sessions/{id}`` and finds
+    the new assistant message after the replacement user message.
+    """
+    try:
+        await session_manager.add_message(
+            session_id,
+            "user",
+            content,
+            wait_for_save=True,
+            extra={"id": replacement_user_message_id},
+        )
+        await resume_runtime_chat(
+            session_id=session_id,
+            request_path="/api/sessions/messages/edit/async",
+            execution_metadata=execution_metadata,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            request_id=request_id,
+            model=model,
+        )
+    except Exception as exc:
+        logger.error(
+            "[edit_async] regeneration failed | session_id=%s request_id=%s error=%s",
+            session_id,
+            request_id,
+            sanitize_exception_message(exc),
+            exc_info=True,
+        )
+        try:
+            await _persist_chat_failure_state(
+                agent_id=agent_id,
+                session_id=session_id,
+                request_id=request_id,
+                user_message=sanitize_exception_message(exc),
+                error_type=type(exc).__name__,
+                metadata=execution_metadata,
+            )
+        except Exception:
+            logger.warning("[edit_async] failed to persist regeneration failure", exc_info=True)
+
+
+async def api_edit_message_async(request: web.Request) -> web.Response:
+    """Edit a user message and regenerate the response in the background.
+
+    POST /api/sessions/{session_id}/messages/{message_id}/edit/async
+    Body: {"content": "edited text", "request_id": "...", "model": "optional"}
+
+    Truncates the conversation from the edited message (inclusive), then starts
+    a detached regeneration whose result the chat UI observes by polling the
+    session. Matches the opencode adapter contract.
+    """
+    message_id = request.match_info.get('message_id')
+    try:
+        session_id = request.match_info.get('session_id')
+        if not session_id or not message_id:
+            return web.json_response(
+                {'error': 'Missing session_id or message_id', 'user_message_id': message_id},
+                status=400,
+            )
+        if not session_manager._initialized:
+            await session_manager.initialize()
+
+        try:
+            data = await request.json()
+        except (json.JSONDecodeError, ContentTypeError):
+            return web.json_response({'error': 'Invalid JSON in request body'}, status=400)
+
+        content = ""
+        for key in ("content", "new_content", "message"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                content = value.strip()
+                break
+        if not content:
+            return web.json_response({'error': "Missing 'content' in request body"}, status=400)
+
+        history = await session_manager.get_history(session_id)
+        target = next((msg for msg in history if msg.get('id') == message_id), None)
+        if target is None:
+            return web.json_response({'error': 'Message not found', 'user_message_id': message_id}, status=404)
+        if str(target.get('role') or '').lower() != 'user':
+            return web.json_response(
+                {'error': 'Only user messages can be edited', 'user_message_id': message_id},
+                status=400,
+            )
+
+        client_request_id = _extract_trusted_client_request_id(request, data)
+        request_id = client_request_id or str(data.get('request_id') or '').strip() or f"edit-{uuid.uuid4()}"
+        model_override = _extract_trusted_model_override(request, data)
+        model = model_override or global_config.llm.get('model', DEFAULT_LLM_MODEL)
+        runtime_agent_id, runtime_agent_name = _resolve_runtime_agent_identity(request)
+        execution_metadata = _extract_trusted_control_plane_metadata(request, data)
+        replacement_user_message_id = f"msg-{uuid.uuid4().hex}"
+
+        # Truncate from the edited message (inclusive); the edited text is
+        # re-sent as a fresh user turn by the background regeneration.
+        await session_manager.delete_messages_from(session_id, message_id, wait_for_save=True)
+        truncated_history = await session_manager.get_history(session_id)
+
+        asyncio.create_task(
+            _run_edit_resend_in_background(
+                session_id=session_id,
+                content=content,
+                request_id=request_id,
+                replacement_user_message_id=replacement_user_message_id,
+                agent_id=runtime_agent_id,
+                agent_name=runtime_agent_name,
+                model=model,
+                execution_metadata=execution_metadata,
+            )
+        )
+
+        return web.json_response(
+            {
+                'success': True,
+                'accepted': True,
+                'async': True,
+                'completion_state': 'pending',
+                'session_id': session_id,
+                'message_id': message_id,
+                'replacement_user_message_id': replacement_user_message_id,
+                'assistant_message_id': '',
+                'request_id': request_id,
+                'response': '',
+                'messages': truncated_history,
+                'metadata': {
+                    'edit': True,
+                    'edited_message_id': message_id,
+                    'replacement_user_message_id': replacement_user_message_id,
+                    'source': 'message_edit_async',
+                    'edit_async': True,
+                    'background_started': True,
+                },
+            },
+            status=202,
+        )
+    except Exception as e:
+        logger.error(f"[api_edit_message_async] ERROR: {e}", exc_info=True)
+        return web.json_response({'error': str(e), 'user_message_id': message_id}, status=500)
+
+
 async def api_apply_runtime_profile(request: web.Request) -> web.Response:
     """Apply managed runtime-profile snapshot from trusted Portal control-plane request."""
     if not _is_trusted_portal_request(request):
@@ -3463,6 +3697,9 @@ def setup_runtime_api_routes(app: web.Application):
     app.router.add_post('/api/sessions/{session_id}/rename', api_rename_session)
     app.router.add_delete('/api/sessions/{session_id}', api_delete_session)
     app.router.add_get('/api/sessions/{session_id}/chatlog', api_session_chatlog)
+    app.router.add_post('/api/sessions/{session_id}/messages/{message_id}/edit', api_edit_message)
+    app.router.add_post('/api/sessions/{session_id}/messages/{message_id}/edit/async', api_edit_message_async)
+    app.router.add_post('/api/sessions/{session_id}/messages/{message_id}/delete-from-here', api_delete_conversation_from)
     app.router.add_get('/api/usage', api_usage)
     app.router.add_post('/api/internal/runtime-profile/apply', api_apply_runtime_profile)
     app.router.add_get('/api/skills', api_skills)

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -5064,3 +5064,151 @@ async def test_run_task_execution_cancelled_during_started_event_marks_cancelled
     assert record.finished_at is not None
     assert (record.payload or {}).get("status") == "cancelled"
     assert "task.failed" not in emitted
+
+
+class _MessageEndpointRequest:
+    """Minimal aiohttp-style request for the message edit/delete handlers."""
+
+    def __init__(self, session_id, message_id, body=None, headers=None):
+        self.match_info = {"session_id": session_id, "message_id": message_id}
+        self.app = {}
+        self.headers = headers or {"X-Portal-Author-Source": "portal"}
+        self._body = body if body is not None else {}
+
+    async def json(self):
+        return self._body
+
+
+def _patch_message_endpoint_common(monkeypatch):
+    from src.gateway import runtime_api
+
+    monkeypatch.setattr(runtime_api.session_manager, "_initialized", True)
+    monkeypatch.setattr(
+        runtime_api.global_config,
+        "_config",
+        {"llm": {"api_key": "k", "model": "gpt-5-mini", "provider": "openai"}},
+        raising=False,
+    )
+    monkeypatch.setattr(runtime_api, "_resolve_runtime_agent_identity", lambda _request: ("agent-1", "Agent One"))
+    return runtime_api
+
+
+@pytest.mark.asyncio
+async def test_api_delete_conversation_from_truncates_and_returns_count(monkeypatch):
+    runtime_api = _patch_message_endpoint_common(monkeypatch)
+    deleted = {}
+
+    async def _fake_get_history(_session_id):
+        return [{"id": "m1", "role": "user", "content": "a"}, {"id": "m2", "role": "assistant", "content": "b"}]
+
+    async def _fake_delete_from(session_id, message_id, wait_for_save=False):
+        deleted["args"] = (session_id, message_id, wait_for_save)
+        return 1
+
+    monkeypatch.setattr(runtime_api.session_manager, "get_history", _fake_get_history)
+    monkeypatch.setattr(runtime_api.session_manager, "delete_messages_from", _fake_delete_from)
+
+    resp = await runtime_api.api_delete_conversation_from(_MessageEndpointRequest("s1", "m2"))
+    assert resp.status == 200
+    payload = json.loads(resp.text)
+    assert payload["success"] is True
+    assert payload["deleted_count"] == 1
+    assert deleted["args"] == ("s1", "m2", True)
+
+
+@pytest.mark.asyncio
+async def test_api_delete_conversation_from_404_when_message_missing(monkeypatch):
+    runtime_api = _patch_message_endpoint_common(monkeypatch)
+
+    async def _fake_get_history(_session_id):
+        return [{"id": "m1", "role": "user", "content": "a"}]
+
+    monkeypatch.setattr(runtime_api.session_manager, "get_history", _fake_get_history)
+
+    resp = await runtime_api.api_delete_conversation_from(_MessageEndpointRequest("s1", "missing"))
+    assert resp.status == 404
+    assert json.loads(resp.text)["user_message_id"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_api_edit_message_async_truncates_and_starts_regeneration(monkeypatch):
+    runtime_api = _patch_message_endpoint_common(monkeypatch)
+    calls = {}
+
+    async def _fake_get_history(_session_id):
+        return [{"id": "u1", "role": "user", "content": "old"}, {"id": "a1", "role": "assistant", "content": "reply"}]
+
+    async def _fake_delete_from(session_id, message_id, wait_for_save=False):
+        calls["delete"] = (session_id, message_id)
+        return 2
+
+    async def _fake_background(**kwargs):
+        calls["background"] = kwargs
+
+    monkeypatch.setattr(runtime_api.session_manager, "get_history", _fake_get_history)
+    monkeypatch.setattr(runtime_api.session_manager, "delete_messages_from", _fake_delete_from)
+    monkeypatch.setattr(runtime_api, "_run_edit_resend_in_background", _fake_background)
+
+    resp = await runtime_api.api_edit_message_async(
+        _MessageEndpointRequest("s1", "u1", body={"content": "edited text", "request_id": "req-edit-1"})
+    )
+    await asyncio.sleep(0)  # let the scheduled background task run
+
+    assert resp.status == 202
+    payload = json.loads(resp.text)
+    assert payload["success"] is True
+    assert payload["accepted"] is True
+    assert payload["session_id"] == "s1"
+    assert payload["message_id"] == "u1"
+    assert payload["request_id"] == "req-edit-1"
+    assert payload["replacement_user_message_id"]
+    assert payload["metadata"]["edit"] is True
+    assert calls["delete"] == ("s1", "u1")
+    assert calls["background"]["content"] == "edited text"
+    assert calls["background"]["request_id"] == "req-edit-1"
+    assert calls["background"]["replacement_user_message_id"] == payload["replacement_user_message_id"]
+
+
+@pytest.mark.asyncio
+async def test_api_edit_message_async_404_when_message_missing(monkeypatch):
+    runtime_api = _patch_message_endpoint_common(monkeypatch)
+
+    async def _fake_get_history(_session_id):
+        return [{"id": "u1", "role": "user", "content": "old"}]
+
+    monkeypatch.setattr(runtime_api.session_manager, "get_history", _fake_get_history)
+
+    resp = await runtime_api.api_edit_message_async(
+        _MessageEndpointRequest("s1", "missing", body={"content": "x"})
+    )
+    assert resp.status == 404
+
+
+@pytest.mark.asyncio
+async def test_api_edit_message_async_rejects_non_user_message(monkeypatch):
+    runtime_api = _patch_message_endpoint_common(monkeypatch)
+
+    async def _fake_get_history(_session_id):
+        return [{"id": "a1", "role": "assistant", "content": "reply"}]
+
+    monkeypatch.setattr(runtime_api.session_manager, "get_history", _fake_get_history)
+
+    resp = await runtime_api.api_edit_message_async(
+        _MessageEndpointRequest("s1", "a1", body={"content": "x"})
+    )
+    assert resp.status == 400
+
+
+def test_setup_runtime_api_routes_registers_message_endpoints():
+    from aiohttp import web
+    from src.gateway.runtime_api import setup_runtime_api_routes
+
+    app = web.Application()
+    setup_runtime_api_routes(app)
+    routes = {
+        (route.method, route.resource.canonical)
+        for route in app.router.routes()
+    }
+    assert ("POST", "/api/sessions/{session_id}/messages/{message_id}/edit") in routes
+    assert ("POST", "/api/sessions/{session_id}/messages/{message_id}/edit/async") in routes
+    assert ("POST", "/api/sessions/{session_id}/messages/{message_id}/delete-from-here") in routes


### PR DESCRIPTION
## Problem

On **native** agents, two chat-UI actions returned **404 Not Found**:
1. Edit message → "Save & Resend" → `POST /api/sessions/{sid}/messages/{mid}/edit/async`
2. Retry an assistant reply → `POST /api/sessions/{sid}/messages/{mid}/delete-from-here`

opencode agents were unaffected, and native worked before.

## Root cause

Commit #521 ("Add unified Runtime v2 opencode source replacement") renamed `src/gateway/webchat.py` → `src/gateway/runtime_api.py` and, in that 1630-line reduction, **dropped the message-level session routes** that webchat.py registered (`.../messages/{id}/edit` and `.../messages/{id}/delete-from-here`). The new `setup_runtime_api_routes` only kept `sessions`, `sessions/{id}`, `rename`, `delete`, `chatlog`. The `RuntimeSessionManager` methods they rely on (`get_history`, `edit_message`, `delete_messages_after`, `delete_messages_from`, `add_message`) all survived — only the routes and handlers were lost. The chat UI calls `/edit/async` and `/delete-from-here`, so both 404'd; opencode kept its equivalents and worked.

## Fix

Restore three routes:
- **`/delete-from-here`** (Retry) — truncates the conversation from the message inclusive; returns `{success, deleted_count}`.
- **`/edit`** (sync) — restored for compatibility.
- **`/edit/async`** (Save & Resend) — matches the opencode adapter contract: truncate from the edited user message, return **202** `{success, accepted, session_id, request_id, replacement_user_message_id, messages}`, and regenerate in the background. The background task re-appends the edited text as a fresh user turn with a **known id** (so the UI's poll of `GET /api/sessions/{id}` finds the new assistant after the replacement user message via `findAssistantAfterEditedUserMessage`) and calls `resume_runtime_chat`; failures are recorded via `_persist_chat_failure_state` so the UI surfaces them.

## Tests

151 pass in `test_runtime_api.py` (145 existing + 6 new): a route-registration guard (prevents another silent drop), truncation + returned count, 404 on missing message, 400 on non-user edit, the 202 async contract, and background-regeneration scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)