### PR TITLE
Cache session reads and serve the list endpoint from lightweight summaries

### DIFF
--- a/src/efp_runtime/session/file_store.py
+++ b/src/efp_runtime/session/file_store.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from copy import deepcopy
+from dataclasses import dataclass
 import json
 import os
 from pathlib import Path
 import tempfile
 from threading import RLock
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
 from ..types import new_id
 from .checkpoint import SessionCheckpoint
@@ -22,6 +24,125 @@ from .serialization import (
     session_to_dict,
 )
 from .todo import FileSessionTodoStore
+
+
+# Cache sizing. These bound the extra memory the store may hold on top of what
+# a request already needs; both are intentionally small so the cache can never
+# become the leak it is meant to prevent.
+_DEFAULT_PARSE_CACHE_MAX = 24
+_DEFAULT_PARSE_CACHE_MAX_BYTES = 8 * 1024 * 1024  # do not retain giant sessions
+_DEFAULT_SUMMARY_CACHE_MAX = 4096
+_SUMMARY_PREVIEW_CHARS = 256
+_SUMMARY_SCAN_CAP = 320  # stop deriving preview text once we have enough
+
+
+@dataclass(frozen=True)
+class SessionSummary:
+    """Lightweight session header used by list endpoints.
+
+    Deriving these instead of loading + deepcopying full sessions is what keeps
+    ``GET /api/sessions`` from re-parsing every session file (with all inlined
+    tool output) on every poll.
+    """
+
+    session_id: str
+    title: Optional[str]
+    custom_name: Optional[str]
+    created_at: str
+    updated_at: str
+    message_count: int
+    user_message_count: int
+    first_user_preview: str
+    last_preview: str
+
+
+# malloc_trim(0) hands freed arenas back to the OS after a large parse burst.
+# CPython's allocator otherwise keeps them mapped, which is exactly why RSS
+# stayed high and did not reclaim. Best-effort: a no-op off glibc.
+_MALLOC_TRIM: Any = None
+
+
+def _release_allocator_memory() -> None:
+    global _MALLOC_TRIM
+    if _MALLOC_TRIM is False:
+        return
+    try:
+        if _MALLOC_TRIM is None:
+            import ctypes
+            import ctypes.util
+
+            lib_name = ctypes.util.find_library("c") or "libc.so.6"
+            libc = ctypes.CDLL(lib_name)
+            _MALLOC_TRIM = getattr(libc, "malloc_trim", False) or False
+        if _MALLOC_TRIM:
+            _MALLOC_TRIM(0)
+    except Exception:
+        _MALLOC_TRIM = False
+
+
+def _summary_preview_text(message: Message) -> str:
+    """Preview string for a message, mirroring gateway legacy ``content``.
+
+    Kept byte-for-byte consistent with ``_message_content`` in gateway_facade
+    for the leading characters, but stops early so a multi-MB tool result is
+    never fully materialised just to render a 50-char preview.
+    """
+    chunks: List[str] = []
+    total = 0
+    for part in message.parts:
+        piece: Optional[str] = None
+        if part.type is MessagePartType.TEXT and part.text:
+            piece = part.text
+        elif part.type is MessagePartType.REASONING and part.reasoning and not chunks:
+            piece = part.reasoning
+        elif part.type is MessagePartType.TOOL_RESULT and part.tool_result is not None:
+            piece = part.tool_result.content
+        elif part.type is MessagePartType.COMPACTION and part.compaction is not None:
+            piece = part.compaction.summary
+        elif part.type is MessagePartType.ERROR and part.text:
+            piece = part.text
+        if piece is None:
+            continue
+        # Slice each piece so a multi-MB tool result is never fully copied for a
+        # preview. The kept prefix (>= the final 256-char cut) is unchanged.
+        chunks.append(piece[:_SUMMARY_SCAN_CAP])
+        total += min(len(piece), _SUMMARY_SCAN_CAP)
+        if total >= _SUMMARY_SCAN_CAP:
+            break
+    return "\n".join(chunk for chunk in chunks if chunk is not None)
+
+
+def _truncate_preview(value: str, limit: int = _SUMMARY_PREVIEW_CHARS) -> str:
+    return value if len(value) <= limit else value[:limit]
+
+
+def build_session_summary(session: Session) -> SessionSummary:
+    user_count = 0
+    first_user_preview = ""
+    for message in session.messages:
+        if message.role is MessageRole.USER:
+            user_count += 1
+            if not first_user_preview:
+                first_user_preview = _truncate_preview(_summary_preview_text(message))
+    last_preview = ""
+    for message in reversed(session.messages):
+        if message.role in (MessageRole.USER, MessageRole.ASSISTANT):
+            last_preview = _truncate_preview(_summary_preview_text(message))
+            break
+    metadata = session.metadata if isinstance(session.metadata, dict) else {}
+    custom_name = metadata.get("custom_session_name")
+    custom_name = custom_name.strip() if isinstance(custom_name, str) and custom_name.strip() else None
+    return SessionSummary(
+        session_id=session.session_id,
+        title=session.title,
+        custom_name=custom_name,
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+        message_count=len(session.messages),
+        user_message_count=user_count,
+        first_user_preview=first_user_preview,
+        last_preview=last_preview,
+    )
 
 
 class FileSessionStore:
@@ -40,6 +161,14 @@ class FileSessionStore:
         self.todos_dir = todos_dir.resolve()
         self._todo_store = FileSessionTodoStore(self.todos_dir)
         self._lock = RLock()
+        # mtime+size validated caches. Reads that hit an unchanged file skip the
+        # json.load + session_from_dict cost entirely; the summary cache lets the
+        # list endpoint answer without touching full session bodies at all.
+        self._parse_cache: "OrderedDict[str, Tuple[int, int, Session]]" = OrderedDict()
+        self._summary_cache: "OrderedDict[str, Tuple[int, int, SessionSummary]]" = OrderedDict()
+        self._parse_cache_max = _DEFAULT_PARSE_CACHE_MAX
+        self._parse_cache_max_bytes = _DEFAULT_PARSE_CACHE_MAX_BYTES
+        self._summary_cache_max = _DEFAULT_SUMMARY_CACHE_MAX
 
     def create_session(
         self,
@@ -73,7 +202,7 @@ class FileSessionStore:
         replace_metadata: bool = False,
     ) -> Session:
         with self._lock:
-            session = self._read_session_locked(session_id)
+            session = self._read_session_locked_mutable(session_id)
             if title is not None:
                 session.title = title
             if replace_metadata:
@@ -100,7 +229,7 @@ class FileSessionStore:
         completed_at: Optional[str] = None,
     ) -> Message:
         with self._lock:
-            session = self._read_session_locked(session_id)
+            session = self._read_session_locked_mutable(session_id)
             message = Message(
                 role=role,
                 session_id=session.session_id,
@@ -120,7 +249,7 @@ class FileSessionStore:
 
     def append_part(self, session_id: str, message_id: str, part: MessagePart) -> MessagePart:
         with self._lock:
-            session = self._read_session_locked(session_id)
+            session = self._read_session_locked_mutable(session_id)
             message = self._require_message(session, message_id)
             stored_part = self._append_part_locked(session, message, part)
             session.touch()
@@ -133,7 +262,7 @@ class FileSessionStore:
 
     def replace_history(self, session_id: str, messages: Iterable[Message]) -> Session:
         with self._lock:
-            session = self._read_session_locked(session_id)
+            session = self._read_session_locked_mutable(session_id)
             session.messages = [deepcopy(message) for message in messages]
             self._rebind_session(session)
             session.touch()
@@ -165,16 +294,61 @@ class FileSessionStore:
         with self._lock:
             sessions = []
             for path in sorted(self.sessions_dir.glob("*.json")):
-                sessions.append(self._read_session_file_locked(path))
+                # Full-list scans must not evict the hot single-session entries
+                # from the small parse LRU, so they read without storing.
+                sessions.append(self._read_session_file_locked(path, cache_store=False))
             return deepcopy(sessions)
+
+    def list_session_summaries(self) -> List[SessionSummary]:
+        """Return lightweight headers for every session without loading bodies.
+
+        Unchanged files are answered straight from the summary cache (a stat
+        call, no parse); only a file whose mtime/size changed is re-read. This
+        is the replacement for ``list_sessions()`` on the list endpoint, which
+        otherwise parsed and deepcopied every session (including inlined tool
+        output) on every poll.
+        """
+        with self._lock:
+            summaries: List[SessionSummary] = []
+            parsed_any = False
+            for path in sorted(self.sessions_dir.glob("*.json")):
+                key = str(path)
+                try:
+                    stat = path.stat()
+                except OSError:
+                    continue
+                cached = self._summary_cache.get(key)
+                if (
+                    cached is not None
+                    and cached[0] == stat.st_mtime_ns
+                    and cached[1] == stat.st_size
+                ):
+                    self._summary_cache.move_to_end(key)
+                    summaries.append(cached[2])
+                    continue
+                try:
+                    session = self._read_session_file_locked(path, cache_store=False)
+                except Exception:
+                    # A corrupt or half-written file must not break listing.
+                    continue
+                summary = build_session_summary(session)
+                self._summary_cache_put(key, stat.st_mtime_ns, stat.st_size, summary)
+                summaries.append(summary)
+                parsed_any = True
+            if parsed_any:
+                _release_allocator_memory()
+            return summaries
 
     def delete_session(self, session_id: str) -> bool:
         with self._lock:
             path = self._session_path(session_id)
             if not path.exists():
+                self._evict_caches(session_id)
                 return False
             path.unlink()
+            self._evict_caches(session_id)
             self._todo_store.clear(session_id)
+            _release_allocator_memory()
             return True
 
     def fork_session(
@@ -287,7 +461,21 @@ class FileSessionStore:
             raise KeyError(f"unknown session: {session_id}")
         return self._read_session_file_locked(path)
 
-    def _read_session_file_locked(self, path: Path) -> Session:
+    def _read_session_file_locked(self, path: Path, *, cache_store: bool = True) -> Session:
+        # The returned Session may be a shared cache object. Every public read
+        # method deepcopies before returning it, and mutators go through
+        # ``_read_session_locked_mutable`` (which deepcopies), so callers never
+        # observe or corrupt a cached instance.
+        key = str(path)
+        try:
+            stat = path.stat()
+        except OSError:
+            stat = None
+        if stat is not None:
+            cached = self._parse_cache.get(key)
+            if cached is not None and cached[0] == stat.st_mtime_ns and cached[1] == stat.st_size:
+                self._parse_cache.move_to_end(key)
+                return cached[2]
         with path.open("r", encoding="utf-8") as handle:
             payload = json.load(handle)
         session = session_from_dict(payload)
@@ -296,7 +484,49 @@ class FileSessionStore:
             raise ValueError(
                 f"session file/name mismatch: expected {expected_path.name}, got {path.name}"
             )
+        if cache_store and stat is not None:
+            self._parse_cache_put(key, stat.st_mtime_ns, stat.st_size, session)
         return session
+
+    def _read_session_locked_mutable(self, session_id: str) -> Session:
+        """Private, mutable copy for read-modify-write callers."""
+        return deepcopy(self._read_session_locked(session_id))
+
+    def _parse_cache_put(self, key: str, mtime_ns: int, size: int, session: Session) -> None:
+        if size > self._parse_cache_max_bytes:
+            # Never retain oversized sessions; the summary cache still covers
+            # the list path, and re-parsing one giant session on demand is far
+            # cheaper than pinning it in memory.
+            self._parse_cache.pop(key, None)
+            return
+        self._parse_cache[key] = (mtime_ns, size, session)
+        self._parse_cache.move_to_end(key)
+        while len(self._parse_cache) > self._parse_cache_max:
+            self._parse_cache.popitem(last=False)
+
+    def _summary_cache_put(self, key: str, mtime_ns: int, size: int, summary: SessionSummary) -> None:
+        self._summary_cache[key] = (mtime_ns, size, summary)
+        self._summary_cache.move_to_end(key)
+        while len(self._summary_cache) > self._summary_cache_max:
+            self._summary_cache.popitem(last=False)
+
+    def _refresh_caches_after_write(self, path: Path, session: Session) -> None:
+        key = str(path)
+        try:
+            stat = path.stat()
+        except OSError:
+            self._parse_cache.pop(key, None)
+            self._summary_cache.pop(key, None)
+            return
+        self._parse_cache_put(key, stat.st_mtime_ns, stat.st_size, session)
+        self._summary_cache_put(
+            key, stat.st_mtime_ns, stat.st_size, build_session_summary(session)
+        )
+
+    def _evict_caches(self, session_id: str) -> None:
+        key = str(self._session_path(session_id))
+        self._parse_cache.pop(key, None)
+        self._summary_cache.pop(key, None)
 
     def _write_session_locked(self, session: Session) -> None:
         path = self._session_path(session.session_id)
@@ -318,6 +548,10 @@ class FileSessionStore:
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(tmp_name, path)
+            # Serve the just-written state from cache instead of re-parsing it
+            # on the next read. Callers do not mutate ``session`` after the
+            # write returns, so caching the reference is safe.
+            self._refresh_caches_after_write(path, session)
         finally:
             if tmp_name is not None:
                 tmp_path = Path(tmp_name)

--- a/src/efp_runtime/session/gateway_facade.py
+++ b/src/efp_runtime/session/gateway_facade.py
@@ -14,7 +14,7 @@ import uuid
 from typing import Any, Callable, Iterable, Mapping, Optional
 
 from ..types import ToolCall, ToolResult
-from .file_store import FileSessionStore
+from .file_store import FileSessionStore, SessionSummary
 from .models import (
     CompactionPart,
     Message,
@@ -155,11 +155,30 @@ class RuntimeSessionManager:
         )
         return [session.session_id for session in sessions]
 
+    async def list_session_summaries(self) -> list[SessionSummary]:
+        """Ordered lightweight session headers for the list endpoint.
+
+        The store read (and any cold re-parse) runs in a worker thread so the
+        CPU-bound work never blocks the event loop, keeping SSE/WebSocket
+        streams responsive even with many large sessions on disk.
+        """
+        loop = asyncio.get_running_loop()
+        summaries = await loop.run_in_executor(None, self.store.list_session_summaries)
+        summaries.sort(key=lambda summary: (summary.updated_at, summary.session_id), reverse=True)
+        return summaries
+
     async def get_session(self, session_id: str) -> dict[str, Any]:
         session = self._ensure_session(session_id)
         return self._session_to_legacy(session)
 
     async def get_existing_session(self, session_id: str) -> Optional[dict[str, Any]]:
+        # Offloaded: parsing a large session body and building its legacy view
+        # are CPU-bound; running them in a thread keeps the loop responsive for
+        # the sessions the UI polls while a run streams.
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._load_existing_session, session_id)
+
+    def _load_existing_session(self, session_id: str) -> Optional[dict[str, Any]]:
         try:
             return self._session_to_legacy(self.store.get_session(session_id))
         except KeyError:

--- a/src/efp_runtime/session/store.py
+++ b/src/efp_runtime/session/store.py
@@ -74,6 +74,14 @@ class InMemorySessionStore:
             )
             return deepcopy(sessions)
 
+    def list_session_summaries(self) -> list:
+        # Parity with FileSessionStore so the gateway facade works against
+        # either backend. In-memory sessions are cheap, so no caching is needed.
+        from .file_store import build_session_summary
+
+        with self._lock:
+            return [build_session_summary(session) for session in self._sessions.values()]
+
     def delete_session(self, session_id: str) -> bool:
         with self._lock:
             if session_id not in self._sessions:

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -3143,60 +3143,64 @@ async def api_sessions(request: web.Request) -> web.Response:
     """
     import time
     start_time = time.time()
-    logger.info("[api_sessions] Request start")
     try:
         # Initialize session manager if needed
         if not session_manager._initialized:
-            logger.info("[api_sessions] Initializing session manager")
             await session_manager.initialize()
-        
+
         limit = int(request.query.get('limit', 10))
         include_task_sessions = _request_includes_task_sessions(request)
-        session_ids = await session_manager.list_sessions()
-        logger.info(f"[api_sessions] Found {len(session_ids)} sessions: {session_ids[:5]}")
-        
+        # Lightweight, already-ordered headers built in a worker thread. No full
+        # session bodies are loaded or deepcopied here, so this stays cheap and
+        # off the event loop even with many large sessions on disk.
+        summaries = await session_manager.list_session_summaries()
+
         # Format sessions with details, filter out empty sessions
         detailed_sessions = []
-        for session_id in session_ids:
-            if not include_task_sessions and _runtime_session_id_is_task_session(session_id):
-                logger.info(f"[api_sessions] Skipping task session: {session_id}")
+        for summary in summaries:
+            if not include_task_sessions and _runtime_session_id_is_task_session(summary.session_id):
                 continue
-            # Get session info
-            session_info = await session_manager.get_session_info(session_id)
-            
-            if not session_info:
-                logger.warning(f"[api_sessions] No info for session: {session_id}")
-                continue
-            
-            history = session_info.get('history', [])
-            
+
             # Skip empty sessions (no user messages)
-            user_messages = [msg for msg in history if msg.get('role') == 'user']
-            if not user_messages:
-                logger.info(f"[api_sessions] Skipping empty session: {session_id}")
+            if summary.user_message_count <= 0:
                 continue
-            
-            session_name = resolve_session_display_name(session_info)
-            
-            # Get last message preview
-            last_message = ''
-            for msg in reversed(history):
-                if msg.get('role') in ('user', 'assistant'):
-                    last_message = truncate(msg.get('content', '') or '', 50)
-                    break
-            
+
+            # Reuse the exact display-name precedence (custom name -> title ->
+            # first user message) via a minimal session_info projection so the
+            # rendered name is byte-for-byte identical to the full-load path.
+            session_info_like = {
+                "metadata": (
+                    {"custom_session_name": summary.custom_name}
+                    if summary.custom_name
+                    else {}
+                ),
+                "title": summary.title,
+                "history": (
+                    [{"role": "user", "content": summary.first_user_preview}]
+                    if summary.user_message_count
+                    else []
+                ),
+            }
+            session_name = resolve_session_display_name(session_info_like)
+
+            last_message = truncate(summary.last_preview or '', 50)
+
             detailed_sessions.append({
-                'session_id': session_id,
+                'session_id': summary.session_id,
                 'name': session_name,
                 'last_message': last_message,
-                'updated_at': session_info.get('updated_at', datetime.utcnow().isoformat()),
-                'message_count': len(user_messages),
+                'updated_at': summary.updated_at or datetime.utcnow().isoformat(),
+                'message_count': summary.user_message_count,
             })
-            logger.info(f"[api_sessions] Added session: {session_id} -> name='{session_name}'")
             if len(detailed_sessions) >= limit:
                 break
-        
-        logger.info(f"[api_sessions] Returning {len(detailed_sessions)} sessions")
+
+        logger.info(
+            "[api_sessions] Returning %d sessions from %d headers in %.1fms",
+            len(detailed_sessions),
+            len(summaries),
+            (time.time() - start_time) * 1000.0,
+        )
         return web.json_response({'sessions': detailed_sessions})
     except Exception as e:
         logger.error(f"[api_sessions] ERROR: {e}", exc_info=True)

--- a/tests/runtime/test_file_session_store_cache.py
+++ b/tests/runtime/test_file_session_store_cache.py
@@ -1,0 +1,205 @@
+"""Regression tests for FileSessionStore caching + summary listing.
+
+These lock in the memory/CPU optimisation for the "many sessions + large
+inlined tool output" case: repeated reads of an unchanged session must not
+re-parse it, the list endpoint must answer from lightweight summaries without
+loading full bodies, and none of the caching may change observable results
+(stale reads, corrupted store state, or a different session display name).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import efp_runtime.session.file_store as fs_mod
+from efp_runtime import FileSessionStore, MessagePart, MessageRole
+from efp_runtime.session.file_store import SessionSummary, build_session_summary
+from efp_runtime.session.gateway_facade import (
+    RuntimeSessionManager,
+    resolve_session_display_name,
+)
+
+
+def _seed(store: FileSessionStore, session_id: str, *, title=None, user_text="hi", assistant_text="ok"):
+    store.create_session(session_id=session_id, title=title)
+    store.append_message(
+        session_id,
+        role="user",
+        parts=[MessagePart.text_part(user_text)],
+        status="complete",
+    )
+    if assistant_text is not None:
+        store.append_message(
+            session_id,
+            role="assistant",
+            parts=[MessagePart.text_part(assistant_text)],
+            status="complete",
+        )
+
+
+def test_summaries_match_session_content(tmp_path: Path):
+    store = FileSessionStore(tmp_path)
+    _seed(store, "s-1", title="My Title", user_text="first question", assistant_text="the answer")
+
+    summaries = store.list_session_summaries()
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert isinstance(summary, SessionSummary)
+    assert summary.session_id == "s-1"
+    assert summary.title == "My Title"
+    assert summary.user_message_count == 1
+    assert summary.message_count == 2
+    assert summary.first_user_preview == "first question"
+    assert summary.last_preview == "the answer"
+
+
+def test_summary_refreshes_after_write(tmp_path: Path):
+    store = FileSessionStore(tmp_path)
+    _seed(store, "s-1", user_text="q1", assistant_text="a1")
+
+    assert store.list_session_summaries()[0].last_preview == "a1"
+
+    store.append_message(
+        "s-1", role="user", parts=[MessagePart.text_part("q2")], status="complete"
+    )
+    refreshed = store.list_session_summaries()[0]
+    # mtime changed -> summary cache must not serve the stale preview/count.
+    assert refreshed.user_message_count == 2
+    assert refreshed.last_preview == "q2"
+
+
+def test_delete_removes_from_summaries_and_caches(tmp_path: Path):
+    store = FileSessionStore(tmp_path)
+    _seed(store, "s-1")
+    store.get_session("s-1")  # populate parse cache
+    assert store.list_session_summaries()  # populate summary cache
+
+    assert store.delete_session("s-1") is True
+    assert store.list_session_summaries() == []
+    key = str(store._session_path("s-1"))
+    assert key not in store._parse_cache
+    assert key not in store._summary_cache
+
+
+def test_unchanged_session_is_not_reparsed(tmp_path: Path, monkeypatch):
+    # Seed with one instance, then read with a fresh one so the caches start
+    # cold (the writing instance already warms its own cache).
+    seed_store = FileSessionStore(tmp_path)
+    _seed(seed_store, "s-1")
+    store = FileSessionStore(tmp_path)
+
+    calls = {"n": 0}
+    real_load = fs_mod.json.load
+
+    def counting_load(handle):
+        calls["n"] += 1
+        return real_load(handle)
+
+    monkeypatch.setattr(fs_mod.json, "load", counting_load)
+
+    first = store.get_session("s-1")
+    assert calls["n"] == 1  # cold: parsed exactly once
+
+    # Repeated reads of the unchanged file are cache hits: no extra json.load.
+    for _ in range(5):
+        again = store.get_session("s-1")
+    assert calls["n"] == 1
+    assert again.session_id == first.session_id
+
+    # A write refreshes the cache in place, so the next read is still a hit.
+    store.append_message(
+        "s-1", role="user", parts=[MessagePart.text_part("more")], status="complete"
+    )
+    before = calls["n"]
+    store.get_session("s-1")
+    assert calls["n"] == before
+
+
+def test_returned_session_is_isolated_from_cache(tmp_path: Path):
+    store = FileSessionStore(tmp_path)
+    _seed(store, "s-1", user_text="original")
+
+    got = store.get_session("s-1")
+    # Mutating a returned copy must never leak into the cached/stored state.
+    got.title = "MUTATED"
+    got.messages.clear()
+
+    again = store.get_session("s-1")
+    assert again.title != "MUTATED"
+    assert len(again.messages) == 2
+    assert store.read_history("s-1")[0].parts[0].text == "original"
+
+
+def test_oversized_session_not_pinned_in_parse_cache(tmp_path: Path):
+    store = FileSessionStore(tmp_path)
+    store._parse_cache_max_bytes = 256  # force the "too big to retain" path
+    _seed(store, "s-big", user_text="x" * 4096)
+
+    store.get_session("s-big")
+    key = str(store._session_path("s-big"))
+    assert key not in store._parse_cache  # not retained
+    # Still fully correct on read.
+    assert store.read_history("s-big")[0].parts[0].text == "x" * 4096
+
+
+def test_display_name_parity_with_full_load(tmp_path: Path):
+    store = FileSessionStore(tmp_path)
+    manager = RuntimeSessionManager(store=store)
+
+    # custom name wins
+    _seed(store, "s-custom", title="A Title", user_text="hello")
+    store.update_session("s-custom", metadata={"custom_session_name": "  Pinned Name  "})
+    # title only (no custom)
+    _seed(store, "s-title", title="Just A Title", user_text="hello there")
+    # first-user only (no title, no custom), long content to exercise truncation
+    _seed(store, "s-firstuser", title=None, user_text="q" * 200, assistant_text=None)
+
+    summaries = {s.session_id: s for s in store.list_session_summaries()}
+
+    for session_id, summary in summaries.items():
+        projection = {
+            "metadata": (
+                {"custom_session_name": summary.custom_name} if summary.custom_name else {}
+            ),
+            "title": summary.title,
+            "history": (
+                [{"role": "user", "content": summary.first_user_preview}]
+                if summary.user_message_count
+                else []
+            ),
+        }
+        full = manager._session_to_legacy(store.get_session(session_id))
+        assert resolve_session_display_name(projection) == resolve_session_display_name(full)
+
+
+def test_manager_summaries_are_sorted_desc(tmp_path: Path):
+    store = FileSessionStore(tmp_path)
+    manager = RuntimeSessionManager(store=store)
+    _seed(store, "s-a")
+    _seed(store, "s-b")
+    # Touch s-a again so it becomes the most-recently-updated.
+    store.append_message(
+        "s-a", role="user", parts=[MessagePart.text_part("later")], status="complete"
+    )
+
+    summaries = asyncio.run(manager.list_session_summaries())
+    expected = sorted(
+        summaries, key=lambda s: (s.updated_at, s.session_id), reverse=True
+    )
+    assert [s.session_id for s in summaries] == [s.session_id for s in expected]
+    # s-a was updated last, so it must sort first.
+    assert summaries[0].session_id == "s-a"
+
+
+def test_build_summary_counts_only_user_messages(tmp_path: Path):
+    store = FileSessionStore(tmp_path)
+    _seed(store, "s-1", user_text="u1", assistant_text="a1")
+    store.append_message(
+        "s-1", role="user", parts=[MessagePart.text_part("u2")], status="complete"
+    )
+    session = store.get_session("s-1")
+    summary = build_session_summary(session)
+    assert summary.user_message_count == 2
+    assert summary.message_count == 3
+    assert summary.last_preview == "u2"

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -132,6 +132,22 @@ def test_resolve_runtime_session_id_avoids_same_second_collisions_without_client
     assert runtime_api._resolve_runtime_session_id({"session_id": ""}).startswith("runtime_api_")
 
 
+def _fake_summary(session_id):
+    from src.efp_runtime.session.file_store import SessionSummary
+
+    return SessionSummary(
+        session_id=session_id,
+        title=session_id,
+        custom_name=None,
+        created_at="2026-06-21T00:00:00Z",
+        updated_at="2026-06-21T00:00:00Z",
+        message_count=1,
+        user_message_count=1,
+        first_user_preview=f"hello from {session_id}",
+        last_preview=f"hello from {session_id}",
+    )
+
+
 @pytest.mark.asyncio
 async def test_api_sessions_hides_task_sessions_by_default(monkeypatch):
     from src.gateway import runtime_api
@@ -142,20 +158,13 @@ async def test_api_sessions_hides_task_sessions_by_default(monkeypatch):
         async def initialize(self):
             raise AssertionError("already initialized")
 
-        async def list_sessions(self):
+        async def list_session_summaries(self):
             return [
-                "agent-task-task-1",
-                "generic-task-task-2",
-                "delegation-rule-1-event-1",
-                "s-human",
+                _fake_summary("agent-task-task-1"),
+                _fake_summary("generic-task-task-2"),
+                _fake_summary("delegation-rule-1-event-1"),
+                _fake_summary("s-human"),
             ]
-
-        async def get_session_info(self, session_id):
-            return {
-                "title": session_id,
-                "history": [{"role": "user", "content": f"hello from {session_id}"}],
-                "updated_at": "2026-06-21T00:00:00Z",
-            }
 
     monkeypatch.setattr(runtime_api, "session_manager", _FakeSessionManager())
 
@@ -175,15 +184,8 @@ async def test_api_sessions_can_include_task_sessions_for_debug(monkeypatch):
         async def initialize(self):
             raise AssertionError("already initialized")
 
-        async def list_sessions(self):
-            return ["agent-task-task-1", "s-human"]
-
-        async def get_session_info(self, session_id):
-            return {
-                "title": session_id,
-                "history": [{"role": "user", "content": f"hello from {session_id}"}],
-                "updated_at": "2026-06-21T00:00:00Z",
-            }
+        async def list_session_summaries(self):
+            return [_fake_summary("agent-task-task-1"), _fake_summary("s-human")]
 
     monkeypatch.setattr(runtime_api, "session_manager", _FakeSessionManager())
 


### PR DESCRIPTION
## Problem

A native pod showed **100% CPU + 5.7GB non-reclaimed RSS**. Root cause (source-level): the file session store re-read, `session_from_dict`'d and `deepcopy`'d whole session bodies on **every** access, **synchronously on the event loop**.

`GET /api/sessions` was the worst offender — `FileSessionStore.list_sessions()` read + deepcopied *every* session file, then the handler loaded each candidate **again** via `get_session_info` just to read a name, a preview and a count. With many sessions and large inlined `tool_result` content, this pegged one core and inflated RSS (CPython keeps the arenas from the short-lived object graphs mapped). The event-loop blocking also starved SSE/WebSocket writes, producing the `events.py` `Cannot write to closing transport` bursts seen in the logs.

This is a **behaviour-preserving** optimisation — no stored content, agent-visible context, API shapes, or displayed session names change.

## Changes

**`FileSessionStore`**
- mtime+size validated **parse cache** at the single read choke point; an unchanged file skips `json.load + session_from_dict`. Reads still return deepcopies and mutators read a private copy, so no caller can observe or corrupt a cached instance. Bounded LRU; oversized sessions are never pinned.
- **`list_session_summaries()`**: tiny per-session headers backed by an mtime summary cache, so an unchanged listing is answered with `stat()` calls and no parse. Preview derivation stops early so a multi-MB tool result is never fully materialised for a 50-char preview.
- Caches refreshed on write, evicted on delete; best-effort `malloc_trim` after cold builds/deletes so freed memory returns to the OS.
- `InMemorySessionStore` gets a matching summaries method for parity.

**Gateway facade / API**
- `list_session_summaries()` and `get_existing_session()` run store work in a thread (`run_in_executor`) so CPU-bound parsing no longer blocks the loop.
- `api_sessions` consumes the ordered summaries and reproduces the display name byte-for-byte via `resolve_session_display_name` on a minimal projection; per-session INFO log spam removed.

## Deliberately NOT included (would change behaviour)
- Blob-offloading already-stored `tool_result` content (changes LLM-visible context + UI display).
- Cold/hot metadata sidecar split (changes on-disk layout + recovery).

Both are left as separate, flag-gated follow-ups.

## opencode
Unaffected by design: session history lives in the OpenCode process and is paginated (`list_messages`); the adapter never full-scans session bodies (`chatlog_store.list_session_ids` has no callers). No change needed.

## Tests
- New `tests/runtime/test_file_session_store_cache.py` (9 tests): summary parity, mtime refresh, delete eviction, no-reparse-on-unchanged, returned-copy isolation, oversized bypass, display-name parity vs full load, manager ordering.
- Updated the two `api_sessions` tests to the summaries contract.
- All 220 tests in the touched suites pass. (24 unrelated failures in tool/shell/read/edit tests are pre-existing Windows CRLF/shell platform failures — reproduced on unmodified HEAD via `git stash`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
