### PR TITLE
Workspace file management: rename/move, mkdir/new-file, read cap, streamed downloads

### DIFF
--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -40,6 +40,24 @@ logger = logging.getLogger(__name__)
 SYSTEM_PROMPT_AGENTS_SECTION = "agents"
 SYSTEM_PROMPT_AGENTS_FILENAME = "AGENTS.md"
 
+# Upload sizing. EFP_MAX_UPLOAD_MB is the user-facing per-file cap the Portal
+# enforces and reports; the runtime allows that plus headroom for multipart /
+# transport overhead so it is never the gate for a file the Portal accepted.
+DEFAULT_MAX_UPLOAD_MB = 25
+UPLOAD_TRANSPORT_HEADROOM_MB = 5
+
+
+def resolve_upload_client_max_size() -> int:
+    """aiohttp ``client_max_size`` (bytes) for request bodies incl. uploads."""
+    raw = os.getenv("EFP_MAX_UPLOAD_MB", str(DEFAULT_MAX_UPLOAD_MB))
+    try:
+        mb = int(str(raw).strip())
+    except (TypeError, ValueError):
+        mb = DEFAULT_MAX_UPLOAD_MB
+    if mb <= 0:
+        mb = DEFAULT_MAX_UPLOAD_MB
+    return (mb + UPLOAD_TRANSPORT_HEADROOM_MB) * 1024 * 1024
+
 
 def _runtime_workspace_root() -> Path:
     """Canonical runtime workspace root."""
@@ -199,7 +217,7 @@ class Gateway:
         self.jira_enabled = config.jira.get("enabled", False)
         self.host = config.server.get("host", "0.0.0.0")
         self.port = config.server.get("port", 8000)
-        self.app = web.Application()
+        self.app = web.Application(client_max_size=resolve_upload_client_max_size())
         self.runner: web.AppRunner | None = None
         self.site: web.TCPSite | None = None
 

--- a/src/gateway/server_files.py
+++ b/src/gateway/server_files.py
@@ -8,6 +8,7 @@ import mimetypes
 import os
 import shutil
 import stat
+import tempfile
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -22,6 +23,21 @@ from src.workspace_defaults import resolve_runtime_workspace
 
 
 logger = logging.getLogger(__name__)
+
+# Editor/preview read cap. Reading a whole multi-hundred-MB file into memory and
+# returning it as a JSON string would spike memory and mangle binary; cap the
+# bytes returned and flag truncation/binary instead. Configurable for large
+# text files that genuinely need a bigger window.
+DEFAULT_READ_FILE_MAX_BYTES = 1024 * 1024
+
+
+def _read_file_max_bytes() -> int:
+    raw = os.getenv("EFP_MAX_READ_FILE_BYTES", str(DEFAULT_READ_FILE_MAX_BYTES))
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        value = DEFAULT_READ_FILE_MAX_BYTES
+    return value if value > 0 else DEFAULT_READ_FILE_MAX_BYTES
 
 
 @dataclass(frozen=True)
@@ -38,6 +54,8 @@ class PreparedDownload:
     content_type: str | None
     file_path: Path | None = None
     data: bytes | None = None
+    # True when file_path is a temp archive the caller must stream then delete.
+    is_temp: bool = False
 
 
 def _runtime_workspace_root() -> Path:
@@ -127,17 +145,30 @@ class WorkspaceServerFilesService:
 
     def read_file(self, user_path: str | None) -> dict[str, Any]:
         target = self._resolve_existing_file(user_path)
-        raw = target.read_bytes()
+        size = target.stat().st_size
+        limit = _read_file_max_bytes()
+        with target.open("rb") as handle:
+            raw = handle.read(limit + 1)
+        truncated = len(raw) > limit
+        if truncated:
+            raw = raw[:limit]
+        # NUL byte in the sampled prefix is a reliable "this is binary" signal;
+        # binary content is not decoded (would be lossy) and is left for the
+        # download endpoint instead.
+        is_binary = b"\x00" in raw
         content_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
         relative_path = self.workspace_relative_path(target)
         return {
             "success": True,
             "path": self.workspace_absolute_path(target),
             "relative_path": relative_path,
-            "content": raw.decode("utf-8", errors="replace"),
+            "content": "" if is_binary else raw.decode("utf-8", errors="replace"),
             "language": _guess_language(target),
             "content_type": content_type,
-            "size": len(raw),
+            "size": size,
+            "returned_bytes": len(raw),
+            "truncated": truncated,
+            "is_binary": is_binary,
         }
 
     def get_content_path(self, user_path: str | None) -> Path:
@@ -156,6 +187,79 @@ class WorkspaceServerFilesService:
             "target_path": str(target),
             "size": len(data),
             "content_type": mimetypes.guess_type(name)[0] or "application/octet-stream",
+        }
+
+    def move_path(self, source: str | None, destination: str | None) -> dict[str, Any]:
+        """Rename or move a file/directory within the workspace (B1)."""
+        src = self.resolve_workspace_path(source)
+        if src == self.root:
+            raise PermissionError("cannot move workspace root")
+        if not src.exists():
+            raise FileNotFoundError
+        if src.is_symlink():
+            raise PermissionError("path outside workspace")
+
+        dst = self.resolve_workspace_path(destination, allow_missing=True)
+        if dst == self.root or dst == src:
+            raise ValueError("invalid destination")
+        if dst.exists():
+            # Never silently overwrite; the caller must delete first.
+            raise ValueError("destination already exists")
+
+        source_relative = self.workspace_relative_path(src)
+        self._reject_symlink_components(dst.parent, allow_missing=True)
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        self._reject_symlink_components(dst.parent)
+        shutil.move(str(src), str(dst))
+        destination_relative = self.workspace_relative_path(dst)
+        return {
+            "success": True,
+            "mode": "move",
+            "source_relative_path": source_relative,
+            "path": self.workspace_absolute_path(dst),
+            "relative_path": destination_relative,
+            "is_dir": dst.is_dir(),
+            "is_file": dst.is_file(),
+        }
+
+    def make_directory(self, user_path: str | None) -> dict[str, Any]:
+        """Create a new directory (B2)."""
+        target = self.resolve_workspace_path(user_path, allow_missing=True)
+        if target == self.root:
+            raise ValueError("path is required")
+        self._reject_symlink_components(target, allow_missing=True)
+        if target.exists():
+            raise ValueError("already exists")
+        target.mkdir(parents=True, exist_ok=False)
+        self._reject_symlink_components(target)
+        return {
+            "success": True,
+            "mode": "mkdir",
+            "path": self.workspace_absolute_path(target),
+            "relative_path": self.workspace_relative_path(target),
+            "is_dir": True,
+        }
+
+    def create_file(self, user_path: str | None) -> dict[str, Any]:
+        """Create a new empty file (B2)."""
+        target = self.resolve_workspace_path(user_path, allow_missing=True)
+        if target == self.root:
+            raise ValueError("path is required")
+        self._reject_symlink_components(target, allow_missing=True)
+        if target.exists():
+            raise ValueError("already exists")
+        self._reject_symlink_components(target.parent, allow_missing=True)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        self._reject_symlink_components(target.parent)
+        target.touch()
+        return {
+            "success": True,
+            "mode": "file_create",
+            "path": self.workspace_absolute_path(target),
+            "relative_path": self.workspace_relative_path(target),
+            "is_file": True,
+            "size": 0,
+            "content_type": mimetypes.guess_type(target.name)[0] or "application/octet-stream",
         }
 
     def extract_zip_safely(
@@ -280,11 +384,12 @@ class WorkspaceServerFilesService:
             )
 
         archive_name = self._archive_name(targets)
-        data = self._build_zip_bytes(targets)
+        tmp_path = self._write_zip_tempfile(targets)
         return PreparedDownload(
             filename=archive_name,
             content_type="application/zip",
-            data=data,
+            file_path=tmp_path,
+            is_temp=True,
         )
 
     def _resolve_existing_file(self, user_path: str | None) -> Path:
@@ -366,27 +471,39 @@ class WorkspaceServerFilesService:
             filtered.append(target)
         return filtered
 
-    def _build_zip_bytes(self, targets: Sequence[Path]) -> bytes:
-        buf = io.BytesIO()
-        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-            for target in targets:
-                if target.is_file():
-                    zf.write(target, arcname=self.workspace_relative_path(target))
-                    continue
-                if target.is_dir():
-                    base_rel = self.workspace_relative_path(target)
-                    for path in target.rglob("*"):
-                        if path.is_symlink():
-                            continue
-                        if not path.is_file():
-                            continue
-                        resolved = self._ensure_under_workspace(path.resolve(strict=False))
-                        child_rel = path.relative_to(target).as_posix()
-                        arcname = child_rel if base_rel == "." else (PurePosixPath(base_rel) / child_rel).as_posix()
-                        zf.write(resolved, arcname=arcname)
-                    continue
-                raise ValueError("unsupported path")
-        return buf.getvalue()
+    def _write_zip_tempfile(self, targets: Sequence[Path]) -> Path:
+        """Build the download archive on disk (streamed out by the route).
+
+        Writing to a temp file instead of an in-memory BytesIO keeps peak
+        memory at one file's copy buffer rather than the whole archive, so a
+        large workspace download no longer spikes the runtime pod.
+        """
+        fd, tmp_name = tempfile.mkstemp(suffix=".zip", prefix="efp-download-")
+        os.close(fd)
+        tmp_path = Path(tmp_name)
+        try:
+            with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                for target in targets:
+                    if target.is_file():
+                        zf.write(target, arcname=self.workspace_relative_path(target))
+                        continue
+                    if target.is_dir():
+                        base_rel = self.workspace_relative_path(target)
+                        for path in target.rglob("*"):
+                            if path.is_symlink():
+                                continue
+                            if not path.is_file():
+                                continue
+                            resolved = self._ensure_under_workspace(path.resolve(strict=False))
+                            child_rel = path.relative_to(target).as_posix()
+                            arcname = child_rel if base_rel == "." else (PurePosixPath(base_rel) / child_rel).as_posix()
+                            zf.write(resolved, arcname=arcname)
+                        continue
+                    raise ValueError("unsupported path")
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+        return tmp_path
 
     def _archive_name(self, targets: Sequence[Path]) -> str:
         if len(targets) == 1:
@@ -534,6 +651,40 @@ def _is_relative_to(path: Path, base: Path) -> bool:
     return True
 
 
+async def _stream_temp_download(
+    request: web.Request,
+    prepared: PreparedDownload,
+    headers: dict[str, str],
+) -> web.StreamResponse:
+    """Stream a temp archive to the client in chunks, then delete it.
+
+    Keeps runtime memory flat for large downloads and guarantees the temp file
+    is removed even if the client disconnects mid-stream.
+    """
+    response = web.StreamResponse(headers=headers)
+    response.content_type = prepared.content_type or "application/octet-stream"
+    assert prepared.file_path is not None
+    try:
+        response.content_length = prepared.file_path.stat().st_size
+    except OSError:
+        pass
+    await response.prepare(request)
+    try:
+        with prepared.file_path.open("rb") as handle:
+            while True:
+                chunk = handle.read(256 * 1024)
+                if not chunk:
+                    break
+                await response.write(chunk)
+        await response.write_eof()
+    finally:
+        try:
+            prepared.file_path.unlink()
+        except OSError:
+            pass
+    return response
+
+
 def setup_server_files_routes(app: web.Application) -> None:
     service = app.get(SERVER_FILES_SERVICE_KEY)
     if service is None:
@@ -615,19 +766,64 @@ def setup_server_files_routes(app: web.Application) -> None:
                 paths = request.query.getall("paths[]", [])
             if not paths:
                 paths = [request.query.get("path") or "."]
-
             prepared = service.prepare_download(paths)
-            headers = {"Content-Disposition": _content_disposition(prepared.filename)}
-            if prepared.file_path is not None:
-                response = web.FileResponse(prepared.file_path, headers=headers)
-                if prepared.content_type:
-                    response.content_type = prepared.content_type
-                return response
-            return web.Response(
-                body=prepared.data or b"",
-                content_type=prepared.content_type or "application/octet-stream",
-                headers=headers,
-            )
+        except Exception as exc:
+            return _error(exc)
+
+        headers = {"Content-Disposition": _content_disposition(prepared.filename)}
+        if prepared.is_temp and prepared.file_path is not None:
+            return await _stream_temp_download(request, prepared, headers)
+        if prepared.file_path is not None:
+            response = web.FileResponse(prepared.file_path, headers=headers)
+            if prepared.content_type:
+                response.content_type = prepared.content_type
+            return response
+        return web.Response(
+            body=prepared.data or b"",
+            content_type=prepared.content_type or "application/octet-stream",
+            headers=headers,
+        )
+
+    async def _read_json_body(request: web.Request) -> dict[str, Any]:
+        if request.content_type.startswith("application/json"):
+            payload = await request.json()
+            return payload if isinstance(payload, dict) else {}
+        if request.content_type.startswith("multipart/") or request.content_type.startswith(
+            "application/x-www-form-urlencoded"
+        ):
+            return dict(await request.post())
+        return {}
+
+    async def server_files_mkdir(request: web.Request) -> web.Response:
+        try:
+            payload = await _read_json_body(request)
+            path = payload.get("path") or request.query.get("path")
+            if not path:
+                raise ValueError("path is required")
+            return web.json_response(service.make_directory(path))
+        except Exception as exc:
+            return _error(exc)
+
+    async def server_files_new_file(request: web.Request) -> web.Response:
+        try:
+            payload = await _read_json_body(request)
+            path = payload.get("path") or request.query.get("path")
+            if not path:
+                raise ValueError("path is required")
+            return web.json_response(service.create_file(path))
+        except Exception as exc:
+            return _error(exc)
+
+    async def server_files_move(request: web.Request) -> web.Response:
+        try:
+            payload = await _read_json_body(request)
+            source = payload.get("source") or payload.get("path") or request.query.get("source")
+            destination = payload.get("destination") or request.query.get("destination")
+            if not source:
+                raise ValueError("source is required")
+            if not destination:
+                raise ValueError("destination is required")
+            return web.json_response(service.move_path(source, destination))
         except Exception as exc:
             return _error(exc)
 
@@ -637,5 +833,8 @@ def setup_server_files_routes(app: web.Application) -> None:
     app.router.add_post("/api/server-files/upload", server_files_upload)
     app.router.add_post("/api/server-files/delete", server_files_delete)
     app.router.add_get("/api/server-files/download", server_files_download)
+    app.router.add_post("/api/server-files/mkdir", server_files_mkdir)
+    app.router.add_post("/api/server-files/new-file", server_files_new_file)
+    app.router.add_post("/api/server-files/move", server_files_move)
 
     logger.info("Server Files API routes registered for workspace root: %s", service.root)

--- a/tests/test_server_files_management.py
+++ b/tests/test_server_files_management.py
@@ -1,0 +1,207 @@
+"""Workspace file management: move/mkdir/new-file, read_file cap, temp-zip download.
+
+Covers the B1/B2 management operations, the A3 read cap + binary handling, and
+the A1 streaming (temp-file) download for directories.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from src.gateway.server_files import WorkspaceServerFilesService
+
+
+# --------------------------------------------------------------------------- #
+# Service-level tests
+# --------------------------------------------------------------------------- #
+
+def _svc(root: Path) -> WorkspaceServerFilesService:
+    return WorkspaceServerFilesService(root)
+
+
+def test_move_renames_file(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hi", encoding="utf-8")
+    result = _svc(tmp_path).move_path("a.txt", "b.txt")
+    assert result["success"] is True
+    assert result["relative_path"] == "b.txt"
+    assert not (tmp_path / "a.txt").exists()
+    assert (tmp_path / "b.txt").read_text(encoding="utf-8") == "hi"
+
+
+def test_move_into_subdirectory_creates_parents(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hi", encoding="utf-8")
+    result = _svc(tmp_path).move_path("a.txt", "sub/deep/a.txt")
+    assert result["relative_path"] == "sub/deep/a.txt"
+    assert (tmp_path / "sub" / "deep" / "a.txt").exists()
+
+
+def test_move_rejects_overwrite(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+    with pytest.raises(ValueError):
+        _svc(tmp_path).move_path("a.txt", "b.txt")
+    assert (tmp_path / "a.txt").exists()  # unchanged
+
+
+def test_move_rejects_missing_source(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        _svc(tmp_path).move_path("nope.txt", "x.txt")
+
+
+def test_move_rejects_escape(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    with pytest.raises(PermissionError):
+        _svc(tmp_path).move_path("a.txt", "../escape.txt")
+
+
+def test_mkdir_creates_nested_directory(tmp_path: Path):
+    result = _svc(tmp_path).make_directory("x/y/z")
+    assert result["success"] is True and result["is_dir"] is True
+    assert (tmp_path / "x" / "y" / "z").is_dir()
+
+
+def test_mkdir_rejects_existing(tmp_path: Path):
+    (tmp_path / "d").mkdir()
+    with pytest.raises(ValueError):
+        _svc(tmp_path).make_directory("d")
+
+
+def test_new_file_creates_empty_file_with_parents(tmp_path: Path):
+    result = _svc(tmp_path).create_file("notes/todo.md")
+    assert result["success"] is True and result["size"] == 0
+    p = tmp_path / "notes" / "todo.md"
+    assert p.is_file() and p.read_bytes() == b""
+
+
+def test_new_file_rejects_existing(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError):
+        _svc(tmp_path).create_file("a.txt")
+
+
+def test_read_file_truncates_over_cap(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("EFP_MAX_READ_FILE_BYTES", "10")
+    (tmp_path / "big.txt").write_text("x" * 25, encoding="utf-8")
+    result = _svc(tmp_path).read_file("big.txt")
+    assert result["truncated"] is True
+    assert result["returned_bytes"] == 10
+    assert result["size"] == 25
+    assert result["content"] == "x" * 10
+    assert result["is_binary"] is False
+
+
+def test_read_file_flags_binary_and_skips_decode(tmp_path: Path):
+    (tmp_path / "blob.bin").write_bytes(b"PNG\x00\x01\x02data")
+    result = _svc(tmp_path).read_file("blob.bin")
+    assert result["is_binary"] is True
+    assert result["content"] == ""
+    assert result["truncated"] is False
+
+
+def test_prepare_download_single_file_is_not_temp(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hi", encoding="utf-8")
+    prepared = _svc(tmp_path).prepare_download(["a.txt"])
+    assert prepared.is_temp is False
+    assert prepared.file_path == (tmp_path / "a.txt").resolve()
+
+
+def test_prepare_download_directory_writes_temp_zip(tmp_path: Path):
+    (tmp_path / "d").mkdir()
+    (tmp_path / "d" / "one.txt").write_text("1", encoding="utf-8")
+    (tmp_path / "d" / "two.txt").write_text("2", encoding="utf-8")
+    prepared = _svc(tmp_path).prepare_download(["d"])
+    try:
+        assert prepared.is_temp is True
+        assert prepared.content_type == "application/zip"
+        assert prepared.file_path is not None and prepared.file_path.exists()
+        with zipfile.ZipFile(prepared.file_path) as zf:
+            names = set(zf.namelist())
+        assert {"d/one.txt", "d/two.txt"} <= names
+    finally:
+        if prepared.file_path is not None:
+            prepared.file_path.unlink(missing_ok=True)
+
+
+# --------------------------------------------------------------------------- #
+# Route-level tests (exercise handlers + temp cleanup)
+# --------------------------------------------------------------------------- #
+
+async def _client_for_workspace(workspace: Path) -> TestClient:
+    from src.gateway.server_files import (
+        SERVER_FILES_SERVICE_KEY,
+        WorkspaceServerFilesService,
+        setup_server_files_routes,
+    )
+
+    app = web.Application()
+    app[SERVER_FILES_SERVICE_KEY] = WorkspaceServerFilesService(workspace)
+    setup_server_files_routes(app)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_mkdir_move_new_file_routes(tmp_path: Path):
+    client = await _client_for_workspace(tmp_path)
+    try:
+        r = await client.post("/api/server-files/mkdir", json={"path": "docs"})
+        assert r.status == 200 and (await r.json())["is_dir"] is True
+
+        r = await client.post("/api/server-files/new-file", json={"path": "docs/readme.md"})
+        assert r.status == 200 and (await r.json())["size"] == 0
+
+        r = await client.post(
+            "/api/server-files/move",
+            json={"source": "docs/readme.md", "destination": "docs/guide.md"},
+        )
+        assert r.status == 200 and (await r.json())["relative_path"] == "docs/guide.md"
+        assert (tmp_path / "docs" / "guide.md").exists()
+        assert not (tmp_path / "docs" / "readme.md").exists()
+
+        # Missing required fields -> 400
+        r = await client.post("/api/server-files/mkdir", json={})
+        assert r.status == 400
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_directory_download_streams_zip_and_cleans_temp(tmp_path: Path, monkeypatch):
+    (tmp_path / "d").mkdir()
+    (tmp_path / "d" / "a.txt").write_text("alpha", encoding="utf-8")
+
+    created: list[Path] = []
+    import src.gateway.server_files as sf
+    real_mkstemp = sf.tempfile.mkstemp
+
+    def _tracking_mkstemp(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        created.append(Path(name))
+        return fd, name
+
+    monkeypatch.setattr(sf.tempfile, "mkstemp", _tracking_mkstemp)
+
+    client = await _client_for_workspace(tmp_path)
+    try:
+        resp = await client.get("/api/server-files/download", params={"path": "d"})
+        assert resp.status == 200
+        assert resp.headers["Content-Type"] == "application/zip"
+        body = await resp.read()
+    finally:
+        await client.close()
+
+    # Valid zip with the expected member...
+    import io as _io
+    with zipfile.ZipFile(_io.BytesIO(body)) as zf:
+        assert "d/a.txt" in zf.namelist()
+        assert zf.read("d/a.txt") == b"alpha"
+
+    # ...and the temp archive was created then deleted (no leak).
+    assert created, "expected a temp archive to be created"
+    assert all(not p.exists() for p in created), "temp archive was not cleaned up"

--- a/tests/test_upload_client_max_size.py
+++ b/tests/test_upload_client_max_size.py
@@ -1,0 +1,43 @@
+"""Upload size: runtime aiohttp client_max_size is env-configurable.
+
+The gateway aiohttp app previously used aiohttp's 1MB default, silently
+capping every upload (and returning 413) regardless of the Portal's limit.
+These lock the EFP_MAX_UPLOAD_MB wiring and its transport headroom.
+"""
+
+from pathlib import Path
+
+from src.gateway import server
+
+_HEADROOM = server.UPLOAD_TRANSPORT_HEADROOM_MB
+_DEFAULT = server.DEFAULT_MAX_UPLOAD_MB
+
+
+def test_default_client_max_size(monkeypatch):
+    monkeypatch.delenv("EFP_MAX_UPLOAD_MB", raising=False)
+    assert server.resolve_upload_client_max_size() == (_DEFAULT + _HEADROOM) * 1024 * 1024
+
+
+def test_env_override(monkeypatch):
+    monkeypatch.setenv("EFP_MAX_UPLOAD_MB", "50")
+    assert server.resolve_upload_client_max_size() == (50 + _HEADROOM) * 1024 * 1024
+
+
+def test_invalid_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("EFP_MAX_UPLOAD_MB", "not-a-number")
+    assert server.resolve_upload_client_max_size() == (_DEFAULT + _HEADROOM) * 1024 * 1024
+
+
+def test_non_positive_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("EFP_MAX_UPLOAD_MB", "0")
+    assert server.resolve_upload_client_max_size() == (_DEFAULT + _HEADROOM) * 1024 * 1024
+
+
+def test_runtime_headroom_exceeds_user_cap():
+    # The runtime must never be the gate for a file the Portal accepted.
+    assert _HEADROOM > 0
+
+
+def test_application_is_wired_with_client_max_size():
+    source = Path("src/gateway/server.py").read_text(encoding="utf-8")
+    assert "web.Application(client_max_size=resolve_upload_client_max_size())" in source


### PR DESCRIPTION
## What

Adds the workspace file-management operations the Server Files panel was missing, and closes two large-file sharp edges — reusing the existing path-traversal / symlink safety scaffolding.

- **move_path (B1)** — rename/move a file or directory. Refuses to overwrite an existing destination or touch the workspace root; creates parent dirs.
- **make_directory / create_file (B2)** — new folder / new empty file; both reject an existing target and reject symlink components.
- **read_file (A3)** — caps the bytes returned (`EFP_MAX_READ_FILE_BYTES`, default 1MB) and flags `truncated` / `is_binary` instead of decoding a whole multi-hundred-MB or binary file into a JSON string. Existing fields preserved.
- **prepare_download (A1)** — builds the directory/multi-file archive to a **temp file on disk** instead of an in-memory `BytesIO`; the route streams it in chunks and deletes it afterward (even if the client disconnects mid-stream). Peak memory is one copy buffer, not the whole archive.

New routes: `POST /api/server-files/{mkdir,new-file,move}`.

## Tests
`tests/test_server_files_management.py` — 15 service- + route-level tests (move/mkdir/new-file, read cap, binary flag, temp-zip download **with cleanup assertion**). All green.

## Related
Paired with matching changes in the opencode runtime and the Portal (streaming download proxy + upload progress). B1/B2 need no Portal routes — the generic proxy already forwards `api/server-files/*` behind a write-access check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
