### PR TITLE
Export tools config as bare-name env vars instead of EFP_CONFIG_JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,11 @@ boot (no hot apply; config changes require a Portal-triggered restart):
   the read-only base `config.yaml` and scrubbed from the process environment
   after projection.
 - `EFP_PROFILE_REVISION` / `EFP_PROFILE_ID` — profile revision and id.
-- `EFP_CONFIG_JSON` — exported by the runtime for CLI child processes
-  (`jira`, `confluence`, `jenkins`, `aws-auth`, `mobile-auto`, `visual`).
+- Tools config env vars — exported by the runtime for CLI child processes
+  (`jira`, `confluence`, `jenkins`, `aws-auth`, `mobile-auto`, `visual`) as
+  bare-name, indexed variables flattened from the tools `RootConfig`-shaped
+  config (e.g. `JIRA_DEFAULT_INSTANCE`, `JIRA_INSTANCES_0_BASE_URL`,
+  `AWS_DOMAIN`, `MOBILE_AUTO_BROWSERSTACK_USERNAME`).
 
 `GET /ready` reports readiness only after the boot projection succeeded. In
 local development (no `EFP_PROFILE_CONFIG`), the runtime uses `config.yaml`

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ boot (no hot apply; config changes require a Portal-triggered restart):
 - `EFP_PROFILE_REVISION` / `EFP_PROFILE_ID` — profile revision and id.
 - Tools config env vars — exported by the runtime for CLI child processes
   (`jira`, `confluence`, `jenkins`, `aws-auth`, `mobile-auto`, `visual`) as
-  bare-name, indexed variables flattened from the tools `RootConfig`-shaped
-  config (e.g. `JIRA_DEFAULT_INSTANCE`, `JIRA_INSTANCES_0_BASE_URL`,
-  `AWS_DOMAIN`, `MOBILE_AUTO_BROWSERSTACK_USERNAME`).
+  EFP_-prefixed, indexed variables flattened from the tools `RootConfig`-shaped
+  config (e.g. `EFP_JIRA_DEFAULT_INSTANCE`, `EFP_JIRA_INSTANCES_0_BASE_URL`,
+  `EFP_AWS_DOMAIN`, `EFP_MOBILE_AUTO_BROWSERSTACK_USERNAME`).
 
 `GET /ready` reports readiness only after the boot projection succeeded. In
 local development (no `EFP_PROFILE_CONFIG`), the runtime uses `config.yaml`

--- a/docs/runtime_contract.md
+++ b/docs/runtime_contract.md
@@ -41,13 +41,13 @@ Portal-triggered restart with a new Secret.
 - `EFP_PROFILE_REVISION`: profile revision string from the same Secret.
 - `EFP_PROFILE_ID`: bound profile id, or `none` for unbound agents.
 - Tools config env vars: exported by the runtime itself after projection —
-  bare-name, indexed environment variables flattened from the tools
+  EFP_-prefixed, indexed environment variables flattened from the tools
   `RootConfig`-shaped subset (`version`/`jira`/`confluence`/`jenkins`/`aws`/
-  `visual`/`mobile-auto`) of the effective config. Each scalar leaf becomes an
-  UPPERCASED `_`-joined path from the root (with `-` replaced by `_` and list
-  elements indexed by position), e.g. `JIRA_DEFAULT_INSTANCE`,
-  `JIRA_INSTANCES_0_BASE_URL`, `AWS_DOMAIN`,
-  `MOBILE_AUTO_BROWSERSTACK_USERNAME`. Only present values are emitted, and
+  `visual`/`mobile-auto`) of the effective config. Each scalar leaf becomes the
+  literal prefix `EFP_` plus an UPPERCASED `_`-joined path from the root (with
+  `-` replaced by `_` and list elements indexed by position), e.g.
+  `EFP_JIRA_DEFAULT_INSTANCE`, `EFP_JIRA_INSTANCES_0_BASE_URL`, `EFP_AWS_DOMAIN`,
+  `EFP_MOBILE_AUTO_BROWSERSTACK_USERNAME`. Only present values are emitted, and
   every CLI child process reads them.
 - `GET /ready` returns `200 {"ready": true, "runtime_profile_id", "revision"}`
   only after the boot projection succeeded, `503 {"ready": false, "error"}`
@@ -68,7 +68,7 @@ Portal-triggered restart with a new Secret.
 - Legacy Python tool packages such as `src.bash_tools` are not present, and Jira/GitHub/Confluence/Git Python tools are not exposed as LLM tools.
 - The runtime image may include prebuilt `engineering-flow-platform-tools` CLI binaries on `PATH` in `/usr/local/bin`. Current binaries include `jira`, `confluence`, `browser`, and `mobile-auto`; future binaries are discovered from `cmd/<tool>` in that repo.
 - Agents use those CLIs through the model-visible `bash` built-in in the workspace-full-access runtime workspace. They should run `<tool> commands --json`, then `<tool> schema <command> --json`, prefer `--json`, use `--dry-run` before writes, and pass `--yes` for destructive operations.
-- Runtime profile boot projection applies GitHub, AWS, and Git configuration through real CLIs and exports Jira, Confluence, Jenkins, mobile BrowserStack, and visual configuration to CLI child processes via bare-name indexed tools config env vars (e.g. `JIRA_INSTANCES_0_BASE_URL`, `AWS_DOMAIN`, `MOBILE_AUTO_BROWSERSTACK_USERNAME`).
+- Runtime profile boot projection applies GitHub, AWS, and Git configuration through real CLIs and exports Jira, Confluence, Jenkins, mobile BrowserStack, and visual configuration to CLI child processes via EFP_-prefixed indexed tools config env vars (e.g. `EFP_JIRA_INSTANCES_0_BASE_URL`, `EFP_AWS_DOMAIN`, `EFP_MOBILE_AUTO_BROWSERSTACK_USERNAME`).
 - Private managed mobile runs require BrowserStackLocal at `/usr/local/bin/BrowserStackLocal` or a configured `BROWSERSTACK_LOCAL_BINARY`; CI may stage that third-party binary into `runtime-tools/BrowserStackLocal`.
 - Legacy `EFP_TOOLS_DIR` / `EFP_EXTERNAL_TOOLS_*` Python external tool loaders are ignored by native runtime. `runtime-tools/*` is a Docker/CI build input for prebuilt CLI binaries and is copied into `PATH`; it is not a Python loader.
 - MCP servers and external protocol tool providers are intentionally excluded.

--- a/docs/runtime_contract.md
+++ b/docs/runtime_contract.md
@@ -40,9 +40,15 @@ Portal-triggered restart with a new Secret.
   process can spawn.
 - `EFP_PROFILE_REVISION`: profile revision string from the same Secret.
 - `EFP_PROFILE_ID`: bound profile id, or `none` for unbound agents.
-- `EFP_CONFIG_JSON`: exported by the runtime itself after projection — a
-  tools `RootConfig`-shaped JSON (`version`/`jira`/`confluence`/`jenkins`/
-  `aws`/`visual`/`mobile-auto`) read by every CLI child process.
+- Tools config env vars: exported by the runtime itself after projection —
+  bare-name, indexed environment variables flattened from the tools
+  `RootConfig`-shaped subset (`version`/`jira`/`confluence`/`jenkins`/`aws`/
+  `visual`/`mobile-auto`) of the effective config. Each scalar leaf becomes an
+  UPPERCASED `_`-joined path from the root (with `-` replaced by `_` and list
+  elements indexed by position), e.g. `JIRA_DEFAULT_INSTANCE`,
+  `JIRA_INSTANCES_0_BASE_URL`, `AWS_DOMAIN`,
+  `MOBILE_AUTO_BROWSERSTACK_USERNAME`. Only present values are emitted, and
+  every CLI child process reads them.
 - `GET /ready` returns `200 {"ready": true, "runtime_profile_id", "revision"}`
   only after the boot projection succeeded, `503 {"ready": false, "error"}`
   otherwise. `GET /health` stays always-ok as the liveness probe.
@@ -62,7 +68,7 @@ Portal-triggered restart with a new Secret.
 - Legacy Python tool packages such as `src.bash_tools` are not present, and Jira/GitHub/Confluence/Git Python tools are not exposed as LLM tools.
 - The runtime image may include prebuilt `engineering-flow-platform-tools` CLI binaries on `PATH` in `/usr/local/bin`. Current binaries include `jira`, `confluence`, `browser`, and `mobile-auto`; future binaries are discovered from `cmd/<tool>` in that repo.
 - Agents use those CLIs through the model-visible `bash` built-in in the workspace-full-access runtime workspace. They should run `<tool> commands --json`, then `<tool> schema <command> --json`, prefer `--json`, use `--dry-run` before writes, and pass `--yes` for destructive operations.
-- Runtime profile boot projection applies GitHub, AWS, and Git configuration through real CLIs and exports Jira, Confluence, Jenkins, mobile BrowserStack, and visual configuration to CLI child processes via `EFP_CONFIG_JSON`.
+- Runtime profile boot projection applies GitHub, AWS, and Git configuration through real CLIs and exports Jira, Confluence, Jenkins, mobile BrowserStack, and visual configuration to CLI child processes via bare-name indexed tools config env vars (e.g. `JIRA_INSTANCES_0_BASE_URL`, `AWS_DOMAIN`, `MOBILE_AUTO_BROWSERSTACK_USERNAME`).
 - Private managed mobile runs require BrowserStackLocal at `/usr/local/bin/BrowserStackLocal` or a configured `BROWSERSTACK_LOCAL_BINARY`; CI may stage that third-party binary into `runtime-tools/BrowserStackLocal`.
 - Legacy `EFP_TOOLS_DIR` / `EFP_EXTERNAL_TOOLS_*` Python external tool loaders are ignored by native runtime. `runtime-tools/*` is a Docker/CI build input for prebuilt CLI binaries and is copied into `PATH`; it is not a Python loader.
 - MCP servers and external protocol tool providers are intentionally excluded.

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ from src.config import bootstrap_profile_boot, config
 from src.workspace_defaults import resolve_runtime_workspace
 
 # Project the EFP_PROFILE_CONFIG overlay exactly once: external CLI projection,
-# EFP_CONFIG_JSON export, proxy/jenkins/mobile env, then scrub the profile blob.
+# tools config env-var export, proxy/jenkins/mobile env, then scrub the profile blob.
 # Must run before importing src.gateway.server (Gateway() executes at import).
 bootstrap_profile_boot()
 

--- a/src/config.py
+++ b/src/config.py
@@ -1009,10 +1009,11 @@ def bootstrap_profile_boot() -> bool:
 
     1. Project gh/aws/git external CLI config from the overlay via real CLIs.
        Jira/Confluence/Jenkins/mobile-auto/visual reach the Go CLIs through
-       the bare-name tools config env vars only.
-    2. Export the tools config env vars (bare-name indexed vars flattened from
-       the tools RootConfig-shaped subset of the effective config, e.g.
-       JIRA_INSTANCES_0_BASE_URL / AWS_DOMAIN) for every CLI child process.
+       the EFP_-prefixed tools config env vars only.
+    2. Export the tools config env vars (EFP_-prefixed indexed vars flattened
+       from the tools RootConfig-shaped subset of the effective config, e.g.
+       EFP_JIRA_INSTANCES_0_BASE_URL / EFP_AWS_DOMAIN) for every CLI child
+       process.
     3. Apply proxy / jenkins / mobile env exactly once.
     4. Scrub EFP_PROFILE_CONFIG from os.environ so no child process can see the
        full profile blob.

--- a/src/config.py
+++ b/src/config.py
@@ -1009,9 +1009,10 @@ def bootstrap_profile_boot() -> bool:
 
     1. Project gh/aws/git external CLI config from the overlay via real CLIs.
        Jira/Confluence/Jenkins/mobile-auto/visual reach the Go CLIs through
-       EFP_CONFIG_JSON only.
-    2. Export EFP_CONFIG_JSON (tools RootConfig-shaped subset of the effective
-       config) for every CLI child process.
+       the bare-name tools config env vars only.
+    2. Export the tools config env vars (bare-name indexed vars flattened from
+       the tools RootConfig-shaped subset of the effective config, e.g.
+       JIRA_INSTANCES_0_BASE_URL / AWS_DOMAIN) for every CLI child process.
     3. Apply proxy / jenkins / mobile env exactly once.
     4. Scrub EFP_PROFILE_CONFIG from os.environ so no child process can see the
        full profile blob.
@@ -1041,15 +1042,18 @@ def bootstrap_profile_boot() -> bool:
 
     if profile_env_present:
         try:
-            from src.external_cli.profile_config import build_tools_config_json
-
-            os.environ["EFP_CONFIG_JSON"] = json.dumps(
-                build_tools_config_json(config.get_effective_config())
+            from src.external_cli.profile_config import (
+                build_tools_config_json,
+                flatten_config_to_env,
             )
+
+            root = build_tools_config_json(config.get_effective_config())
+            for key, value in flatten_config_to_env(root).items():
+                os.environ[key] = value
         except Exception as exc:
             if error is None:
-                error = f"Failed to build EFP_CONFIG_JSON: {exc}"
-            logger.warning("Failed to build EFP_CONFIG_JSON", exc_info=True)
+                error = f"Failed to build tools config env vars: {exc}"
+            logger.warning("Failed to build tools config env vars", exc_info=True)
 
     config.apply_proxy()
     config.apply_jenkins_env()

--- a/src/config.py
+++ b/src/config.py
@@ -316,6 +316,7 @@ class Config:
         },
         "jenkins": {
             "enabled": True,
+            "url": True,
             "username": True,
             "password": True,
         },

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -58,8 +58,8 @@ def apply_runtime_profile_external_config(
     metadata: dict[str, Any] = {"version": _METADATA_VERSION, "managed_by": _MANAGED_BY}
 
     # NOTE: jira/confluence are intentionally NOT projected through CLI writes
-    # anymore; those CLIs read the bare-name tools config env vars exported at
-    # boot (see flatten_config_to_env).
+    # anymore; those CLIs read the EFP_-prefixed tools config env vars exported
+    # at boot (see flatten_config_to_env).
     try:
         _apply_github(profile_config, metadata=metadata, cli_environment=cli_environment)
         _apply_aws(profile_config, metadata=metadata, cli_environment=cli_environment)
@@ -112,7 +112,7 @@ def build_tools_config_json(effective_config: dict[str, Any]) -> dict[str, Any]:
     are taken from the effective config verbatim. Empty sections are omitted.
 
     The returned dict is flattened by :func:`flatten_config_to_env` into the
-    bare-name indexed env vars the Go CLIs consume.
+    EFP_-prefixed indexed env vars the Go CLIs consume.
     """
     root: dict[str, Any] = {}
     if not isinstance(effective_config, dict):
@@ -141,13 +141,15 @@ def build_tools_config_json(effective_config: dict[str, Any]) -> dict[str, Any]:
 
 
 def flatten_config_to_env(root: dict[str, Any]) -> dict[str, str]:
-    """Flatten a RootConfig-shaped dict into bare-name indexed env vars.
+    """Flatten a RootConfig-shaped dict into EFP_-prefixed indexed env vars.
 
     Produces the deterministic naming convention consumed by the Go CLIs: each
-    scalar leaf becomes an UPPERCASED, "_"-joined path from the root, with "-"
-    replaced by "_" and list elements indexed by their 0-based position. For
-    example ``{"jira": {"instances": [{"base_url": "x"}]}}`` yields
-    ``{"JIRA_INSTANCES_0_BASE_URL": "x"}``.
+    scalar leaf becomes the literal prefix ``EFP_`` plus an UPPERCASED,
+    "_"-joined path from the root, with "-" replaced by "_" and list elements
+    indexed by their 0-based position. For example
+    ``{"jira": {"instances": [{"base_url": "x"}]}}`` yields
+    ``{"EFP_JIRA_INSTANCES_0_BASE_URL": "x"}``. The EFP_ prefix keeps these
+    names out of other tools' namespaces (AWS_*, JIRA_*, JENKINS_*).
 
     Scalar encoding: bool -> "true"/"false"; int -> decimal string; str ->
     verbatim. ``None`` and empty strings are omitted entirely (no key emitted),
@@ -180,7 +182,7 @@ def _flatten_into(value: Any, path: tuple[str, ...], out: dict[str, str]) -> Non
             return
     if not path:
         return
-    out["_".join(path)] = rendered
+    out["EFP_" + "_".join(path)] = rendered
 
 
 def _tools_instance_config(instance: dict[str, Any], *, product: str) -> dict[str, Any]:

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -107,9 +107,11 @@ def build_tools_config_json(effective_config: dict[str, Any]) -> dict[str, Any]:
 
     The shape matches ``RootConfig`` in engineering-flow-platform-tools
     (internal/config/config.go): top-level keys version/jira/confluence/
-    jenkins/aws/visual/mobile-auto. Jira/Confluence sections are transformed
-    from the profile shape into the tools instances shape; the other sections
-    are taken from the effective config verbatim. Empty sections are omitted.
+    jenkins/aws/visual/mobile-auto. Jira/Confluence/Jenkins sections are
+    transformed from the profile shape into the tools instances shape (Jenkins
+    is a single flat instance wrapped into a one-element list); the other
+    sections are taken from the effective config verbatim. Empty sections are
+    omitted.
 
     The returned dict is flattened by :func:`flatten_config_to_env` into the
     EFP_-prefixed indexed env vars the Go CLIs consume.
@@ -132,7 +134,15 @@ def build_tools_config_json(effective_config: dict[str, Any]) -> dict[str, Any]:
             "instances": [_tools_instance_config(instance, product=product) for instance in instances],
         }
 
-    for section_name in ("jenkins", "aws", "visual", "mobile-auto"):
+    jenkins_section = effective_config.get("jenkins")
+    jenkins_instances = _build_jenkins_instances(jenkins_section)
+    if jenkins_instances:
+        root["jenkins"] = {
+            "default_instance": _default_instance_name(jenkins_section, jenkins_instances),
+            "instances": [_tools_instance_config(instance, product="jenkins") for instance in jenkins_instances],
+        }
+
+    for section_name in ("aws", "visual", "mobile-auto"):
         section = effective_config.get(section_name)
         if isinstance(section, dict) and section:
             root[section_name] = json.loads(json.dumps(section))
@@ -507,6 +517,24 @@ def _build_product_instances(product_config: Any, *, product: str) -> list[dict[
             }
         instances.append(instance)
     return instances
+
+
+def _build_jenkins_instances(section: Any) -> list[dict[str, Any]]:
+    """Wrap the flat Jenkins profile section into a single tools instance.
+
+    The Jenkins profile is a single flat ``{enabled, url, username, password}``
+    block (not a multi-instance list like Jira/Confluence), so it maps to a
+    one-element instances list. Dropped (returns ``[]``) when disabled or when
+    no base URL is present, since the Jenkins CLI requires a base URL.
+    """
+    if not isinstance(section, dict) or section.get("enabled") is False:
+        return []
+    base_url = _profile_instance_base_url(section)
+    if not base_url:
+        return []
+    auth = _build_auth(section)
+    name = str(section.get("name") or "jenkins").strip() or "jenkins"
+    return [{"name": name, "base_url": base_url, "rest_path": str(section.get("rest_path") or ""), "auth": auth}]
 
 
 def _profile_instance_base_url(raw: dict[str, Any]) -> str:

--- a/src/external_cli/profile_config.py
+++ b/src/external_cli/profile_config.py
@@ -58,7 +58,8 @@ def apply_runtime_profile_external_config(
     metadata: dict[str, Any] = {"version": _METADATA_VERSION, "managed_by": _MANAGED_BY}
 
     # NOTE: jira/confluence are intentionally NOT projected through CLI writes
-    # anymore; those CLIs read the EFP_CONFIG_JSON env blob exported at boot.
+    # anymore; those CLIs read the bare-name tools config env vars exported at
+    # boot (see flatten_config_to_env).
     try:
         _apply_github(profile_config, metadata=metadata, cli_environment=cli_environment)
         _apply_aws(profile_config, metadata=metadata, cli_environment=cli_environment)
@@ -102,13 +103,16 @@ def redact_runtime_profile_external_config_error(
 
 
 def build_tools_config_json(effective_config: dict[str, Any]) -> dict[str, Any]:
-    """Build the EFP_CONFIG_JSON payload for the Go CLI tools.
+    """Build the tools config payload (RootConfig-shaped dict) for the Go CLIs.
 
     The shape matches ``RootConfig`` in engineering-flow-platform-tools
     (internal/config/config.go): top-level keys version/jira/confluence/
     jenkins/aws/visual/mobile-auto. Jira/Confluence sections are transformed
     from the profile shape into the tools instances shape; the other sections
     are taken from the effective config verbatim. Empty sections are omitted.
+
+    The returned dict is flattened by :func:`flatten_config_to_env` into the
+    bare-name indexed env vars the Go CLIs consume.
     """
     root: dict[str, Any] = {}
     if not isinstance(effective_config, dict):
@@ -134,6 +138,49 @@ def build_tools_config_json(effective_config: dict[str, Any]) -> dict[str, Any]:
             root[section_name] = json.loads(json.dumps(section))
 
     return root
+
+
+def flatten_config_to_env(root: dict[str, Any]) -> dict[str, str]:
+    """Flatten a RootConfig-shaped dict into bare-name indexed env vars.
+
+    Produces the deterministic naming convention consumed by the Go CLIs: each
+    scalar leaf becomes an UPPERCASED, "_"-joined path from the root, with "-"
+    replaced by "_" and list elements indexed by their 0-based position. For
+    example ``{"jira": {"instances": [{"base_url": "x"}]}}`` yields
+    ``{"JIRA_INSTANCES_0_BASE_URL": "x"}``.
+
+    Scalar encoding: bool -> "true"/"false"; int -> decimal string; str ->
+    verbatim. ``None`` and empty strings are omitted entirely (no key emitted),
+    matching the "only present values are emitted" contract on the Go side.
+    """
+    out: dict[str, str] = {}
+    _flatten_into(root, (), out)
+    return out
+
+
+def _flatten_into(value: Any, path: tuple[str, ...], out: dict[str, str]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            segment = str(key).upper().replace("-", "_")
+            _flatten_into(child, path + (segment,), out)
+        return
+    if isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            _flatten_into(child, path + (str(index),), out)
+        return
+    if value is None:
+        return
+    if isinstance(value, bool):
+        rendered = "true" if value else "false"
+    elif isinstance(value, int):
+        rendered = str(value)
+    else:
+        rendered = str(value)
+        if rendered == "":
+            return
+    if not path:
+        return
+    out["_".join(path)] = rendered
 
 
 def _tools_instance_config(instance: dict[str, Any], *, product: str) -> dict[str, Any]:

--- a/tests/test_p3_docs_contract.py
+++ b/tests/test_p3_docs_contract.py
@@ -32,7 +32,7 @@ def test_runtime_contract_doc_mentions_current_native_contract_surfaces():
         "EFP_PROFILE_CONFIG",
         "EFP_PROFILE_REVISION",
         "EFP_PROFILE_ID",
-        "JIRA_INSTANCES_0_BASE_URL",
+        "EFP_JIRA_INSTANCES_0_BASE_URL",
         "EFP_SKILLS_DIR",
         "/app/skills",
         "/workspace",

--- a/tests/test_p3_docs_contract.py
+++ b/tests/test_p3_docs_contract.py
@@ -32,7 +32,7 @@ def test_runtime_contract_doc_mentions_current_native_contract_surfaces():
         "EFP_PROFILE_CONFIG",
         "EFP_PROFILE_REVISION",
         "EFP_PROFILE_ID",
-        "EFP_CONFIG_JSON",
+        "JIRA_INSTANCES_0_BASE_URL",
         "EFP_SKILLS_DIR",
         "/app/skills",
         "/workspace",

--- a/tests/test_profile_boot.py
+++ b/tests/test_profile_boot.py
@@ -63,6 +63,9 @@ def test_bootstrap_exports_tools_config_env_vars_scrubs_env_and_applies_env_sect
         "EFP_JENKINS_PASSWORD",
         "JENKINS_USERNAME",
         "JENKINS_PASSWORD",
+        "EFP_JENKINS_DEFAULT_INSTANCE",
+        "EFP_JENKINS_INSTANCES_0_BASE_URL",
+        "EFP_JENKINS_INSTANCES_0_AUTH_PASSWORD",
         "EFP_CONFIG_JSON",
         "EFP_JIRA_DEFAULT_INSTANCE",
         "EFP_JIRA_INSTANCES_0_BASE_URL",
@@ -97,7 +100,12 @@ def test_bootstrap_exports_tools_config_env_vars_scrubs_env_and_applies_env_sect
                     }
                 ],
             },
-            "jenkins": {"enabled": True, "username": "jenkins-user", "password": "jenkins-password"},
+            "jenkins": {
+                "enabled": True,
+                "url": "https://jenkins.example.test",
+                "username": "jenkins-user",
+                "password": "jenkins-password",
+            },
             "github": {"enabled": True, "access_token": "gh-token"},
         },
     )
@@ -124,7 +132,16 @@ def test_bootstrap_exports_tools_config_env_vars_scrubs_env_and_applies_env_sect
     assert os.environ["EFP_JIRA_INSTANCES_0_AUTH_TYPE"] == "basic_api_key"
     assert os.environ["EFP_JIRA_INSTANCES_0_AUTH_USERNAME"] == "bot"
     assert os.environ["EFP_JIRA_INSTANCES_0_AUTH_API_KEY"] == "jira-token"
-    assert os.environ["EFP_JENKINS_ENABLED"] == "true"
+    # Jenkins is projected as a single tools instance via the flatten convention;
+    # the old verbatim EFP_JENKINS_ENABLED is no longer emitted.
+    assert "EFP_JENKINS_ENABLED" not in os.environ
+    assert os.environ["EFP_JENKINS_DEFAULT_INSTANCE"] == "jenkins"
+    assert os.environ["EFP_JENKINS_INSTANCES_0_NAME"] == "jenkins"
+    assert os.environ["EFP_JENKINS_INSTANCES_0_BASE_URL"] == "https://jenkins.example.test"
+    assert os.environ["EFP_JENKINS_INSTANCES_0_AUTH_TYPE"] == "basic_password"
+    assert os.environ["EFP_JENKINS_INSTANCES_0_AUTH_USERNAME"] == "jenkins-user"
+    assert os.environ["EFP_JENKINS_INSTANCES_0_AUTH_PASSWORD"] == "jenkins-password"
+    # The agent-facing JENKINS_* creds come from apply_jenkins_env, unchanged.
     assert os.environ["JENKINS_USERNAME"] == "jenkins-user"
     assert os.environ["JENKINS_PASSWORD"] == "jenkins-password"
 

--- a/tests/test_profile_boot.py
+++ b/tests/test_profile_boot.py
@@ -64,9 +64,9 @@ def test_bootstrap_exports_tools_config_env_vars_scrubs_env_and_applies_env_sect
         "JENKINS_USERNAME",
         "JENKINS_PASSWORD",
         "EFP_CONFIG_JSON",
-        "JIRA_DEFAULT_INSTANCE",
-        "JIRA_INSTANCES_0_BASE_URL",
-        "JIRA_INSTANCES_0_AUTH_API_KEY",
+        "EFP_JIRA_DEFAULT_INSTANCE",
+        "EFP_JIRA_INSTANCES_0_BASE_URL",
+        "EFP_JIRA_INSTANCES_0_AUTH_API_KEY",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -115,16 +115,16 @@ def test_bootstrap_exports_tools_config_env_vars_scrubs_env_and_applies_env_sect
     # The full profile blob is scrubbed before any child process can spawn.
     assert "EFP_PROFILE_CONFIG" not in os.environ
 
-    # The bare-name, indexed tools config env vars carry the RootConfig subset.
-    assert os.environ["JIRA_DEFAULT_INSTANCE"] == "jira-main"
-    assert os.environ["JIRA_INSTANCES_0_NAME"] == "jira-main"
-    assert os.environ["JIRA_INSTANCES_0_BASE_URL"] == "https://jira.example.test"
-    assert os.environ["JIRA_INSTANCES_0_REST_PATH"] == "/rest/api/3"
-    assert os.environ["JIRA_INSTANCES_0_API_VERSION"] == "3"
-    assert os.environ["JIRA_INSTANCES_0_AUTH_TYPE"] == "basic_api_key"
-    assert os.environ["JIRA_INSTANCES_0_AUTH_USERNAME"] == "bot"
-    assert os.environ["JIRA_INSTANCES_0_AUTH_API_KEY"] == "jira-token"
-    assert os.environ["JENKINS_ENABLED"] == "true"
+    # The EFP_-prefixed, indexed tools config env vars carry the RootConfig subset.
+    assert os.environ["EFP_JIRA_DEFAULT_INSTANCE"] == "jira-main"
+    assert os.environ["EFP_JIRA_INSTANCES_0_NAME"] == "jira-main"
+    assert os.environ["EFP_JIRA_INSTANCES_0_BASE_URL"] == "https://jira.example.test"
+    assert os.environ["EFP_JIRA_INSTANCES_0_REST_PATH"] == "/rest/api/3"
+    assert os.environ["EFP_JIRA_INSTANCES_0_API_VERSION"] == "3"
+    assert os.environ["EFP_JIRA_INSTANCES_0_AUTH_TYPE"] == "basic_api_key"
+    assert os.environ["EFP_JIRA_INSTANCES_0_AUTH_USERNAME"] == "bot"
+    assert os.environ["EFP_JIRA_INSTANCES_0_AUTH_API_KEY"] == "jira-token"
+    assert os.environ["EFP_JENKINS_ENABLED"] == "true"
     assert os.environ["JENKINS_USERNAME"] == "jenkins-user"
     assert os.environ["JENKINS_PASSWORD"] == "jenkins-password"
 
@@ -144,7 +144,7 @@ def test_bootstrap_exports_tools_config_env_vars_scrubs_env_and_applies_env_sect
 
 
 def test_bootstrap_dev_mode_without_profile_env(tmp_path, monkeypatch, boot_state_reset):
-    for key in ("EFP_CONFIG_JSON", "JIRA_INSTANCES_0_BASE_URL", "AWS_DOMAIN"):
+    for key in ("EFP_CONFIG_JSON", "EFP_JIRA_INSTANCES_0_BASE_URL", "EFP_AWS_DOMAIN"):
         monkeypatch.delenv(key, raising=False)
 
     def _fail_apply(*_args, **_kwargs):
@@ -158,7 +158,7 @@ def test_bootstrap_dev_mode_without_profile_env(tmp_path, monkeypatch, boot_stat
 
     assert config_module.bootstrap_profile_boot() is True
     assert "EFP_CONFIG_JSON" not in os.environ
-    assert "JIRA_INSTANCES_0_BASE_URL" not in os.environ
+    assert "EFP_JIRA_INSTANCES_0_BASE_URL" not in os.environ
     assert config_module.get_profile_boot_state() == {
         "completed": True,
         "ready": True,
@@ -167,7 +167,7 @@ def test_bootstrap_dev_mode_without_profile_env(tmp_path, monkeypatch, boot_stat
 
 
 def test_bootstrap_empty_profile_config_is_ready(tmp_path, monkeypatch, boot_state_reset):
-    for key in ("EFP_CONFIG_JSON", "JIRA_INSTANCES_0_BASE_URL", "AWS_DOMAIN"):
+    for key in ("EFP_CONFIG_JSON", "EFP_JIRA_INSTANCES_0_BASE_URL", "EFP_AWS_DOMAIN"):
         monkeypatch.delenv(key, raising=False)
     applied = []
     monkeypatch.setattr(
@@ -182,8 +182,8 @@ def test_bootstrap_empty_profile_config_is_ready(tmp_path, monkeypatch, boot_sta
     assert applied == [{}]
     # An empty profile flattens to zero tools config env vars (not env-managed).
     assert "EFP_CONFIG_JSON" not in os.environ
-    assert "JIRA_INSTANCES_0_BASE_URL" not in os.environ
-    assert "AWS_DOMAIN" not in os.environ
+    assert "EFP_JIRA_INSTANCES_0_BASE_URL" not in os.environ
+    assert "EFP_AWS_DOMAIN" not in os.environ
     assert config_module.get_profile_boot_state()["ready"] is True
 
 

--- a/tests/test_profile_boot.py
+++ b/tests/test_profile_boot.py
@@ -55,12 +55,20 @@ def _install_config(tmp_path, monkeypatch, overlay_config, **payload_kwargs):
     return cfg
 
 
-def test_bootstrap_exports_efp_config_json_scrubs_env_and_applies_env_sections(
+def test_bootstrap_exports_tools_config_env_vars_scrubs_env_and_applies_env_sections(
     tmp_path, monkeypatch, boot_state_reset
 ):
-    for key in ("EFP_JENKINS_USERNAME", "EFP_JENKINS_PASSWORD", "JENKINS_USERNAME", "JENKINS_PASSWORD"):
+    for key in (
+        "EFP_JENKINS_USERNAME",
+        "EFP_JENKINS_PASSWORD",
+        "JENKINS_USERNAME",
+        "JENKINS_PASSWORD",
+        "EFP_CONFIG_JSON",
+        "JIRA_DEFAULT_INSTANCE",
+        "JIRA_INSTANCES_0_BASE_URL",
+        "JIRA_INSTANCES_0_AUTH_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
-    monkeypatch.setenv("EFP_CONFIG_JSON", "")
 
     applied = []
 
@@ -107,23 +115,24 @@ def test_bootstrap_exports_efp_config_json_scrubs_env_and_applies_env_sections(
     # The full profile blob is scrubbed before any child process can spawn.
     assert "EFP_PROFILE_CONFIG" not in os.environ
 
-    # EFP_CONFIG_JSON carries the tools RootConfig-shaped subset.
-    tools_config = json.loads(os.environ["EFP_CONFIG_JSON"])
-    assert tools_config["jira"]["instances"] == [
-        {
-            "name": "jira-main",
-            "base_url": "https://jira.example.test",
-            "rest_path": "/rest/api/3",
-            "api_version": "3",
-            "auth": {"type": "basic_api_key", "username": "bot", "api_key": "jira-token"},
-        }
-    ]
-    assert tools_config["jenkins"] == {
-        "enabled": True,
-        "username": "jenkins-user",
-        "password": "jenkins-password",
-    }
-    assert "github" not in tools_config
+    # The bare-name, indexed tools config env vars carry the RootConfig subset.
+    assert os.environ["JIRA_DEFAULT_INSTANCE"] == "jira-main"
+    assert os.environ["JIRA_INSTANCES_0_NAME"] == "jira-main"
+    assert os.environ["JIRA_INSTANCES_0_BASE_URL"] == "https://jira.example.test"
+    assert os.environ["JIRA_INSTANCES_0_REST_PATH"] == "/rest/api/3"
+    assert os.environ["JIRA_INSTANCES_0_API_VERSION"] == "3"
+    assert os.environ["JIRA_INSTANCES_0_AUTH_TYPE"] == "basic_api_key"
+    assert os.environ["JIRA_INSTANCES_0_AUTH_USERNAME"] == "bot"
+    assert os.environ["JIRA_INSTANCES_0_AUTH_API_KEY"] == "jira-token"
+    assert os.environ["JENKINS_ENABLED"] == "true"
+    assert os.environ["JENKINS_USERNAME"] == "jenkins-user"
+    assert os.environ["JENKINS_PASSWORD"] == "jenkins-password"
+
+    # github is projected via real CLIs, never through the tools config env vars.
+    assert not any(key.startswith("GITHUB_") for key in os.environ)
+
+    # The legacy single-blob env var is no longer exported.
+    assert "EFP_CONFIG_JSON" not in os.environ
 
     # apply_jenkins_env ran exactly once at boot.
     assert os.environ["EFP_JENKINS_USERNAME"] == "jenkins-user"
@@ -135,7 +144,8 @@ def test_bootstrap_exports_efp_config_json_scrubs_env_and_applies_env_sections(
 
 
 def test_bootstrap_dev_mode_without_profile_env(tmp_path, monkeypatch, boot_state_reset):
-    monkeypatch.delenv("EFP_CONFIG_JSON", raising=False)
+    for key in ("EFP_CONFIG_JSON", "JIRA_INSTANCES_0_BASE_URL", "AWS_DOMAIN"):
+        monkeypatch.delenv(key, raising=False)
 
     def _fail_apply(*_args, **_kwargs):
         raise AssertionError("external CLI projection must not run in dev mode")
@@ -148,6 +158,7 @@ def test_bootstrap_dev_mode_without_profile_env(tmp_path, monkeypatch, boot_stat
 
     assert config_module.bootstrap_profile_boot() is True
     assert "EFP_CONFIG_JSON" not in os.environ
+    assert "JIRA_INSTANCES_0_BASE_URL" not in os.environ
     assert config_module.get_profile_boot_state() == {
         "completed": True,
         "ready": True,
@@ -156,7 +167,8 @@ def test_bootstrap_dev_mode_without_profile_env(tmp_path, monkeypatch, boot_stat
 
 
 def test_bootstrap_empty_profile_config_is_ready(tmp_path, monkeypatch, boot_state_reset):
-    monkeypatch.setenv("EFP_CONFIG_JSON", "")
+    for key in ("EFP_CONFIG_JSON", "JIRA_INSTANCES_0_BASE_URL", "AWS_DOMAIN"):
+        monkeypatch.delenv(key, raising=False)
     applied = []
     monkeypatch.setattr(
         profile_config_module,
@@ -168,15 +180,16 @@ def test_bootstrap_empty_profile_config_is_ready(tmp_path, monkeypatch, boot_sta
 
     assert config_module.bootstrap_profile_boot() is True
     assert applied == [{}]
-    assert json.loads(os.environ["EFP_CONFIG_JSON"]) == {}
+    # An empty profile flattens to zero tools config env vars (not env-managed).
+    assert "EFP_CONFIG_JSON" not in os.environ
+    assert "JIRA_INSTANCES_0_BASE_URL" not in os.environ
+    assert "AWS_DOMAIN" not in os.environ
     assert config_module.get_profile_boot_state()["ready"] is True
 
 
 def test_bootstrap_projection_failure_keeps_process_alive_but_unready(
     tmp_path, monkeypatch, boot_state_reset
 ):
-    monkeypatch.setenv("EFP_CONFIG_JSON", "")
-
     def _fail_apply(_overlay, **_kwargs):
         raise RuntimeError("External CLI command failed: gh auth login with gh-token")
 
@@ -210,7 +223,6 @@ def test_bootstrap_invalid_profile_payload_is_unready(tmp_path, monkeypatch, boo
     config_path = tmp_path / "config.yaml"
     _write_base_config(config_path)
     monkeypatch.setenv("EFP_PROFILE_CONFIG", "{not json")
-    monkeypatch.setenv("EFP_CONFIG_JSON", "")
     cfg = Config(str(config_path))
     monkeypatch.setattr(config_module, "config", cfg)
 
@@ -235,7 +247,6 @@ async def _ready_response():
 
 @pytest.mark.asyncio
 async def test_ready_endpoint_gates_on_boot_projection(tmp_path, monkeypatch, boot_state_reset):
-    monkeypatch.setenv("EFP_CONFIG_JSON", "")
     monkeypatch.setattr(
         profile_config_module,
         "apply_runtime_profile_external_config",
@@ -274,8 +285,6 @@ async def test_ready_endpoint_dev_mode_reports_null_profile(tmp_path, monkeypatc
 
 @pytest.mark.asyncio
 async def test_ready_endpoint_reports_projection_failure(tmp_path, monkeypatch, boot_state_reset):
-    monkeypatch.setenv("EFP_CONFIG_JSON", "")
-
     def _fail_apply(_overlay, **_kwargs):
         raise RuntimeError("External CLI command failed: aws-auth login")
 

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -622,7 +622,7 @@ def test_external_config_apply_skips_atlassian_and_jenkins_clis(tmp_path, monkey
         }
     )
 
-    # Jira/Confluence/Jenkins reach CLIs via EFP_CONFIG_JSON only, never CLI writes.
+    # Jira/Confluence/Jenkins reach CLIs via bare-name tools config env vars only, never CLI writes.
     assert _command_calls(recorder, ["jira"]) == []
     assert _command_calls(recorder, ["confluence"]) == []
     assert _command_calls(recorder, ["jenkins"]) == []
@@ -1194,7 +1194,7 @@ def test_runtime_profile_external_cli_failure_redacts_profile_proxy_secrets(tmp_
 
 
 # ---------------------------------------------------------------------------
-# EFP_CONFIG_JSON builder (tools RootConfig shape)
+# Tools config builder (RootConfig shape) + env-var flattener
 # ---------------------------------------------------------------------------
 
 
@@ -1302,3 +1302,75 @@ def test_build_tools_config_json_omits_empty_and_disabled_sections():
         }
     )
     assert root == {}
+
+
+def test_flatten_config_to_env_produces_bare_name_indexed_vars():
+    root = {
+        "version": 1,
+        "jira": {
+            "default_instance": "jira-main",
+            "instances": [
+                {
+                    "name": "jira-main",
+                    "base_url": "https://jira.example.test",
+                    "rest_path": "/rest/api/3",
+                    "api_version": "3",
+                    "auth": {"type": "basic_api_key", "username": "bot", "api_key": "jira-token"},
+                },
+                {
+                    "name": "jira-2",
+                    "base_url": "https://jira2.example.test",
+                    "rest_path": "/rest/api/2",
+                    "api_version": "2",
+                    "auth": {"type": "bearer_token", "token": "jira2-token"},
+                },
+            ],
+        },
+        "aws": {"enabled": True, "domain": "HBEU", "username": "aws-user", "password": ""},
+        "mobile-auto": {
+            "browserstack": {
+                "username": "bs-user",
+                "no_proxy_hosts": ["host-a", "host-b"],
+            },
+        },
+    }
+
+    env = profile_config_module.flatten_config_to_env(root)
+
+    assert env == {
+        "VERSION": "1",
+        "JIRA_DEFAULT_INSTANCE": "jira-main",
+        "JIRA_INSTANCES_0_NAME": "jira-main",
+        "JIRA_INSTANCES_0_BASE_URL": "https://jira.example.test",
+        "JIRA_INSTANCES_0_REST_PATH": "/rest/api/3",
+        "JIRA_INSTANCES_0_API_VERSION": "3",
+        "JIRA_INSTANCES_0_AUTH_TYPE": "basic_api_key",
+        "JIRA_INSTANCES_0_AUTH_USERNAME": "bot",
+        "JIRA_INSTANCES_0_AUTH_API_KEY": "jira-token",
+        "JIRA_INSTANCES_1_NAME": "jira-2",
+        "JIRA_INSTANCES_1_BASE_URL": "https://jira2.example.test",
+        "JIRA_INSTANCES_1_REST_PATH": "/rest/api/2",
+        "JIRA_INSTANCES_1_API_VERSION": "2",
+        "JIRA_INSTANCES_1_AUTH_TYPE": "bearer_token",
+        "JIRA_INSTANCES_1_AUTH_TOKEN": "jira2-token",
+        # bool renders lowercase; the empty-string "password" is omitted.
+        "AWS_ENABLED": "true",
+        "AWS_DOMAIN": "HBEU",
+        "AWS_USERNAME": "aws-user",
+        # "mobile-auto" -> MOBILE_AUTO; []string elements indexed by position.
+        "MOBILE_AUTO_BROWSERSTACK_USERNAME": "bs-user",
+        "MOBILE_AUTO_BROWSERSTACK_NO_PROXY_HOSTS_0": "host-a",
+        "MOBILE_AUTO_BROWSERSTACK_NO_PROXY_HOSTS_1": "host-b",
+    }
+
+    # Empty/absent scalars emit no key at all.
+    assert "AWS_PASSWORD" not in env
+
+
+def test_flatten_config_to_env_omits_empty_and_none_and_renders_bool_false():
+    root = {
+        "aws": {"enabled": False, "domain": "D", "username": None, "password": ""},
+        "empty": {},
+    }
+    env = profile_config_module.flatten_config_to_env(root)
+    assert env == {"AWS_ENABLED": "false", "AWS_DOMAIN": "D"}

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -622,7 +622,7 @@ def test_external_config_apply_skips_atlassian_and_jenkins_clis(tmp_path, monkey
         }
     )
 
-    # Jira/Confluence/Jenkins reach CLIs via bare-name tools config env vars only, never CLI writes.
+    # Jira/Confluence/Jenkins reach CLIs via EFP_-prefixed tools config env vars only, never CLI writes.
     assert _command_calls(recorder, ["jira"]) == []
     assert _command_calls(recorder, ["confluence"]) == []
     assert _command_calls(recorder, ["jenkins"]) == []
@@ -1304,7 +1304,7 @@ def test_build_tools_config_json_omits_empty_and_disabled_sections():
     assert root == {}
 
 
-def test_flatten_config_to_env_produces_bare_name_indexed_vars():
+def test_flatten_config_to_env_produces_efp_prefixed_indexed_vars():
     root = {
         "version": 1,
         "jira": {
@@ -1338,33 +1338,33 @@ def test_flatten_config_to_env_produces_bare_name_indexed_vars():
     env = profile_config_module.flatten_config_to_env(root)
 
     assert env == {
-        "VERSION": "1",
-        "JIRA_DEFAULT_INSTANCE": "jira-main",
-        "JIRA_INSTANCES_0_NAME": "jira-main",
-        "JIRA_INSTANCES_0_BASE_URL": "https://jira.example.test",
-        "JIRA_INSTANCES_0_REST_PATH": "/rest/api/3",
-        "JIRA_INSTANCES_0_API_VERSION": "3",
-        "JIRA_INSTANCES_0_AUTH_TYPE": "basic_api_key",
-        "JIRA_INSTANCES_0_AUTH_USERNAME": "bot",
-        "JIRA_INSTANCES_0_AUTH_API_KEY": "jira-token",
-        "JIRA_INSTANCES_1_NAME": "jira-2",
-        "JIRA_INSTANCES_1_BASE_URL": "https://jira2.example.test",
-        "JIRA_INSTANCES_1_REST_PATH": "/rest/api/2",
-        "JIRA_INSTANCES_1_API_VERSION": "2",
-        "JIRA_INSTANCES_1_AUTH_TYPE": "bearer_token",
-        "JIRA_INSTANCES_1_AUTH_TOKEN": "jira2-token",
+        "EFP_VERSION": "1",
+        "EFP_JIRA_DEFAULT_INSTANCE": "jira-main",
+        "EFP_JIRA_INSTANCES_0_NAME": "jira-main",
+        "EFP_JIRA_INSTANCES_0_BASE_URL": "https://jira.example.test",
+        "EFP_JIRA_INSTANCES_0_REST_PATH": "/rest/api/3",
+        "EFP_JIRA_INSTANCES_0_API_VERSION": "3",
+        "EFP_JIRA_INSTANCES_0_AUTH_TYPE": "basic_api_key",
+        "EFP_JIRA_INSTANCES_0_AUTH_USERNAME": "bot",
+        "EFP_JIRA_INSTANCES_0_AUTH_API_KEY": "jira-token",
+        "EFP_JIRA_INSTANCES_1_NAME": "jira-2",
+        "EFP_JIRA_INSTANCES_1_BASE_URL": "https://jira2.example.test",
+        "EFP_JIRA_INSTANCES_1_REST_PATH": "/rest/api/2",
+        "EFP_JIRA_INSTANCES_1_API_VERSION": "2",
+        "EFP_JIRA_INSTANCES_1_AUTH_TYPE": "bearer_token",
+        "EFP_JIRA_INSTANCES_1_AUTH_TOKEN": "jira2-token",
         # bool renders lowercase; the empty-string "password" is omitted.
-        "AWS_ENABLED": "true",
-        "AWS_DOMAIN": "HBEU",
-        "AWS_USERNAME": "aws-user",
+        "EFP_AWS_ENABLED": "true",
+        "EFP_AWS_DOMAIN": "HBEU",
+        "EFP_AWS_USERNAME": "aws-user",
         # "mobile-auto" -> MOBILE_AUTO; []string elements indexed by position.
-        "MOBILE_AUTO_BROWSERSTACK_USERNAME": "bs-user",
-        "MOBILE_AUTO_BROWSERSTACK_NO_PROXY_HOSTS_0": "host-a",
-        "MOBILE_AUTO_BROWSERSTACK_NO_PROXY_HOSTS_1": "host-b",
+        "EFP_MOBILE_AUTO_BROWSERSTACK_USERNAME": "bs-user",
+        "EFP_MOBILE_AUTO_BROWSERSTACK_NO_PROXY_HOSTS_0": "host-a",
+        "EFP_MOBILE_AUTO_BROWSERSTACK_NO_PROXY_HOSTS_1": "host-b",
     }
 
     # Empty/absent scalars emit no key at all.
-    assert "AWS_PASSWORD" not in env
+    assert "EFP_AWS_PASSWORD" not in env
 
 
 def test_flatten_config_to_env_omits_empty_and_none_and_renders_bool_false():
@@ -1373,4 +1373,4 @@ def test_flatten_config_to_env_omits_empty_and_none_and_renders_bool_false():
         "empty": {},
     }
     env = profile_config_module.flatten_config_to_env(root)
-    assert env == {"AWS_ENABLED": "false", "AWS_DOMAIN": "D"}
+    assert env == {"EFP_AWS_ENABLED": "false", "EFP_AWS_DOMAIN": "D"}

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -1232,7 +1232,12 @@ def test_build_tools_config_json_transforms_atlassian_and_copies_verbatim_sectio
                 },
             ],
         },
-        "jenkins": {"enabled": True, "username": "jenkins-user", "password": "jenkins-password"},
+        "jenkins": {
+            "enabled": True,
+            "url": "https://jenkins.example.test",
+            "username": "jenkins-user",
+            "password": "jenkins-password",
+        },
         "aws": {"enabled": True, "domain": "HBEU", "username": "aws-user", "password": "aws-password"},
         "mobile-auto": {
             "enabled": True,
@@ -1283,8 +1288,23 @@ def test_build_tools_config_json_transforms_atlassian_and_copies_verbatim_sectio
         },
     ]
 
+    # Jenkins is projected as a single tools instance (not copied verbatim).
+    assert root["jenkins"] == {
+        "default_instance": "jenkins",
+        "instances": [
+            {
+                "name": "jenkins",
+                "base_url": "https://jenkins.example.test",
+                "rest_path": "",
+                "auth": {
+                    "type": "basic_password",
+                    "username": "jenkins-user",
+                    "password": "jenkins-password",
+                },
+            }
+        ],
+    }
     # Verbatim sections.
-    assert root["jenkins"] == {"enabled": True, "username": "jenkins-user", "password": "jenkins-password"}
     assert root["aws"] == {"enabled": True, "domain": "HBEU", "username": "aws-user", "password": "aws-password"}
     assert root["mobile-auto"]["browserstack"]["access_key"] == "bs-key"
 
@@ -1302,6 +1322,83 @@ def test_build_tools_config_json_omits_empty_and_disabled_sections():
         }
     )
     assert root == {}
+
+
+def test_build_tools_config_json_projects_jenkins_as_single_instance():
+    root = profile_config_module.build_tools_config_json(
+        {
+            "jenkins": {
+                "enabled": True,
+                "url": "https://jenkins.example.test/",
+                "username": "jenkins-user",
+                "password": "jenkins-password",
+            },
+        }
+    )
+    assert root == {
+        "jenkins": {
+            "default_instance": "jenkins",
+            "instances": [
+                {
+                    "name": "jenkins",
+                    "base_url": "https://jenkins.example.test",
+                    "rest_path": "",
+                    "auth": {
+                        "type": "basic_password",
+                        "username": "jenkins-user",
+                        "password": "jenkins-password",
+                    },
+                }
+            ],
+        }
+    }
+
+
+def test_build_tools_config_json_jenkins_bearer_token_instance():
+    root = profile_config_module.build_tools_config_json(
+        {"jenkins": {"enabled": True, "url": "https://ci.example.test", "token": "ci-token"}}
+    )
+    assert root["jenkins"]["instances"][0]["auth"] == {
+        "type": "bearer_token",
+        "token": "ci-token",
+    }
+
+
+def test_build_tools_config_json_drops_jenkins_without_url():
+    assert profile_config_module.build_tools_config_json(
+        {"jenkins": {"enabled": True, "username": "u", "password": "p"}}
+    ) == {}
+
+
+def test_build_tools_config_json_drops_disabled_jenkins():
+    assert profile_config_module.build_tools_config_json(
+        {"jenkins": {"enabled": False, "url": "https://jenkins.example.test"}}
+    ) == {}
+
+
+def test_flatten_config_to_env_produces_jenkins_instance_vars():
+    root = profile_config_module.build_tools_config_json(
+        {
+            "jenkins": {
+                "enabled": True,
+                "url": "https://jenkins.example.test",
+                "username": "jenkins-user",
+                "password": "jenkins-password",
+            },
+        }
+    )
+    env = profile_config_module.flatten_config_to_env(root)
+    assert env == {
+        "EFP_JENKINS_DEFAULT_INSTANCE": "jenkins",
+        "EFP_JENKINS_INSTANCES_0_NAME": "jenkins",
+        "EFP_JENKINS_INSTANCES_0_BASE_URL": "https://jenkins.example.test",
+        "EFP_JENKINS_INSTANCES_0_AUTH_TYPE": "basic_password",
+        "EFP_JENKINS_INSTANCES_0_AUTH_USERNAME": "jenkins-user",
+        "EFP_JENKINS_INSTANCES_0_AUTH_PASSWORD": "jenkins-password",
+    }
+    # Empty rest_path emits no key; the old verbatim EFP_JENKINS_ENABLED is gone.
+    assert "EFP_JENKINS_INSTANCES_0_REST_PATH" not in env
+    assert "EFP_JENKINS_ENABLED" not in env
 
 
 def test_flatten_config_to_env_produces_efp_prefixed_indexed_vars():


### PR DESCRIPTION
## 概述

native runtime 启动时不再把工具配置导出成单个 `EFP_CONFIG_JSON` blob,改为导出**裸名、按约定映射的扁平环境变量**,由 Go CLI 侧的通用解码器读取。

## 改动

- `src/external_cli/profile_config.py` 新增 `flatten_config_to_env(root)`:把 `build_tools_config_json`(不变)产出的 `RootConfig` 形状 dict 递归扁平化成约定键——大写、`_` 连接的 json-tag 路径,`-`→`_`,列表元素按位置索引,bool→`true`/`false`,空值省略。
- `bootstrap_profile_boot()`(`src/config.py`)把原来的 `os.environ["EFP_CONFIG_JSON"] = json.dumps(...)` 换成逐个导出扁平变量;其余启动步骤(proxy/jenkins/mobile env、`EFP_PROFILE_CONFIG` scrub)不变。
- 更新 config.py / profile_config.py / main.py 注释、README、docs/runtime_contract.md 及 doc-needle 契约测试。

映射示例:`jira.instances[0].auth.token → JIRA_INSTANCES_0_AUTH_TOKEN`、`aws.domain → AWS_DOMAIN`、`mobile-auto.browserstack.username → MOBILE_AUTO_BROWSERSTACK_USERNAME`。

## 测试

`pytest tests/test_profile_boot.py tests/test_config.py tests/test_runtime_profile_overlay.py tests/test_p3_docs_contract.py` → profile-boot / flatten / overlay / docs 全过(4 个失败是 test_config.py 里既有的 Windows tempfile 权限问题,HEAD 上同样失败)。新增 `flatten_config_to_env` 单测(嵌套 dict、双元素 instances 列表、`[]string` 索引、bool、空省略)。

**跨仓库端到端验证**:本分支用双实例 jira profile 实际导出的裸名变量,喂给真实构建的 Go `jira instance list` CLI,正确解出两个实例。

## ⚠️ 配套 PR(必须一起合并部署)

- tools(读裸名 env 约定):dvnuo/engineering-flow-platform-tools#(见评论)
- **本 PR**(native runtime:导出裸名变量)

两者 env 约定必须一致(已端到端验证)。opencode runtime 不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
