### PR TITLE
Pin HOME=/root in the native image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
+    HOME=/root \
     VIRTUAL_ENV=/opt/venv
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
合并后审计的收尾修复(native 镜像侧)。

native 镜像以 root 跑但**没设 HOME**,`$HOME` 派生的凭证/配置写入(gh/aws/git/`~/.config/efp`)依赖容器运行时默认值。显式 `ENV HOME=/root`(portal 也在 pod spec 给 native 注入,见 dvnuo/engineering-flow-platform-portal#412)。

## 配套
portal dvnuo/engineering-flow-platform-portal#412 · opencode dvnuo/engineering-flow-platform-opencode-runtime#112

🤖 Generated with [Claude Code](https://claude.com/claude-code)