### PR TITLE
Trim GitHub Copilot models to 5.4/5.5/5.6; default gpt-5.6-terra

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -24,25 +24,13 @@ llm:
   # If EFP_GITHUB_COPILOT_TOKEN/GITHUB_COPILOT_TOKEN is already a Copilot token,
   # EFP uses it directly.
   api_key: "ghp_YOUR_GITHUB_TOKEN"
-  model: "gpt-5.4"
+  model: "gpt-5.6-terra"
   reasoning_effort: "high"
   
   max_tokens: 128000
   allow_lower_max_tokens_than_model_limit: false
   model_limits:
-    gpt-5-mini:
-      max_context_window_tokens: 264000
-      max_prompt_tokens: 128000
-      max_output_tokens: 64000
-    gpt-5.3-codex:
-      max_context_window_tokens: 400000
-      max_prompt_tokens: 272000
-      max_output_tokens: 128000
     gpt-5.4:
-      max_context_window_tokens: 400000
-      max_prompt_tokens: 272000
-      max_output_tokens: 128000
-    gpt-5.4-mini:
       max_context_window_tokens: 400000
       max_prompt_tokens: 272000
       max_output_tokens: 128000
@@ -50,14 +38,18 @@ llm:
       max_context_window_tokens: 400000
       max_prompt_tokens: 272000
       max_output_tokens: 128000
-    gemini-2.5-pro:
-      max_context_window_tokens: 128000
-      max_prompt_tokens: 128000
-      max_output_tokens: 64000
-    gemini-3.5-flash:
-      max_context_window_tokens: 128000
-      max_prompt_tokens: 128000
-      max_output_tokens: 64000
+    gpt-5.6-luna:
+      max_context_window_tokens: 328000
+      max_prompt_tokens: 200000
+      max_output_tokens: 128000
+    gpt-5.6-sol:
+      max_context_window_tokens: 400000
+      max_prompt_tokens: 272000
+      max_output_tokens: 128000
+    gpt-5.6-terra:
+      max_context_window_tokens: 400000
+      max_prompt_tokens: 272000
+      max_output_tokens: 128000
   temperature: 0.7
   reasoning_replay: false
   max_retries: 3
@@ -173,7 +165,7 @@ cost_tracking:
 #   retention_days: 30
 
 # EFP runtime native provider and common models:
-# - github_copilot: gpt-5.4, gpt-5.4-mini, gpt-5.5, gpt-5.3-codex, gpt-5-mini, gemini-2.5-pro, gemini-3.5-flash
+# - github_copilot: gpt-5.4, gpt-5.5, gpt-5.6-luna, gpt-5.6-sol, gpt-5.6-terra (default: gpt-5.6-terra)
 
 # ============================================
 # Workspace Configuration (OPTIONAL)

--- a/src/efp_runtime/llm/models.py
+++ b/src/efp_runtime/llm/models.py
@@ -7,18 +7,16 @@ from typing import Any
 
 
 DEFAULT_PROVIDER_ID = "github-copilot"
-DEFAULT_MODEL_ID = "gpt-5.4"
+DEFAULT_MODEL_ID = "gpt-5.6-terra"
 DEFAULT_CHARS_PER_TOKEN = 4
 MIN_PRESERVE_RECENT_TOKENS = 2_000
 MAX_PRESERVE_RECENT_TOKENS = 8_000
 SUPPORTED_COPILOT_MODEL_IDS = (
-    "gpt-5-mini",
-    "gpt-5.3-codex",
     "gpt-5.4",
-    "gpt-5.4-mini",
     "gpt-5.5",
-    "gemini-2.5-pro",
-    "gemini-3.5-flash",
+    "gpt-5.6-luna",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
 )
 
 
@@ -124,23 +122,8 @@ def _default_preserve_recent_tokens(
 
 
 _COPILOT_PROFILES = {
-    "gpt-5-mini": _profile(
-        "gpt-5-mini",
-        context_window_tokens=264_000,
-        default_reserve_tokens=64_000,
-    ),
-    "gpt-5.3-codex": _profile(
-        "gpt-5.3-codex",
-        context_window_tokens=400_000,
-        default_reserve_tokens=128_000,
-    ),
     "gpt-5.4": _profile(
         "gpt-5.4",
-        context_window_tokens=400_000,
-        default_reserve_tokens=128_000,
-    ),
-    "gpt-5.4-mini": _profile(
-        "gpt-5.4-mini",
         context_window_tokens=400_000,
         default_reserve_tokens=128_000,
     ),
@@ -149,15 +132,20 @@ _COPILOT_PROFILES = {
         context_window_tokens=400_000,
         default_reserve_tokens=128_000,
     ),
-    "gemini-2.5-pro": _profile(
-        "gemini-2.5-pro",
-        context_window_tokens=128_000,
-        default_reserve_tokens=64_000,
+    "gpt-5.6-luna": _profile(
+        "gpt-5.6-luna",
+        context_window_tokens=328_000,
+        default_reserve_tokens=128_000,
     ),
-    "gemini-3.5-flash": _profile(
-        "gemini-3.5-flash",
-        context_window_tokens=128_000,
-        default_reserve_tokens=64_000,
+    "gpt-5.6-sol": _profile(
+        "gpt-5.6-sol",
+        context_window_tokens=400_000,
+        default_reserve_tokens=128_000,
+    ),
+    "gpt-5.6-terra": _profile(
+        "gpt-5.6-terra",
+        context_window_tokens=400_000,
+        default_reserve_tokens=128_000,
     ),
 }
 

--- a/tests/runtime/test_auto_session_compaction.py
+++ b/tests/runtime/test_auto_session_compaction.py
@@ -188,7 +188,7 @@ async def test_token_budget_converts_to_char_budget_for_auto_compaction():
     assert result.status == LoopStatus.COMPLETED
     request_metadata = provider.requests[0].provider_request.metadata
     assert request_metadata["provider_id"] == "github-copilot"
-    assert request_metadata["model_id"] == "gpt-5.4"
+    assert request_metadata["model_id"] == "gpt-5.6-terra"
     assert request_metadata["context_window_tokens"] == 400_000
     assert request_metadata["max_context_tokens"] == 20
     assert request_metadata["max_context_chars"] == 80

--- a/tests/runtime/test_model_context_profiles.py
+++ b/tests/runtime/test_model_context_profiles.py
@@ -16,20 +16,16 @@ from efp_runtime.llm.models import (
 @pytest.mark.parametrize(
     ("model", "expected_model"),
     [
-        ("github-copilot/gpt-5-mini", "gpt-5-mini"),
-        ("github-copilot/gpt-5.3-codex", "gpt-5.3-codex"),
         ("github-copilot/gpt-5.4", "gpt-5.4"),
-        ("github-copilot/gpt-5.4-mini", "gpt-5.4-mini"),
         ("github-copilot/gpt-5.5", "gpt-5.5"),
-        ("github-copilot/gemini-2.5-pro", "gemini-2.5-pro"),
-        ("github-copilot/gemini-3.5-flash", "gemini-3.5-flash"),
-        ("gpt-5 mini", "gpt-5-mini"),
-        ("gpt-5.3-codex", "gpt-5.3-codex"),
+        ("github-copilot/gpt-5.6-luna", "gpt-5.6-luna"),
+        ("github-copilot/gpt-5.6-sol", "gpt-5.6-sol"),
+        ("github-copilot/gpt-5.6-terra", "gpt-5.6-terra"),
         ("gpt-5.4", "gpt-5.4"),
-        ("gpt-5.4 mini", "gpt-5.4-mini"),
         ("gpt-5.5", "gpt-5.5"),
-        ("gemini 2.5 pro", "gemini-2.5-pro"),
-        ("gemini 3.5 flash", "gemini-3.5-flash"),
+        ("gpt-5.6 luna", "gpt-5.6-luna"),
+        ("gpt-5.6 sol", "gpt-5.6-sol"),
+        ("gpt-5.6 terra", "gpt-5.6-terra"),
     ],
 )
 def test_github_copilot_profile_resolution(model: str, expected_model: str):
@@ -38,34 +34,29 @@ def test_github_copilot_profile_resolution(model: str, expected_model: str):
     assert isinstance(profile, ModelContextProfile)
     assert profile.provider_id == DEFAULT_PROVIDER_ID
     assert profile.model_id == expected_model
-    if expected_model in {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"}:
+    if expected_model == "gpt-5.6-luna":
+        assert profile.context_window_tokens == 328_000
+        assert profile.default_reserve_tokens == 128_000
+    else:
         assert profile.context_window_tokens == 400_000
         assert profile.default_reserve_tokens == 128_000
-    elif expected_model == "gpt-5-mini":
-        assert profile.context_window_tokens == 264_000
-        assert profile.default_reserve_tokens == 64_000
-    else:
-        assert profile.context_window_tokens == 128_000
-        assert profile.default_reserve_tokens == 64_000
     assert profile.default_preserve_recent_tokens == 8_000
     assert profile.tokens_to_chars(100) == 400
 
 
 def test_default_and_supported_model_list_are_copilot_responses_models():
-    assert DEFAULT_MODEL_ID == "gpt-5.4"
+    assert DEFAULT_MODEL_ID == "gpt-5.6-terra"
     assert SUPPORTED_COPILOT_MODEL_IDS == (
-        "gpt-5-mini",
-        "gpt-5.3-codex",
         "gpt-5.4",
-        "gpt-5.4-mini",
         "gpt-5.5",
-        "gemini-2.5-pro",
-        "gemini-3.5-flash",
+        "gpt-5.6-luna",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
     )
 
 
 def test_canonicalize_copilot_model_id_rejects_unsupported_models():
-    assert canonicalize_copilot_model_id("gemini 3.5 flash") == "gemini-3.5-flash"
+    assert canonicalize_copilot_model_id("gpt-5.6 terra") == "gpt-5.6-terra"
     with pytest.raises(ValueError, match="unsupported GitHub Copilot model"):
         canonicalize_copilot_model_id("gpt-5")
 

--- a/tests/runtime/test_provider_transport.py
+++ b/tests/runtime/test_provider_transport.py
@@ -220,12 +220,12 @@ async def test_github_copilot_provider_defaults_strict_responses_payload():
     )
 
     assert result.status == LoopStatus.COMPLETED
-    assert provider.model == "gpt-5.4"
+    assert provider.model == "gpt-5.6-terra"
     assert provider.endpoint == "responses"
     assert provider.reasoning_effort == DEFAULT_COPILOT_REASONING_EFFORT
     assert provider.metadata["provider_id"] == "github-copilot"
     payload = transport.payloads[0]
-    assert payload["model"] == "gpt-5.4"
+    assert payload["model"] == "gpt-5.6-terra"
     assert "input" in payload
     assert "messages" not in payload
     assert payload["reasoning"] == {"effort": "high"}
@@ -251,12 +251,12 @@ async def test_github_copilot_provider_requested_model_only_changes_payload_mode
     result = await runner.run(
         session_id="session-copilot-model-hint",
         user_text="Answer with requested model.",
-        metadata={"requested_model": "gpt-5 mini"},
+        metadata={"requested_model": "gpt-5.6 luna"},
     )
 
     assert result.status == LoopStatus.COMPLETED
-    assert provider.model == "gpt-5.4"
-    assert transport.payloads[0]["model"] == "gpt-5-mini"
+    assert provider.model == "gpt-5.6-terra"
+    assert transport.payloads[0]["model"] == "gpt-5.6-luna"
     assert "metadata" not in transport.payloads[0]
 
 
@@ -287,13 +287,11 @@ def test_github_copilot_provider_rejects_invalid_reasoning_effort_locally():
 
 def test_github_copilot_supported_models_and_reasoning_are_exact():
     assert SUPPORTED_COPILOT_MODEL_IDS == (
-        "gpt-5-mini",
-        "gpt-5.3-codex",
         "gpt-5.4",
-        "gpt-5.4-mini",
         "gpt-5.5",
-        "gemini-2.5-pro",
-        "gemini-3.5-flash",
+        "gpt-5.6-luna",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
     )
     assert SUPPORTED_COPILOT_REASONING_EFFORTS == (
         "low",
@@ -1133,7 +1131,7 @@ def test_github_copilot_provider_from_env_reads_token_and_base_url():
         }
     )
 
-    assert provider.model == "gpt-5.4"
+    assert provider.model == "gpt-5.6-terra"
     assert provider.endpoint == "responses"
     assert provider.reasoning_effort == "medium"
     assert provider.metadata["provider_id"] == "github-copilot"
@@ -1149,11 +1147,11 @@ def test_github_copilot_provider_from_env_reads_token_and_base_url():
 
 def test_github_copilot_provider_from_env_falls_back_to_github_token():
     provider = github_copilot_provider_from_env(
-        model="gemini 3.5 flash",
+        model="gpt-5.6 sol",
         env={"GITHUB_COPILOT_TOKEN": "github-token"},
     )
 
-    assert provider.model == "gemini-3.5-flash"
+    assert provider.model == "gpt-5.6-sol"
     assert isinstance(provider.transport, GitHubCopilotHTTPTransport)
     assert provider.transport._headers()["Authorization"] == "Bearer github-token"
 
@@ -1174,7 +1172,7 @@ def test_github_copilot_provider_from_env_exchanges_github_source_token(monkeypa
         env={"EFP_GITHUB_COPILOT_TOKEN": "ghu_source123"}
     )
 
-    assert provider.model == "gpt-5.4"
+    assert provider.model == "gpt-5.6-terra"
     assert isinstance(provider.transport, GitHubCopilotHTTPTransport)
     assert provider.transport.token_source == "github_exchange"
     assert provider.transport.endpoint == "https://api.enterprise.githubcopilot.com/responses"
@@ -1219,11 +1217,11 @@ def test_github_copilot_smoke_dry_run_outputs_payload_without_token():
     assert payload["dry_run"] is True
     assert payload["provider"] == "github-copilot"
     assert payload["provider_id"] == "github-copilot"
-    assert payload["model"] == "gpt-5.4"
+    assert payload["model"] == "gpt-5.6-terra"
     assert payload["payload_summary"]["tool_count"] == 0
     assert payload["payload_summary"]["stream"] is False
     assert payload["payload_summary"]["reasoning"] == {"effort": "high"}
-    assert payload["payload"]["model"] == "gpt-5.4"
+    assert payload["payload"]["model"] == "gpt-5.6-terra"
     assert payload["payload"]["reasoning"] == {"effort": "high"}
     assert payload["payload"]["input"][-1]["role"] == "user"
     input_item = payload["payload"]["input"][-1]["content"][0]

--- a/tests/runtime/test_runtime_chat_gateway.py
+++ b/tests/runtime/test_runtime_chat_gateway.py
@@ -57,12 +57,12 @@ def test_runtime_chat_resolves_default_and_alias_models(monkeypatch):
     class _FakeConfig:
         @property
         def llm(self):
-            return {"model": "gpt-5.4 mini"}
+            return {"model": "gpt-5.6 terra"}
 
     monkeypatch.setattr(runtime_chat, "config", _FakeConfig())
 
-    assert runtime_chat._resolve_model(None) == "gpt-5.4-mini"
-    assert runtime_chat._resolve_model("gemini 3.5 flash") == "gemini-3.5-flash"
+    assert runtime_chat._resolve_model(None) == "gpt-5.6-terra"
+    assert runtime_chat._resolve_model("gpt-5.6 luna") == "gpt-5.6-luna"
 
 
 def test_runtime_chat_rejects_invalid_model_locally(monkeypatch):
@@ -375,7 +375,7 @@ async def test_runtime_chat_applies_trusted_portal_runtime_profile_config(monkey
         message="hello",
         session_id="s-profile",
         request_id="req-profile",
-        model="gpt-5.4 mini",
+        model="gpt-5.6 terra",
         track_usage=False,
         execution_metadata={
             "runtime_profile": {
@@ -386,10 +386,10 @@ async def test_runtime_chat_applies_trusted_portal_runtime_profile_config(monkey
     )
 
     runtime_config = captured["config"]
-    assert captured["provider_model"] == "gpt-5.4-mini"
+    assert captured["provider_model"] == "gpt-5.6-terra"
     assert runtime_config.workspace_root == runtime_chat._runtime_workspace_root()
     assert runtime_config.default_provider_id == "github-copilot"
-    assert runtime_config.default_model == "gpt-5.4-mini"
+    assert runtime_config.default_model == "gpt-5.6-terra"
     assert runtime_config.track_usage is False
     assert runtime_config.enabled_tools == ["read"]
     assert runtime_config.disabled_tools == ["write"]
@@ -582,7 +582,7 @@ async def test_runtime_error_result_raises_sanitized_chat_error_after_recording(
             "llm": {
                 "provider": "github_copilot",
                 "api_key": "copilot-config-token",
-                "model": "gpt-5-mini",
+                "model": "gpt-5.6-terra",
             },
             "session": {"max_iterations": 1},
         },


### PR DESCRIPTION
把 github-copilot provider 的模型收窄为 **gpt-5.4 / gpt-5.5 / gpt-5.6-luna / gpt-5.6-sol / gpt-5.6-terra**,默认改为 **gpt-5.6-terra**。

## native 改动
- `src/efp_runtime/llm/models.py`:`DEFAULT_MODEL_ID`、`SUPPORTED_COPILOT_MODEL_IDS`、`_COPILOT_PROFILES` 更新为这 5 个(luna 上下文 328k,其余 400k;输出 128k)。
- `config.yaml.example`:默认模型 + `model_limits` 目录 + 注释同步。

参数取自 Copilot 官方模型 JSON。openai/anthropic 不变。需与 portal PR 一起部署(dvnuo/engineering-flow-platform-portal#,见评论)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)