### PR TITLE
Project the canonical profile config for native at boot

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
+from src.runtime_profile_projection import project_canonical_for_runtime
+
 
 logger = logging.getLogger(__name__)
 
@@ -92,37 +94,6 @@ PORTAL_MANAGED_RUNTIME_FIELDS = frozenset(
     }
 )
 
-RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS = [
-    (
-        "Use bash for external CLI tools configured by the runtime profile: "
-        "jira, confluence, gh, aws, jenkins, mobile-auto, and git."
-    ),
-    (
-        "For jira, confluence, jenkins, and mobile-auto, always pass --json. Before complex commands, "
-        "inspect commands/schema/help llm; prefer --dry-run for writes, and use "
-        "--yes only when a destructive action was explicitly confirmed."
-    ),
-    (
-        "Use gh for GitHub issues, pull requests, and api calls; use aws for AWS operations; "
-        "use jenkins for Jenkins controller operations; use mobile-auto for BrowserStack/Appium device automation; "
-        "use git for clone, fetch, push, and status."
-    ),
-    (
-        "For mobile automation, start with `mobile-auto doctor --json` and `mobile-auto auth test --json`. "
-        "Use `private-external` with an existing BrowserStackLocal identifier, or `private-managed` only when "
-        "the runtime image provides `/usr/local/bin/BrowserStackLocal`."
-    ),
-    (
-        "Jenkins runtime profile credentials are available as EFP_JENKINS_USERNAME and EFP_JENKINS_PASSWORD. "
-        "When the user provides a Jenkins controller URL or pipeline/job, configure or log in to that controller at that time and pass the password through stdin."
-    ),
-    (
-        "Credentials were applied by the runtime profile through real CLIs or environment variables; "
-        "if jira, confluence, jenkins, or mobile-auto returns auth_failed, aws returns an auth error, or gh/git authentication fails, "
-        "report a runtime profile configuration problem."
-    ),
-]
-
 _ATLASSIAN_INSTANCE_URL_FIELDS = ("url", "base_url", "baseUrl", "uri")
 
 
@@ -134,77 +105,6 @@ def _first_atlassian_instance_url(value: Dict[str, Any]) -> str:
         if text:
             return text.rstrip("/")
     return ""
-
-
-def _should_inject_runtime_profile_external_cli_instructions(overlay: Dict[str, Any]) -> bool:
-    if not isinstance(overlay, dict) or "instruction_texts" in overlay:
-        return False
-    return (
-        _has_atlassian_profile_instances(overlay.get("jira"))
-        or _has_atlassian_profile_instances(overlay.get("confluence"))
-        or _has_jenkins_profile_credentials(overlay.get("jenkins"))
-        or _has_mobile_profile_config(overlay.get("mobile-auto"))
-        or _has_github_profile_token(overlay.get("github"))
-        or _has_aws_profile_config(overlay.get("aws"))
-        or _has_git_profile_user(overlay.get("git"))
-    )
-
-
-def _has_atlassian_profile_instances(section: Any) -> bool:
-    if not isinstance(section, dict) or section.get("enabled") is False:
-        return False
-    instances = section.get("instances")
-    if not isinstance(instances, list):
-        return False
-    for instance in instances:
-        if not isinstance(instance, dict) or instance.get("enabled") is False:
-            continue
-        if _first_atlassian_instance_url(instance):
-            return True
-    return False
-
-
-def _has_github_profile_token(section: Any) -> bool:
-    if not isinstance(section, dict) or section.get("enabled") is False:
-        return False
-    return bool(str(section.get("api_token") or section.get("token") or section.get("access_token") or "").strip())
-
-
-def _has_aws_profile_config(section: Any) -> bool:
-    if not isinstance(section, dict) or section.get("enabled") is False:
-        return False
-    domain = str(section.get("domain") or "").strip()
-    username = str(section.get("username") or "").strip()
-    password = str(section.get("password") or "").strip()
-    return bool(domain and username and password)
-
-
-def _has_jenkins_profile_credentials(section: Any) -> bool:
-    if not isinstance(section, dict) or section.get("enabled") is False:
-        return False
-    username = str(section.get("username") or "").strip()
-    password = str(section.get("password") or "").strip()
-    return bool(username and password)
-
-
-def _has_mobile_profile_config(section: Any) -> bool:
-    if not isinstance(section, dict) or section.get("enabled") is False:
-        return False
-    browserstack = section.get("browserstack")
-    if not isinstance(browserstack, dict):
-        return False
-    return bool(
-        str(browserstack.get("username") or browserstack.get("username_env") or "").strip()
-        or str(browserstack.get("access_key") or browserstack.get("access_key_env") or "").strip()
-        or str(browserstack.get("api_base_url") or browserstack.get("appium_base_url") or "").strip()
-    )
-
-
-def _has_git_profile_user(section: Any) -> bool:
-    user = section.get("user") if isinstance(section, dict) else None
-    if not isinstance(user, dict):
-        return False
-    return bool(str(user.get("name") or "").strip() and str(user.get("email") or "").strip())
 
 
 class Config:
@@ -454,9 +354,14 @@ class Config:
             return
 
         overlay_config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
+        # The Secret stores a single runtime-agnostic canonical config; this
+        # native runtime applies its own projection at boot (the portal used to
+        # bake this into the per-runtime Secret payload). For native this
+        # re-adds the CLI tool instructions and keeps the LLM in canonical
+        # github_copilot/bare-model form. The payload no longer carries a
+        # runtime_type field; native is always the native runtime.
+        overlay_config = project_canonical_for_runtime(overlay_config, "native")
         overlay = self._filter_managed_overlay_sections(overlay_config)
-        if _should_inject_runtime_profile_external_cli_instructions(overlay):
-            overlay["instruction_texts"] = list(RUNTIME_PROFILE_EXTERNAL_CLI_INSTRUCTIONS)
         self._env_overlay = overlay
         self._managed_overlay_meta = {
             "runtime_profile_id": payload.get("runtime_profile_id"),

--- a/src/runtime_profile_projection.py
+++ b/src/runtime_profile_projection.py
@@ -1,0 +1,296 @@
+"""Per-runtime projection of the canonical runtime-profile config.
+
+The runtime-profile Secret now stores a single, runtime-agnostic canonical
+config (``config.json``). Each runtime must apply its OWN projection to that
+parsed canonical config at boot. This module is a self-contained (stdlib-only)
+verbatim port of the portal's projection so that, for any canonical config::
+
+    project_canonical_for_runtime(canonical, "<runtime>")
+
+produces byte-identical output to what the portal's old
+``build_runtime_profile_context_config(profile_config, runtime_type="<runtime>")``
+baked into the per-runtime Secret payload.
+
+For the native runtime this re-normalizes the LLM to itself (github_copilot +
+bare model, a no-op), leaves opencode-restricted fields untouched (profile
+configs never carry them), and re-adds the native CLI tool instructions. For
+opencode it would instead normalize the LLM to ``github-copilot`` +
+``provider/model`` and drop the opencode-restricted fields.
+
+Ported verbatim from:
+  - engineering-flow-platform-portal app/contracts/provider_projection.py
+  - engineering-flow-platform-portal app/services/runtime_profile_llm_projection.py
+  - engineering-flow-platform-portal app/services/runtime_profile_context_projection.py
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# provider_projection.py (verbatim)
+# ---------------------------------------------------------------------------
+
+
+def normalize_provider_for_portal(value: str | None) -> str:
+    raw = (value or "").strip().lower()
+    if raw in {"github", "github-copilot", "copilot", "github_copilot"}:
+        return "github_copilot"
+    if raw in {"claude", "anthropic"}:
+        return "anthropic"
+    return raw
+
+
+def normalize_provider_for_runtime(runtime_type: str, provider: str | None) -> str:
+    portal_provider = normalize_provider_for_portal(provider)
+    if (runtime_type or "").strip().lower() == "opencode" and portal_provider == "github_copilot":
+        return "github-copilot"
+    return portal_provider
+
+
+def normalize_model_for_runtime(runtime_type: str, provider: str | None, model: str | None) -> str | None:
+    if not model:
+        return None
+    model = str(model).strip()
+    runtime_provider = normalize_provider_for_runtime(runtime_type, provider)
+    if "/" in model:
+        prefix, rest = model.split("/", 1)
+        normalized_prefix = normalize_provider_for_runtime(runtime_type, prefix)
+        return f"{normalized_prefix}/{rest}"
+    if (runtime_type or "").strip().lower() == "opencode" and runtime_provider:
+        return f"{runtime_provider}/{model}"
+    return model
+
+
+# ---------------------------------------------------------------------------
+# runtime_profile_llm_projection.py (verbatim)
+# ---------------------------------------------------------------------------
+
+
+def _is_copilot_provider(provider: str | None) -> bool:
+    return normalize_provider_for_portal(provider) == "github_copilot"
+
+
+def _provider_hint_from_llm(llm: dict) -> str | None:
+    provider = llm.get("provider")
+    if isinstance(provider, str) and provider.strip():
+        return provider.strip()
+    model = llm.get("model")
+    if isinstance(model, str) and "/" in model:
+        prefix = model.split("/", 1)[0].strip()
+        if prefix:
+            return prefix
+    return None
+
+
+def project_llm_for_runtime(llm: dict, runtime_type: str) -> dict:
+    projected = deepcopy(llm)
+    provider_hint = _provider_hint_from_llm(projected)
+    runtime_type = "opencode" if str(runtime_type or "").strip().lower() == "opencode" else "native"
+    if provider_hint:
+        projected["provider"] = normalize_provider_for_runtime(runtime_type, provider_hint)
+    if projected.get("model"):
+        normalized_model = normalize_model_for_runtime(runtime_type, provider_hint, projected.get("model"))
+        if normalized_model:
+            projected["model"] = normalized_model
+
+    if not _is_copilot_provider(provider_hint):
+        projected.pop("oauth", None)
+        projected.pop("oauth_by_runtime", None)
+        return projected
+
+    token = str(projected.get("api_key") or "").strip()
+    projected.pop("oauth", None)
+    projected.pop("oauth_by_runtime", None)
+
+    if token:
+        projected["api_key"] = token
+    else:
+        projected.pop("api_key", None)
+    return projected
+
+
+# ---------------------------------------------------------------------------
+# runtime_profile_context_projection.py (verbatim subset)
+# ---------------------------------------------------------------------------
+
+
+RUNTIME_PROFILE_CLI_TOOL_INSTRUCTIONS = (
+    "Use bash for runtime profile CLI tools: jira/confluence for Atlassian, "
+    "gh for GitHub issues, PRs, and api calls, aws for AWS operations, "
+    "jenkins for Jenkins controller operations, mobile-auto for BrowserStack/Appium device automation, "
+    "and git for clone, fetch, push, and status. "
+    "For every jira, confluence, jenkins, and mobile-auto command add --json. For complex jira/confluence/jenkins/mobile-auto calls, "
+    "inspect commands, schema, or help llm first, for example `jira commands --json`, "
+    "`jira schema <command> --json`, `jira help llm --json`, and the matching confluence/jenkins/mobile-auto commands. "
+    "For mobile work, start with `mobile-auto doctor --json` and `mobile-auto auth test --json`; use BrowserStackLocal through "
+    "`private-external` with a supplied local identifier or `private-managed` only when the runtime image has BrowserStackLocal installed. "
+    "Jenkins runtime profile credentials are available as EFP_JENKINS_USERNAME and EFP_JENKINS_PASSWORD; "
+    "when the user provides a Jenkins controller URL or pipeline/job, configure or log in to that controller at that time and pass the password through stdin, never by echoing it. "
+    "For AWS, prefer `aws --output json` for inspection and avoid changing cloud resources unless the user asks. "
+    "Run write operations with --dry-run before executing them. Use --yes only for destructive "
+    "operations after the user explicitly confirms. Runtime profile credentials are applied in "
+    "the runtime container through CLIs or environment variables; if a CLI returns auth_failed, report a runtime profile "
+    "configuration problem instead of guessing or inventing tokens."
+)
+
+OPENCODE_RUNTIME_RESTRICTION_FIELDS = frozenset(
+    {
+        "enabled_tools",
+        "disabled_tools",
+        "tool_permissions",
+        "allowed_external_systems",
+        "allowed_actions",
+        "allowed_adapter_actions",
+        "allowed_capability_ids",
+        "allowed_capability_types",
+        "resolved_action_mappings",
+        "unresolved_tools",
+        "unresolved_skills",
+        "unresolved_channels",
+        "unresolved_actions",
+        "skill_details",
+        "allowed_skills",
+        "denied_skills",
+        "denied_actions",
+        "denied_capability_types",
+        "skill_set",
+        "policy_context",
+        "derived_runtime_rules",
+    }
+)
+
+
+def is_opencode_runtime_type(runtime_type: str | None) -> bool:
+    return str(runtime_type or "").strip().lower() == "opencode"
+
+
+def strip_opencode_runtime_restrictions(
+    config: dict[str, Any] | None,
+    runtime_type: str | None,
+) -> dict[str, Any]:
+    projected = deepcopy(config) if isinstance(config, dict) else {}
+    if not is_opencode_runtime_type(runtime_type):
+        return projected
+    for key in OPENCODE_RUNTIME_RESTRICTION_FIELDS:
+        projected.pop(key, None)
+    return projected
+
+
+def _has_enabled_instance_section(config: dict[str, Any], section: str) -> bool:
+    section_config = config.get(section)
+    if not isinstance(section_config, dict) or section_config.get("enabled") is not True:
+        return False
+    instances = section_config.get("instances")
+    if not isinstance(instances, list):
+        return False
+    for item in instances:
+        if not isinstance(item, dict) or item.get("enabled") is False:
+            continue
+        endpoint = ""
+        for key in ("url", "base_url", "baseUrl", "uri"):
+            endpoint = str(item.get(key) or "").strip()
+            if endpoint:
+                break
+        if endpoint:
+            return True
+    return False
+
+
+def _has_enabled_github_config(config: dict[str, Any]) -> bool:
+    github = config.get("github")
+    if not isinstance(github, dict) or github.get("enabled") is not True:
+        return False
+    return bool(str(github.get("api_token") or github.get("base_url") or "").strip())
+
+
+def _has_git_config(config: dict[str, Any]) -> bool:
+    git = config.get("git")
+    if not isinstance(git, dict):
+        return False
+    user = git.get("user")
+    if not isinstance(user, dict):
+        return False
+    return bool(str(user.get("name") or user.get("email") or "").strip())
+
+
+def _has_enabled_aws_config(config: dict[str, Any]) -> bool:
+    aws = config.get("aws")
+    if not isinstance(aws, dict) or aws.get("enabled") is not True:
+        return False
+    domain = str(aws.get("domain") or "").strip()
+    username = str(aws.get("username") or "").strip()
+    password = str(aws.get("password") or "").strip()
+    return bool(domain and username and password)
+
+
+def _has_enabled_jenkins_config(config: dict[str, Any]) -> bool:
+    jenkins = config.get("jenkins")
+    if not isinstance(jenkins, dict) or jenkins.get("enabled") is not True:
+        return False
+    username = str(jenkins.get("username") or "").strip()
+    password = str(jenkins.get("password") or "").strip()
+    return bool(username and password)
+
+
+def _has_enabled_mobile_config(config: dict[str, Any]) -> bool:
+    mobile = config.get("mobile-auto")
+    if not isinstance(mobile, dict) or mobile.get("enabled") is not True:
+        return False
+    browserstack = mobile.get("browserstack")
+    if not isinstance(browserstack, dict):
+        return False
+    return bool(
+        str(browserstack.get("username") or browserstack.get("username_env") or "").strip()
+        or str(browserstack.get("access_key") or browserstack.get("access_key_env") or "").strip()
+        or str(browserstack.get("api_base_url") or browserstack.get("appium_base_url") or "").strip()
+    )
+
+
+def _has_enabled_external_cli_config(config: dict[str, Any]) -> bool:
+    return (
+        _has_enabled_instance_section(config, "jira")
+        or _has_enabled_instance_section(config, "confluence")
+        or _has_enabled_jenkins_config(config)
+        or _has_enabled_mobile_config(config)
+        or _has_enabled_github_config(config)
+        or _has_enabled_aws_config(config)
+        or _has_git_config(config)
+    )
+
+
+def _with_native_cli_tool_instructions(
+    config: dict[str, Any],
+    runtime_type: str | None,
+) -> dict[str, Any]:
+    if is_opencode_runtime_type(runtime_type) or not _has_enabled_external_cli_config(config):
+        return config
+    projected = deepcopy(config)
+    instruction_texts = projected.get("instruction_texts")
+    if not isinstance(instruction_texts, list):
+        instruction_texts = []
+    if RUNTIME_PROFILE_CLI_TOOL_INSTRUCTIONS not in instruction_texts:
+        instruction_texts.append(RUNTIME_PROFILE_CLI_TOOL_INSTRUCTIONS)
+    projected["instruction_texts"] = instruction_texts
+    return projected
+
+
+def project_canonical_for_runtime(
+    canonical: dict[str, Any] | None,
+    runtime_type: str | None,
+) -> dict[str, Any]:
+    """Apply the per-runtime projection to a canonical config.
+
+    The runtimes call this at boot on the config parsed from the Secret. Native
+    re-normalizes the LLM to itself (a no-op) and gains the CLI tool
+    instructions; opencode re-normalizes the LLM to its ``provider/model`` form
+    and drops the opencode-restricted fields.
+    """
+    projected = deepcopy(canonical) if isinstance(canonical, dict) else {}
+    llm = projected.get("llm")
+    if isinstance(llm, dict):
+        projected["llm"] = project_llm_for_runtime(llm, runtime_type)
+    projected = strip_opencode_runtime_restrictions(projected, runtime_type)
+    return _with_native_cli_tool_instructions(projected, runtime_type)

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -6,6 +6,7 @@ import pytest
 from ruamel.yaml import YAML
 from src.config import Config
 from src.external_cli import profile_config as profile_config_module
+from src.runtime_profile_projection import RUNTIME_PROFILE_CLI_TOOL_INSTRUCTIONS
 
 
 class _FakeCompleted:
@@ -370,10 +371,13 @@ def test_external_cli_instructions_are_injected_for_atlassian_config(tmp_path, m
     )
 
     instructions = cfg.get_effective_config()["instruction_texts"]
+    # Boot-time projection re-adds the portal's single canonical CLI-tool
+    # instruction string byte-for-byte (it used to be baked into native.json).
+    assert instructions == [RUNTIME_PROFILE_CLI_TOOL_INSTRUCTIONS]
     joined = "\n".join(instructions)
     assert "Use bash" in joined
-    assert "jira, confluence, gh, aws, jenkins, mobile-auto, and git" in joined
-    assert "always pass --json" in joined
+    assert "jira/confluence for Atlassian" in joined
+    assert "add --json" in joined
     assert "EFP_JENKINS_USERNAME" in joined
     assert "EFP_JENKINS_PASSWORD" in joined
     assert "git for clone, fetch, push, and status" in joined
@@ -423,6 +427,47 @@ def test_external_cli_instructions_preserve_portal_texts(tmp_path, monkeypatch):
     assert cfg.get_effective_config()["instruction_texts"] == [
         "Portal supplied instructions."
     ]
+
+
+def test_boot_projection_adds_cli_instructions_and_keeps_canonical_llm(tmp_path, monkeypatch):
+    # A canonical (runtime-agnostic) profile config: github_copilot + bare model,
+    # jira enabled. The native runtime projects it at boot, which re-adds the CLI
+    # tool instructions and leaves the LLM in canonical github_copilot form.
+    cfg = _env_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "llm": {"provider": "github_copilot", "model": "gpt-5.4"},
+            "jira": {
+                "enabled": True,
+                "instances": [
+                    {"name": "jira-main", "url": "https://jira.example.test", "token": "t"}
+                ],
+            },
+        },
+    )
+
+    effective = cfg.get_effective_config()
+    assert effective["instruction_texts"] == [RUNTIME_PROFILE_CLI_TOOL_INSTRUCTIONS]
+    # native keeps the canonical github_copilot provider and the bare model.
+    assert effective["llm"]["provider"] == "github_copilot"
+    assert effective["llm"]["model"] == "gpt-5.4"
+
+
+def test_boot_projection_omits_cli_instructions_when_no_tools_enabled(tmp_path, monkeypatch):
+    cfg = _env_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "llm": {"provider": "github_copilot", "model": "gpt-5.4"},
+            "jira": {"enabled": False},
+        },
+    )
+
+    effective = cfg.get_effective_config()
+    assert "instruction_texts" not in effective
+    assert effective["llm"]["provider"] == "github_copilot"
+    assert effective["llm"]["model"] == "gpt-5.4"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
配合 Secret 合并成单份 canonical config:native 启动时对解析出的 `EFP_PROFILE_CONFIG` overlay 应用 `project_canonical_for_runtime(..., \"native\")`。

- 新增 `src/runtime_profile_projection.py`:从 portal 逐字节移植的 per-runtime 投影(provider 契约 + project_llm_for_runtime + strip + native instruction 注入 + gate helpers + project_canonical_for_runtime)。
- `src/config.py` 解析 payload config 处应用 native 投影——重新注入 native 过去从 portal 拿到的 CLI 工具 instruction_texts,LLM 保持 native 形态。

逐字节等价于 portal 旧的 native 投影(跨仓库 parity 已验)。配套:portal + opencode(见评论)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)