### PR TITLE
Decrypt ENC: profile-config values at boot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ openai
 python-dotenv
 httpx
 requests
+cryptography>=42.0.0
 
 # OCR support (for image preview)
 pytesseract>=0.3.10

--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
+from src.runtime_profile_encryption import decrypt_sensitive_fields
 from src.runtime_profile_projection import project_canonical_for_runtime
 
 
@@ -354,6 +355,18 @@ class Config:
             return
 
         overlay_config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
+        # The portal encrypts the sensitive VALUES (api keys, tokens, passwords)
+        # of the canonical config as ENC:<fernet-token> so broad Secret readers
+        # see ciphertext. Decrypt them here, immediately after parsing the payload
+        # and BEFORE the per-runtime projection, so the projection and every
+        # downstream consumer see plaintext. Raises if an ENC: value is present
+        # but EFP_CONFIG_KEY is unset; surface that like a parse error below.
+        try:
+            overlay_config = decrypt_sensitive_fields(overlay_config)
+        except Exception as exc:
+            self._profile_load_error = f"Invalid EFP_PROFILE_CONFIG payload: {exc}"
+            logger.error(self._profile_load_error)
+            return
         # The Secret stores a single runtime-agnostic canonical config; this
         # native runtime applies its own projection at boot (the portal used to
         # bake this into the per-runtime Secret payload). For native this

--- a/src/runtime_profile_encryption.py
+++ b/src/runtime_profile_encryption.py
@@ -1,0 +1,135 @@
+"""Field-level decryption for the runtime-profile Secret config.
+
+The portal encrypts the sensitive VALUES of the canonical profile config
+(api keys, tokens, passwords) as ``ENC:<fernet-token>`` before writing them into
+the ``efp-profile-*`` Secret, so operators with broad Secret read access (e.g. a
+shared k8s dashboard) see ciphertext instead of live credentials. This runtime
+decrypts these values at boot, before projecting/using the config.
+
+Both sides derive a Fernet key from the raw ``EFP_CONFIG_KEY`` env var
+(sha256 -> urlsafe base64), so this module MUST be a byte-identical copy of the
+portal's ``app/services/profile_secret_encryption.py``. Only field values are
+encrypted; the config structure and non-secret fields stay readable, and
+decryption is a no-op when no ``ENC:`` values are present (plaintext, for dev).
+The decryption key's protection is an ops concern: keep EFP_CONFIG_KEY out of
+the broadly-readable Secret set, otherwise this is obfuscation rather than
+isolation.
+
+Ported verbatim from:
+  - engineering-flow-platform-portal app/services/profile_secret_encryption.py
+
+Runtimes only need :func:`decrypt_sensitive_fields`; the full module is copied
+verbatim so the derivation stays byte-compatible with portal encryption.
+Self-contained (stdlib + cryptography only).
+"""
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import os
+from typing import Any
+
+ENC_PREFIX = "ENC:"
+# Field names whose string values are treated as secrets and encrypted.
+SENSITIVE_FIELD_NAMES = frozenset(
+    {"api_key", "password", "token", "api_token", "access_token", "access_key", "secret"}
+)
+
+
+def config_encryption_key() -> str | None:
+    key = os.environ.get("EFP_CONFIG_KEY")
+    return key if key else None
+
+
+def _fernet(key: str):
+    from cryptography.fernet import Fernet
+
+    return Fernet(base64.urlsafe_b64encode(hashlib.sha256(key.encode()).digest()))
+
+
+def encrypt_sensitive_fields(config: Any) -> Any:
+    """Return a copy of ``config`` with sensitive string values encrypted.
+
+    A no-op (returns an unchanged deep copy) when EFP_CONFIG_KEY is not set, so
+    profiles still work in environments that have not provisioned a key.
+    """
+    result = copy.deepcopy(config)
+    key = config_encryption_key()
+    if not key:
+        return result
+    _walk_encrypt(result, _fernet(key))
+    return result
+
+
+def decrypt_sensitive_fields(config: Any) -> Any:
+    """Return a copy of ``config`` with every ``ENC:`` value decrypted.
+
+    Decryption is driven by the ``ENC:`` prefix (not the field name), so it
+    recovers any encrypted value. Raises if an ``ENC:`` value is present but
+    EFP_CONFIG_KEY is not set.
+    """
+    result = copy.deepcopy(config)
+    if not _has_encrypted_value(result):
+        return result
+    key = config_encryption_key()
+    if not key:
+        raise RuntimeError(
+            "Found an ENC: value in the profile config but EFP_CONFIG_KEY is not set. "
+            "Set EFP_CONFIG_KEY to the correct key before starting."
+        )
+    _walk_decrypt(result, _fernet(key))
+    return result
+
+
+def _walk_encrypt(obj: Any, fernet) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if (
+                k in SENSITIVE_FIELD_NAMES
+                and isinstance(v, str)
+                and v
+                and not v.startswith(ENC_PREFIX)
+                and not v.startswith("${")
+            ):
+                obj[k] = ENC_PREFIX + fernet.encrypt(v.encode()).decode()
+            elif isinstance(v, (dict, list)):
+                _walk_encrypt(v, fernet)
+    elif isinstance(obj, list):
+        for item in obj:
+            if isinstance(item, (dict, list)):
+                _walk_encrypt(item, fernet)
+
+
+def _walk_decrypt(obj: Any, fernet) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(v, str) and v.startswith(ENC_PREFIX):
+                obj[k] = _decrypt_value(v, fernet)
+            elif isinstance(v, (dict, list)):
+                _walk_decrypt(v, fernet)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            if isinstance(item, str) and item.startswith(ENC_PREFIX):
+                obj[i] = _decrypt_value(item, fernet)
+            elif isinstance(item, (dict, list)):
+                _walk_decrypt(item, fernet)
+
+
+def _decrypt_value(value: str, fernet) -> str:
+    from cryptography.fernet import InvalidToken
+
+    try:
+        return fernet.decrypt(value[len(ENC_PREFIX):].encode()).decode()
+    except (InvalidToken, ValueError) as exc:
+        raise RuntimeError(
+            "Failed to decrypt an ENC: profile config value; check EFP_CONFIG_KEY."
+        ) from exc
+
+
+def _has_encrypted_value(obj: Any) -> bool:
+    if isinstance(obj, dict):
+        return any(_has_encrypted_value(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_has_encrypted_value(v) for v in obj)
+    return isinstance(obj, str) and obj.startswith(ENC_PREFIX)

--- a/tests/test_profile_secret_decryption_boot.py
+++ b/tests/test_profile_secret_decryption_boot.py
@@ -1,0 +1,148 @@
+"""Boot-time decryption of ENC: sensitive values in the EFP_PROFILE_CONFIG.
+
+The portal encrypts sensitive VALUES (api_key/token/password/...) of the
+canonical profile config as ``ENC:<fernet-token>``. The runtime must decrypt
+them at boot, immediately after parsing EFP_PROFILE_CONFIG and BEFORE the
+per-runtime projection, so the projection and every downstream consumer see
+plaintext.
+"""
+
+import base64
+import hashlib
+import json
+
+import pytest
+
+import src.config as config_module
+from src.config import Config
+from src.runtime_profile_encryption import ENC_PREFIX
+
+
+TEST_KEY = "unit-test-config-key"
+
+
+def _enc(value: str, key: str = TEST_KEY) -> str:
+    """Encrypt ``value`` with the same Fernet derivation the portal uses."""
+    from cryptography.fernet import Fernet
+
+    fernet = Fernet(base64.urlsafe_b64encode(hashlib.sha256(key.encode()).digest()))
+    return ENC_PREFIX + fernet.encrypt(value.encode()).decode()
+
+
+def _write_base_config(path):
+    path.write_text(
+        "llm:\n"
+        "  provider: github_copilot\n"
+        "  model: gpt-4o\n"
+        "proxy:\n"
+        "  enabled: false\n",
+        encoding="utf-8",
+    )
+
+
+def _payload(config):
+    return json.dumps(
+        {
+            "runtime_profile_id": "rp_enc",
+            "name": "enc-profile",
+            "revision": 3,
+            "runtime_type": "native",
+            "config": config,
+        }
+    )
+
+
+def _canonical_with_secrets(*, encrypt: bool):
+    def maybe(value):
+        return _enc(value) if encrypt else value
+
+    return {
+        "llm": {
+            "provider": "github_copilot",
+            "model": "gpt-4o",
+            "api_key": maybe("sk-live-secret"),
+        },
+        "jira": {
+            "enabled": True,
+            "instances": [
+                {
+                    "name": "jira-main",
+                    "url": "https://jira.example.test",
+                    "username": "bot",
+                    "api_token": maybe("jira-token-secret"),
+                    "password": maybe("jira-password-secret"),
+                    "api_version": "3",
+                }
+            ],
+        },
+    }
+
+
+@pytest.fixture()
+def projection_spy(monkeypatch):
+    """Capture the config handed to project_canonical_for_runtime."""
+    captured = {}
+    real = config_module.project_canonical_for_runtime
+
+    def _spy(canonical, runtime_type):
+        captured["config"] = json.loads(json.dumps(canonical))
+        captured["runtime_type"] = runtime_type
+        return real(canonical, runtime_type)
+
+    monkeypatch.setattr(config_module, "project_canonical_for_runtime", _spy)
+    return captured
+
+
+def _build_config(tmp_path, monkeypatch, overlay_config):
+    config_path = tmp_path / "config.yaml"
+    _write_base_config(config_path)
+    monkeypatch.setenv("EFP_PROFILE_CONFIG", _payload(overlay_config))
+    return Config(str(config_path))
+
+
+def test_enc_values_decrypt_to_plaintext_before_projection(
+    tmp_path, monkeypatch, projection_spy
+):
+    monkeypatch.setenv("EFP_CONFIG_KEY", TEST_KEY)
+    cfg = _build_config(tmp_path, monkeypatch, _canonical_with_secrets(encrypt=True))
+
+    # No load error: decryption succeeded.
+    assert cfg._profile_load_error is None
+
+    # The projection received PLAINTEXT (decrypt ran first). No ENC: survives.
+    projected_input = projection_spy["config"]
+    assert projection_spy["runtime_type"] == "native"
+    assert projected_input["llm"]["api_key"] == "sk-live-secret"
+    instance = projected_input["jira"]["instances"][0]
+    assert instance["api_token"] == "jira-token-secret"
+    assert instance["password"] == "jira-password-secret"
+    blob = json.dumps(projected_input)
+    assert ENC_PREFIX not in blob
+
+
+def test_no_enc_values_is_a_noop(tmp_path, monkeypatch, projection_spy):
+    # No EFP_CONFIG_KEY at all; a plaintext canonical config must load fine.
+    monkeypatch.delenv("EFP_CONFIG_KEY", raising=False)
+    plaintext = _canonical_with_secrets(encrypt=False)
+    cfg = _build_config(tmp_path, monkeypatch, plaintext)
+
+    assert cfg._profile_load_error is None
+    projected_input = projection_spy["config"]
+    assert projected_input["llm"]["api_key"] == "sk-live-secret"
+    instance = projected_input["jira"]["instances"][0]
+    assert instance["api_token"] == "jira-token-secret"
+    assert instance["password"] == "jira-password-secret"
+
+
+def test_enc_present_without_key_records_load_error(
+    tmp_path, monkeypatch, projection_spy
+):
+    monkeypatch.delenv("EFP_CONFIG_KEY", raising=False)
+    cfg = _build_config(tmp_path, monkeypatch, _canonical_with_secrets(encrypt=True))
+
+    # Decryption raised (ENC present, no key) -> surfaced like a parse error.
+    assert cfg._profile_load_error is not None
+    assert "Invalid EFP_PROFILE_CONFIG" in cfg._profile_load_error
+    assert "EFP_CONFIG_KEY" in cfg._profile_load_error
+    # Projection must NOT run when decryption fails.
+    assert projection_spy == {}


### PR DESCRIPTION
## Why
The portal now encrypts the sensitive **values** (api keys, tokens, passwords) of the canonical profile config as `ENC:<fernet-token>` in the `efp-profile-*` Secret (portal PR dvnuo/engineering-flow-platform-portal#416). The native runtime must decrypt them before use.

## What
- **`runtime_profile_encryption.py`** (new): verbatim port of the portal's `profile_secret_encryption` crypto. The code body is **byte-identical** to portal's (verified by sha256) so the Fernet key derivation stays compatible.
- **`config.py`** `_parse_profile_env`: decrypts `overlay_config` right after parsing `EFP_PROFILE_CONFIG` and **before** the per-runtime projection, so the projection and every downstream consumer see plaintext. An `ENC:` value with no/wrong `EFP_CONFIG_KEY` is recorded as a profile load error.
- `cryptography>=42.0.0` re-added; tests in `test_profile_secret_decryption_boot.py`.

No-op when the config has no `ENC:` values (plaintext dev configs still work).

## Stacking
⚠️ Stacked on #570 (`feature/single-canonical-profile-secret`). Merge #570 first; GitHub will retarget this to `master`. Coordinated with portal (encrypt) dvnuo/engineering-flow-platform-portal#416 and the opencode decrypt PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)