### PR TITLE
Trim runtime profile encryption module to decrypt-only

### DIFF
--- a/src/runtime_profile_encryption.py
+++ b/src/runtime_profile_encryption.py
@@ -6,20 +6,17 @@ the ``efp-profile-*`` Secret, so operators with broad Secret read access (e.g. a
 shared k8s dashboard) see ciphertext instead of live credentials. This runtime
 decrypts these values at boot, before projecting/using the config.
 
-Both sides derive a Fernet key from the raw ``EFP_CONFIG_KEY`` env var
-(sha256 -> urlsafe base64), so this module MUST be a byte-identical copy of the
-portal's ``app/services/profile_secret_encryption.py``. Only field values are
-encrypted; the config structure and non-secret fields stay readable, and
-decryption is a no-op when no ``ENC:`` values are present (plaintext, for dev).
-The decryption key's protection is an ops concern: keep EFP_CONFIG_KEY out of
-the broadly-readable Secret set, otherwise this is obfuscation rather than
-isolation.
+This runtime only ever DECRYPTS, so it carries just the decrypt path. Both sides
+derive a Fernet key from the raw ``EFP_CONFIG_KEY`` env var
+(sha256 -> urlsafe base64); the shared key-derivation core (``ENC_PREFIX``,
+``config_encryption_key``, ``_fernet``, ``_decrypt_value``) MUST stay
+byte-identical to the portal's ``app/services/profile_secret_encryption.py`` so
+this runtime can read the portal's ciphertext. Decryption is driven by the
+``ENC:`` prefix (not the field name) and is a no-op when no ``ENC:`` values are
+present (plaintext, for dev). The key's protection is an ops concern: keep
+EFP_CONFIG_KEY out of the broadly-readable Secret set, otherwise this is
+obfuscation rather than isolation.
 
-Ported verbatim from:
-  - engineering-flow-platform-portal app/services/profile_secret_encryption.py
-
-Runtimes only need :func:`decrypt_sensitive_fields`; the full module is copied
-verbatim so the derivation stays byte-compatible with portal encryption.
 Self-contained (stdlib + cryptography only).
 """
 from __future__ import annotations
@@ -31,10 +28,6 @@ import os
 from typing import Any
 
 ENC_PREFIX = "ENC:"
-# Field names whose string values are treated as secrets and encrypted.
-SENSITIVE_FIELD_NAMES = frozenset(
-    {"api_key", "password", "token", "api_token", "access_token", "access_key", "secret"}
-)
 
 
 def config_encryption_key() -> str | None:
@@ -46,20 +39,6 @@ def _fernet(key: str):
     from cryptography.fernet import Fernet
 
     return Fernet(base64.urlsafe_b64encode(hashlib.sha256(key.encode()).digest()))
-
-
-def encrypt_sensitive_fields(config: Any) -> Any:
-    """Return a copy of ``config`` with sensitive string values encrypted.
-
-    A no-op (returns an unchanged deep copy) when EFP_CONFIG_KEY is not set, so
-    profiles still work in environments that have not provisioned a key.
-    """
-    result = copy.deepcopy(config)
-    key = config_encryption_key()
-    if not key:
-        return result
-    _walk_encrypt(result, _fernet(key))
-    return result
 
 
 def decrypt_sensitive_fields(config: Any) -> Any:
@@ -80,25 +59,6 @@ def decrypt_sensitive_fields(config: Any) -> Any:
         )
     _walk_decrypt(result, _fernet(key))
     return result
-
-
-def _walk_encrypt(obj: Any, fernet) -> None:
-    if isinstance(obj, dict):
-        for k, v in obj.items():
-            if (
-                k in SENSITIVE_FIELD_NAMES
-                and isinstance(v, str)
-                and v
-                and not v.startswith(ENC_PREFIX)
-                and not v.startswith("${")
-            ):
-                obj[k] = ENC_PREFIX + fernet.encrypt(v.encode()).decode()
-            elif isinstance(v, (dict, list)):
-                _walk_encrypt(v, fernet)
-    elif isinstance(obj, list):
-        for item in obj:
-            if isinstance(item, (dict, list)):
-                _walk_encrypt(item, fernet)
 
 
 def _walk_decrypt(obj: Any, fernet) -> None:


### PR DESCRIPTION
The runtime only ever **decrypts** `ENC:` values at boot (`src/config.py`). The encrypt half — `encrypt_sensitive_fields`, `_walk_encrypt`, `SENSITIVE_FIELD_NAMES` — was unused dead code carried over when the module was ported verbatim from the portal. Remove it (−40 net lines).

The **shared key-derivation core** (`ENC_PREFIX`, `config_encryption_key`, `_fernet`, `_decrypt_value`) stays **byte-identical** to the portal's `app/services/profile_secret_encryption.py`, so this runtime can still read portal ciphertext.

**Verified:**
- `inspect.getsource` equality of every shared decrypt-core symbol vs portal.
- Cross-repo round-trip: portal encrypts → this runtime decrypts → recovers plaintext, no `ENC:` leaks.
- `tests/test_profile_secret_decryption_boot.py` — 3 passed (unchanged; it never used encrypt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)