### PR TITLE
Coerce the LLM provider to GitHub Copilot in the runtime projection

### DIFF
--- a/src/runtime_profile_projection.py
+++ b/src/runtime_profile_projection.py
@@ -35,12 +35,10 @@ from typing import Any
 
 
 def normalize_provider_for_portal(value: str | None) -> str:
-    raw = (value or "").strip().lower()
-    if raw in {"github", "github-copilot", "copilot", "github_copilot"}:
-        return "github_copilot"
-    if raw in {"claude", "anthropic"}:
-        return "anthropic"
-    return raw
+    # GitHub Copilot is the only supported provider; coerce every value
+    # (copilot aliases, blank, and any legacy openai/anthropic value) to it.
+    _ = value
+    return "github_copilot"
 
 
 def normalize_provider_for_runtime(runtime_type: str, provider: str | None) -> str:

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -175,7 +175,9 @@ def test_env_overlay_merges_whitelisted_sections_and_keeps_base_read_only(tmp_pa
     )
 
     effective = cfg.get_effective_config()
-    assert effective["llm"]["provider"] == "anthropic"
+    # GitHub Copilot is the only supported provider: the overlay provider is
+    # coerced to it at projection time.
+    assert effective["llm"]["provider"] == "github_copilot"
     # Deep merge: unmanaged base llm fields survive the overlay.
     assert effective["llm"]["model"] == "gpt-4o"
     assert effective["llm"]["api_base"] == "https://api.local"
@@ -252,7 +254,8 @@ def test_env_overlay_filters_unmanaged_nested_fields(tmp_path, monkeypatch):
     )
 
     effective = cfg.get_effective_config()
-    assert effective["llm"]["provider"] == "openai"
+    # Overlay provider is coerced to the only supported provider, Copilot.
+    assert effective["llm"]["provider"] == "github_copilot"
     assert effective["llm"]["model"] == "gpt-5"
     assert effective["llm"]["api_base"] == "https://api.local"
     assert effective["github"]["enabled"] is True


### PR DESCRIPTION
Part of locking the platform to **GitHub Copilot** as the only LLM provider. Coordinated with the portal (source of truth, dvnuo/engineering-flow-platform-portal#…) and the opencode runtime.

`normalize_provider_for_portal` in the verbatim projection port now coerces **every** provider value (copilot aliases, blank, and any legacy openai/anthropic) to `github_copilot` — kept in sync with the portal's `app/contracts/provider_projection.py` and the opencode port. The native LLM client (`runtime_chat.py`) was already Copilot-only; this ensures a stray non-Copilot provider in a stored config is coerced at boot rather than reaching the gateway.

Portal-side canonicalization remains the source of truth for **model** validity; this projection only guarantees the provider.

**Tests:** `test_runtime_profile_overlay` updated — a non-copilot overlay provider is coerced to `github_copilot` at projection time (37 passed). Other suite failures are pre-existing Windows-only env issues (shell/filesystem), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)