### PR TITLE
Add the AI Platform LLM provider to the native runtime (P2)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -182,6 +182,19 @@ class Config:
             "context_projection": True,
             "response_flow": True,
             "tool_loop": True,
+            # AI Platform rich config (chat/ib2b endpoints + credentials).
+            "ai_platform": {
+                "chat": {"host": True, "uri": True},
+                "ib2b": {"host": True, "uri": True},
+                "auth": {
+                    "username": True,
+                    "password": True,
+                    "usercase": True,
+                    "trust_token_header": True,
+                    "tracking_prefix": True,
+                    "token": True,
+                },
+            },
         },
         "proxy": {
             "enabled": True,

--- a/src/efp_runtime/llm/models.py
+++ b/src/efp_runtime/llm/models.py
@@ -19,6 +19,10 @@ SUPPORTED_COPILOT_MODEL_IDS = (
     "gpt-5.6-terra",
 )
 
+# AI Platform (enterprise gateway) models.
+DEFAULT_AI_PLATFORM_MODEL = "gpt-5.4"
+AI_PLATFORM_MODEL_IDS = ("gpt-5.4",)
+
 
 @dataclass(frozen=True)
 class ModelContextProfile:

--- a/src/efp_runtime/llm/provider.py
+++ b/src/efp_runtime/llm/provider.py
@@ -566,6 +566,312 @@ class GitHubCopilotProvider(OpenAICompatibleProvider):
         return response
 
 
+DEFAULT_AI_PLATFORM_TOKEN_TTL_SECONDS = 30
+AI_PLATFORM_TOKEN_REFRESH_MARGIN_SECONDS = 5
+DEFAULT_AI_PLATFORM_TRUST_TOKEN_HEADER = "X-XXXX-E2E-Trust-Token"
+DEFAULT_AI_PLATFORM_TRACKING_PREFIX = "EFP"
+
+
+class AIPlatformHTTPTransport:
+    """HTTP JSON transport for the AI Platform OpenAI-compatible chat endpoint.
+
+    Auth is two-legged: username/password/usercase are exchanged at an iB2B STS
+    endpoint for a short-lived JWT ("trust token"), which is sent in a
+    configurable trust-token header on each chat call (plus tracking ids). The
+    JWT is re-exchanged when missing or within a refresh margin of expiry, and
+    once reactively on a 401/403.
+    """
+
+    def __init__(
+        self,
+        *,
+        chat_endpoint: str,
+        ib2b_endpoint: str = "",
+        username: str = "",
+        password: str = "",
+        usercase: str = "",
+        token: str = "",
+        trust_token_header: str = DEFAULT_AI_PLATFORM_TRUST_TOKEN_HEADER,
+        tracking_prefix: str = DEFAULT_AI_PLATFORM_TRACKING_PREFIX,
+        timeout: float | None = DEFAULT_GITHUB_COPILOT_TIMEOUT_SECONDS,
+        token_ttl_seconds: int = DEFAULT_AI_PLATFORM_TOKEN_TTL_SECONDS,
+    ) -> None:
+        self.endpoint = _required_non_empty_string(chat_endpoint, "chat_endpoint")
+        self.ib2b_endpoint = (ib2b_endpoint or "").strip()
+        self.timeout = timeout
+        self.token_source = "ai_platform"
+        self._username = (username or "").strip()
+        self._password = (password or "").strip()
+        self._usercase = (usercase or "").strip()
+        self._trust_token_header = (trust_token_header or DEFAULT_AI_PLATFORM_TRUST_TOKEN_HEADER).strip()
+        self._tracking_prefix = (tracking_prefix or DEFAULT_AI_PLATFORM_TRACKING_PREFIX).strip()
+        self._token_ttl_seconds = max(1, int(token_ttl_seconds or DEFAULT_AI_PLATFORM_TOKEN_TTL_SECONDS))
+        self._token = (token or "").strip()
+        self._token_expires_at: float | None = (
+            time.time() + self._token_ttl_seconds if self._token else None
+        )
+        self._refresh_lock = threading.Lock()
+
+    # -- token management --------------------------------------------------
+
+    def _token_is_fresh(self) -> bool:
+        if not self._token:
+            return False
+        if self._token_expires_at is None:
+            return True
+        return self._token_expires_at > time.time() + AI_PLATFORM_TOKEN_REFRESH_MARGIN_SECONDS
+
+    def _ensure_token(self, *, force: bool = False) -> None:
+        if not force and self._token_is_fresh():
+            return
+        with self._refresh_lock:
+            if not force and self._token_is_fresh():
+                return
+            self._exchange_token()
+
+    def _exchange_token(self) -> None:
+        if not (self._username and self._password and self.ib2b_endpoint):
+            if self._token:
+                return
+            raise ProviderTransportError(
+                "AI Platform requires a token, or username/password plus an iB2B endpoint."
+            )
+        body = json.dumps(
+            {
+                "input_token_state": {
+                    "token_type": "CREDENTIAL",
+                    "username": self._username,
+                    "password": self._password,
+                },
+                "output_token_state": {"token_type": "JWT"},
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        request = urllib_request.Request(
+            self.ib2b_endpoint,
+            data=body,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib_request.urlopen(request, timeout=self.timeout) as response:
+                raw = response.read()
+        except urllib_error.HTTPError as exc:
+            text = _read_http_error_body(exc)
+            raise ProviderTransportError(
+                "AI Platform token exchange failed ({0}): {1}".format(
+                    exc.code, _redact_secret(text, self._password)
+                )
+            ) from None
+        except urllib_error.URLError as exc:
+            reason = _redact_secret(str(getattr(exc, "reason", exc)), self._password)
+            raise ProviderTransportError(
+                "AI Platform token exchange failed: {0}".format(reason)
+            ) from None
+        except TimeoutError:
+            raise ProviderTransportError(
+                _format_timeout_message("AI Platform token exchange", self.timeout)
+            ) from None
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ProviderTransportError(
+                "AI Platform token exchange returned invalid JSON"
+            ) from exc
+        token = str(data.get("issued_token") or "").strip() if isinstance(data, dict) else ""
+        if not token:
+            raise ProviderTransportError(
+                "AI Platform token exchange did not return issued_token."
+            )
+        self._token = token
+        self._token_expires_at = time.time() + self._token_ttl_seconds
+
+    def _tracking_id(self) -> str:
+        prefix = self._tracking_prefix or DEFAULT_AI_PLATFORM_TRACKING_PREFIX
+        return "{0}-{1}".format(prefix, time.strftime("%Y%m%d%H%M%S", time.gmtime()))
+
+    def _headers(self, *, stream: bool = False) -> dict[str, str]:
+        tracking = self._tracking_id()
+        return {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream" if stream else "application/json",
+            self._trust_token_header: self._token,
+            "x-correlation-id": tracking,
+            "x-usersession-id": tracking,
+        }
+
+    @staticmethod
+    def _should_reexchange(exc: urllib_error.HTTPError) -> bool:
+        return getattr(exc, "code", None) in (401, 403)
+
+    # -- send --------------------------------------------------------------
+
+    async def send(self, payload: dict[str, Any]) -> TransportOutput:
+        if payload.get("stream") is True:
+            return self._send_stream(payload)
+        return await asyncio.to_thread(self._send_sync, payload)
+
+    async def _send_stream(self, payload: dict[str, Any]) -> AsyncIterator[Mapping[str, Any]]:
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        done = object()
+        loop = asyncio.get_running_loop()
+
+        def worker() -> None:
+            try:
+                for chunk in self._send_stream_sync(payload):
+                    loop.call_soon_threadsafe(queue.put_nowait, chunk)
+            except BaseException as exc:  # noqa: BLE001 - propagated through async iterator.
+                loop.call_soon_threadsafe(queue.put_nowait, exc)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, done)
+
+        task = asyncio.create_task(asyncio.to_thread(worker))
+        try:
+            while True:
+                item = await queue.get()
+                if item is done:
+                    break
+                if isinstance(item, BaseException):
+                    raise item
+                yield item
+        finally:
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+    def _encode_payload(self, payload: dict[str, Any]) -> bytes:
+        try:
+            return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise ProviderTransportError(
+                "AI Platform HTTP transport received a non-JSON payload"
+            ) from exc
+
+    def _send_stream_sync(self, payload: dict[str, Any]) -> Iterable[Mapping[str, Any]]:
+        body = self._encode_payload(payload)
+        self._ensure_token()
+        for attempt in range(2):
+            request = urllib_request.Request(
+                self.endpoint, data=body, headers=self._headers(stream=True), method="POST"
+            )
+            try:
+                with urllib_request.urlopen(request, timeout=self.timeout) as response:
+                    yield from parse_sse_json_events(_iter_response_lines(response))
+                return
+            except urllib_error.HTTPError as exc:
+                if attempt == 0 and self._should_reexchange(exc):
+                    self._ensure_token(force=True)
+                    continue
+                text = _read_http_error_body(exc)
+                raise ProviderTransportError(
+                    "AI Platform HTTP transport failed ({0}): {1}".format(
+                        exc.code, _redact_secret(text, self._token)
+                    )
+                ) from None
+            except urllib_error.URLError as exc:
+                reason = _redact_secret(str(getattr(exc, "reason", exc)), self._token)
+                raise ProviderTransportError(
+                    "AI Platform HTTP transport failed: {0}".format(reason)
+                ) from None
+            except TimeoutError:
+                raise ProviderTransportError(
+                    _format_timeout_message("AI Platform HTTP transport", self.timeout)
+                ) from None
+
+    def _send_sync(self, payload: dict[str, Any]) -> dict[str, Any]:
+        body = self._encode_payload(payload)
+        self._ensure_token()
+        for attempt in range(2):
+            request = urllib_request.Request(
+                self.endpoint, data=body, headers=self._headers(), method="POST"
+            )
+            try:
+                with urllib_request.urlopen(request, timeout=self.timeout) as response:
+                    return self._decode_json_response(response.read())
+            except urllib_error.HTTPError as exc:
+                if attempt == 0 and self._should_reexchange(exc):
+                    self._ensure_token(force=True)
+                    continue
+                text = _read_http_error_body(exc)
+                raise ProviderTransportError(
+                    "AI Platform HTTP transport failed ({0}): {1}".format(
+                        exc.code, _redact_secret(text, self._token)
+                    )
+                ) from None
+            except urllib_error.URLError as exc:
+                reason = _redact_secret(str(getattr(exc, "reason", exc)), self._token)
+                raise ProviderTransportError(
+                    "AI Platform HTTP transport failed: {0}".format(reason)
+                ) from None
+            except TimeoutError:
+                raise ProviderTransportError(
+                    _format_timeout_message("AI Platform HTTP transport", self.timeout)
+                ) from None
+        raise ProviderTransportError("AI Platform HTTP transport exhausted retries")
+
+    def _decode_json_response(self, raw_body: bytes) -> dict[str, Any]:
+        try:
+            data = json.loads(raw_body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ProviderTransportError(
+                "AI Platform HTTP transport returned invalid JSON"
+            ) from exc
+        if not isinstance(data, dict):
+            raise ProviderTransportError(
+                "AI Platform HTTP transport returned a non-object JSON response"
+            )
+        return data
+
+
+class AIPlatformProvider(OpenAICompatibleProvider):
+    """OpenAI-compatible facade for the AI Platform chat/completions endpoint."""
+
+    def __init__(
+        self,
+        *,
+        transport: ProviderTransport,
+        model: str,
+        instructions: Optional[str] = None,
+        stream: bool = False,
+        metadata: Optional[Mapping[str, Any]] = None,
+        reasoning_effort: Optional[str] = None,
+        usercase: Optional[str] = None,
+        adapter: Optional[LLMEventAdapter] = None,
+    ) -> None:
+        provider_metadata = dict(metadata or {})
+        provider_metadata.update({"provider": "ai_platform", "provider_id": "ai_platform"})
+        self._usercase = (usercase or "").strip()
+        super().__init__(
+            model=model,
+            transport=transport,
+            endpoint="chat",
+            instructions=instructions,
+            stream=stream,
+            metadata=provider_metadata,
+            reasoning_effort=reasoning_effort,
+            adapter=adapter,
+        )
+
+    def build_payload(self, request: RuntimeRequest) -> dict[str, Any]:
+        payload = super().build_payload(request)
+        if self.reasoning_effort:
+            payload.setdefault("reasoning_effort", self.reasoning_effort)
+        if self._usercase:
+            payload.setdefault("user", self._usercase)
+        return payload
+
+    def _transport_error_response(self, exc: BaseException) -> dict[str, Any]:
+        response = super()._transport_error_response(exc)
+        metadata = response.setdefault("metadata", {})
+        if isinstance(metadata, dict):
+            metadata["provider"] = "ai_platform"
+            metadata["provider_id"] = "ai_platform"
+        return response
+
+
 class RecordingTransport:
     """Small deterministic transport for tests and local prototypes."""
 

--- a/src/gateway/runtime_api.py
+++ b/src/gateway/runtime_api.py
@@ -1220,12 +1220,18 @@ async def api_chat(request: web.Request) -> web.Response:
         if not message and not attachment_ids:
             return web.json_response({'error': 'Empty message'}, status=400)
         
-        # Check if LLM is configured before processing
-        api_key = global_config.llm.get('api_key')
-        if not api_key:
+        # Check if an LLM is configured before processing. Copilot needs an
+        # api_key; AI Platform authenticates via its own ai_platform.auth block
+        # (username/password or a direct token) and has no api_key.
+        llm_cfg = global_config.llm if isinstance(global_config.llm, dict) else {}
+        provider = str(llm_cfg.get('provider') or '').strip().lower()
+        ai_platform_configured = provider in ('ai_platform', 'ai-platform') and isinstance(
+            llm_cfg.get('ai_platform'), dict
+        )
+        if not llm_cfg.get('api_key') and not ai_platform_configured:
             return web.json_response({
                 'error': 'LLM not configured',
-                'message': 'Please configure LLM API Key in Settings to use the chat feature.',
+                'message': 'Please configure an LLM provider in Settings to use the chat feature.',
                 'code': 'llm_not_configured'
             }, status=503)
         

--- a/src/gateway/runtime_chat.py
+++ b/src/gateway/runtime_chat.py
@@ -26,7 +26,7 @@ from src.efp_runtime.llm.provider import (
     ProviderTransportError,
     validate_copilot_reasoning_effort,
 )
-from src.efp_runtime.llm.models import DEFAULT_AI_PLATFORM_MODEL, canonicalize_copilot_model_id
+from src.efp_runtime.llm.models import AI_PLATFORM_MODEL_IDS, DEFAULT_AI_PLATFORM_MODEL, canonicalize_copilot_model_id
 from src.efp_runtime.loop.runner import LoopStatus, RuntimeLoopResult
 from src.efp_runtime.runtime import AgentRuntime, RuntimeConfig
 from src.efp_runtime.session.gateway_facade import (
@@ -547,8 +547,13 @@ def _join_url(host: str, uri: str) -> str:
 
 
 def _resolve_ai_platform_model(model: str | None) -> str:
-    configured = model or config.llm.get("model") or DEFAULT_AI_PLATFORM_MODEL
-    return str(configured).strip() or DEFAULT_AI_PLATFORM_MODEL
+    # Coerce to a valid AI Platform model. /api/chat forwards a Copilot default
+    # model id (e.g. gpt-5.6-terra) when llm.model is unset, which AI Platform
+    # does not serve; fall back to the AI Platform default in that case.
+    configured = str(model or config.llm.get("model") or "").strip()
+    if configured in AI_PLATFORM_MODEL_IDS:
+        return configured
+    return DEFAULT_AI_PLATFORM_MODEL
 
 
 def _build_ai_platform_provider(model: str) -> AIPlatformProvider:

--- a/src/gateway/runtime_chat.py
+++ b/src/gateway/runtime_chat.py
@@ -15,14 +15,18 @@ from src.workspace_defaults import resolve_runtime_workspace
 from src.efp_runtime.event_bus import RuntimeEventBus
 from src.efp_runtime.events import RuntimeEvent
 from src.efp_runtime.llm.provider import (
+    DEFAULT_AI_PLATFORM_TRACKING_PREFIX,
+    DEFAULT_AI_PLATFORM_TRUST_TOKEN_HEADER,
     DEFAULT_COPILOT_REASONING_EFFORT,
     DEFAULT_GITHUB_COPILOT_TIMEOUT_SECONDS,
+    AIPlatformHTTPTransport,
+    AIPlatformProvider,
     GitHubCopilotHTTPTransport,
     GitHubCopilotProvider,
     ProviderTransportError,
     validate_copilot_reasoning_effort,
 )
-from src.efp_runtime.llm.models import canonicalize_copilot_model_id
+from src.efp_runtime.llm.models import DEFAULT_AI_PLATFORM_MODEL, canonicalize_copilot_model_id
 from src.efp_runtime.loop.runner import LoopStatus, RuntimeLoopResult
 from src.efp_runtime.runtime import AgentRuntime, RuntimeConfig
 from src.efp_runtime.session.gateway_facade import (
@@ -92,8 +96,7 @@ async def run_runtime_chat(
 ) -> dict[str, Any]:
     """Run the production chat loop through ``efp_runtime.runtime.AgentRuntime``."""
 
-    runtime_model = _resolve_model(model)
-    provider = _build_github_copilot_provider(runtime_model)
+    provider, runtime_model = _build_llm_provider(model)
     event_bus = RuntimeEventBus()
     runtime = AgentRuntime(
         provider=provider,
@@ -212,8 +215,7 @@ async def resume_runtime_chat(
 ) -> dict[str, Any]:
     """Resume an existing native runtime session without appending a new user message."""
 
-    runtime_model = _resolve_model(model)
-    provider = _build_github_copilot_provider(runtime_model)
+    provider, runtime_model = _build_llm_provider(model)
     event_bus = RuntimeEventBus()
     runtime = AgentRuntime(
         provider=provider,
@@ -532,6 +534,73 @@ def _build_github_copilot_provider(model: str) -> GitHubCopilotProvider:
         metadata={"gateway": "runtime_api"},
         reasoning_effort=_resolve_reasoning_effort(llm_config),
     )
+
+
+def _join_url(host: str, uri: str) -> str:
+    host = (host or "").rstrip("/")
+    uri = (uri or "").strip()
+    if uri.startswith("http://") or uri.startswith("https://"):
+        return uri
+    if uri and not uri.startswith("/"):
+        uri = "/" + uri
+    return host + uri
+
+
+def _resolve_ai_platform_model(model: str | None) -> str:
+    configured = model or config.llm.get("model") or DEFAULT_AI_PLATFORM_MODEL
+    return str(configured).strip() or DEFAULT_AI_PLATFORM_MODEL
+
+
+def _build_ai_platform_provider(model: str) -> AIPlatformProvider:
+    llm_config = config.llm if isinstance(config.llm, dict) else {}
+    ap = llm_config.get("ai_platform") if isinstance(llm_config.get("ai_platform"), dict) else {}
+    chat = ap.get("chat") if isinstance(ap.get("chat"), dict) else {}
+    ib2b = ap.get("ib2b") if isinstance(ap.get("ib2b"), dict) else {}
+    auth = ap.get("auth") if isinstance(ap.get("auth"), dict) else {}
+
+    chat_host = str(chat.get("host") or "").strip()
+    if not chat_host:
+        raise RuntimeChatError(
+            "AI Platform chat host is required (llm.ai_platform.chat.host).",
+            status_code=400,
+            error_type="invalid_config",
+            details={"provider": "ai_platform"},
+        )
+    chat_endpoint = _join_url(chat_host, str(chat.get("uri") or "/v1/api/v1/chat/completions"))
+    ib2b_host = str(ib2b.get("host") or "").strip()
+    ib2b_endpoint = _join_url(ib2b_host, str(ib2b.get("uri") or "")) if ib2b_host else ""
+    usercase = str(auth.get("usercase") or "").strip()
+
+    transport = AIPlatformHTTPTransport(
+        chat_endpoint=chat_endpoint,
+        ib2b_endpoint=ib2b_endpoint,
+        username=str(auth.get("username") or ""),
+        password=str(auth.get("password") or ""),
+        usercase=usercase,
+        token=str(auth.get("token") or ""),
+        trust_token_header=str(auth.get("trust_token_header") or "") or DEFAULT_AI_PLATFORM_TRUST_TOKEN_HEADER,
+        tracking_prefix=str(auth.get("tracking_prefix") or "") or DEFAULT_AI_PLATFORM_TRACKING_PREFIX,
+        timeout=_resolve_github_copilot_timeout(llm_config),
+    )
+    return AIPlatformProvider(
+        transport=transport,
+        model=model,
+        stream=True,
+        metadata={"gateway": "runtime_api"},
+        reasoning_effort=_resolve_reasoning_effort(llm_config),
+        usercase=usercase,
+    )
+
+
+def _build_llm_provider(model: str | None):
+    """Dispatch to the configured provider; returns (provider, runtime_model)."""
+    llm_config = config.llm if isinstance(config.llm, dict) else {}
+    provider = str(llm_config.get("provider") or "").strip().lower()
+    if provider in {"ai_platform", "ai-platform"}:
+        runtime_model = _resolve_ai_platform_model(model)
+        return _build_ai_platform_provider(runtime_model), runtime_model
+    runtime_model = _resolve_model(model)
+    return _build_github_copilot_provider(runtime_model), runtime_model
 
 
 def _resolve_reasoning_effort(llm_config: Mapping[str, Any]) -> str:

--- a/src/runtime_profile_projection.py
+++ b/src/runtime_profile_projection.py
@@ -34,17 +34,26 @@ from typing import Any
 # ---------------------------------------------------------------------------
 
 
+_AI_PLATFORM_ALIASES = {"ai_platform", "ai-platform", "ai platform"}
+
+
 def normalize_provider_for_portal(value: str | None) -> str:
-    # GitHub Copilot is the only supported provider; coerce every value
-    # (copilot aliases, blank, and any legacy openai/anthropic value) to it.
-    _ = value
+    # Two supported providers: github_copilot (default) and ai_platform.
+    # Anything blank/unknown (incl. copilot aliases and legacy openai/anthropic)
+    # falls back to github_copilot.
+    raw = (value or "").strip().lower()
+    if raw in _AI_PLATFORM_ALIASES:
+        return "ai_platform"
     return "github_copilot"
 
 
 def normalize_provider_for_runtime(runtime_type: str, provider: str | None) -> str:
     portal_provider = normalize_provider_for_portal(provider)
-    if (runtime_type or "").strip().lower() == "opencode" and portal_provider == "github_copilot":
-        return "github-copilot"
+    if (runtime_type or "").strip().lower() == "opencode":
+        if portal_provider == "github_copilot":
+            return "github-copilot"
+        if portal_provider == "ai_platform":
+            return "ai-platform"
     return portal_provider
 
 
@@ -94,19 +103,18 @@ def project_llm_for_runtime(llm: dict, runtime_type: str) -> dict:
         if normalized_model:
             projected["model"] = normalized_model
 
-    if not _is_copilot_provider(provider_hint):
-        projected.pop("oauth", None)
-        projected.pop("oauth_by_runtime", None)
-        return projected
-
-    token = str(projected.get("api_key") or "").strip()
+    # Portal-only oauth fields never reach a runtime.
     projected.pop("oauth", None)
     projected.pop("oauth_by_runtime", None)
 
-    if token:
-        projected["api_key"] = token
-    else:
-        projected.pop("api_key", None)
+    if _is_copilot_provider(provider_hint):
+        token = str(projected.get("api_key") or "").strip()
+        if token:
+            projected["api_key"] = token
+        else:
+            projected.pop("api_key", None)
+    # For ai_platform the rich block (llm.ai_platform: chat/ib2b endpoints +
+    # auth credentials) is preserved as-is for the runtime to consume.
     return projected
 
 

--- a/tests/test_ai_platform_provider.py
+++ b/tests/test_ai_platform_provider.py
@@ -1,0 +1,121 @@
+"""AI Platform native transport: iB2B token exchange + chat call + refresh."""
+import io
+import json
+
+import pytest
+
+from src.efp_runtime.llm import provider as provider_mod
+from src.efp_runtime.llm.provider import AIPlatformHTTPTransport, ProviderTransportError
+
+
+class _FakeResp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _urlopen_script(steps):
+    """steps: list of dict-body (returned) or urllib HTTPError (raised)."""
+    calls = []
+    it = iter(steps)
+
+    def _open(request, timeout=None):
+        calls.append(request)
+        step = next(it)
+        if isinstance(step, BaseException):
+            raise step
+        return _FakeResp(json.dumps(step).encode("utf-8"))
+
+    return _open, calls
+
+
+def _http_error(code):
+    from urllib import error as urllib_error
+
+    return urllib_error.HTTPError("https://x", code, "denied", {}, io.BytesIO(b'{"error":"nope"}'))
+
+
+def _transport(**kw):
+    base = dict(
+        chat_endpoint="https://chat.int/v1/api/v1/chat/completions",
+        ib2b_endpoint="https://ib2b.int/dsp",
+        username="u",
+        password="pw",
+        usercase="uc",
+        trust_token_header="X-Trust",
+        tracking_prefix="EFP",
+    )
+    base.update(kw)
+    return AIPlatformHTTPTransport(**base)
+
+
+def test_exchange_then_chat_carries_trust_token(monkeypatch):
+    t = _transport()
+    open_fn, calls = _urlopen_script([
+        {"issued_token": "JWT-1"},
+        {"choices": [{"message": {"content": "pong"}}]},
+    ])
+    monkeypatch.setattr(provider_mod.urllib_request, "urlopen", open_fn)
+
+    out = t._send_sync({"model": "gpt-5.4", "messages": [{"role": "user", "content": "ping"}]})
+    assert out["choices"][0]["message"]["content"] == "pong"
+    assert len(calls) == 2
+    # 1) iB2B exchange with the CREDENTIAL body
+    body0 = json.loads(calls[0].data)
+    assert body0["input_token_state"]["token_type"] == "CREDENTIAL"
+    assert body0["input_token_state"]["username"] == "u"
+    # 2) chat call carries the exchanged JWT in the trust-token header + tracking
+    header_values = list(calls[1].headers.values())
+    assert "JWT-1" in header_values
+    assert any(str(v).startswith("EFP-") for v in header_values)
+
+
+def test_token_is_reused_until_expiry(monkeypatch):
+    t = _transport()
+    open_fn, calls = _urlopen_script([
+        {"issued_token": "JWT-1"},
+        {"choices": []},
+        {"choices": []},
+    ])
+    monkeypatch.setattr(provider_mod.urllib_request, "urlopen", open_fn)
+    t._send_sync({"messages": []})
+    t._send_sync({"messages": []})
+    # 1 exchange + 2 chat calls (token reused for the second)
+    assert len(calls) == 3
+
+
+def test_reexchanges_once_on_401(monkeypatch):
+    t = _transport()
+    open_fn, calls = _urlopen_script([
+        {"issued_token": "JWT-1"},   # initial exchange
+        _http_error(401),            # chat -> 401
+        {"issued_token": "JWT-2"},   # forced re-exchange
+        {"choices": []},             # chat retry OK
+    ])
+    monkeypatch.setattr(provider_mod.urllib_request, "urlopen", open_fn)
+    t._send_sync({"messages": []})
+    assert len(calls) == 4
+    assert "JWT-2" in list(calls[3].headers.values())
+
+
+def test_missing_credentials_raises(monkeypatch):
+    t = _transport(username="", password="", ib2b_endpoint="")
+    with pytest.raises(ProviderTransportError):
+        t._send_sync({"messages": []})
+
+
+def test_direct_token_skips_exchange(monkeypatch):
+    t = _transport(username="", password="", ib2b_endpoint="", token="JWT-DIRECT")
+    open_fn, calls = _urlopen_script([{"choices": []}])
+    monkeypatch.setattr(provider_mod.urllib_request, "urlopen", open_fn)
+    t._send_sync({"messages": []})
+    assert len(calls) == 1  # no exchange, straight to chat
+    assert "JWT-DIRECT" in list(calls[0].headers.values())

--- a/tests/test_ai_platform_provider.py
+++ b/tests/test_ai_platform_provider.py
@@ -112,6 +112,52 @@ def test_missing_credentials_raises(monkeypatch):
         t._send_sync({"messages": []})
 
 
+def test_resolve_ai_platform_model_coerces_non_ai_platform_model(monkeypatch):
+    import src.gateway.runtime_chat as rc
+
+    monkeypatch.setattr(rc.config, "_config", {"llm": {"provider": "ai_platform"}}, raising=False)
+    assert rc._resolve_ai_platform_model("gpt-5.6-terra") == "gpt-5.4"  # copilot id coerced
+    assert rc._resolve_ai_platform_model("gpt-5.4") == "gpt-5.4"
+    assert rc._resolve_ai_platform_model(None) == "gpt-5.4"
+
+
+def test_build_llm_provider_dispatches_to_ai_platform(monkeypatch):
+    import src.gateway.runtime_chat as rc
+    from src.efp_runtime.llm.provider import AIPlatformProvider
+
+    monkeypatch.setattr(
+        rc.config,
+        "_config",
+        {
+            "llm": {
+                "provider": "ai_platform",
+                "model": "gpt-5.4",
+                "ai_platform": {
+                    "chat": {"host": "https://c", "uri": "/v1/api/v1/chat/completions"},
+                    "auth": {"username": "u", "password": "p"},
+                },
+            }
+        },
+        raising=False,
+    )
+    provider, model = rc._build_llm_provider(None)
+    assert isinstance(provider, AIPlatformProvider)
+    assert model == "gpt-5.4"
+
+
+def test_build_ai_platform_provider_requires_chat_host(monkeypatch):
+    import src.gateway.runtime_chat as rc
+
+    monkeypatch.setattr(
+        rc.config,
+        "_config",
+        {"llm": {"provider": "ai_platform", "ai_platform": {"auth": {"username": "u"}}}},
+        raising=False,
+    )
+    with pytest.raises(rc.RuntimeChatError):
+        rc._build_llm_provider(None)
+
+
 def test_direct_token_skips_exchange(monkeypatch):
     t = _transport(username="", password="", ib2b_endpoint="", token="JWT-DIRECT")
     open_fn, calls = _urlopen_script([{"choices": []}])

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -235,6 +235,32 @@ def test_env_overlay_invalid_json_records_load_error_without_crashing(tmp_path, 
     assert cfg.get_effective_config()["llm"]["provider"] == "openai"
 
 
+def test_env_overlay_ai_platform_provider_and_block(tmp_path, monkeypatch):
+    cfg = _env_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "llm": {
+                "provider": "ai_platform",
+                "model": "gpt-5.4",
+                "ai_platform": {
+                    "chat": {"host": "https://chat.int", "uri": "/v1/api/v1/chat/completions"},
+                    "ib2b": {"host": "https://ib2b.int", "uri": "/dsp/token"},
+                    "auth": {"username": "u", "password": "pw", "usercase": "uc"},
+                },
+            },
+        },
+    )
+    effective = cfg.get_effective_config()["llm"]
+    # ai_platform is a supported provider: it is NOT coerced to copilot at boot.
+    assert effective["provider"] == "ai_platform"
+    assert effective["model"] == "gpt-5.4"
+    ap = effective["ai_platform"]
+    assert ap["chat"]["host"] == "https://chat.int"
+    assert ap["ib2b"]["uri"] == "/dsp/token"
+    assert ap["auth"]["password"] == "pw"
+
+
 def test_env_overlay_filters_unmanaged_nested_fields(tmp_path, monkeypatch):
     cfg = _env_config(
         tmp_path,


### PR DESCRIPTION
**P2 of the ai_platform rollout** — makes the native runtime actually drive AI Platform. Depends on portal **P1** (dvnuo/engineering-flow-platform-portal#419, which added the provider whitelist + rich config + projection).

## Changes
- **`runtime_profile_projection.py`**: sync the projection port to the portal whitelist — `ai_platform` is preserved (not coerced to copilot); opencode form `ai-platform`. **Verified byte-identical to portal's projection functions.**
- **`efp_runtime/llm/provider.py`**: `AIPlatformHTTPTransport` — exchanges `username/password` for a short-lived JWT via the **iB2B** endpoint, caches it with a refresh margin (re-exchanges when near expiry, and once reactively on 401/403), and sends it in the configurable trust-token header (+ tracking ids) on each chat call. `AIPlatformProvider` reuses the existing `OpenAICompatibleProvider` base with `endpoint="chat"`.
- **`gateway/runtime_chat.py`**: `_build_llm_provider` dispatches to copilot or ai_platform based on `llm.provider`; the ai_platform builder reads the transport config from `llm.ai_platform`.
- **`models.py`**: `DEFAULT_AI_PLATFORM_MODEL = gpt-5.4`.
- **`config.py`**: allow the nested `llm.ai_platform` block through the boot overlay filter.

## Tests
`test_ai_platform_provider.py` — exchange→chat with the trust token, token reuse until expiry, 401 re-exchange, direct-token (skip exchange), missing-credentials error. Plus a boot-overlay test carrying `ai_platform` end-to-end. Full native suite: **2388 passed**, 31 failures are pre-existing Windows-only env issues (file/shell tools — confirmed identical with these changes stashed).

## Note
The AI Platform wire integration (real iB2B endpoint + streaming) is exercised by unit tests with a mocked HTTP layer and reuses the proven SSE parser; a real-endpoint smoke is worth running before production use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)