### PR TITLE
Forward attached images to the LLM request as image content

### DIFF
--- a/src/efp_runtime/compaction/strategy.py
+++ b/src/efp_runtime/compaction/strategy.py
@@ -702,11 +702,14 @@ def _part_chars(part: MessagePart) -> int:
     if part.type is MessagePartType.TOOL_RESULT and part.tool_result is not None:
         return len(part.tool_result.content or "")
     if part.type is MessagePartType.ATTACHMENT and part.attachment is not None:
+        url = part.attachment.url or ""
+        # Inline image data: URIs are not text tokens; don't count the (large)
+        # base64 payload against the char budget or it would distort compaction.
         metadata = {
             "attachment_id": part.attachment.attachment_id,
             "mime_type": part.attachment.mime_type,
             "filename": part.attachment.filename,
-            "url": part.attachment.url,
+            "url": "" if url.startswith("data:") else url,
             "metadata": _copy_mapping(part.attachment.metadata),
             "created_at": part.attachment.created_at,
         }

--- a/src/efp_runtime/compaction/summary.py
+++ b/src/efp_runtime/compaction/summary.py
@@ -225,6 +225,16 @@ def _render_source_context(
     return "\n\n".join(section for section in sections if section)
 
 
+def _summary_url(url: object) -> str:
+    """Render an attachment url for summaries, collapsing inline data: URIs to a
+    short placeholder so a base64 image payload never bloats a compaction summary."""
+    text = str(url or "")
+    if text.startswith("data:"):
+        head = text[5:].split(",", 1)[0]
+        return f"[inline {head or 'data'}]"
+    return text
+
+
 def _render_messages_for_prompt(messages: list[Message]) -> str:
     if not messages:
         return "(none)"
@@ -286,7 +296,7 @@ def _render_part_for_prompt(index: int, part: MessagePart) -> list[str]:
         return [
             (
                 f"{prefix} attachment_id={part.attachment.attachment_id} "
-                f"filename={part.attachment.filename} url={part.attachment.url} "
+                f"filename={part.attachment.filename} url={_summary_url(part.attachment.url)} "
                 f"text_ref={part.attachment.text_ref}"
             )
         ]
@@ -317,7 +327,7 @@ def _part_text_sources(part: MessagePart) -> list[str]:
         sources.extend(
             [
                 part.attachment.filename or "",
-                part.attachment.url or "",
+                _summary_url(part.attachment.url),
                 part.attachment.text_ref or "",
             ]
         )

--- a/src/efp_runtime/llm/openai.py
+++ b/src/efp_runtime/llm/openai.py
@@ -135,7 +135,7 @@ def request_message_to_openai_chat_messages(message: RequestMessage) -> List[Jso
             return
         chat_message: JsonDict = {
             "role": message.role,
-            "content": _parts_to_text(buffered_parts),
+            "content": _chat_content_from_parts(buffered_parts),
         }
         if buffered_tool_calls:
             chat_message["tool_calls"] = [
@@ -221,6 +221,8 @@ def request_part_to_openai_responses_content(
                 "metadata": _copy_mapping(part.reasoning.metadata),
             }
         ]
+    if _is_image_attachment_part(part):
+        return [{"type": "input_image", "image_url": part.attachment.url}]
     if _part_has_projectable_text(part):
         return [
             {
@@ -345,6 +347,40 @@ def _tool_schema_trace(index: int, schema: RequestToolSchema) -> JsonDict:
 def _parts_to_text(parts: List[RequestMessagePart]) -> str:
     chunks = [_part_to_text(part) for part in parts]
     return "\n\n".join(chunk for chunk in chunks if chunk != "")
+
+
+def _is_image_attachment_part(part: RequestMessagePart) -> bool:
+    att = part.attachment
+    return (
+        att is not None
+        and isinstance(getattr(att, "mime_type", None), str)
+        and att.mime_type.startswith("image/")
+        and bool(getattr(att, "url", None))
+    )
+
+
+def _chat_content_from_parts(parts: List[RequestMessagePart]):
+    """Chat Completions content: a plain string, or a list mixing text and
+    image_url blocks when any part is an image attachment."""
+    if not any(_is_image_attachment_part(part) for part in parts):
+        return _parts_to_text(parts)
+    items: List[JsonDict] = []
+    text_buffer: List[str] = []
+
+    def _flush_text() -> None:
+        joined = "\n\n".join(chunk for chunk in text_buffer if chunk != "")
+        if joined:
+            items.append({"type": "text", "text": joined})
+        text_buffer.clear()
+
+    for part in parts:
+        if _is_image_attachment_part(part):
+            _flush_text()
+            items.append({"type": "image_url", "image_url": {"url": part.attachment.url}})
+        else:
+            text_buffer.append(_part_to_text(part))
+    _flush_text()
+    return items
 
 
 def _part_has_projectable_text(part: RequestMessagePart) -> bool:

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -85,7 +85,7 @@ from ..tools.registry import ToolRegistry
 from ..tools.runtime import ToolRuntime
 from ..tools.selection import ToolSelection, resolve_tool_selection
 from ..tools.truncation import ToolOutputTruncator, TruncationLimits
-from ..types import SkillPackage, ToolCall, ToolResult, new_id
+from ..types import Attachment, SkillPackage, ToolCall, ToolResult, new_id
 from ..workspace_snapshots import (
     WorkspaceSnapshot,
     WorkspaceSnapshotDiff,
@@ -131,6 +131,16 @@ class _AgentMention:
 class _CommandSubtaskExecution:
     user_text: str | None = None
     events: list[RuntimeEvent] = field(default_factory=list)
+
+
+def _mime_from_data_uri(uri: str) -> str:
+    """Parse the MIME type from a data: URI, defaulting to image/png."""
+    text = str(uri or "")
+    if text.startswith("data:"):
+        mime = text[5:].split(",", 1)[0].split(";", 1)[0].strip()
+        if mime:
+            return mime
+    return "image/png"
 
 
 class AgentRuntime:
@@ -477,6 +487,7 @@ class AgentRuntime:
         *,
         agent: "str | AgentProfile | None" = None,
         output_schema: Mapping[str, Any] | None = None,
+        attached_images: list[str] | None = None,
     ) -> RuntimeLoopResult:
         skill_command = parse_skill_commands(user_text)
         run_metadata = self._base_run_metadata(metadata)
@@ -617,6 +628,9 @@ class AgentRuntime:
             )
             run_metadata["skill_context_count"] = len(skill_context_messages)
             user_parts = self._resolve_user_parts(user_text_for_request)
+            user_parts = self._merge_attached_images(
+                user_parts, user_text_for_request, attached_images
+            )
             runner = RuntimeLoopRunner(
                 store=self.store,
                 provider=self.provider,
@@ -1261,6 +1275,31 @@ class AgentRuntime:
             max_directory_entries=self.config.max_prompt_directory_entries,
         )
         return resolved_prompt.parts
+
+    def _merge_attached_images(self, user_parts, user_text: str, attached_images):
+        """Append gateway-supplied images as ATTACHMENT parts on the user message
+        so they reach the LLM request as image content (not just a text note)."""
+        images = [str(uri or "").strip() for uri in (attached_images or []) if str(uri or "").strip()]
+        if not images:
+            return user_parts
+        if user_parts is not None:
+            parts = list(user_parts)
+        elif str(user_text or "").strip():
+            parts = [MessagePart.text_part(user_text)]
+        else:
+            parts = []
+        for data_uri in images:
+            parts.append(
+                MessagePart.attachment_part(
+                    Attachment(
+                        mime_type=_mime_from_data_uri(data_uri),
+                        url=data_uri,
+                        metadata={"kind": "image", "source": "gateway.attached_images"},
+                    ),
+                    metadata={"source": "gateway.attached_images"},
+                )
+            )
+        return parts
 
     def _expand_command_prompt(
         self,

--- a/src/gateway/runtime_chat.py
+++ b/src/gateway/runtime_chat.py
@@ -155,6 +155,7 @@ async def run_runtime_chat(
             prompt,
             session_id=session_id,
             metadata=run_metadata,
+            attached_images=attached_images,
         )
         await get_runtime_session_manager().record_runtime_result(
             session_id,

--- a/tests/runtime/test_runtime_chat_gateway.py
+++ b/tests/runtime/test_runtime_chat_gateway.py
@@ -315,7 +315,7 @@ async def test_runtime_chat_applies_trusted_portal_runtime_profile_config(monkey
         def __init__(self, **kwargs):
             captured.update(kwargs)
 
-        async def run(self, _prompt, *, session_id, metadata=None):
+        async def run(self, _prompt, *, session_id, metadata=None, attached_images=None):
             captured["run_metadata"] = metadata
             return RuntimeLoopResult(
                 session_id=session_id,

--- a/tests/test_native_image_content.py
+++ b/tests/test_native_image_content.py
@@ -1,0 +1,77 @@
+"""Native image pipeline: attached images reach the LLM request as image content.
+
+Chat Completions (AI Platform) -> {type:image_url, image_url:{url}};
+Responses (Copilot) -> {type:input_image, image_url:<data-uri>}.
+"""
+from src.efp_runtime.llm.openai import (
+    provider_request_to_openai_chat,
+    provider_request_to_openai_responses,
+)
+from src.efp_runtime.llm.request import (
+    ProviderRequest,
+    RequestAttachment,
+    RequestMessage,
+    RequestMessagePart,
+)
+from src.efp_runtime.runtime.agent import AgentRuntime, _mime_from_data_uri
+from src.efp_runtime.session.models import MessagePartType
+
+DATA = "data:image/png;base64,iVBORw0KGgo="
+
+
+def _img_req():
+    att = RequestAttachment(attachment_id="a1", mime_type="image/png", url=DATA)
+    msg = RequestMessage(
+        role="user",
+        parts=[
+            RequestMessagePart(type="text", text="hi"),
+            RequestMessagePart(type="attachment", attachment=att),
+        ],
+    )
+    return ProviderRequest(messages=[msg], tools=[])
+
+
+def _text_req():
+    msg = RequestMessage(role="user", parts=[RequestMessagePart(type="text", text="hi")])
+    return ProviderRequest(messages=[msg], tools=[])
+
+
+def test_chat_emits_image_url_list():
+    content = provider_request_to_openai_chat(_img_req(), model="m")["messages"][-1]["content"]
+    assert isinstance(content, list)
+    assert {"type": "text", "text": "hi"} in content
+    assert {"type": "image_url", "image_url": {"url": DATA}} in content
+
+
+def test_chat_text_only_stays_a_string():
+    # No images -> plain string content, unchanged from before.
+    content = provider_request_to_openai_chat(_text_req(), model="m")["messages"][-1]["content"]
+    assert content == "hi"
+
+
+def test_responses_emits_input_image():
+    items = provider_request_to_openai_responses(_img_req(), model="m")["input"][-1]["content"]
+    assert {"type": "input_image", "image_url": DATA} in items
+
+
+def test_mime_from_data_uri():
+    assert _mime_from_data_uri("data:image/jpeg;base64,x") == "image/jpeg"
+    assert _mime_from_data_uri("data:image/webp,x") == "image/webp"
+    assert _mime_from_data_uri("plain") == "image/png"
+
+
+def test_merge_attached_images_injects_attachment_parts():
+    # self is unused by the method.
+    parts = AgentRuntime._merge_attached_images(None, None, "look at this", [DATA, "  "])
+    assert parts is not None
+    assert parts[0].type is MessagePartType.TEXT and parts[0].text == "look at this"
+    images = [p for p in parts if p.type is MessagePartType.ATTACHMENT]
+    assert len(images) == 1  # blank entries skipped
+    assert images[0].attachment.url == DATA
+    assert images[0].attachment.mime_type == "image/png"
+
+
+def test_merge_no_images_returns_input_unchanged():
+    assert AgentRuntime._merge_attached_images(None, None, "hi", None) is None
+    sentinel = ["existing"]
+    assert AgentRuntime._merge_attached_images(None, sentinel, "hi", []) is sentinel


### PR DESCRIPTION
## Problem
Native agents received attached images only as a **text note** ("Image attachment data URI count: N") — the LLM never saw the pixels. `attached_images` were dropped before `efp_runtime`, and both OpenAI payload builders flattened attachments to text. So "send an image to the model" didn't actually work for **any** provider on the native runtime.

This surfaced while verifying the AI Platform image path: AI Platform's chat/completions API is multimodal, but nothing wired images into the request.

## Fix (threads the data URI end-to-end)
- **`gateway/runtime_chat.py`**: pass `attached_images` into `AgentRuntime.run`.
- **`runtime/agent.py`**: `run()` accepts `attached_images`; each data URI becomes an `ATTACHMENT` `MessagePart` (`Attachment.url` = data URI, mime parsed from `data:<mime>;...`) appended to the user message, alongside any prompt-reference parts.
- **`llm/openai.py`**: the **chat** builder emits list content mixing `{type:text}` and `{type:image_url, image_url:{url}}` for image attachments (plain string content unchanged when there are no images → backwards compatible); the **responses** builder emits `{type:input_image, image_url:<uri>}`.
- No change needed in `context/render.py` (already carries `Attachment.url` → `RequestAttachment.url`) or the Copilot sanitizer (`provider.py:1133`, already passes `input_image` through).

## Effect per provider
- **AI Platform** (chat/completions, `endpoint="chat"`) → images now arrive as `image_url` content.
- **GitHub Copilot** (responses) → images now arrive as `input_image` content.

## Tests
`test_native_image_content.py`: both builders emit image content, text-only stays a string, mime parsing, and the attachment-part injection. Full native suite: **2388 passed**; 31 failures are pre-existing Windows-only env issues (confirmed identical with these changes stashed). Updated one gateway-test fake runtime whose `run()` didn't accept the new kwarg.

Independent of the AI Platform provider PRs but complements them — with this, an ai_platform agent can receive images inline instead of routing through the inspect-image tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)