### PR TITLE
Log request/snapshot timing; stop revert losing files

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -29,34 +30,110 @@ from src.workspace_defaults import resolve_runtime_workspace
 # Must run before importing src.gateway.server (Gateway() executes at import).
 bootstrap_profile_boot()
 
+from src.utils.logger import setup_logging, get_logger
+
+# Log destination. The pod's workingDir is the (network) workspace volume, so a
+# relative "logs" default would write onto EFS and inside the snapshotted tree.
+DEFAULT_LOG_DIR = "/app/logs"
+LOG_DIR_ENV = "EFP_LOG_DIR"
+LOG_LEVEL_ENV = "EFP_LOG_LEVEL"
+
+
+def resolve_log_level() -> str:
+    """Effective log level: EFP_LOG_LEVEL > config.debug.log_level > debug flag.
+
+    The env override lets operators run `kubectl set env ... EFP_LOG_LEVEL=DEBUG`
+    without editing the runtime profile.
+    """
+    env_level = str(os.getenv(LOG_LEVEL_ENV) or "").strip()
+    if env_level:
+        return env_level.upper()
+
+    configured = str(config.debug.get("log_level") or "").strip()
+    if configured:
+        return configured.upper()
+
+    return "DEBUG" if config.debug.get("enabled") else "INFO"
+
+
+def merge_debug_cli_overrides(
+    current_debug: object,
+    *,
+    debug: bool,
+    httpx_trace: bool,
+) -> dict:
+    """Fold --debug/--httpx-trace into the existing debug config.
+
+    Merged rather than replaced: replacing the dict wiped sibling debug keys
+    (notably ``log_level``), so `--debug` silently reset the configured level.
+    """
+    merged = dict(current_debug or {})
+    if debug:
+        merged.update({"enabled": True, "httpx_trace": httpx_trace})
+    elif httpx_trace:
+        merged["httpx_trace"] = True
+    return merged
+
+
+def setup_logging_config() -> logging.Logger:
+    """Configure comprehensive logging with detailed output.
+
+    Returns:
+        Logger instance
+    """
+    # Determine log level from env / config
+    log_level_str = resolve_log_level()
+
+    # Setup enhanced logging
+    logger = setup_logging(
+        level=log_level_str,
+        log_dir=os.getenv(LOG_DIR_ENV, DEFAULT_LOG_DIR),
+        log_file="efp.log",
+        max_size_mb=10,
+        backup_count=5
+    )
+
+    return logger
+
+
+# Logging must be configured BEFORE importing src.gateway.server: Gateway() is
+# constructed at import time and logs while doing it, so anything emitted
+# during import would otherwise be dropped.
+setup_logging_config()
+
 from src.efp_runtime.session.gateway_facade import runtime_session_manager
+from src.efp_runtime.workspace_snapshots import snapshot_storage_root
 from src.gateway.server import gateway
 from src.sessions.persistence import session_persistence
 from src.sessions.usage import usage_tracker
 from src.cron.jira_reconciliation import start_reconciliation, stop_reconciliation, is_enabled as is_jira_reconciliation_enabled
 from src.git.api import setup_git_user
-from src.utils.logger import setup_logging, get_logger
 
 
-def setup_logging_config() -> logging.Logger:
-    """Configure comprehensive logging with detailed output.
-    
-    Returns:
-        Logger instance
+def log_runtime_paths(logger: logging.Logger, workspace_root: Path) -> None:
+    """One greppable line naming every root the runtime reads/writes.
+
+    Makes "which of these lives on the network volume?" permanently answerable
+    from `kubectl logs` alone.
     """
-    # Determine log level from config
-    log_level_str = config.debug.get("log_level", "INFO").upper()
-    
-    # Setup enhanced logging
-    logger = setup_logging(
-        level=log_level_str,
-        log_dir="logs",
-        log_file="efp.log",
-        max_size_mb=10,
-        backup_count=5
-    )
-    
-    return logger
+    try:
+        from src.skills.registry import (
+            resolve_project_skills_dir,
+            resolve_user_skills_dir,
+        )
+
+        logger.info(
+            "runtime.paths "
+            f"workspace_root={workspace_root} "
+            f"session_root={runtime_session_manager.root} "
+            f"project_skills_dir={resolve_project_skills_dir()} "
+            f"user_skills_dir={resolve_user_skills_dir()} "
+            f"snapshot_storage_root={snapshot_storage_root(workspace_root)} "
+            f"log_dir={os.getenv(LOG_DIR_ENV, DEFAULT_LOG_DIR)} "
+            f"cwd={Path.cwd()}"
+        )
+    except Exception as e:
+        logger.warning(f"Failed to log runtime paths | error={e}", exc_info=True)
 
 
 def check_config() -> tuple[bool, list[str]]:
@@ -168,14 +245,13 @@ async def main() -> None:
                         help="Enable debug logging")
     args, _ = parser.parse_known_args()
     
-    # Apply command line arguments to config
-    if args.debug:
-        config._config["debug"] = {"enabled": True, "httpx_trace": args.httpx_trace}
-    elif args.httpx_trace:
-        current_debug = config._config.get("debug", {})
-        current_debug["httpx_trace"] = True
-        config._config["debug"] = current_debug
-    
+    # Apply command line arguments to config.
+    config._config["debug"] = merge_debug_cli_overrides(
+        config._config.get("debug"),
+        debug=args.debug,
+        httpx_trace=args.httpx_trace,
+    )
+
     # Setup httpx logging level BEFORE setup_logging
     httpx_logger = logging.getLogger("httpx")
     httpcore_logger = logging.getLogger("httpcore")
@@ -191,6 +267,8 @@ async def main() -> None:
         httpx_logger.setLevel(logging.WARNING)
         httpcore_logger.setLevel(logging.WARNING)
     
+    # Re-apply now that CLI flags have been merged into the debug config
+    # (logging was already configured at import time, see above).
     logger = setup_logging_config()
     logger.info("=" * 60)
     logger.info("Engineering Flow Platform - Starting...")
@@ -212,7 +290,7 @@ async def main() -> None:
     logger.info("Configuration check passed")
 
     # Initialize workspace
-    initialize_workspace(logger)
+    workspace_root = initialize_workspace(logger)
 
     # Initialize session store and usage tracker
     try:
@@ -221,6 +299,7 @@ async def main() -> None:
         logger.info(f"Usage tracker initialized | path={usage_tracker.base_path}")
         await runtime_session_manager.initialize()
         logger.info("Runtime session manager initialized successfully")
+        log_runtime_paths(logger, workspace_root)
     except Exception as e:
         logger.error(f"Failed to initialize session/usage tracking | error={e}", exc_info=True)
 

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, Mapping, MutableMapping
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from html import escape
@@ -88,6 +88,7 @@ from ..tools.selection import ToolSelection, resolve_tool_selection
 from ..tools.truncation import ToolOutputTruncator, TruncationLimits
 from ..types import Attachment, SkillPackage, ToolCall, ToolResult, new_id
 from ..workspace_snapshots import (
+    DEFAULT_MAX_RETAINED_SNAPSHOTS,
     WorkspaceSnapshot,
     WorkspaceSnapshotDiff,
     WorkspaceSnapshotStore,
@@ -208,7 +209,7 @@ class AgentRuntime:
             WorkspaceSnapshotStore(
                 self.config.workspace_root,
                 on_snapshot_removed=self._invalidate_session_snapshot_references,
-                retain_snapshot=self._retain_workspace_snapshot,
+                retain_snapshots=self._retain_workspace_snapshots,
             )
             if self.config.workspace_root is not None
             else None
@@ -1835,31 +1836,79 @@ class AgentRuntime:
             session_id=session_id if isinstance(session_id, str) else None,
         )
 
-    def _retain_workspace_snapshot(self, snapshot: WorkspaceSnapshot) -> bool:
-        if snapshot.metadata.get("purpose") != "session_unrevert":
-            return False
-        session_id = snapshot.metadata.get("session_id")
-        if not isinstance(session_id, str):
-            return False
+    def _session_revert_snapshot_ids(
+        self, session_id: str
+    ) -> tuple[bool, Any, Any] | None:
+        """(revert_active, workspace_snapshot_id, unrevert_snapshot_id)."""
         try:
             get_summary = getattr(self.store, "get_session_summary", None)
             if callable(get_summary):
                 summary = get_summary(session_id)
-                revert_active = summary.revert_active is True
-                unrevert_snapshot_id = summary.unrevert_snapshot_id
-            else:
-                session = self.store.get_session(session_id)
-                revert_metadata = session.metadata.get("revert")
-                if not isinstance(revert_metadata, Mapping):
-                    return False
-                revert_active = revert_metadata.get("active") is True
-                unrevert_snapshot_id = revert_metadata.get("unrevert_snapshot_id")
+                return (
+                    summary.revert_active is True,
+                    summary.workspace_snapshot_id,
+                    summary.unrevert_snapshot_id,
+                )
+            session = self.store.get_session(session_id)
         except KeyError:
-            return False
+            return None
+        revert_metadata = session.metadata.get("revert")
+        if not isinstance(revert_metadata, Mapping):
+            return None
         return (
-            revert_active is True
-            and unrevert_snapshot_id == snapshot.snapshot_id
+            revert_metadata.get("active") is True,
+            revert_metadata.get("workspace_snapshot_id"),
+            revert_metadata.get("unrevert_snapshot_id"),
         )
+
+    def _retain_workspace_snapshots(
+        self,
+        snapshots: Sequence[WorkspaceSnapshot],
+    ) -> list[str]:
+        """Snapshot ids to keep past the store's retention cap.
+
+        ``snapshots`` arrives oldest-first. Two kinds must survive pruning:
+
+        * the BEFORE snapshot a session's revert target points at — pruning it
+          turns a later ``revert_session`` into a silent history-only trim;
+        * the unrevert snapshot of a revert that is currently *active*.
+
+        A revert target is published on every finished turn, so pinning one per
+        session that has ever run grows with lifetime session count rather than
+        with live work — unbounded on a long-lived gateway. Only the newest
+        ``max_retained_snapshots`` revert targets are pinned, which keeps recent
+        sessions (including the turn that just finished) revertible while making
+        total retention independent of how many sessions ever ran. Sessions that
+        fall out of the window lose their workspace target and their revert
+        degrades to the reported history-only trim.
+        """
+        store = self.workspace_snapshot_store
+        revert_target_budget = (
+            store.max_retained_snapshots
+            if store is not None
+            else DEFAULT_MAX_RETAINED_SNAPSHOTS
+        )
+        revert_targets: list[str] = []
+        retained: list[str] = []
+        for snapshot in snapshots:
+            purpose = snapshot.metadata.get("purpose")
+            if purpose not in ("session_revert", "session_unrevert"):
+                continue
+            session_id = snapshot.metadata.get("session_id")
+            if not isinstance(session_id, str):
+                continue
+            state = self._session_revert_snapshot_ids(session_id)
+            if state is None:
+                continue
+            revert_active, workspace_snapshot_id, unrevert_snapshot_id = state
+            if purpose == "session_revert":
+                if workspace_snapshot_id == snapshot.snapshot_id:
+                    revert_targets.append(snapshot.snapshot_id)
+            elif revert_active and unrevert_snapshot_id == snapshot.snapshot_id:
+                retained.append(snapshot.snapshot_id)
+        if revert_target_budget > 0:
+            retained.extend(revert_targets[-revert_target_budget:])
+        return retained
 
     def _replace_history(self, session_id: str, messages: Iterable[Message]) -> Session:
         method = getattr(self.store, "replace_history", None)

--- a/src/efp_runtime/runtime/config.py
+++ b/src/efp_runtime/runtime/config.py
@@ -40,7 +40,18 @@ class RuntimeConfig:
     provider_retry_backoff_seconds: float = 0.0
     provider_retry_backoff_multiplier: float = 2.0
     enable_context_overflow_retry: bool = True
-    enable_session_revert_snapshots: bool = True
+    # Off by default: the workspace snapshot it drives is the single most
+    # expensive thing on the request path (it walks and byte-copies the whole
+    # workspace to the PVC before the LLM call, once per run), and nothing
+    # consumes what it produces. ``AgentRuntime.revert_session`` has no HTTP
+    # route, no Portal UI and no production caller in any EFP repo — the
+    # capability arrived with the Runtime v2 opencode source replacement
+    # (#521) as a port of opencode's revert, but the client that drives it in
+    # opencode was never ported. Operators who want it can set this field per
+    # agent from the Portal (it is in PORTAL_MANAGED_RUNTIME_FIELDS); wiring a
+    # revert UI should flip it back on, ideally alongside deferring the
+    # capture until a workspace-mutating tool actually runs.
+    enable_session_revert_snapshots: bool = False
     emit_llm_stream_events: bool = True
     track_usage: bool = True
     usage_pricing: dict[str, float] = field(default_factory=dict)

--- a/src/efp_runtime/session/revert.py
+++ b/src/efp_runtime/session/revert.py
@@ -15,6 +15,20 @@ from .protocol import SessionStore
 from .summary import summarize_session_diffs
 
 
+# ``status`` values written to session ``metadata["revert"]``.
+REVERT_STATUS_REVERTED = "reverted"
+# History was trimmed but the workspace was NOT restored: the run captured a
+# workspace snapshot and it is no longer available (pruned/invalidated). A
+# caller must not present this as a complete revert.
+REVERT_STATUS_HISTORY_ONLY = "reverted_history_only"
+
+# ``workspace_restore_status`` values written alongside it.
+WORKSPACE_RESTORE_NOT_APPLICABLE = "not_applicable"
+WORKSPACE_RESTORE_RESTORED = "restored"
+WORKSPACE_RESTORE_PARTIAL = "partial"
+WORKSPACE_RESTORE_HISTORY_ONLY = "history_only"
+
+
 @dataclass(frozen=True)
 class SessionRevertRunRecord:
     """Pre-run state needed to publish a later session revert target."""
@@ -26,6 +40,10 @@ class SessionRevertRunRecord:
     workspace_snapshot_id: str | None
     created_at: str
     workspace_snapshot_protected: bool = False
+    # Whether a workspace snapshot was *attempted* for this run. Distinguishes
+    # "revert never had a workspace target" from "the target was lost", which
+    # is the difference between a complete and an incomplete revert.
+    workspace_snapshot_enabled: bool = False
 
 
 def prepare_session_revert_record(
@@ -46,7 +64,10 @@ def prepare_session_revert_record(
         session = store.create_session(session_id=session_id)
 
     workspace_snapshot_id = None
-    if enable_workspace_snapshot and workspace_snapshot_store is not None:
+    workspace_snapshot_enabled = (
+        enable_workspace_snapshot and workspace_snapshot_store is not None
+    )
+    if workspace_snapshot_enabled:
         snapshot = workspace_snapshot_store.create_snapshot(
             label=f"session:{session_id}:{source}:before",
             metadata={
@@ -69,6 +90,7 @@ def prepare_session_revert_record(
         workspace_snapshot_protected=(
             workspace_snapshot_id is not None and protect_workspace_snapshot
         ),
+        workspace_snapshot_enabled=workspace_snapshot_enabled,
     )
 
 
@@ -92,6 +114,7 @@ def finalize_session_revert_record(
         "active": False,
         "message_id": target_message_id,
         "workspace_snapshot_id": record.workspace_snapshot_id,
+        "workspace_snapshot_enabled": record.workspace_snapshot_enabled,
         "run_id": record.run_id,
         "source": record.source,
         "created_at": record.created_at,
@@ -171,9 +194,25 @@ def revert_session_state(
     workspace_snapshot_id = _string_or_none(
         current_revert.get("workspace_snapshot_id")
     )
+    workspace_snapshot_enabled = (
+        current_revert.get("workspace_snapshot_enabled") is True
+    )
     unrevert_snapshot_id = None
     if workspace_snapshot_id is not None and workspace_snapshot_store is None:
         raise TypeError("workspace snapshots require workspace_root")
+
+    # A run that captured a workspace snapshot whose target is now gone can
+    # only trim history: the turn's file changes stay on disk. That is a
+    # different outcome from a complete revert and must never be reported as
+    # one, so it gets its own status instead of a plain success.
+    workspace_restore_status = (
+        WORKSPACE_RESTORE_HISTORY_ONLY
+        if workspace_snapshot_id is None and workspace_snapshot_enabled
+        else WORKSPACE_RESTORE_NOT_APPLICABLE
+    )
+    unrestored_paths: list[str] = []
+    excluded_directories: list[str] = []
+
     snapshot_protection = (
         workspace_snapshot_store.protect_snapshot(workspace_snapshot_id)
         if workspace_snapshot_id is not None and workspace_snapshot_store is not None
@@ -190,9 +229,18 @@ def revert_session_state(
                 },
             )
             unrevert_snapshot_id = unrevert_snapshot.snapshot_id
-            workspace_snapshot_store.restore_snapshot(
+            restored = workspace_snapshot_store.restore_snapshot(
                 workspace_snapshot_id,
                 delete_added=delete_added,
+            )
+            # Paths the snapshot never captured cannot be put back; report them
+            # instead of letting a partial restore look complete.
+            unrestored_paths = sorted(restored.skipped_files)
+            excluded_directories = sorted(restored.excluded_directories)
+            workspace_restore_status = (
+                WORKSPACE_RESTORE_PARTIAL
+                if unrestored_paths
+                else WORKSPACE_RESTORE_RESTORED
             )
 
         trimmed_history, removed_counts = trim_session_history(
@@ -217,7 +265,16 @@ def revert_session_state(
                 "removed_message_count": removed_counts["messages"],
                 "removed_part_count": removed_counts["parts"],
                 "summary": summary,
-                "status": "reverted",
+                "status": (
+                    REVERT_STATUS_HISTORY_ONLY
+                    if workspace_restore_status == WORKSPACE_RESTORE_HISTORY_ONLY
+                    else REVERT_STATUS_REVERTED
+                ),
+                "workspace_restore_status": workspace_restore_status,
+                "workspace_restored": workspace_restore_status
+                in (WORKSPACE_RESTORE_RESTORED, WORKSPACE_RESTORE_PARTIAL),
+                "workspace_unrestored_paths": unrestored_paths,
+                "workspace_excluded_directories": excluded_directories,
                 "reverted_at": now,
                 "updated_at": now,
             }
@@ -386,6 +443,12 @@ def _string_or_none(value: Any) -> str | None:
 
 
 __all__ = [
+    "REVERT_STATUS_HISTORY_ONLY",
+    "REVERT_STATUS_REVERTED",
+    "WORKSPACE_RESTORE_HISTORY_ONLY",
+    "WORKSPACE_RESTORE_NOT_APPLICABLE",
+    "WORKSPACE_RESTORE_PARTIAL",
+    "WORKSPACE_RESTORE_RESTORED",
     "SessionRevertRunRecord",
     "finalize_session_revert_record",
     "invalidate_session_snapshot_references",

--- a/src/efp_runtime/workspace_snapshots.py
+++ b/src/efp_runtime/workspace_snapshots.py
@@ -9,7 +9,7 @@ disk one file at a time for restore/diff.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -21,6 +21,7 @@ import os
 from pathlib import Path, PurePosixPath
 import shutil
 from threading import RLock
+import time
 from typing import Any, Literal
 
 from .types import utc_now_iso
@@ -32,24 +33,86 @@ _ALWAYS_EXCLUDED_NAMES = {
     ".pytest_cache",
     "__pycache__",
 }
-_EXCLUDED_DIRECTORY_NAMES = {
-    # Heavy dependency/build directories: never useful to revert and they
-    # dominate tree size (a node_modules alone is routinely hundreds of MB).
-    "node_modules",
-    ".venv",
-    "venv",
-    ".tox",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".cache",
-    ".next",
-    ".nuxt",
-    "dist",
-    "build",
-    "target",
-    "vendor",
-    "coverage",
-}
+# Runtime-owned state that lives inside the workspace, matched on the
+# *workspace-relative path* rather than the entry name. ``.efp`` itself is real,
+# agent-editable workspace content (config.json/config.jsonc, skills/, commands/,
+# agents/, modes/, instructions/) and must stay capturable, diffable and
+# restorable; the entries below are runtime-owned state that would otherwise
+# grow every snapshot and be dropped back on top of itself by a restore.
+_ALWAYS_EXCLUDED_RELATIVE_DIRS = frozenset(
+    {
+        # Session store / chatlogs.
+        ".efp/runtime",
+        # Background-task persistence store. Written live by the gateway
+        # (``src/gateway/runtime_api.py`` ->
+        # ``_runtime_task_persistence_storage_dir``), enabled by default
+        # (``EFP_RUNTIME_TASKS_PERSISTENCE`` defaults to "true") and resolved
+        # from the same ``resolve_runtime_workspace()`` root as this snapshot
+        # store. Capturing it copies a live task queue into every snapshot and
+        # a restore rewinds/deletes records for tasks that are still running.
+        # Kept as a literal because ``efp_runtime`` must not import the
+        # gateway; the resolver above is the source of truth for the name.
+        ".efp/runtime_tasks",
+    }
+)
+DEFAULT_EXCLUDED_DIRECTORY_NAMES = frozenset(
+    {
+        # Heavy dependency/build/tool-cache directories. ``create_snapshot``
+        # runs synchronously on the request path against a network PVC, once
+        # per turn, and up to ``max_retained_snapshots`` copies are kept — so
+        # what is captured here is a latency and disk budget, not a preference.
+        # Measured on a modest tree (200 source files + 3000 build artifacts,
+        # 24 MB): capturing these took 10.6 s / 24.4 MB versus 0.43 s / 0.4 MB
+        # without them — 24x the time, 61x the bytes, and a Rust/Java
+        # ``target/`` is GB-scale.
+        #
+        # Some repos do legitimately commit ``vendor/`` (Go) or build output,
+        # and skipping those means a revert cannot restore them. That is
+        # answered by *reporting* rather than by capturing everything: the
+        # directories skipped here are recorded on the snapshot as
+        # ``excluded_directories`` and surfaced through the restore/revert
+        # result, so a partial restore is declared instead of hidden. Callers
+        # that need a different policy pass ``excluded_directory_names``.
+        "node_modules",
+        ".venv",
+        "venv",
+        ".tox",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".cache",
+        ".next",
+        ".nuxt",
+        "dist",
+        "build",
+        "target",
+        "vendor",
+        "coverage",
+    }
+)
+# Directory names that older captures may have skipped. Frozen in time on
+# purpose: a snapshot written before manifests recorded ``excluded_directories``
+# carries no record of what its capture skipped, so a restore cannot tell
+# "this file is new" from "this file was never in scope". Deleting the latter
+# is data loss, so anything under one of these names is left alone when the
+# manifest has no ``excluded_directories`` key. Never narrow this set.
+_HISTORIC_EXCLUDED_DIRECTORY_NAMES = frozenset(
+    {
+        "node_modules",
+        ".venv",
+        "venv",
+        ".tox",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".cache",
+        ".next",
+        ".nuxt",
+        "dist",
+        "build",
+        "target",
+        "vendor",
+        "coverage",
+    }
+)
 _RUNTIME_DIR_NAME = ".efp_runtime"
 _SNAPSHOT_DIR_NAME = "workspace_snapshots"
 _SNAPSHOT_FILES_DIR_NAME = "files"
@@ -61,6 +124,10 @@ _HASH_CHUNK_BYTES = 1024 * 1024
 
 _LOGGER = logging.getLogger(__name__)
 
+# A capture slower than this blocks the caller (today: the event loop) long
+# enough to be the dominant request cost, so it is logged as a warning.
+SLOW_SNAPSHOT_WARN_MS = 1000.0
+
 # Files larger than this are not captured (recorded as skipped instead).
 DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024
 # Oldest snapshots beyond this count are pruned from disk after each capture.
@@ -69,6 +136,18 @@ DEFAULT_MAX_RETAINED_SNAPSHOTS = 20
 _COORDINATION_LOCK = RLock()
 _WORKSPACE_LOCKS: dict[Path, RLock] = {}
 _WORKSPACE_PROTECTED_SNAPSHOTS: dict[Path, dict[str, int]] = {}
+# Cap a workspace root was last reported overshooting at. Pruning runs several
+# times per turn (and a fresh store is built per request), so without this the
+# overshoot warning would repeat forever once tripped; it is emitted on each
+# (root, cap) transition into overshoot instead.
+_WORKSPACE_RETENTION_OVERSHOOT: dict[Path, int] = {}
+
+
+def snapshot_storage_root(workspace_root: str | Path) -> Path:
+    """Directory holding persisted snapshots for ``workspace_root``."""
+
+    resolved = Path(workspace_root).expanduser().resolve()
+    return resolved / _RUNTIME_DIR_NAME / _SNAPSHOT_DIR_NAME
 
 
 @dataclass
@@ -80,10 +159,20 @@ class WorkspaceSnapshot:
     metadata: dict[str, Any]
     file_count: int
     total_bytes: int
+    # Paths that existed at capture time but hold no captured content (above
+    # ``max_file_bytes``), mapped to their observed size. A restore can neither
+    # recreate nor delete these, so they are surfaced instead of hidden.
+    skipped_files: dict[str, int] = field(default_factory=dict)
+    # Workspace-relative directories present at capture time that the exclusion
+    # policy skipped. Anything below them is outside the snapshot and therefore
+    # outside a restore.
+    excluded_directories: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.workspace_root = Path(self.workspace_root)
         self.metadata = dict(self.metadata)
+        self.skipped_files = dict(self.skipped_files)
+        self.excluded_directories = list(self.excluded_directories)
 
 
 @dataclass
@@ -122,6 +211,14 @@ class _SnapshotRecord:
     # cap), mapped to their observed size. Restore must neither recreate nor
     # delete these.
     skipped: dict[str, int] = field(default_factory=dict)
+    # Workspace-relative directories the exclusion policy skipped at capture.
+    excluded_directories: list[str] = field(default_factory=list)
+    # Whether the manifest actually carried an ``excluded_directories`` key.
+    # False for format-1 manifests and for format-2 manifests written before
+    # the key existed: those record nothing about what capture skipped, so a
+    # restore must not treat "present now, absent from the snapshot" as
+    # "added by this turn" for anything that could have been excluded.
+    excluded_directories_recorded: bool = True
 
 
 class WorkspaceSnapshotStore:
@@ -133,18 +230,32 @@ class WorkspaceSnapshotStore:
         *,
         max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
         max_retained_snapshots: int = DEFAULT_MAX_RETAINED_SNAPSHOTS,
+        excluded_directory_names: Iterable[str] | None = None,
         on_snapshot_removed: Callable[[WorkspaceSnapshot], None] | None = None,
-        retain_snapshot: Callable[[WorkspaceSnapshot], bool] | None = None,
+        retain_snapshots: (
+            Callable[[Sequence[WorkspaceSnapshot]], Iterable[str]] | None
+        ) = None,
     ) -> None:
         self.workspace_root = Path(workspace_root).expanduser().resolve()
-        self.storage_root = (
-            self.workspace_root / _RUNTIME_DIR_NAME / _SNAPSHOT_DIR_NAME
-        )
+        self.storage_root = snapshot_storage_root(self.workspace_root)
         self.max_file_bytes = max(0, int(max_file_bytes))
         self.max_retained_snapshots = max(1, int(max_retained_snapshots))
+        self.excluded_directory_names = frozenset(
+            DEFAULT_EXCLUDED_DIRECTORY_NAMES
+            if excluded_directory_names is None
+            else excluded_directory_names
+        )
         self._on_snapshot_removed = on_snapshot_removed
-        self._retain_snapshot = retain_snapshot
+        # Called with every retained snapshot, oldest first, and returns the
+        # ids to keep past the cap. It is a *batch* hook on purpose: a
+        # per-snapshot predicate cannot see the whole set, so it cannot bound
+        # how much it pins, and an unbounded pin grows the store forever.
+        self._retain_snapshots = retain_snapshots
         self._snapshots: dict[str, _SnapshotRecord] = {}
+        # (snapshot_id -> manifest mtime) already reported as a legacy rehash.
+        # Every runtime operation reloads every manifest, so without this the
+        # warning fires once per retained format-1 snapshot per operation.
+        self._legacy_rehash_logged: dict[str, int | None] = {}
         self._next_snapshot_index = 1
         self._lock, self._protected_snapshot_ids = _workspace_coordination(
             self.workspace_root
@@ -160,7 +271,9 @@ class WorkspaceSnapshotStore:
         protect: bool = False,
     ) -> WorkspaceSnapshot:
         with self._lock:
+            started = time.perf_counter()
             self._reload_existing_snapshots()
+            reload_ms = (time.perf_counter() - started) * 1000.0
             snapshot_id = self._allocate_snapshot_id()
             snapshot_dir = self._snapshot_dir(snapshot_id)
             if snapshot_dir.exists():
@@ -170,10 +283,19 @@ class WorkspaceSnapshotStore:
 
             files: dict[str, _CapturedFile] = {}
             skipped: dict[str, int] = {}
+            excluded_directories: list[str] = []
             try:
+                capture_started = time.perf_counter()
                 self._capture_directory(
-                    self.workspace_root, (), files_dir, files, skipped
+                    self.workspace_root,
+                    (),
+                    files_dir,
+                    files,
+                    skipped,
+                    excluded_directories,
                 )
+                capture_ms = (time.perf_counter() - capture_started) * 1000.0
+                excluded_directories.sort()
                 snapshot = WorkspaceSnapshot(
                     snapshot_id=snapshot_id,
                     workspace_root=self.workspace_root,
@@ -182,11 +304,14 @@ class WorkspaceSnapshotStore:
                     metadata=dict(metadata or {}),
                     file_count=len(files),
                     total_bytes=sum(item.size for item in files.values()),
+                    skipped_files=dict(skipped),
+                    excluded_directories=list(excluded_directories),
                 )
                 record = _SnapshotRecord(
                     snapshot=deepcopy(snapshot),
                     files=files,
                     skipped=skipped,
+                    excluded_directories=excluded_directories,
                 )
                 # Manifest is written last: its presence marks the snapshot
                 # as complete (partial dirs without a manifest are ignored
@@ -201,7 +326,40 @@ class WorkspaceSnapshotStore:
                 self._protected_snapshot_ids[snapshot.snapshot_id] = (
                     self._protected_snapshot_ids.get(snapshot.snapshot_id, 0) + 1
                 )
+            prune_started = time.perf_counter()
             self._prune_old_snapshots(protect={snapshot.snapshot_id})
+            prune_ms = (time.perf_counter() - prune_started) * 1000.0
+            total_ms = (time.perf_counter() - started) * 1000.0
+            _LOGGER.info(
+                "workspace_snapshot.created id=%s root=%s files=%d skipped=%d "
+                "excluded_dirs=%d bytes=%d reload_ms=%.0f capture_ms=%.0f "
+                "prune_ms=%.0f total_ms=%.0f",
+                snapshot.snapshot_id,
+                self.workspace_root,
+                snapshot.file_count,
+                len(skipped),
+                len(excluded_directories),
+                snapshot.total_bytes,
+                reload_ms,
+                capture_ms,
+                prune_ms,
+                total_ms,
+            )
+            if total_ms > SLOW_SNAPSHOT_WARN_MS:
+                _LOGGER.warning(
+                    "workspace_snapshot.slow id=%s root=%s files=%d bytes=%d "
+                    "reload_ms=%.0f capture_ms=%.0f prune_ms=%.0f total_ms=%.0f "
+                    "threshold_ms=%.0f",
+                    snapshot.snapshot_id,
+                    self.workspace_root,
+                    snapshot.file_count,
+                    snapshot.total_bytes,
+                    reload_ms,
+                    capture_ms,
+                    prune_ms,
+                    total_ms,
+                    SLOW_SNAPSHOT_WARN_MS,
+                )
             return deepcopy(snapshot)
 
     def list_snapshots(self) -> list[WorkspaceSnapshot]:
@@ -269,12 +427,23 @@ class WorkspaceSnapshotStore:
             load_content = self._snapshot_content_loader(snapshot_id)
 
             for relative_path in sorted(record.files):
+                # Snapshots taken before a directory became runtime-owned still
+                # hold its blobs; writing them back drops a stale session store
+                # / background-task queue on top of the live one.
+                if _directory_prefixes(relative_path) & _ALWAYS_EXCLUDED_RELATIVE_DIRS:
+                    continue
                 self._write_file(relative_path, load_content(relative_path))
 
             if delete_added:
                 current_files = self._scan_workspace()
                 protected = set(record.files) | set(record.skipped)
                 for relative_path in sorted(set(current_files) - protected):
+                    # "Absent from the snapshot" only means "added by the turn"
+                    # for paths the capture actually looked at. Anything the
+                    # capture excluded was never in scope, and deleting it is
+                    # data loss, not a revert.
+                    if _is_outside_snapshot_scope(record, relative_path):
+                        continue
                     self._delete_regular_file(relative_path)
 
             return deepcopy(record.snapshot)
@@ -307,24 +476,34 @@ class WorkspaceSnapshotStore:
 
     def _prune_old_snapshots(self, *, protect: set[str]) -> None:
         if len(self._snapshots) <= self.max_retained_snapshots:
+            # Nothing can be retained past a cap nothing reaches; clear any
+            # standing overshoot so a later one is reported again.
+            self._report_retention_overshoot(len(self._snapshots))
             return
         protected = protect | set(self._protected_snapshot_ids)
-        if self._retain_snapshot is not None:
-            for snapshot_id, record in self._snapshots.items():
-                try:
-                    retain = self._retain_snapshot(deepcopy(record.snapshot))
-                except Exception:
-                    _LOGGER.exception(
-                        "failed to inspect retention for workspace snapshot %s",
-                        snapshot_id,
-                    )
-                    continue
-                if retain:
-                    protected.add(snapshot_id)
         ordered = sorted(
             self._snapshots,
             key=lambda snapshot_id: _snapshot_sort_key(snapshot_id),
         )
+        if self._retain_snapshots is not None:
+            try:
+                requested = set(
+                    self._retain_snapshots(
+                        [
+                            deepcopy(self._snapshots[snapshot_id].snapshot)
+                            for snapshot_id in ordered
+                        ]
+                    )
+                )
+            except Exception:
+                _LOGGER.exception(
+                    "failed to inspect retention for workspace snapshots under %s",
+                    self.workspace_root,
+                )
+                requested = set()
+            protected |= requested & set(self._snapshots)
+        retained = protected & set(self._snapshots)
+        self._report_retention_overshoot(len(retained))
         excess = len(self._snapshots) - self.max_retained_snapshots
         for snapshot_id in ordered:
             if excess <= 0:
@@ -333,6 +512,31 @@ class WorkspaceSnapshotStore:
                 continue
             self._remove_snapshot(snapshot_id)
             excess -= 1
+
+    def _report_retention_overshoot(self, retained: int) -> None:
+        """Warn once per (root, cap) transition into retention overshoot.
+
+        Retention wins over the cap (dropping a referenced snapshot turns a
+        later revert into a silent history-only trim), so the overshoot is
+        reported instead of being silently unbounded. Pruning runs several
+        times per turn, so the report is edge-triggered rather than repeated.
+        """
+        cap = self.max_retained_snapshots
+        with _COORDINATION_LOCK:
+            if retained <= cap:
+                _WORKSPACE_RETENTION_OVERSHOOT.pop(self.workspace_root, None)
+                return
+            if _WORKSPACE_RETENTION_OVERSHOOT.get(self.workspace_root) == cap:
+                return
+            _WORKSPACE_RETENTION_OVERSHOOT[self.workspace_root] = cap
+        _LOGGER.warning(
+            "workspace_snapshot.retention_exceeds_cap root=%s retained=%d "
+            "cap=%d total=%d",
+            self.workspace_root,
+            retained,
+            cap,
+            len(self._snapshots),
+        )
 
     def _remove_snapshot(self, snapshot_id: str) -> None:
         try:
@@ -348,6 +552,7 @@ class WorkspaceSnapshotStore:
         finally:
             shutil.rmtree(self._snapshot_dir(snapshot_id), ignore_errors=True)
             del self._snapshots[snapshot_id]
+            self._legacy_rehash_logged.pop(snapshot_id, None)
 
     def _validate_snapshot_blobs(
         self,
@@ -478,6 +683,14 @@ class WorkspaceSnapshotStore:
                 if isinstance(raw_path, str) and size is not None:
                     skipped[raw_path] = size
 
+        excluded_payload = payload.get("excluded_directories")
+        excluded_directories_recorded = isinstance(excluded_payload, list)
+        excluded_directories = sorted(
+            {item for item in excluded_payload if isinstance(item, str)}
+            if excluded_directories_recorded
+            else set()
+        )
+
         metadata = payload.get("metadata")
         label = payload.get("label")
         snapshot = WorkspaceSnapshot(
@@ -490,8 +703,16 @@ class WorkspaceSnapshotStore:
             metadata=dict(metadata) if isinstance(metadata, dict) else {},
             file_count=len(files),
             total_bytes=calculated_total_bytes,
+            skipped_files=dict(skipped),
+            excluded_directories=list(excluded_directories),
         )
-        return _SnapshotRecord(snapshot=snapshot, files=files, skipped=skipped)
+        return _SnapshotRecord(
+            snapshot=snapshot,
+            files=files,
+            skipped=skipped,
+            excluded_directories=excluded_directories,
+            excluded_directories_recorded=excluded_directories_recorded,
+        )
 
     def _load_snapshot_file_metadata(
         self, snapshot_dir: Path, payload: dict[str, Any]
@@ -516,8 +737,29 @@ class WorkspaceSnapshotStore:
             return files
         # Legacy manifest (format 1) without a files map: derive metadata by
         # streaming the persisted blobs — content is hashed chunk-wise and
-        # never retained in memory.
-        return self._scan_snapshot_files_metadata(snapshot_dir)
+        # never retained in memory. This re-hashes every blob on every reload,
+        # so it is logged loudly: on a network volume it can cost minutes.
+        # Every runtime operation reloads every manifest, so the warning is
+        # emitted once per (snapshot, manifest mtime) instead of once per read.
+        started = time.perf_counter()
+        legacy_files = self._scan_snapshot_files_metadata(snapshot_dir)
+        snapshot_id = snapshot_dir.name
+        manifest_mtime = _manifest_mtime_ns(snapshot_dir)
+        if (
+            snapshot_id not in self._legacy_rehash_logged
+            or self._legacy_rehash_logged[snapshot_id] != manifest_mtime
+        ):
+            self._legacy_rehash_logged[snapshot_id] = manifest_mtime
+            _LOGGER.warning(
+                "workspace_snapshot.legacy_manifest_rehash id=%s format=%s "
+                "files=%d bytes=%d elapsed_ms=%.0f",
+                snapshot_id,
+                payload.get("format"),
+                len(legacy_files),
+                sum(item.size for item in legacy_files.values()),
+                (time.perf_counter() - started) * 1000.0,
+            )
+        return legacy_files
 
     def _scan_snapshot_files_metadata(
         self, snapshot_dir: Path
@@ -572,6 +814,7 @@ class WorkspaceSnapshotStore:
                 for item in record.files.values()
             },
             "skipped_files": dict(record.skipped),
+            "excluded_directories": sorted(record.excluded_directories),
         }
         (snapshot_dir / _SNAPSHOT_MANIFEST_NAME).write_text(
             json.dumps(manifest, default=str, indent=2, sort_keys=True) + "\n",
@@ -642,12 +885,21 @@ class WorkspaceSnapshotStore:
         files_dir: Path,
         files: dict[str, _CapturedFile],
         skipped: dict[str, int],
+        excluded_directories: list[str],
     ) -> None:
         """Walk the workspace, streaming each captured file straight to disk.
 
         Content is copied chunk-wise into the snapshot directory while the
         sha256 is computed, so peak memory is one chunk — never the tree.
+
+        The mirrored destination directory is created at most once per source
+        directory (lazily, on the first file actually captured here) instead of
+        once per file: on a network volume the redundant ``mkdir`` was a large
+        share of all round-trips, and staying lazy keeps directories whose
+        files are all excluded/skipped from leaving stray empty mirrors.
         """
+        destination_dir_ready = False
+
         with os.scandir(directory) as entries:
             sorted_entries = sorted(entries, key=lambda entry: entry.name)
 
@@ -661,10 +913,21 @@ class WorkspaceSnapshotStore:
                 path = Path(entry.path)
                 child_parts = (*relative_parts, name)
                 if entry.is_dir(follow_symlinks=False):
-                    if name in _EXCLUDED_DIRECTORY_NAMES:
+                    relative_dir = "/".join(child_parts)
+                    if relative_dir in _ALWAYS_EXCLUDED_RELATIVE_DIRS:
+                        continue
+                    if name in self.excluded_directory_names:
+                        # Reported on the snapshot: everything below is outside
+                        # the snapshot and therefore outside a later restore.
+                        excluded_directories.append(relative_dir)
                         continue
                     self._capture_directory(
-                        path, child_parts, files_dir, files, skipped
+                        path,
+                        child_parts,
+                        files_dir,
+                        files,
+                        skipped,
+                        excluded_directories,
                     )
                     continue
                 if not entry.is_file(follow_symlinks=False):
@@ -677,7 +940,9 @@ class WorkspaceSnapshotStore:
                     continue
 
                 destination = self._snapshot_file_path(files_dir, relative_path)
-                destination.parent.mkdir(parents=True, exist_ok=True)
+                if not destination_dir_ready:
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    destination_dir_ready = True
                 digest = hashlib.sha256()
                 copied = 0
                 exceeded_limit = False
@@ -730,7 +995,10 @@ class WorkspaceSnapshotStore:
                 path = Path(entry.path)
                 child_parts = (*relative_parts, name)
                 if entry.is_dir(follow_symlinks=False):
-                    if name in _EXCLUDED_DIRECTORY_NAMES:
+                    relative_dir = "/".join(child_parts)
+                    if relative_dir in _ALWAYS_EXCLUDED_RELATIVE_DIRS:
+                        continue
+                    if name in self.excluded_directory_names:
                         continue
                     self._scan_directory(path, child_parts, files)
                     continue
@@ -793,6 +1061,40 @@ class WorkspaceSnapshotStore:
         if path.is_symlink() or not path.exists() or not path.is_file():
             return
         path.unlink()
+
+
+def _directory_prefixes(relative_path: str) -> set[str]:
+    """Every workspace-relative directory ``relative_path`` sits under."""
+
+    directories = relative_path.split("/")[:-1]
+    return {"/".join(directories[: index + 1]) for index in range(len(directories))}
+
+
+def _is_outside_snapshot_scope(record: _SnapshotRecord, relative_path: str) -> bool:
+    """Whether ``relative_path`` sits under a directory the capture skipped."""
+
+    directories = relative_path.split("/")[:-1]
+    if not directories:
+        return False
+    prefixes = {
+        "/".join(directories[: index + 1]) for index in range(len(directories))
+    }
+    if prefixes & set(record.excluded_directories):
+        return True
+    if prefixes & _ALWAYS_EXCLUDED_RELATIVE_DIRS:
+        return True
+    if record.excluded_directories_recorded:
+        return False
+    # No record of what this snapshot excluded: assume the historic defaults
+    # were in force rather than deleting files that may never have been in it.
+    return any(name in _HISTORIC_EXCLUDED_DIRECTORY_NAMES for name in directories)
+
+
+def _manifest_mtime_ns(snapshot_dir: Path) -> int | None:
+    try:
+        return (snapshot_dir / _SNAPSHOT_MANIFEST_NAME).stat().st_mtime_ns
+    except OSError:
+        return None
 
 
 def _stream_sha256(path: Path) -> tuple[str, int]:

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -6,7 +6,9 @@ import asyncio
 import json
 import logging
 import sys
+import time
 import traceback
+import uuid
 from pathlib import Path
 
 from aiohttp import web
@@ -39,6 +41,18 @@ logger = logging.getLogger(__name__)
 SYSTEM_PROMPT_AGENTS_SECTION = "agents"
 SYSTEM_PROMPT_AGENTS_FILENAME = "AGENTS.md"
 
+# Access logging. Request ids are reused from the caller when supplied so a
+# Portal-side trace and a runtime-side trace line up in kubectl logs.
+REQUEST_ID_HEADERS = ("X-Request-Id", "X-Trace-Id")
+# aiohttp's own access log is disabled: ``access_log_middleware`` already emits
+# a richer http.start/http.end pair carrying the request id (which aiohttp's
+# ``%{X-Request-Id}i`` cannot see, because it reads the *inbound* header and so
+# prints "-" whenever the middleware mints the id — the common case). Leaving
+# both on emitted two near-duplicate lines per request.
+ACCESS_LOG = None
+# Status reported for a client disconnect / cancelled handler (nginx idiom).
+CLIENT_CLOSED_REQUEST_STATUS = 499
+
 # Upload sizing. EFP_MAX_UPLOAD_MB is the user-facing per-file cap the Portal
 # enforces and reports; the runtime allows that plus headroom for multipart /
 # transport overhead so it is never the gate for a file the Portal accepted.
@@ -56,6 +70,61 @@ def resolve_upload_client_max_size() -> int:
     if mb <= 0:
         mb = DEFAULT_MAX_UPLOAD_MB
     return (mb + UPLOAD_TRANSPORT_HEADROOM_MB) * 1024 * 1024
+
+
+def _sanitize_request_id(value: object, max_len: int = 64) -> str:
+    """One-line, greppable request id (mirrors runtime_api trace sanitizing)."""
+    if value is None:
+        return ""
+    cleaned = re.sub(r"[^A-Za-z0-9._:-]+", "", str(value)).strip()
+    return cleaned[:max_len]
+
+
+def resolve_request_id(request: Request) -> str:
+    """Reuse an inbound correlation id when present, else mint a short one."""
+    headers = getattr(request, "headers", {}) or {}
+    for header in REQUEST_ID_HEADERS:
+        candidate = _sanitize_request_id(headers.get(header))
+        if candidate:
+            return candidate
+    return uuid.uuid4().hex[:12]
+
+
+@web.middleware
+async def access_log_middleware(request: Request, handler):
+    """Log one ``http.start`` line before and one ``http.end`` line after.
+
+    The start line is emitted before awaiting the handler on purpose: a slow
+    handler (e.g. a synchronous workspace snapshot) otherwise leaves no
+    evidence in stdout that the request was even received.
+    """
+    request_id = resolve_request_id(request)
+    request["request_id"] = request_id
+    method = request.method
+    path = request.path
+    remote = request.remote or "-"
+    started = time.perf_counter()
+    status = 500
+
+    logger.info(
+        f"http.start method={method} path={path} remote={remote} request_id={request_id}"
+    )
+    try:
+        response = await handler(request)
+        status = getattr(response, "status", status)
+        return response
+    except web.HTTPException as http_error:
+        status = http_error.status
+        raise
+    except asyncio.CancelledError:
+        status = CLIENT_CLOSED_REQUEST_STATUS
+        raise
+    finally:
+        duration_ms = (time.perf_counter() - started) * 1000
+        logger.info(
+            f"http.end method={method} path={path} status={status} "
+            f"duration_ms={duration_ms:.1f} request_id={request_id}"
+        )
 
 
 def _runtime_workspace_root() -> Path:
@@ -215,7 +284,10 @@ class Gateway:
         self.jira_enabled = config.jira.get("enabled", False)
         self.host = config.server.get("host", "0.0.0.0")
         self.port = config.server.get("port", 8000)
-        self.app = web.Application(client_max_size=resolve_upload_client_max_size())
+        self.app = web.Application(
+            client_max_size=resolve_upload_client_max_size(),
+            middlewares=[access_log_middleware],
+        )
         self.runner: web.AppRunner | None = None
         self.site: web.TCPSite | None = None
 
@@ -599,7 +671,7 @@ class Gateway:
     async def start(self) -> None:
         """Start the gateway server."""
         # Start HTTP server
-        self.runner = web.AppRunner(self.app)
+        self.runner = web.AppRunner(self.app, access_log=ACCESS_LOG)
         await self.runner.setup()
         self.site = web.TCPSite(self.runner, self.host, self.port)
         await self.site.start()

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -70,6 +70,9 @@ _TRACE_FIELD_MAPPING = (
     ("path", "path"),
 )
 _FIRST_PARTY_LOGGER_PREFIXES = ("src.", "skills.")
+# Rotating log files are dead weight in k8s (nobody reads them) and slow when
+# the working directory is a network volume, so they are opt-in.
+LOG_TO_FILE_ENV = "EFP_LOG_TO_FILE"
 _log_context_var: contextvars.ContextVar[Dict[str, str]] = contextvars.ContextVar(
     "efp_log_context",
     default=dict(_LOG_CONTEXT_DEFAULTS),
@@ -272,6 +275,11 @@ class EnhancedLogger:
             self.info(msg)
 
 
+def log_to_file_enabled() -> bool:
+    """Whether rotating log files are enabled (default: off, stdout only)."""
+    return os.getenv(LOG_TO_FILE_ENV, "").strip() == "1"
+
+
 def setup_logging(
     level: str = "INFO",
     log_dir: str = "logs",
@@ -279,10 +287,11 @@ def setup_logging(
     max_size_mb: int = 10,
     backup_count: int = 5,
     structured: bool = False,
-    console: bool = True
+    console: bool = True,
+    log_to_file: Optional[bool] = None
 ) -> logging.Logger:
     """Setup comprehensive logging configuration.
-    
+
     Args:
         level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
         log_dir: Directory for log files
@@ -291,16 +300,21 @@ def setup_logging(
         backup_count: Number of backup files to keep
         structured: Whether to use structured (JSON) logging
         console: Whether to output to console
-    
+        log_to_file: Whether to attach rotating file handlers. Defaults to
+            the EFP_LOG_TO_FILE=1 env flag (off), because in k8s only stdout
+            is read and the log directory may live on a network volume.
+
     Returns:
         Root logger instance
     """
     # Convert level string to logging level
     log_level = getattr(logging, level.upper(), logging.INFO)
-    
-    # Create logs directory
-    Path(log_dir).mkdir(parents=True, exist_ok=True)
-    
+    file_logging = log_to_file_enabled() if log_to_file is None else bool(log_to_file)
+
+    # Create logs directory (only when files are actually written)
+    if file_logging:
+        Path(log_dir).mkdir(parents=True, exist_ok=True)
+
     # Create root logger
     root_logger = logging.getLogger()
     root_logger.setLevel(log_level)
@@ -321,40 +335,46 @@ def setup_logging(
         console_handler.addFilter(RedactingFilter())
         root_logger.addHandler(console_handler)
     
-    # File handler with rotation
-    log_path = Path(log_dir) / log_file
-    file_handler = RotatingFileHandler(
-        log_path,
-        maxBytes=max_size_mb * 1024 * 1024,
-        backupCount=backup_count,
-        encoding='utf-8'
-    )
-    file_handler.setLevel(log_level)
-    file_handler.setFormatter(formatter)
-    file_handler.addFilter(RedactingFilter())
-    root_logger.addHandler(file_handler)
-    
-    # Error-only file handler (only ERROR and above)
-    error_log_path = Path(log_dir) / "errors.log"
-    error_handler = RotatingFileHandler(
-        error_log_path,
-        maxBytes=max_size_mb * 1024 * 1024,
-        backupCount=backup_count,
-        encoding='utf-8'
-    )
-    error_handler.setLevel(logging.ERROR)
-    error_handler.setFormatter(formatter)
-    error_handler.addFilter(RedactingFilter())
-    root_logger.addHandler(error_handler)
-    
+    log_path = None
+    error_log_path = None
+    if file_logging:
+        # File handler with rotation
+        log_path = Path(log_dir) / log_file
+        file_handler = RotatingFileHandler(
+            log_path,
+            maxBytes=max_size_mb * 1024 * 1024,
+            backupCount=backup_count,
+            encoding='utf-8'
+        )
+        file_handler.setLevel(log_level)
+        file_handler.setFormatter(formatter)
+        file_handler.addFilter(RedactingFilter())
+        root_logger.addHandler(file_handler)
+
+        # Error-only file handler (only ERROR and above)
+        error_log_path = Path(log_dir) / "errors.log"
+        error_handler = RotatingFileHandler(
+            error_log_path,
+            maxBytes=max_size_mb * 1024 * 1024,
+            backupCount=backup_count,
+            encoding='utf-8'
+        )
+        error_handler.setLevel(logging.ERROR)
+        error_handler.setFormatter(formatter)
+        error_handler.addFilter(RedactingFilter())
+        root_logger.addHandler(error_handler)
+
     # Log startup info
     root_logger.info("=" * 60)
     root_logger.info("Engineering Flow Platform - Logging Initialized")
     root_logger.info(f"Log Level: {level}")
-    root_logger.info(f"Log File: {log_path}")
-    root_logger.info(f"Error Log: {error_log_path}")
+    root_logger.info(
+        f"logging.sinks console={str(bool(console)).lower()} "
+        f"file={str(file_logging).lower()} log_file={log_path or '-'} "
+        f"error_log={error_log_path or '-'}"
+    )
     root_logger.info("=" * 60)
-    
+
     return root_logger
 
 

--- a/tests/runtime/test_session_revert_summary.py
+++ b/tests/runtime/test_session_revert_summary.py
@@ -105,6 +105,7 @@ async def test_runtime_session_revert_and_unrevert_restore_history_and_workspace
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             max_iterations=2,
             model_aware_tool_selection=False,
@@ -171,6 +172,7 @@ async def test_runtime_session_revert_preserves_oldest_target_at_retention_limit
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             max_iterations=2,
             model_aware_tool_selection=False,
@@ -213,6 +215,7 @@ async def test_runtime_pruning_keeps_recent_session_revert_targets(
             [{"content": "first"}, {"content": "second"}, {"content": "third"}]
         ),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             model_aware_tool_selection=False,
         ),
@@ -286,6 +289,7 @@ async def test_runtime_retention_of_session_revert_targets_is_bounded(
     runtime = AgentRuntime(
         provider=ScriptedLLMProvider(responses),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             max_iterations=2,
             model_aware_tool_selection=False,
@@ -328,6 +332,7 @@ async def test_runtime_pruning_invalidates_expired_unrevert_snapshot_reference(
     runtime = AgentRuntime(
         provider=ScriptedLLMProvider([{"content": "first"}]),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             model_aware_tool_selection=False,
         ),
@@ -376,6 +381,7 @@ async def test_runtime_retention_protects_snapshot_until_run_finalizes(
     runtime = AgentRuntime(
         provider=BlockingProvider(),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             model_aware_tool_selection=False,
         ),
@@ -383,6 +389,7 @@ async def test_runtime_retention_protects_snapshot_until_run_finalizes(
     competing_runtime = AgentRuntime(
         provider=ScriptedLLMProvider([]),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             model_aware_tool_selection=False,
         ),
@@ -447,6 +454,7 @@ async def test_runtime_retention_preserves_active_unrevert_snapshot(tmp_path: Pa
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             max_iterations=2,
             model_aware_tool_selection=False,
@@ -500,6 +508,7 @@ async def test_runtime_revert_restores_workspace_despite_retention_cap(
     runtime = AgentRuntime(
         provider=provider,
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             max_iterations=2,
             model_aware_tool_selection=False,
@@ -560,6 +569,7 @@ async def test_revert_still_restores_after_many_newer_snapshots_in_workspace(
     runtime = AgentRuntime(
         provider=_writing_provider("call-write-crowded", "created.txt", "created\n"),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             max_iterations=2,
             model_aware_tool_selection=False,
@@ -572,6 +582,7 @@ async def test_revert_still_restores_after_many_newer_snapshots_in_workspace(
     subagent_runtime = AgentRuntime(
         provider=ScriptedLLMProvider([]),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             model_aware_tool_selection=False,
         ),
@@ -609,6 +620,7 @@ async def test_revert_without_its_workspace_snapshot_reports_history_only(
     runtime = AgentRuntime(
         provider=_writing_provider("call-write-lost", "created.txt", "created\n"),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             max_iterations=2,
             model_aware_tool_selection=False,
@@ -676,6 +688,7 @@ async def test_revert_reports_paths_the_snapshot_could_not_capture(tmp_path: Pat
     runtime = AgentRuntime(
         provider=_writing_provider("call-write-partial", "created.txt", "created\n"),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             max_iterations=2,
             model_aware_tool_selection=False,
@@ -715,6 +728,7 @@ async def test_complete_revert_reports_no_unrestored_paths(tmp_path: Path):
     runtime = AgentRuntime(
         provider=_writing_provider("call-write-clean", "created.txt", "created\n"),
         config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
             workspace_root=tmp_path,
             max_iterations=2,
             model_aware_tool_selection=False,

--- a/tests/runtime/test_session_revert_summary.py
+++ b/tests/runtime/test_session_revert_summary.py
@@ -198,9 +198,16 @@ async def test_runtime_session_revert_preserves_oldest_target_at_retention_limit
 
 
 @pytest.mark.asyncio
-async def test_runtime_pruning_invalidates_expired_session_snapshot_reference(
+async def test_runtime_pruning_keeps_recent_session_revert_targets(
     tmp_path: Path,
 ):
+    """Recent sessions keep their revert target; older ones age out.
+
+    Retention beats the retained-snapshot cap for recent sessions on purpose:
+    dropping the BEFORE snapshot turns a later revert into a silent
+    history-only trim. It is bounded by the cap so that it cannot grow with
+    lifetime session count.
+    """
     runtime = AgentRuntime(
         provider=ScriptedLLMProvider(
             [{"content": "first"}, {"content": "second"}, {"content": "third"}]
@@ -218,22 +225,139 @@ async def test_runtime_pruning_invalidates_expired_session_snapshot_reference(
         "workspace_snapshot_id"
     ]
     await runtime.run("Second", session_id="session-second")
+    second_snapshot_id = runtime.get_session("session-second").metadata["revert"][
+        "workspace_snapshot_id"
+    ]
     runtime.store.list_sessions = lambda: pytest.fail(
         "snapshot pruning must not load every session body"
     )
     await runtime.run("Third", session_id="session-third")
+    third_snapshot_id = runtime.get_session("session-third").metadata["revert"][
+        "workspace_snapshot_id"
+    ]
 
-    assert first_snapshot_id not in {
+    retained = {
+        snapshot.snapshot_id for snapshot in runtime.list_workspace_snapshots()
+    }
+
+    assert retained == {second_snapshot_id, third_snapshot_id}
+    assert first_snapshot_id not in retained
+    # The two newest sessions are still fully revertible.
+    reverted = runtime.revert_session("session-second")
+    assert reverted.metadata["revert"]["status"] == "reverted"
+    assert reverted.metadata["revert"]["workspace_restore_status"] == "restored"
+
+
+@pytest.mark.asyncio
+async def test_runtime_retention_of_session_revert_targets_is_bounded(
+    tmp_path: Path,
+):
+    """Retention scales with the cap, not with lifetime session count.
+
+    ``finalize_session_revert_record`` publishes a revert target on every
+    finished turn, so pinning one per session that has ever run grows the
+    on-disk snapshot store forever on a long-lived gateway.
+    """
+    cap = 3
+    older_sessions = 8
+    responses: list[dict] = [
+        {"content": f"turn-{index}"} for index in range(older_sessions)
+    ]
+    responses.extend(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-write-bounded",
+                        "type": "function",
+                        "function": {
+                            "name": "write",
+                            "arguments": json.dumps(
+                                {"filePath": "created.txt", "content": "created\n"},
+                                sort_keys=True,
+                            ),
+                        },
+                    }
+                ]
+            },
+            {"content": "done"},
+        ]
+    )
+    runtime = AgentRuntime(
+        provider=ScriptedLLMProvider(responses),
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            max_iterations=2,
+            model_aware_tool_selection=False,
+            tool_permissions={"write": "allow"},
+        ),
+    )
+    assert runtime.workspace_snapshot_store is not None
+    runtime.workspace_snapshot_store.max_retained_snapshots = cap
+
+    for index in range(older_sessions):
+        await runtime.run("Turn", session_id=f"session-{index}")
+
+    assert len(runtime.list_workspace_snapshots()) <= cap
+
+    await runtime.run("Create a file.", session_id="session-recent")
+
+    assert (tmp_path / "created.txt").exists()
+    assert len(runtime.list_workspace_snapshots()) <= cap
+
+    # The turn that just finished is still revertible for real.
+    reverted = runtime.revert_session("session-recent")
+
+    assert reverted.metadata["revert"]["status"] == "reverted"
+    assert reverted.metadata["revert"]["workspace_restore_status"] == "restored"
+    assert not (tmp_path / "created.txt").exists()
+
+    # A session far outside the window lost its target and says so instead of
+    # reporting a complete revert.
+    aged_out = runtime.revert_session("session-0")
+
+    assert aged_out.metadata["revert"]["status"] == "reverted_history_only"
+    assert aged_out.metadata["revert"]["workspace_restored"] is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_pruning_invalidates_expired_unrevert_snapshot_reference(
+    tmp_path: Path,
+):
+    """A snapshot nothing references any more is pruned and de-referenced."""
+    runtime = AgentRuntime(
+        provider=ScriptedLLMProvider([{"content": "first"}]),
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            model_aware_tool_selection=False,
+        ),
+    )
+    assert runtime.workspace_snapshot_store is not None
+    runtime.workspace_snapshot_store.max_retained_snapshots = 2
+
+    await runtime.run("First", session_id="session-expiring")
+    runtime.revert_session("session-expiring")
+    runtime.unrevert_session("session-expiring")
+    unrevert_snapshot_id = runtime.get_session("session-expiring").metadata["revert"][
+        "unrevert_snapshot_id"
+    ]
+    assert unrevert_snapshot_id
+
+    runtime.store.list_sessions = lambda: pytest.fail(
+        "snapshot pruning must not load every session body"
+    )
+    runtime.create_workspace_snapshot(label="newer-one")
+    runtime.create_workspace_snapshot(label="newer-two")
+
+    assert unrevert_snapshot_id not in {
         snapshot.snapshot_id for snapshot in runtime.list_workspace_snapshots()
     }
     assert (
-        runtime.get_session("session-first").metadata["revert"][
-            "workspace_snapshot_id"
+        runtime.get_session("session-expiring").metadata["revert"][
+            "unrevert_snapshot_id"
         ]
         is None
     )
-    reverted = runtime.revert_session("session-first")
-    assert reverted.metadata["revert"]["status"] == "reverted"
 
 
 @pytest.mark.asyncio
@@ -282,14 +406,20 @@ async def test_runtime_retention_protects_snapshot_until_run_finalizes(
     result = await asyncio.wait_for(task, timeout=1)
 
     assert result.status == LoopStatus.COMPLETED
+    # Releasing the in-flight lease re-prunes, but the finalized revert target
+    # is retained by reference, so it is still there for a later revert.
     assert (
         runtime.get_session("session-in-flight").metadata["revert"][
             "workspace_snapshot_id"
         ]
-        is None
+        == pending_snapshot.snapshot_id
     )
+    assert pending_snapshot.snapshot_id in {
+        snapshot.snapshot_id for snapshot in runtime.list_workspace_snapshots()
+    }
     reverted = runtime.revert_session("session-in-flight")
     assert reverted.metadata["revert"]["status"] == "reverted"
+    assert reverted.metadata["revert"]["workspace_restore_status"] == "restored"
 
 
 @pytest.mark.asyncio
@@ -344,7 +474,9 @@ async def test_runtime_retention_preserves_active_unrevert_snapshot(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_runtime_revert_does_not_republish_pruned_target(tmp_path: Path):
+async def test_runtime_revert_restores_workspace_despite_retention_cap(
+    tmp_path: Path,
+):
     provider = ScriptedLLMProvider(
         [
             {
@@ -378,11 +510,221 @@ async def test_runtime_revert_does_not_republish_pruned_target(tmp_path: Path):
     runtime.workspace_snapshot_store.max_retained_snapshots = 1
 
     await runtime.run("Create a file.", session_id="session-retention-one")
+    assert (tmp_path / "created.txt").exists()
     reverted = runtime.revert_session("session-retention-one")
 
-    assert reverted.metadata["revert"]["workspace_snapshot_id"] is None
+    # Even with a cap of one snapshot the BEFORE target is retained, so the
+    # revert actually undoes the turn's file changes instead of only trimming
+    # history and reporting success.
+    assert reverted.metadata["revert"]["workspace_snapshot_id"]
     assert reverted.metadata["revert"]["unrevert_snapshot_id"]
+    assert reverted.metadata["revert"]["status"] == "reverted"
+    assert reverted.metadata["revert"]["workspace_restored"] is True
+    assert not (tmp_path / "created.txt").exists()
+
     runtime.unrevert_session("session-retention-one")
     assert (tmp_path / "created.txt").read_bytes() == b"created\n"
     reverted_again = runtime.revert_session("session-retention-one")
     assert reverted_again.metadata["revert"]["status"] == "reverted"
+    assert not (tmp_path / "created.txt").exists()
+
+
+def _writing_provider(call_id: str, path: str, content: str) -> ScriptedLLMProvider:
+    return ScriptedLLMProvider(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": "write",
+                            "arguments": json.dumps(
+                                {"filePath": path, "content": content},
+                                sort_keys=True,
+                            ),
+                        },
+                    }
+                ]
+            },
+            {"content": "done"},
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_revert_still_restores_after_many_newer_snapshots_in_workspace(
+    tmp_path: Path,
+):
+    """Subagent/other-session snapshots must not evict a live revert target."""
+    runtime = AgentRuntime(
+        provider=_writing_provider("call-write-crowded", "created.txt", "created\n"),
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            max_iterations=2,
+            model_aware_tool_selection=False,
+            tool_permissions={"write": "allow"},
+        ),
+    )
+    # A subagent ("task") run shares workspace_root and the session store (see
+    # _default_task_runner) and inherits enable_session_revert_snapshots, so it
+    # churns the same retention window.
+    subagent_runtime = AgentRuntime(
+        provider=ScriptedLLMProvider([]),
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            model_aware_tool_selection=False,
+        ),
+        store=runtime.store,
+    )
+    assert runtime.workspace_snapshot_store is not None
+    assert subagent_runtime.workspace_snapshot_store is not None
+
+    await runtime.run("Create a file.", session_id="session-crowded")
+    target_snapshot_id = runtime.get_session("session-crowded").metadata["revert"][
+        "workspace_snapshot_id"
+    ]
+    assert target_snapshot_id
+    assert (tmp_path / "created.txt").exists()
+
+    cap = runtime.workspace_snapshot_store.max_retained_snapshots
+    for index in range(cap + 5):
+        subagent_runtime.create_workspace_snapshot(label=f"subagent-{index}")
+
+    assert target_snapshot_id in {
+        snapshot.snapshot_id for snapshot in runtime.list_workspace_snapshots()
+    }
+    reverted = runtime.revert_session("session-crowded")
+
+    assert reverted.metadata["revert"]["status"] == "reverted"
+    assert reverted.metadata["revert"]["workspace_restored"] is True
+    assert not (tmp_path / "created.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_revert_without_its_workspace_snapshot_reports_history_only(
+    tmp_path: Path,
+):
+    """A lost workspace target must not be reported as a complete revert."""
+    runtime = AgentRuntime(
+        provider=_writing_provider("call-write-lost", "created.txt", "created\n"),
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            max_iterations=2,
+            model_aware_tool_selection=False,
+            tool_permissions={"write": "allow"},
+        ),
+    )
+
+    await runtime.run("Create a file.", session_id="session-lost-target")
+    target_snapshot_id = runtime.get_session("session-lost-target").metadata["revert"][
+        "workspace_snapshot_id"
+    ]
+    assert target_snapshot_id
+    message_count = len(runtime.get_session("session-lost-target").messages)
+
+    # Deleting the snapshot invalidates the session's reference, exactly as
+    # pruning would.
+    runtime.delete_workspace_snapshot(target_snapshot_id)
+    assert (
+        runtime.get_session("session-lost-target").metadata["revert"][
+            "workspace_snapshot_id"
+        ]
+        is None
+    )
+
+    reverted = runtime.revert_session("session-lost-target")
+    revert_metadata = reverted.metadata["revert"]
+
+    assert revert_metadata["status"] == "reverted_history_only"
+    assert revert_metadata["workspace_restore_status"] == "history_only"
+    assert revert_metadata["workspace_restored"] is False
+    # History was trimmed, but the turn's file change is still on disk.
+    assert len(reverted.messages) < message_count
+    assert (tmp_path / "created.txt").read_bytes() == b"created\n"
+
+
+@pytest.mark.asyncio
+async def test_revert_without_workspace_snapshots_enabled_stays_a_plain_revert(
+    tmp_path: Path,
+):
+    """No workspace snapshots configured is not a partial revert."""
+    runtime = AgentRuntime(
+        provider=_writing_provider("call-write-no-ws", "created.txt", "created\n"),
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            max_iterations=2,
+            model_aware_tool_selection=False,
+            enable_session_revert_snapshots=False,
+            tool_permissions={"write": "allow"},
+        ),
+    )
+
+    await runtime.run("Create a file.", session_id="session-no-workspace-snapshots")
+    reverted = runtime.revert_session("session-no-workspace-snapshots")
+    revert_metadata = reverted.metadata["revert"]
+
+    assert revert_metadata["workspace_snapshot_id"] is None
+    assert revert_metadata["status"] == "reverted"
+    assert revert_metadata["workspace_restore_status"] == "not_applicable"
+    assert revert_metadata["workspace_restored"] is False
+
+
+@pytest.mark.asyncio
+async def test_revert_reports_paths_the_snapshot_could_not_capture(tmp_path: Path):
+    """A >max_file_bytes file and an excluded dir make the revert partial."""
+    runtime = AgentRuntime(
+        provider=_writing_provider("call-write-partial", "created.txt", "created\n"),
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            max_iterations=2,
+            model_aware_tool_selection=False,
+            tool_permissions={"write": "allow"},
+        ),
+    )
+    assert runtime.workspace_snapshot_store is not None
+    runtime.workspace_snapshot_store.max_file_bytes = 16
+
+    big = tmp_path / "big.bin"
+    big.write_text("x" * 64, encoding="utf-8")
+    dependency = tmp_path / "node_modules" / "pkg.js"
+    dependency.parent.mkdir(parents=True, exist_ok=True)
+    dependency.write_text("dep\n", encoding="utf-8")
+
+    await runtime.run("Create a file.", session_id="session-partial")
+    # The turn also touched what the snapshot could not capture.
+    big.write_text("y" * 64, encoding="utf-8")
+    dependency.write_text("changed\n", encoding="utf-8")
+
+    reverted = runtime.revert_session("session-partial")
+    revert_metadata = reverted.metadata["revert"]
+
+    assert revert_metadata["status"] == "reverted"
+    assert revert_metadata["workspace_restore_status"] == "partial"
+    assert revert_metadata["workspace_restored"] is True
+    assert revert_metadata["workspace_unrestored_paths"] == ["big.bin"]
+    assert "node_modules" in revert_metadata["workspace_excluded_directories"]
+    # Reported precisely because they really were not put back.
+    assert big.read_text(encoding="utf-8") == "y" * 64
+    assert dependency.read_text(encoding="utf-8") == "changed\n"
+    assert not (tmp_path / "created.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_complete_revert_reports_no_unrestored_paths(tmp_path: Path):
+    runtime = AgentRuntime(
+        provider=_writing_provider("call-write-clean", "created.txt", "created\n"),
+        config=RuntimeConfig(
+            workspace_root=tmp_path,
+            max_iterations=2,
+            model_aware_tool_selection=False,
+            tool_permissions={"write": "allow"},
+        ),
+    )
+
+    await runtime.run("Create a file.", session_id="session-clean")
+    revert_metadata = runtime.revert_session("session-clean").metadata["revert"]
+
+    assert revert_metadata["workspace_restore_status"] == "restored"
+    assert revert_metadata["workspace_unrestored_paths"] == []
+    assert revert_metadata["workspace_excluded_directories"] == []

--- a/tests/runtime/test_workspace_snapshot_memory.py
+++ b/tests/runtime/test_workspace_snapshot_memory.py
@@ -237,13 +237,13 @@ def test_retention_removes_snapshot_when_invalidation_callback_fails(tmp_path: P
 
 
 def test_retention_ignores_snapshot_retainer_failures(tmp_path: Path):
-    def retain(snapshot):
+    def retain(snapshots):
         raise OSError("session summary unavailable")
 
     store = WorkspaceSnapshotStore(
         tmp_path,
         max_retained_snapshots=1,
-        retain_snapshot=retain,
+        retain_snapshots=retain,
     )
     first = store.create_snapshot(label="first")
     second = store.create_snapshot(label="second", protect=True)

--- a/tests/runtime/test_workspace_snapshots.py
+++ b/tests/runtime/test_workspace_snapshots.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -156,9 +157,13 @@ def test_restore_ignores_excluded_directories_and_does_not_delete_them(
 ):
     excluded_paths = [
         tmp_path / ".git" / "config",
+        tmp_path / ".efp" / "runtime" / "sessions" / "session.json",
+        tmp_path / ".efp" / "runtime_tasks" / "task.json",
         tmp_path / ".efp_runtime" / "state.json",
         tmp_path / "__pycache__" / "module.pyc",
         tmp_path / ".pytest_cache" / "state",
+        tmp_path / "node_modules" / "pkg" / "index.js",
+        tmp_path / "nested" / "node_modules" / "index.js",
     ]
     _write_text(tmp_path / "app.py", "base\n")
     for path in excluded_paths:
@@ -179,6 +184,226 @@ def test_restore_ignores_excluded_directories_and_does_not_delete_them(
     assert not (tmp_path / "new.py").exists()
     for path in excluded_paths:
         assert path.read_text(encoding="utf-8") == "after\n"
+
+
+def test_snapshot_excludes_runtime_owned_state_directories(tmp_path: Path):
+    """`.efp/runtime` and `.efp/runtime_tasks` are runtime-owned, not content.
+
+    Everything else under `.efp` (config, skills, commands, ...) is ordinary
+    agent-editable workspace content and must stay capturable.
+    """
+    _write_text(tmp_path / "app.py", "base\n")
+    _write_text(tmp_path / ".efp" / "runtime" / "sessions" / "s.json", "{}\n")
+    _write_text(tmp_path / ".efp" / "runtime_tasks" / "task-1.json", "{}\n")
+    _write_text(tmp_path / ".efp" / "config.json", "{}\n")
+    # A nested directory with the same *name* is ordinary content: only the
+    # workspace-relative paths are runtime-owned.
+    _write_text(tmp_path / "src" / "runtime_tasks" / "keep.py", "keep\n")
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+    captured = {
+        item.path
+        for item in store._require_snapshot(snapshot.snapshot_id).files.values()
+    }
+
+    assert captured == {
+        "app.py",
+        ".efp/config.json",
+        "src/runtime_tasks/keep.py",
+    }
+    assert snapshot.file_count == 3
+
+
+def test_restore_does_not_delete_the_live_runtime_task_store(tmp_path: Path):
+    """`.efp/runtime_tasks` holds live background tasks; a revert must not touch it."""
+    _write_text(tmp_path / "app.py", "base\n")
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    task_path = tmp_path / ".efp" / "runtime_tasks" / "task-1.json"
+    _write_text(task_path, '{"status": "running"}\n')
+
+    store.restore_snapshot(snapshot.snapshot_id)
+
+    assert task_path.read_text(encoding="utf-8") == '{"status": "running"}\n'
+
+
+def test_restore_of_an_older_snapshot_does_not_rewrite_the_live_task_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Snapshots taken before `.efp/runtime_tasks` was runtime-owned hold its blobs.
+
+    Writing those back on the first revert after a deploy drops a stale
+    background-task queue on top of the running one.
+    """
+    from efp_runtime import workspace_snapshots
+
+    task_path = tmp_path / ".efp" / "runtime_tasks" / "task-1.json"
+    _write_text(tmp_path / "app.py", "base\n")
+    _write_text(task_path, '{"status": "queued"}\n')
+
+    # Capture the way the pre-deploy build did: nothing runtime-owned excluded.
+    monkeypatch.setattr(
+        workspace_snapshots, "_ALWAYS_EXCLUDED_RELATIVE_DIRS", frozenset()
+    )
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+    monkeypatch.undo()
+
+    assert ".efp/runtime_tasks/task-1.json" in set(
+        store._require_snapshot(snapshot.snapshot_id).files
+    )
+
+    _write_text(task_path, '{"status": "running"}\n')
+    _write_text(tmp_path / "app.py", "changed\n")
+    WorkspaceSnapshotStore(tmp_path).restore_snapshot(snapshot.snapshot_id)
+
+    assert (tmp_path / "app.py").read_text(encoding="utf-8") == "base\n"
+    assert task_path.read_text(encoding="utf-8") == '{"status": "running"}\n'
+
+
+def test_log_directories_are_captured_by_default(tmp_path: Path):
+    """`logs/` is legitimately committed (logs/.gitkeep, a `logs` package)."""
+    _write_text(tmp_path / "logs" / ".gitkeep", "")
+    _write_text(tmp_path / "src" / "logs" / "__init__.py", "before\n")
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    assert set(store._require_snapshot(snapshot.snapshot_id).files) == {
+        "logs/.gitkeep",
+        "src/logs/__init__.py",
+    }
+    assert snapshot.excluded_directories == []
+
+    _write_text(tmp_path / "src" / "logs" / "__init__.py", "after\n")
+    store.restore_snapshot(snapshot.snapshot_id)
+
+    assert (tmp_path / "src" / "logs" / "__init__.py").read_text(
+        encoding="utf-8"
+    ) == "before\n"
+
+
+def test_capture_creates_each_destination_directory_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The mirrored directory is created once per source dir, not per file."""
+    for index in range(5):
+        _write_text(tmp_path / "pkg" / f"file{index}.txt", f"content {index}\n")
+
+    store = WorkspaceSnapshotStore(tmp_path)
+
+    made: list[Path] = []
+    original_mkdir = Path.mkdir
+
+    def counting_mkdir(self: Path, *args, **kwargs):
+        made.append(Path(self))
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", counting_mkdir)
+    snapshot = store.create_snapshot()
+    monkeypatch.undo()
+
+    mirror = (
+        tmp_path
+        / ".efp_runtime"
+        / "workspace_snapshots"
+        / snapshot.snapshot_id
+        / "files"
+        / "pkg"
+    )
+
+    assert snapshot.file_count == 5
+    assert made.count(mirror) == 1
+    for index in range(5):
+        assert (mirror / f"file{index}.txt").is_file()
+
+
+def test_capture_leaves_no_mirror_directory_when_nothing_is_captured(
+    tmp_path: Path,
+):
+    _write_text(tmp_path / "keep.txt", "keep\n")
+    _write_text(tmp_path / "node_modules" / "dep.js", "excluded\n")
+    _write_text(tmp_path / "huge" / "big.bin", "x" * 64)
+
+    store = WorkspaceSnapshotStore(tmp_path, max_file_bytes=16)
+    snapshot = store.create_snapshot()
+    files_dir = (
+        tmp_path
+        / ".efp_runtime"
+        / "workspace_snapshots"
+        / snapshot.snapshot_id
+        / "files"
+    )
+
+    assert (files_dir / "keep.txt").is_file()
+    assert not (files_dir / "node_modules").exists()
+    assert not (files_dir / "huge").exists()
+
+
+def test_create_snapshot_logs_one_timing_line(tmp_path: Path, caplog):
+    _write_text(tmp_path / "alpha.txt", "abc")
+    _write_text(tmp_path / "big.bin", "x" * 64)
+    store = WorkspaceSnapshotStore(tmp_path, max_file_bytes=16)
+
+    caplog.set_level(logging.INFO)
+    snapshot = store.create_snapshot()
+
+    lines = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("workspace_snapshot.created")
+    ]
+
+    assert len(lines) == 1
+    line = lines[0]
+    assert "\n" not in line
+    assert f"id={snapshot.snapshot_id}" in line
+    assert f"root={store.workspace_root}" in line
+    assert "files=1" in line
+    assert "skipped=1" in line
+    assert "bytes=3" in line
+    for field in ("reload_ms=", "capture_ms=", "prune_ms=", "total_ms="):
+        assert field in line
+
+
+def test_legacy_manifest_rehash_is_logged_as_a_warning(tmp_path: Path, caplog):
+    import json
+
+    _write_text(tmp_path / "alpha.txt", "abc")
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    manifest_path = (
+        tmp_path
+        / ".efp_runtime"
+        / "workspace_snapshots"
+        / snapshot.snapshot_id
+        / "manifest.json"
+    )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["format"] = 1
+    payload.pop("files")
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    caplog.set_level(logging.WARNING)
+    reloaded = WorkspaceSnapshotStore(tmp_path)
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("workspace_snapshot.legacy_manifest_rehash")
+    ]
+
+    assert [item.snapshot_id for item in reloaded.list_snapshots()] == [
+        snapshot.snapshot_id
+    ]
+    assert len(warnings) >= 1
+    assert f"id={snapshot.snapshot_id}" in warnings[0]
+    assert "format=1" in warnings[0]
+    assert "files=1" in warnings[0]
+    assert "elapsed_ms=" in warnings[0]
 
 
 def test_snapshot_skips_symlinks_and_restore_does_not_follow_file_symlink(
@@ -247,6 +472,372 @@ def test_agent_runtime_workspace_snapshot_methods_work_when_configured(
     assert runtime.delete_workspace_snapshot(snapshot.snapshot_id) is True
     with pytest.raises(KeyError, match=snapshot.snapshot_id):
         runtime.delete_workspace_snapshot(snapshot.snapshot_id)
+
+
+def test_efp_workspace_content_is_captured_diffed_and_restored(tmp_path: Path):
+    """Only `.efp/runtime` is runtime-owned; the rest of `.efp` is user data."""
+    skill = tmp_path / ".efp" / "skills" / "my-skill" / "SKILL.md"
+    config = tmp_path / ".efp" / "config.json"
+    _write_text(skill, "# original skill\n")
+    _write_text(config, '{"model": "before"}\n')
+    _write_text(tmp_path / ".efp" / "commands" / "go.md", "go\n")
+    _write_text(tmp_path / ".efp" / "agents" / "helper.md", "helper\n")
+    _write_text(
+        tmp_path / ".efp" / "instructions" / "style.instructions.md", "style\n"
+    )
+    _write_text(tmp_path / ".efp" / "runtime" / "sessions" / "s.json", "{}\n")
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    captured = set(store._require_snapshot(snapshot.snapshot_id).files)
+    assert captured == {
+        ".efp/skills/my-skill/SKILL.md",
+        ".efp/config.json",
+        ".efp/commands/go.md",
+        ".efp/agents/helper.md",
+        ".efp/instructions/style.instructions.md",
+    }
+
+    # An agent rewrites the skill and the config, and drops a new file in.
+    _write_text(skill, "# corrupted\n")
+    _write_text(config, '{"model": "after"}\n')
+    _write_text(tmp_path / ".efp" / "skills" / "evil" / "x", "evil\n")
+
+    diffs = {
+        item.path: item.status for item in store.diff_snapshot(snapshot.snapshot_id)
+    }
+    assert diffs[".efp/skills/my-skill/SKILL.md"] == "modified"
+    assert diffs[".efp/config.json"] == "modified"
+    assert diffs[".efp/skills/evil/x"] == "added"
+
+    store.restore_snapshot(snapshot.snapshot_id)
+
+    assert skill.read_text(encoding="utf-8") == "# original skill\n"
+    assert config.read_text(encoding="utf-8") == '{"model": "before"}\n'
+    assert not (tmp_path / ".efp" / "skills" / "evil" / "x").exists()
+
+
+def test_session_store_under_efp_is_never_captured_or_deleted(tmp_path: Path):
+    session_file = tmp_path / ".efp" / "runtime" / "sessions" / "s.json"
+    _write_text(tmp_path / ".efp" / "config.json", "{}\n")
+    _write_text(session_file, '{"before": true}\n')
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    assert ".efp/runtime/sessions/s.json" not in set(
+        store._require_snapshot(snapshot.snapshot_id).files
+    )
+
+    _write_text(session_file, '{"after": true}\n')
+    added_session_file = tmp_path / ".efp" / "runtime" / "sessions" / "new.json"
+    _write_text(added_session_file, "{}\n")
+
+    assert not [
+        item
+        for item in store.diff_snapshot(snapshot.snapshot_id)
+        if item.path.startswith(".efp/runtime/")
+    ]
+
+    store.restore_snapshot(snapshot.snapshot_id, delete_added=True)
+
+    # Neither reverted nor deleted: the runtime owns this tree.
+    assert session_file.read_text(encoding="utf-8") == '{"after": true}\n'
+    assert added_session_file.exists()
+
+
+def test_nested_efp_directory_is_ordinary_workspace_content(tmp_path: Path):
+    """Exclusion is path-scoped, so a `.efp` at any other depth is captured."""
+    keep = tmp_path / "docs" / ".efp" / "keep.txt"
+    nested_runtime = tmp_path / "docs" / ".efp" / "runtime" / "notes.txt"
+    _write_text(keep, "keep\n")
+    _write_text(nested_runtime, "also kept\n")
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+    captured = set(store._require_snapshot(snapshot.snapshot_id).files)
+
+    assert captured == {"docs/.efp/keep.txt", "docs/.efp/runtime/notes.txt"}
+
+    _write_text(keep, "changed\n")
+    store.restore_snapshot(snapshot.snapshot_id)
+
+    assert keep.read_text(encoding="utf-8") == "keep\n"
+
+
+def test_snapshot_reports_files_skipped_for_size(tmp_path: Path):
+    _write_text(tmp_path / "small.txt", "ok\n")
+    _write_text(tmp_path / "big.bin", "x" * 64)
+
+    store = WorkspaceSnapshotStore(tmp_path, max_file_bytes=16)
+    snapshot = store.create_snapshot()
+
+    assert snapshot.skipped_files == {"big.bin": 64}
+    assert set(store.list_snapshots()[0].skipped_files) == {"big.bin"}
+
+    # The size-capped file is unrestorable, and the restore result says so.
+    _write_text(tmp_path / "big.bin", "y" * 64)
+    restored = store.restore_snapshot(snapshot.snapshot_id)
+
+    assert restored.skipped_files == {"big.bin": 64}
+    assert (tmp_path / "big.bin").read_text(encoding="utf-8") == "y" * 64
+
+
+def test_snapshot_reports_excluded_directories_present_at_capture(tmp_path: Path):
+    _write_text(tmp_path / "app.py", "base\n")
+    _write_text(tmp_path / "node_modules" / "pkg" / "index.js", "dep\n")
+    _write_text(tmp_path / "src" / ".cache" / "run.bin", "noise\n")
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    assert snapshot.excluded_directories == ["node_modules", "src/.cache"]
+    # Survives a restart and reaches the caller through restore_snapshot.
+    restarted = WorkspaceSnapshotStore(tmp_path)
+    assert restarted.list_snapshots()[0].excluded_directories == [
+        "node_modules",
+        "src/.cache",
+    ]
+    assert restarted.restore_snapshot(snapshot.snapshot_id).excluded_directories == [
+        "node_modules",
+        "src/.cache",
+    ]
+
+
+def test_build_output_directories_are_skipped_but_reported(tmp_path: Path):
+    """Heavy build dirs stay out of the capture, and say so.
+
+    Capturing them is a latency/disk budget, not a preference: create_snapshot
+    runs synchronously on the request path against a network PVC once per turn.
+    Measured on a modest tree, including them cost 24x the time and 61x the
+    bytes. Some repos do commit ``vendor/`` or build output, so the honest
+    answer is to record what was skipped and let revert report a partial
+    restore -- not to silently drop the files, and not to copy a GB-scale
+    ``target/`` on every message.
+    """
+    names = ("vendor", "build", "dist", "target", "coverage")
+    for name in names:
+        _write_text(tmp_path / name / "tracked.txt", "before\n")
+    _write_text(tmp_path / "app.py", "base\n")
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    assert set(store._require_snapshot(snapshot.snapshot_id).files) == {"app.py"}
+    # The skip is recorded, so a caller can tell the user what was not covered.
+    assert set(snapshot.excluded_directories) == {f"{name}" for name in names}
+
+    # A skipped directory is never deleted as an "added" file either.
+    for name in names:
+        _write_text(tmp_path / name / "tracked.txt", "after\n")
+    store.restore_snapshot(snapshot.snapshot_id, delete_added=True)
+
+    for name in names:
+        assert (tmp_path / name / "tracked.txt").read_text(
+            encoding="utf-8"
+        ) == "after\n"
+
+
+def test_excluded_directory_names_are_configurable(tmp_path: Path):
+    _write_text(tmp_path / "app.py", "base\n")
+    _write_text(tmp_path / "vendor" / "dep.go", "before\n")
+    _write_text(tmp_path / "node_modules" / "pkg.js", "dep\n")
+
+    store = WorkspaceSnapshotStore(tmp_path, excluded_directory_names={"vendor"})
+    snapshot = store.create_snapshot()
+    captured = set(store._require_snapshot(snapshot.snapshot_id).files)
+
+    assert captured == {"app.py", "node_modules/pkg.js"}
+    assert snapshot.excluded_directories == ["vendor"]
+
+    _write_text(tmp_path / "vendor" / "dep.go", "after\n")
+    store.restore_snapshot(snapshot.snapshot_id)
+
+    assert (tmp_path / "vendor" / "dep.go").read_text(encoding="utf-8") == "after\n"
+
+
+def test_restore_never_deletes_files_under_a_recorded_excluded_directory(
+    tmp_path: Path,
+):
+    """A directory the capture skipped is out of scope, not "added by the turn".
+
+    The scan that finds "added" files uses the *current* exclusion policy, so a
+    directory excluded only at capture time looks entirely new on restore.
+    """
+    _write_text(tmp_path / "app.py", "base\n")
+    _write_text(tmp_path / "vendor" / "github.com" / "x" / "x.go", "before\n")
+    capturing_store = WorkspaceSnapshotStore(
+        tmp_path, excluded_directory_names={"vendor"}
+    )
+    snapshot = capturing_store.create_snapshot()
+
+    assert snapshot.excluded_directories == ["vendor"]
+
+    # A later store (or a later default) no longer excludes vendor/, so its
+    # files show up in the "added" scan.
+    restoring_store = WorkspaceSnapshotStore(tmp_path, excluded_directory_names=set())
+    _write_text(tmp_path / "new.py", "delete me\n")
+    restoring_store.restore_snapshot(snapshot.snapshot_id)
+
+    assert not (tmp_path / "new.py").exists()
+    assert (tmp_path / "vendor" / "github.com" / "x" / "x.go").read_text(
+        encoding="utf-8"
+    ) == "before\n"
+
+
+def test_restore_from_a_manifest_without_excluded_directories_keeps_historic_dirs(
+    tmp_path: Path,
+):
+    """A manifest that records no exclusions cannot prove a path was ever in scope.
+
+    Format-1 manifests (and format-2 ones written before the key existed) have
+    no ``excluded_directories``, so every file under a historically excluded
+    name looks "added" and would be deleted.
+    """
+    import json
+
+    _write_text(tmp_path / "app.py", "base\n")
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    manifest_path = (
+        tmp_path
+        / ".efp_runtime"
+        / "workspace_snapshots"
+        / snapshot.snapshot_id
+        / "manifest.json"
+    )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["format"] = 1
+    payload.pop("files")
+    payload.pop("excluded_directories")
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    survivors = [
+        tmp_path / "vendor" / "github.com" / "x" / "x.go",
+        tmp_path / "dist" / "bundle.js",
+        tmp_path / "build" / "out.o",
+        tmp_path / "target" / "debug" / "app",
+        tmp_path / "coverage" / "index.html",
+        tmp_path / "src" / "node_modules" / "pkg" / "index.js",
+        tmp_path / ".efp" / "runtime_tasks" / "task-1.json",
+    ]
+    for path in survivors:
+        _write_text(path, "live\n")
+    _write_text(tmp_path / "new.py", "delete me\n")
+
+    legacy_store = WorkspaceSnapshotStore(tmp_path)
+    legacy_store.restore_snapshot(snapshot.snapshot_id)
+
+    assert not (tmp_path / "new.py").exists()
+    for path in survivors:
+        assert path.read_text(encoding="utf-8") == "live\n"
+
+
+def test_restore_from_a_manifest_recording_no_exclusions_still_deletes_added_files(
+    tmp_path: Path,
+):
+    """An empty (but present) ``excluded_directories`` is trustworthy evidence."""
+    _write_text(tmp_path / "app.py", "base\n")
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    assert snapshot.excluded_directories == []
+
+    # Not under an excluded directory, so it really is an added file.
+    _write_text(tmp_path / "src" / "bundle.js", "added by the turn\n")
+    reloaded = WorkspaceSnapshotStore(tmp_path)
+    reloaded.restore_snapshot(snapshot.snapshot_id)
+
+    assert not (tmp_path / "src" / "bundle.js").exists()
+
+
+def test_retained_set_outgrowing_the_cap_is_logged_once_per_transition(
+    tmp_path: Path, caplog
+):
+    """Retention beats the cap, so the overshoot must be visible — but once.
+
+    Pruning runs several times per turn; repeating the warning on every prune
+    turns a one-off condition into an endless log stream.
+    """
+    _write_text(tmp_path / "app.py", "base\n")
+    store = WorkspaceSnapshotStore(
+        tmp_path,
+        max_retained_snapshots=1,
+        retain_snapshots=lambda snapshots: [item.snapshot_id for item in snapshots],
+    )
+
+    caplog.set_level(logging.WARNING)
+    store.create_snapshot(label="one")
+    store.create_snapshot(label="two")
+    store.create_snapshot(label="three")
+    store.create_snapshot(label="four")
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("workspace_snapshot.retention_exceeds_cap")
+    ]
+
+    assert len(store.list_snapshots()) == 4
+    assert len(warnings) == 1
+    assert "retained=2" in warnings[0]
+    assert "cap=1" in warnings[0]
+
+
+def test_retained_set_within_the_cap_is_not_logged(tmp_path: Path, caplog):
+    _write_text(tmp_path / "app.py", "base\n")
+    store = WorkspaceSnapshotStore(
+        tmp_path,
+        max_retained_snapshots=4,
+        retain_snapshots=lambda snapshots: [item.snapshot_id for item in snapshots],
+    )
+
+    caplog.set_level(logging.WARNING)
+    for index in range(3):
+        store.create_snapshot(label=f"snapshot-{index}")
+
+    assert not [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("workspace_snapshot.retention_exceeds_cap")
+    ]
+
+
+def test_legacy_manifest_rehash_warns_once_per_manifest(tmp_path: Path, caplog):
+    """The rehash warning must not fire again on every runtime operation."""
+    import json
+
+    _write_text(tmp_path / "alpha.txt", "abc")
+    store = WorkspaceSnapshotStore(tmp_path)
+    snapshot = store.create_snapshot()
+
+    manifest_path = (
+        tmp_path
+        / ".efp_runtime"
+        / "workspace_snapshots"
+        / snapshot.snapshot_id
+        / "manifest.json"
+    )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["format"] = 1
+    payload.pop("files")
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    caplog.set_level(logging.WARNING)
+    reloaded = WorkspaceSnapshotStore(tmp_path)
+    for _ in range(5):
+        reloaded.list_snapshots()
+        reloaded.diff_snapshot(snapshot.snapshot_id)
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("workspace_snapshot.legacy_manifest_rehash")
+    ]
+
+    assert len(warnings) == 1
 
 
 def _write_text(path: Path, text: str) -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,5 +1,6 @@
 """Tests for Gateway server."""
 
+import logging
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -352,6 +353,155 @@ class TestGatewayEdgeCases:
         assert hasattr(gateway.app, 'router')
         assert hasattr(gateway.app, 'on_startup')
         assert hasattr(gateway.app, 'on_shutdown')
+
+
+class TestGatewayAccessLogMiddleware:
+    """Every request must leave a start and an end line on stdout."""
+
+    @staticmethod
+    def _app_with(handler, path="/probe", method="GET"):
+        from aiohttp import web
+        from src.gateway import server as gateway_server
+
+        app = web.Application(middlewares=[gateway_server.access_log_middleware])
+        app.router.add_route(method, path, handler)
+        return app
+
+    @staticmethod
+    def _lines(caplog, prefix):
+        return [
+            record.getMessage()
+            for record in caplog.records
+            if record.getMessage().startswith(prefix)
+        ]
+
+    def test_middleware_is_wired_into_the_application(self):
+        from src.gateway import server as gateway_server
+
+        gateway = Gateway()
+        assert gateway_server.access_log_middleware in gateway.app.middlewares
+
+    @pytest.mark.asyncio
+    async def test_logs_start_and_end_with_status_and_duration(self, caplog):
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async def handler(request):
+            return web.json_response({"ok": True})
+
+        caplog.set_level(logging.INFO, logger="src.gateway.server")
+        async with TestClient(TestServer(self._app_with(handler))) as client:
+            response = await client.get("/probe")
+            assert response.status == 200
+
+        start_lines = self._lines(caplog, "http.start")
+        end_lines = self._lines(caplog, "http.end")
+
+        assert len(start_lines) == 1
+        assert len(end_lines) == 1
+        assert "method=GET" in start_lines[0]
+        assert "path=/probe" in start_lines[0]
+        assert "remote=" in start_lines[0]
+        assert "request_id=" in start_lines[0]
+        assert "status=200" in end_lines[0]
+        assert "duration_ms=" in end_lines[0]
+        assert "\n" not in end_lines[0]
+
+        start_request_id = start_lines[0].split("request_id=")[1].strip()
+        assert start_request_id
+        assert f"request_id={start_request_id}" in end_lines[0]
+
+    @pytest.mark.asyncio
+    async def test_reuses_inbound_request_id_header(self, caplog):
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async def handler(request):
+            return web.json_response({"request_id": request["request_id"]})
+
+        caplog.set_level(logging.INFO, logger="src.gateway.server")
+        async with TestClient(TestServer(self._app_with(handler))) as client:
+            response = await client.get("/probe", headers={"X-Request-Id": "portal-42"})
+            payload = await response.json()
+
+        assert payload["request_id"] == "portal-42"
+        assert "request_id=portal-42" in self._lines(caplog, "http.start")[0]
+        assert "request_id=portal-42" in self._lines(caplog, "http.end")[0]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_trace_id_header(self, caplog):
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async def handler(request):
+            return web.json_response({"ok": True})
+
+        caplog.set_level(logging.INFO, logger="src.gateway.server")
+        async with TestClient(TestServer(self._app_with(handler))) as client:
+            await client.get("/probe", headers={"X-Trace-Id": "trace one 99"})
+
+        # Whitespace/separator characters are stripped so the line stays greppable.
+        assert "request_id=traceone99" in self._lines(caplog, "http.start")[0]
+
+    @pytest.mark.asyncio
+    async def test_error_responses_keep_status_and_exception_propagates(self, caplog):
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async def boom(request):
+            raise RuntimeError("kaboom")
+
+        async def not_found(request):
+            raise web.HTTPNotFound()
+
+        caplog.set_level(logging.INFO, logger="src.gateway.server")
+        app = self._app_with(boom, path="/boom")
+        app.router.add_route("GET", "/missing", not_found)
+
+        async with TestClient(TestServer(app)) as client:
+            assert (await client.get("/boom")).status == 500
+            assert (await client.get("/missing")).status == 404
+
+        end_lines = self._lines(caplog, "http.end")
+        assert len(end_lines) == 2
+        assert "path=/boom" in end_lines[0] and "status=500" in end_lines[0]
+        assert "path=/missing" in end_lines[1] and "status=404" in end_lines[1]
+
+    @pytest.mark.asyncio
+    async def test_runner_disables_the_duplicate_aiohttp_access_log(self, monkeypatch):
+        """One line pair per request: the middleware's, not aiohttp's too."""
+        from src.gateway import server as gateway_server
+
+        recorded = {}
+
+        class FakeRunner:
+            def __init__(self, app, **kwargs):
+                recorded["app"] = app
+                recorded["kwargs"] = kwargs
+
+            async def setup(self):
+                return None
+
+            async def cleanup(self):
+                return None
+
+        class FakeSite:
+            def __init__(self, runner, host, port):
+                recorded["site"] = (host, port)
+
+            async def start(self):
+                return None
+
+        monkeypatch.setattr(gateway_server.web, "AppRunner", FakeRunner)
+        monkeypatch.setattr(gateway_server.web, "TCPSite", FakeSite)
+
+        instance = Gateway()
+        await instance.start()
+
+        assert recorded["app"] is instance.app
+        assert "access_log" in recorded["kwargs"]
+        assert recorded["kwargs"]["access_log"] is None
+        assert "access_log_format" not in recorded["kwargs"]
 
 
 if __name__ == "__main__":

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -2,6 +2,8 @@
 
 import logging
 import io
+import sys
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 import pytest
 
@@ -41,6 +43,7 @@ from src.utils.logger import (
     RedactingFormatter,
     set_log_context,
     clear_log_context,
+    log_to_file_enabled,
 )
 
 
@@ -234,27 +237,95 @@ class TestSetupLogging:
         assert logger.level == logging.INFO
 
     def test_setup_logging_creates_directory(self, tmp_path):
-        """Test that logging creates log directory."""
+        """Test that logging creates log directory when file logging is on."""
         log_dir = tmp_path / "logs"
         setup_logging(
             level="INFO",
             log_dir=str(log_dir),
             log_file="test.log",
             console=False,
+            log_to_file=True,
         )
         assert log_dir.exists()
 
     def test_setup_logging_creates_files(self, tmp_path):
-        """Test that logging creates log files."""
+        """Test that logging creates log files when file logging is on."""
         log_dir = tmp_path / "logs"
         setup_logging(
             level="INFO",
             log_dir=str(log_dir),
             log_file="test.log",
             console=False,
+            log_to_file=True,
         )
         assert (log_dir / "test.log").exists()
         assert (log_dir / "errors.log").exists()
+
+    def test_setup_logging_file_handlers_off_by_default(self, tmp_path, monkeypatch):
+        """No env flag: stdout only, no log directory and no file handlers."""
+        monkeypatch.delenv("EFP_LOG_TO_FILE", raising=False)
+        log_dir = tmp_path / "logs"
+
+        logger = setup_logging(
+            level="INFO",
+            log_dir=str(log_dir),
+            log_file="test.log",
+            console=True,
+        )
+
+        assert not log_dir.exists()
+        assert not any(
+            isinstance(handler, RotatingFileHandler) for handler in logger.handlers
+        )
+        assert any(
+            isinstance(handler, logging.StreamHandler)
+            and handler.stream is sys.stdout
+            for handler in logger.handlers
+        )
+
+    def test_setup_logging_file_handlers_enabled_by_env_flag(
+        self, tmp_path, monkeypatch
+    ):
+        """EFP_LOG_TO_FILE=1 restores the previous file-handler behaviour."""
+        monkeypatch.setenv("EFP_LOG_TO_FILE", "1")
+        log_dir = tmp_path / "logs"
+
+        logger = setup_logging(
+            level="INFO",
+            log_dir=str(log_dir),
+            log_file="test.log",
+            console=False,
+        )
+
+        assert log_to_file_enabled() is True
+        assert (log_dir / "test.log").exists()
+        assert (log_dir / "errors.log").exists()
+        assert (
+            sum(
+                1
+                for handler in logger.handlers
+                if isinstance(handler, RotatingFileHandler)
+            )
+            == 2
+        )
+
+    def test_setup_logging_explicit_flag_beats_env(self, tmp_path, monkeypatch):
+        """An explicit log_to_file argument overrides the env default."""
+        monkeypatch.setenv("EFP_LOG_TO_FILE", "1")
+        log_dir = tmp_path / "logs"
+
+        logger = setup_logging(
+            level="INFO",
+            log_dir=str(log_dir),
+            log_file="test.log",
+            console=False,
+            log_to_file=False,
+        )
+
+        assert not log_dir.exists()
+        assert not any(
+            isinstance(handler, RotatingFileHandler) for handler in logger.handlers
+        )
 
     def test_setup_logging_structured(self, tmp_path):
         """Test structured logging mode."""
@@ -296,7 +367,7 @@ class TestSetupLogging:
     def test_setup_logging_attaches_redacting_filter(self, tmp_path):
         """All handlers should have redaction filter attached."""
         log_dir = tmp_path / "logs"
-        logger = setup_logging(level="INFO", log_dir=str(log_dir), log_file="test.log", console=False)
+        logger = setup_logging(level="INFO", log_dir=str(log_dir), log_file="test.log", console=False, log_to_file=True)
         assert logger.handlers
         assert all(any(isinstance(f, RedactingFilter) for f in h.filters) for h in logger.handlers)
 

--- a/tests/test_main_startup.py
+++ b/tests/test_main_startup.py
@@ -1,6 +1,34 @@
 import importlib
+import os
+import subprocess
 import sys
-from pathlib import Path
+import textwrap
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def main_module():
+    return importlib.import_module("main")
+
+
+@pytest.fixture
+def debug_config(main_module):
+    """Swap main's debug config dict and restore it afterwards."""
+    original = main_module.config._config.get("debug")
+
+    def _set(value):
+        main_module.config._config["debug"] = value
+
+    yield _set
+
+    if original is None:
+        main_module.config._config.pop("debug", None)
+    else:
+        main_module.config._config["debug"] = original
 
 
 def test_main_does_not_import_automation_watchers_symbols():
@@ -25,3 +53,230 @@ def test_main_source_does_not_reference_automation_watcher_lifecycle_calls():
     assert "start_automation_watchers(" not in source
     assert "stop_automation_watchers(" not in source
     assert "are_automation_watchers_enabled" not in source
+
+
+class TestLogLevelResolution:
+    """EFP_LOG_LEVEL > config.debug.log_level > debug.enabled."""
+
+    def test_env_override_wins_over_config(self, main_module, debug_config, monkeypatch):
+        debug_config({"enabled": False, "log_level": "WARNING"})
+        monkeypatch.setenv("EFP_LOG_LEVEL", "debug")
+
+        assert main_module.resolve_log_level() == "DEBUG"
+
+    def test_config_log_level_used_without_env(self, main_module, debug_config, monkeypatch):
+        debug_config({"enabled": True, "log_level": "warning"})
+        monkeypatch.delenv("EFP_LOG_LEVEL", raising=False)
+
+        assert main_module.resolve_log_level() == "WARNING"
+
+    def test_debug_enabled_implies_debug_level(self, main_module, debug_config, monkeypatch):
+        debug_config({"enabled": True})
+        monkeypatch.delenv("EFP_LOG_LEVEL", raising=False)
+
+        assert main_module.resolve_log_level() == "DEBUG"
+
+    def test_default_is_info(self, main_module, debug_config, monkeypatch):
+        debug_config({})
+        monkeypatch.delenv("EFP_LOG_LEVEL", raising=False)
+
+        assert main_module.resolve_log_level() == "INFO"
+
+    def test_blank_env_falls_through_to_config(self, main_module, debug_config, monkeypatch):
+        debug_config({"enabled": False, "log_level": "ERROR"})
+        monkeypatch.setenv("EFP_LOG_LEVEL", "   ")
+
+        assert main_module.resolve_log_level() == "ERROR"
+
+
+class TestLogDestination:
+    """Log files must default off the (network) workspace volume."""
+
+    def test_default_log_dir_is_absolute_and_off_workspace(self, main_module):
+        # POSIX semantics: the container runs Linux even when tests run on Windows.
+        assert main_module.DEFAULT_LOG_DIR == "/app/logs"
+        assert PurePosixPath(main_module.DEFAULT_LOG_DIR).is_absolute()
+        assert not main_module.DEFAULT_LOG_DIR.startswith("/workspace")
+
+    def test_setup_logging_uses_env_log_dir(self, main_module, monkeypatch, tmp_path):
+        recorded = {}
+
+        def fake_setup_logging(**kwargs):
+            recorded.update(kwargs)
+            return sys.modules["logging"].getLogger("main-startup-test")
+
+        monkeypatch.setattr(main_module, "setup_logging", fake_setup_logging)
+        monkeypatch.setenv("EFP_LOG_DIR", str(tmp_path / "podlogs"))
+        monkeypatch.setenv("EFP_LOG_LEVEL", "DEBUG")
+
+        main_module.setup_logging_config()
+
+        assert recorded["log_dir"] == str(tmp_path / "podlogs")
+        assert recorded["level"] == "DEBUG"
+
+    def test_setup_logging_defaults_to_the_absolute_log_dir(
+        self, main_module, monkeypatch
+    ):
+        """Without EFP_LOG_DIR the sink is the absolute default, never "logs"."""
+        recorded = {}
+
+        def fake_setup_logging(**kwargs):
+            recorded.update(kwargs)
+            return sys.modules["logging"].getLogger("main-startup-test")
+
+        monkeypatch.setattr(main_module, "setup_logging", fake_setup_logging)
+        monkeypatch.delenv("EFP_LOG_DIR", raising=False)
+
+        main_module.setup_logging_config()
+
+        assert recorded["log_dir"] == main_module.DEFAULT_LOG_DIR
+        assert recorded["log_dir"] != "logs"
+        # POSIX semantics: the container runs Linux even when tests run on
+        # Windows, and a relative dir would land on the workspace volume.
+        assert PurePosixPath(recorded["log_dir"]).is_absolute()
+
+
+class TestDebugCliOverrides:
+    """CLI flags merge into the debug config instead of replacing it."""
+
+    def test_debug_flag_keeps_sibling_debug_keys(self, main_module):
+        merged = main_module.merge_debug_cli_overrides(
+            {"log_level": "WARNING", "extra": "keep"},
+            debug=True,
+            httpx_trace=False,
+        )
+
+        assert merged["log_level"] == "WARNING"
+        assert merged["extra"] == "keep"
+        assert merged["enabled"] is True
+        assert merged["httpx_trace"] is False
+
+    def test_httpx_trace_flag_alone_keeps_enabled_and_level(self, main_module):
+        merged = main_module.merge_debug_cli_overrides(
+            {"enabled": False, "log_level": "ERROR"},
+            debug=False,
+            httpx_trace=True,
+        )
+
+        assert merged == {
+            "enabled": False,
+            "log_level": "ERROR",
+            "httpx_trace": True,
+        }
+
+    def test_no_flags_leaves_the_config_untouched(self, main_module):
+        original = {"enabled": False, "log_level": "ERROR"}
+        merged = main_module.merge_debug_cli_overrides(
+            original, debug=False, httpx_trace=False
+        )
+
+        assert merged == original
+        assert merged is not original
+
+    def test_missing_debug_section_is_tolerated(self, main_module):
+        assert main_module.merge_debug_cli_overrides(
+            None, debug=True, httpx_trace=True
+        ) == {"enabled": True, "httpx_trace": True}
+
+    def test_debug_flag_does_not_reset_a_configured_log_level(
+        self, main_module, debug_config, monkeypatch
+    ):
+        """The regression this guards: --debug used to wipe log_level."""
+        monkeypatch.delenv("EFP_LOG_LEVEL", raising=False)
+        debug_config(
+            main_module.merge_debug_cli_overrides(
+                {"log_level": "WARNING"}, debug=True, httpx_trace=False
+            )
+        )
+
+        assert main_module.resolve_log_level() == "WARNING"
+
+
+class TestLoggingSetupOrder:
+    """Logging must be configured before Gateway() is built at import time."""
+
+    def test_logging_is_configured_before_gateway_import(self, tmp_path):
+        """Import main in a subprocess and watch when the sinks come up.
+
+        A sentinel is logged the moment ``src.gateway.server`` starts importing
+        (Gateway() runs at import time). If logging were configured after that
+        import, neither the sentinel nor the gateway's own import-time lines
+        would reach stdout at all.
+        """
+        probe = textwrap.dedent(
+            """
+            import importlib.abc
+            import logging
+            import sys
+
+
+            class _GatewayImportProbe(importlib.abc.MetaPathFinder):
+                def find_spec(self, fullname, path=None, target=None):
+                    if fullname == "src.gateway.server":
+                        logging.getLogger(fullname).info(
+                            "SENTINEL_GATEWAY_IMPORT_BEGIN"
+                        )
+                    return None
+
+
+            sys.meta_path.insert(0, _GatewayImportProbe())
+            import main  # noqa: F401
+            """
+        )
+        env = dict(os.environ)
+        env["EFP_LOG_DIR"] = str(tmp_path / "logs")
+        env.pop("EFP_LOG_TO_FILE", None)
+
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        assert result.returncode == 0, result.stderr
+        stdout = result.stdout
+        assert "Engineering Flow Platform - Logging Initialized" in stdout
+        # Emitted while src.gateway.server was being imported: proves handlers
+        # were already attached at that point.
+        assert "SENTINEL_GATEWAY_IMPORT_BEGIN" in stdout
+        # The gateway's own import-time logging is captured too.
+        assert "Runtime API routes registered" in stdout
+        assert stdout.index("Engineering Flow Platform - Logging Initialized") < (
+            stdout.index("SENTINEL_GATEWAY_IMPORT_BEGIN")
+        )
+        assert stdout.index("SENTINEL_GATEWAY_IMPORT_BEGIN") < (
+            stdout.index("Runtime API routes registered")
+        )
+
+
+class TestRuntimePathsBootLine:
+    def test_log_runtime_paths_emits_one_line_with_every_root(self, main_module, caplog, tmp_path):
+        import logging
+
+        caplog.set_level(logging.INFO)
+        main_module.log_runtime_paths(logging.getLogger("main-paths-test"), tmp_path)
+
+        lines = [
+            record.getMessage()
+            for record in caplog.records
+            if record.getMessage().startswith("runtime.paths")
+        ]
+
+        assert len(lines) == 1
+        line = lines[0]
+        assert "\n" not in line
+        for field in (
+            "workspace_root=",
+            "session_root=",
+            "project_skills_dir=",
+            "user_skills_dir=",
+            "snapshot_storage_root=",
+            "log_dir=",
+            "cwd=",
+        ):
+            assert field in line
+        assert f"workspace_root={tmp_path}" in line
+        assert str(Path(tmp_path) / ".efp_runtime" / "workspace_snapshots") in line

--- a/tests/test_runtime_profile_overlay.py
+++ b/tests/test_runtime_profile_overlay.py
@@ -74,7 +74,7 @@ RUNTIME_OVERLAY_FIELDS = {
     "compaction_prune_protect_chars": 40000,
     "enable_compaction_summarizer": True,
     "enable_context_overflow_retry": False,
-    "enable_session_revert_snapshots": False,
+    "enable_session_revert_snapshots": True,
     "skill_directories": ["/workspace/.efp/skills"],
     "active_skills": ["review"],
     "command_directories": ["/workspace/.efp/commands"],

--- a/tests/test_upload_client_max_size.py
+++ b/tests/test_upload_client_max_size.py
@@ -5,8 +5,6 @@ capping every upload (and returning 413) regardless of the Portal's limit.
 These lock the EFP_MAX_UPLOAD_MB wiring and its transport headroom.
 """
 
-from pathlib import Path
-
 from src.gateway import server
 
 _HEADROOM = server.UPLOAD_TRANSPORT_HEADROOM_MB
@@ -39,5 +37,14 @@ def test_runtime_headroom_exceeds_user_cap():
 
 
 def test_application_is_wired_with_client_max_size():
-    source = Path("src/gateway/server.py").read_text(encoding="utf-8")
-    assert "web.Application(client_max_size=resolve_upload_client_max_size())" in source
+    # Assert the built application, not the source text: a matching kwarg on
+    # some *other* web.Application( call would not raise the real cap.
+    assert (
+        server.Gateway().app._client_max_size
+        == server.resolve_upload_client_max_size()
+    )
+
+
+def test_application_client_max_size_follows_env_override(monkeypatch):
+    monkeypatch.setenv("EFP_MAX_UPLOAD_MB", "37")
+    assert server.Gateway().app._client_max_size == (37 + _HEADROOM) * 1024 * 1024


### PR DESCRIPTION
## Why

A trivial "hey" took **minutes**, and the pod logs said nothing. Root cause: `create_snapshot` walks and byte-copies the whole `/workspace` to the **EFS PVC synchronously on the event loop, before the LLM call, every turn** — which also froze every other request and all log output in that pod. That is why the two symptoms (slow, and silent) are one bug.

Measured on vm-233 with the real code: a 5,000-file tree costs ~10 EFS round-trips per file (~50,800 round-trips) → **50–255 s** at 1–5 ms/op. The LLM call itself is under 5%.

## Latency

- **Exclude the runtime's own state**: `<workspace>/.efp/runtime` (the session store — `EFP_RUNTIME_SESSION_ROOT` lives there) and `.efp/runtime_tasks` (background-task store). Every snapshot was copying the whole conversation history, so capture cost **grew with history** — this is why an old agent becomes unusable while a fresh one is tolerable. Also a correctness fix: restore must not drop a stale session store or task queue onto the live one, so restore refuses to write those paths back.

  Scoped by **relative path, not name** — `.efp` as a name also matched `.efp/config.json`, `.efp/skills/**` and any `docs/.efp/`, which are real agent-editable content.
- `_capture_directory` creates each destination dir **once per source directory** instead of once per file (~2 EFS round-trips/file, ~20% of them).
- `log_dir` defaults to `EFP_LOG_DIR` or `/app/logs`. It was the relative `"logs"` and the pod's workingDir is `/workspace` — so logs were written **onto the network volume, inside the tree being snapshotted**. Enabling DEBUG made the pod slower.

## Observability

- `create_snapshot` emits one INFO line with **reload / capture / prune split out**, warning past 1s. It was the dominant per-request cost and logged nothing. The legacy format-1 rehash path (re-hashes every blob) now warns once per manifest.
- **New aiohttp middleware**: `http.start` before the handler, `http.end` with status + `duration_ms` in a `finally`, carrying an inbound `X-Request-Id`/`X-Trace-Id` or a minted one. There was no middleware and no access log at all, so a request stuck behind the snapshot left no evidence it had even arrived.
- `EFP_LOG_LEVEL` env override (level came only from the runtime profile, so `kubectl set env` did nothing), CLI debug flags **merge** instead of wiping siblings, logging is configured **before** importing the gateway (`Gateway()` logs at import), file handlers are opt-in via `EFP_LOG_TO_FILE`, and one boot line records the effective workspace/session/skills/snapshot roots — permanently answering "which of these is on the network volume".

## Revert correctness

Found by adversarial review of the already-merged #577; all confirmed with repros.

- **Revert silently did nothing while reporting success.** The revert target was pinned only during its own run, so once 20 newer snapshots existed (other sessions and subagent `task` runs share the workspace) it was pruned, the reference was nulled, and revert did a history-only trim while still returning `"reverted"` — with the turn's file changes left on disk. Now the target is retained, **bounded to the newest `max_retained_snapshots`** so retention is O(cap), not O(lifetime sessions).
- When the snapshot is gone but was enabled, revert reports `reverted_history_only` / `workspace_restored=False` instead of plain success.
- Snapshots record `skipped_files` (over the size cap) and `excluded_directories`, surfaced through the restore result, so a **partial restore is declared rather than hidden**.
- **`delete_added` no longer deletes files that were merely out of scope.** It used the *current* exclusion policy, so a directory excluded when the snapshot was taken looked entirely new and every file under it was deleted — a first-revert-after-deploy would have wiped `.efp/config.json`, hand-written skills and a Go repo's `vendor/`. Manifests predating `excluded_directories` fall back to a frozen historic name set instead of deleting.

Heavy build dirs (`dist/build/target/vendor/coverage`) stay excluded **by default**: capture is a latency and disk budget on the request path, and including them measured **24x the time and 61x the bytes** on a modest tree (a Rust/Java `target/` is GB-scale, times 20 retained copies). Repos that commit them are served by the reporting above, and the set is configurable.

## Testing

Every test is a behaviour test and mutation-verified (break the production code → the test must fail), after an earlier round shipped tests that passed with the fix removed.

`tests/runtime` + gateway + logger + main_startup: **24 failed, 1007 passed** — the failing set is *byte-identical* to master's (verified by stashing and diffing the FAILED node ids); all pre-existing Windows-only CRLF/shell issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)