### PR TITLE
Defer the snapshot store; keep probe errors visible

### DIFF
--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -1611,7 +1611,7 @@ class AgentRuntime:
         run_id: str,
         source: str,
     ):
-        # The store is only reached for when a snapshot is actually going to
+        # The store is only reached when a snapshot is actually going to
         # be taken: touching it otherwise would build it on every turn, which
         # is exactly the per-request cost the lazy store exists to avoid.
         enabled = self._session_revert_snapshots_enabled()

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -205,15 +205,8 @@ class AgentRuntime:
         self.compaction_summarizer = compaction_summarizer
         self.question_broker = question_broker or QuestionBroker()
         self.store = store or InMemorySessionStore()
-        self.workspace_snapshot_store = (
-            WorkspaceSnapshotStore(
-                self.config.workspace_root,
-                on_snapshot_removed=self._invalidate_session_snapshot_references,
-                retain_snapshots=self._retain_workspace_snapshots,
-            )
-            if self.config.workspace_root is not None
-            else None
-        )
+        # Materialised on first use only: see ``workspace_snapshot_store``.
+        self._workspace_snapshot_store: WorkspaceSnapshotStore | None = None
         self.skill_discovery = _resolve_skill_discovery(
             config=self.config,
             skill_discovery=skill_discovery,
@@ -1173,19 +1166,19 @@ class AgentRuntime:
         label: str | None = None,
         metadata: Mapping[str, Any] | None = None,
     ) -> WorkspaceSnapshot:
-        return self._workspace_snapshot_store().create_snapshot(
+        return self._require_workspace_snapshot_store().create_snapshot(
             label=label,
             metadata=metadata,
         )
 
     def list_workspace_snapshots(self) -> list[WorkspaceSnapshot]:
-        return self._workspace_snapshot_store().list_snapshots()
+        return self._require_workspace_snapshot_store().list_snapshots()
 
     def diff_workspace_snapshot(
         self,
         snapshot_id: str,
     ) -> list[WorkspaceSnapshotDiff]:
-        return self._workspace_snapshot_store().diff_snapshot(snapshot_id)
+        return self._require_workspace_snapshot_store().diff_snapshot(snapshot_id)
 
     def restore_workspace_snapshot(
         self,
@@ -1193,13 +1186,13 @@ class AgentRuntime:
         *,
         delete_added: bool = True,
     ) -> WorkspaceSnapshot:
-        return self._workspace_snapshot_store().restore_snapshot(
+        return self._require_workspace_snapshot_store().restore_snapshot(
             snapshot_id,
             delete_added=delete_added,
         )
 
     def delete_workspace_snapshot(self, snapshot_id: str) -> bool:
-        return self._workspace_snapshot_store().delete_snapshot(snapshot_id)
+        return self._require_workspace_snapshot_store().delete_snapshot(snapshot_id)
 
     def _build_instruction_context_messages(
         self,
@@ -1618,13 +1611,19 @@ class AgentRuntime:
         run_id: str,
         source: str,
     ):
+        # The store is only reached for when a snapshot is actually going to
+        # be taken: touching it otherwise would build it on every turn, which
+        # is exactly the per-request cost the lazy store exists to avoid.
+        enabled = self._session_revert_snapshots_enabled()
         return prepare_session_revert_record(
             store=self.store,
             session_id=session_id,
             run_id=run_id,
             source=source,
-            workspace_snapshot_store=self.workspace_snapshot_store,
-            enable_workspace_snapshot=self._session_revert_snapshots_enabled(),
+            workspace_snapshot_store=(
+                self.workspace_snapshot_store if enabled else None
+            ),
+            enable_workspace_snapshot=enabled,
             protect_workspace_snapshot=True,
         )
 
@@ -1660,7 +1659,10 @@ class AgentRuntime:
     def _session_revert_snapshots_enabled(self) -> bool:
         if not self.config.enable_session_revert_snapshots:
             return False
-        if self.workspace_snapshot_store is None or self.config.workspace_root is None:
+        # ``workspace_root is None`` is exactly the condition under which there
+        # is no snapshot store, and asking for the store here would build one
+        # just to discover the feature is off.
+        if self.config.workspace_root is None:
             return False
         return Path(self.config.workspace_root).exists()
 
@@ -1820,10 +1822,34 @@ class AgentRuntime:
             raise TypeError("session store does not support checkpoints")
         return method
 
-    def _workspace_snapshot_store(self) -> WorkspaceSnapshotStore:
-        if self.workspace_snapshot_store is None:
+    @property
+    def workspace_snapshot_store(self) -> WorkspaceSnapshotStore | None:
+        """The workspace snapshot store, built on first use.
+
+        ``None`` when the runtime has no workspace root, exactly as before.
+        Otherwise the store is constructed on demand rather than in
+        ``__init__``: constructing it walks the on-disk snapshot directory, and
+        an ``AgentRuntime`` is built once per chat request. A runtime that
+        never captures or restores a snapshot (the default, with
+        ``enable_session_revert_snapshots`` off) must not pay to read a
+        directory nothing is going to use — on a network volume that scan was
+        the dominant cost of a turn.
+        """
+        if self.config.workspace_root is None:
+            return None
+        if self._workspace_snapshot_store is None:
+            self._workspace_snapshot_store = WorkspaceSnapshotStore(
+                self.config.workspace_root,
+                on_snapshot_removed=self._invalidate_session_snapshot_references,
+                retain_snapshots=self._retain_workspace_snapshots,
+            )
+        return self._workspace_snapshot_store
+
+    def _require_workspace_snapshot_store(self) -> WorkspaceSnapshotStore:
+        store = self.workspace_snapshot_store
+        if store is None:
             raise TypeError("workspace snapshots require workspace_root")
-        return self.workspace_snapshot_store
+        return store
 
     def _invalidate_session_snapshot_references(
         self,
@@ -1882,7 +1908,10 @@ class AgentRuntime:
         fall out of the window lose their workspace target and their revert
         degrades to the reported history-only trim.
         """
-        store = self.workspace_snapshot_store
+        # Read the materialised store directly: this runs *from inside* the
+        # store's own pruning, so going through the lazy property would be a
+        # re-entrant construction.
+        store = self._workspace_snapshot_store
         revert_target_budget = (
             store.max_retained_snapshots
             if store is not None

--- a/src/efp_runtime/workspace_snapshots.py
+++ b/src/efp_runtime/workspace_snapshots.py
@@ -867,7 +867,6 @@ class WorkspaceSnapshotStore:
 
         started = time.perf_counter()
         legacy_files = self._scan_snapshot_files_metadata(snapshot_dir)
-        self._legacy_files_cache[snapshot_id] = (manifest_mtime, legacy_files)
         total_bytes = sum(item.size for item in legacy_files.values())
         _LOGGER.warning(
             "workspace_snapshot.legacy_manifest_rehash id=%s format=%s "
@@ -880,12 +879,18 @@ class WorkspaceSnapshotStore:
         )
         declared_file_count = _safe_nonnegative_int(payload.get("file_count"))
         declared_total_bytes = _safe_nonnegative_int(payload.get("total_bytes"))
-        if (
+        counts_differ = (
             declared_file_count is not None
             and declared_file_count != len(legacy_files)
         ) or (
             declared_total_bytes is not None and declared_total_bytes != total_bytes
-        ):
+        )
+        if counts_differ:
+            # Never retain a map that the manifest says is incomplete. The
+            # blobs may be restored without rewriting the manifest, in which
+            # case the next attempt must scan them again rather than reuse the
+            # failed result.
+            self._legacy_files_cache.pop(snapshot_id, None)
             # The header promised a snapshot the blobs no longer back. What is
             # on disk is the truth a restore can deliver, so it is used — and
             # reported, because it means the snapshot is incomplete.
@@ -897,6 +902,11 @@ class WorkspaceSnapshotStore:
                 declared_total_bytes,
                 len(legacy_files),
                 total_bytes,
+            )
+        else:
+            self._legacy_files_cache[snapshot_id] = (
+                manifest_mtime,
+                legacy_files,
             )
         return dict(legacy_files)
 

--- a/src/efp_runtime/workspace_snapshots.py
+++ b/src/efp_runtime/workspace_snapshots.py
@@ -122,6 +122,15 @@ _SNAPSHOT_ID_PREFIX = "workspace_snapshot_"
 _MANIFEST_FORMAT = 2
 _HASH_CHUNK_BYTES = 1024 * 1024
 
+class WorkspaceSnapshotIncompleteError(RuntimeError):
+    """A snapshot's manifest survives but its stored content does not match it.
+
+    Raised instead of quietly treating the surviving blobs as the whole
+    snapshot, which would let a restore delete everything the lost blobs
+    covered.
+    """
+
+
 _LOGGER = logging.getLogger(__name__)
 
 # A capture slower than this blocks the caller (today: the event loop) long
@@ -206,7 +215,13 @@ class _LoadedWorkspaceFile:
 @dataclass
 class _SnapshotRecord:
     snapshot: WorkspaceSnapshot
-    files: dict[str, _CapturedFile] = field(default_factory=dict)
+    # Per-file metadata, or ``None`` while it is still deferred. Read it
+    # through the ``files`` property, never directly.
+    loaded_files: dict[str, _CapturedFile] | None = None
+    # Derives ``files`` for a manifest that does not carry a file map. Deriving
+    # means hashing every persisted blob, so it is called at most once per
+    # record and only by a caller that genuinely needs the map.
+    files_loader: Callable[[], dict[str, _CapturedFile]] | None = None
     # Paths present at capture time but not captured (e.g. above the size
     # cap), mapped to their observed size. Restore must neither recreate nor
     # delete these.
@@ -219,6 +234,53 @@ class _SnapshotRecord:
     # restore must not treat "present now, absent from the snapshot" as
     # "added by this turn" for anything that could have been excluded.
     excluded_directories_recorded: bool = True
+    # Counts the manifest declared, kept for records whose file map is derived
+    # lazily. They are the only evidence of what the snapshot is *supposed* to
+    # contain, so they are checked against the blobs before the map is used.
+    declared_file_count: int | None = None
+    declared_total_bytes: int | None = None
+
+    @property
+    def files(self) -> dict[str, _CapturedFile]:
+        """Per-file metadata, deriving it from disk on first use if needed.
+
+        A derived map is validated against the counts the manifest declared.
+        Reconciling silently down to whatever blobs survive would be data
+        loss: ``restore_snapshot(delete_added=True)`` protects exactly
+        ``record.files | record.skipped``, so a snapshot that lost its blobs
+        would present an empty file set and delete the entire workspace. This
+        is reachable in normal operation, not just on exotic disk failure --
+        ``_remove_snapshot`` uses ``shutil.rmtree(ignore_errors=True)``, which
+        walks bottom-up and so removes ``files/`` before ``manifest.json``;
+        any partial failure leaves exactly that shape. Loading used to reject
+        such a snapshot outright, and refusing to use it preserves that.
+        """
+
+        if self.loaded_files is None:
+            loader = self.files_loader
+            if loader is None:
+                self.loaded_files = {}
+            else:
+                derived = loader()
+                derived_bytes = sum(item.size for item in derived.values())
+                if (
+                    self.declared_file_count is not None
+                    and self.declared_file_count != len(derived)
+                ) or (
+                    self.declared_total_bytes is not None
+                    and self.declared_total_bytes != derived_bytes
+                ):
+                    raise WorkspaceSnapshotIncompleteError(
+                        f"snapshot {self.snapshot.snapshot_id!r} is incomplete: "
+                        f"manifest declares {self.declared_file_count} files / "
+                        f"{self.declared_total_bytes} bytes but its stored "
+                        f"content holds {len(derived)} files / {derived_bytes} "
+                        f"bytes"
+                    )
+                self.loaded_files = derived
+                self.snapshot.file_count = len(derived)
+                self.snapshot.total_bytes = derived_bytes
+        return self.loaded_files
 
 
 class WorkspaceSnapshotStore:
@@ -252,10 +314,13 @@ class WorkspaceSnapshotStore:
         # how much it pins, and an unbounded pin grows the store forever.
         self._retain_snapshots = retain_snapshots
         self._snapshots: dict[str, _SnapshotRecord] = {}
-        # (snapshot_id -> manifest mtime) already reported as a legacy rehash.
-        # Every runtime operation reloads every manifest, so without this the
-        # warning fires once per retained format-1 snapshot per operation.
-        self._legacy_rehash_logged: dict[str, int | None] = {}
+        # snapshot_id -> (manifest mtime, derived file metadata) for manifests
+        # that carry no file map. Every runtime operation reloads every
+        # manifest and records are rebuilt each time, so without this a
+        # snapshot used twice would be re-hashed twice.
+        self._legacy_files_cache: dict[
+            str, tuple[int | None, dict[str, _CapturedFile]]
+        ] = {}
         self._next_snapshot_index = 1
         self._lock, self._protected_snapshot_ids = _workspace_coordination(
             self.workspace_root
@@ -309,7 +374,7 @@ class WorkspaceSnapshotStore:
                 )
                 record = _SnapshotRecord(
                     snapshot=deepcopy(snapshot),
-                    files=files,
+                    loaded_files=files,
                     skipped=skipped,
                     excluded_directories=excluded_directories,
                 )
@@ -552,7 +617,7 @@ class WorkspaceSnapshotStore:
         finally:
             shutil.rmtree(self._snapshot_dir(snapshot_id), ignore_errors=True)
             del self._snapshots[snapshot_id]
-            self._legacy_rehash_logged.pop(snapshot_id, None)
+            self._legacy_files_cache.pop(snapshot_id, None)
 
     def _validate_snapshot_blobs(
         self,
@@ -664,16 +729,31 @@ class WorkspaceSnapshotStore:
             except OSError:
                 return None
 
-        files = self._load_snapshot_file_metadata(snapshot_dir, payload)
-        if files is None:
+        loaded_files, files_loader = self._resolve_snapshot_file_metadata(
+            snapshot_dir, payload
+        )
+        if loaded_files is None and files_loader is None:
             return None
-        file_count = _safe_nonnegative_int(payload.get("file_count"))
-        total_bytes = _safe_nonnegative_int(payload.get("total_bytes"))
-        if file_count is not None and file_count != len(files):
-            return None
-        calculated_total_bytes = sum(item.size for item in files.values())
-        if total_bytes is not None and total_bytes != calculated_total_bytes:
-            return None
+        declared_file_count = _safe_nonnegative_int(payload.get("file_count"))
+        declared_total_bytes = _safe_nonnegative_int(payload.get("total_bytes"))
+        if loaded_files is not None:
+            file_count = len(loaded_files)
+            calculated_total_bytes = sum(item.size for item in loaded_files.values())
+            if declared_file_count is not None and declared_file_count != file_count:
+                return None
+            if (
+                declared_total_bytes is not None
+                and declared_total_bytes != calculated_total_bytes
+            ):
+                return None
+        else:
+            # Header-only load: the manifest's own counts describe the snapshot
+            # until a caller needs the file map. They are reconciled against
+            # the blobs at that point (see ``_SnapshotRecord.files``).
+            file_count = declared_file_count if declared_file_count is not None else 0
+            calculated_total_bytes = (
+                declared_total_bytes if declared_total_bytes is not None else 0
+            )
 
         skipped_payload = payload.get("skipped_files")
         skipped: dict[str, int] = {}
@@ -701,65 +781,124 @@ class WorkspaceSnapshotStore:
             else utc_now_iso(),
             label=label if isinstance(label, str) else None,
             metadata=dict(metadata) if isinstance(metadata, dict) else {},
-            file_count=len(files),
+            file_count=file_count,
             total_bytes=calculated_total_bytes,
             skipped_files=dict(skipped),
             excluded_directories=list(excluded_directories),
         )
         return _SnapshotRecord(
             snapshot=snapshot,
-            files=files,
+            loaded_files=loaded_files,
+            files_loader=files_loader,
             skipped=skipped,
             excluded_directories=excluded_directories,
             excluded_directories_recorded=excluded_directories_recorded,
+            declared_file_count=declared_file_count,
+            declared_total_bytes=declared_total_bytes,
         )
 
-    def _load_snapshot_file_metadata(
+    def _resolve_snapshot_file_metadata(
         self, snapshot_dir: Path, payload: dict[str, Any]
-    ) -> dict[str, _CapturedFile] | None:
+    ) -> tuple[
+        dict[str, _CapturedFile] | None,
+        Callable[[], dict[str, _CapturedFile]] | None,
+    ]:
+        """Per-file metadata for a manifest, deferred when it has to be derived.
+
+        Returns ``(files, None)`` when the metadata is known without touching
+        blobs, ``(None, loader)`` when it has to be derived on demand, and
+        ``(None, None)`` when the manifest is invalid.
+
+        A legacy manifest (format 1) carries no file map, so the metadata can
+        only come from hashing every persisted blob. That runs per store
+        construction and stores are built per request: one production pod was
+        re-hashing 577 MB across 27 retained snapshots — 26 s a turn — for a
+        feature that was switched off. Listing, pruning, retention and
+        protection all work from the manifest header alone, so the hashing is
+        deferred to the first caller that actually needs the file map
+        (diff/restore).
+        """
         manifest_files = payload.get("files")
         if isinstance(manifest_files, dict):
-            files: dict[str, _CapturedFile] = {}
-            for raw_path, raw_meta in manifest_files.items():
-                if not isinstance(raw_path, str) or not isinstance(raw_meta, dict):
-                    return None
-                sha256 = raw_meta.get("sha256")
-                size = _safe_nonnegative_int(raw_meta.get("size"))
-                if not isinstance(sha256, str) or size is None:
-                    return None
-                try:
-                    self._validate_relative_path(raw_path)
-                except ValueError:
-                    return None
-                files[raw_path] = _CapturedFile(
-                    path=raw_path, sha256=sha256, size=size
-                )
-            return files
-        # Legacy manifest (format 1) without a files map: derive metadata by
-        # streaming the persisted blobs — content is hashed chunk-wise and
-        # never retained in memory. This re-hashes every blob on every reload,
-        # so it is logged loudly: on a network volume it can cost minutes.
-        # Every runtime operation reloads every manifest, so the warning is
-        # emitted once per (snapshot, manifest mtime) instead of once per read.
-        started = time.perf_counter()
-        legacy_files = self._scan_snapshot_files_metadata(snapshot_dir)
+            return self._parse_manifest_file_metadata(manifest_files), None
+        if (
+            _safe_nonnegative_int(payload.get("file_count")) is None
+            or _safe_nonnegative_int(payload.get("total_bytes")) is None
+        ):
+            # No file map and no header counts: nothing describes the snapshot
+            # without reading the blobs, so there is nothing to defer.
+            return self._rehash_legacy_snapshot_files(snapshot_dir, payload), None
+        return None, lambda: self._rehash_legacy_snapshot_files(snapshot_dir, payload)
+
+    def _parse_manifest_file_metadata(
+        self, manifest_files: dict[Any, Any]
+    ) -> dict[str, _CapturedFile] | None:
+        files: dict[str, _CapturedFile] = {}
+        for raw_path, raw_meta in manifest_files.items():
+            if not isinstance(raw_path, str) or not isinstance(raw_meta, dict):
+                return None
+            sha256 = raw_meta.get("sha256")
+            size = _safe_nonnegative_int(raw_meta.get("size"))
+            if not isinstance(sha256, str) or size is None:
+                return None
+            try:
+                self._validate_relative_path(raw_path)
+            except ValueError:
+                return None
+            files[raw_path] = _CapturedFile(path=raw_path, sha256=sha256, size=size)
+        return files
+
+    def _rehash_legacy_snapshot_files(
+        self, snapshot_dir: Path, payload: dict[str, Any]
+    ) -> dict[str, _CapturedFile]:
+        """Derive one legacy snapshot's file metadata by streaming its blobs.
+
+        Content is hashed chunk-wise and never retained in memory. The result
+        is cached per (snapshot, manifest mtime) because every runtime
+        operation rebuilds every record, and it is logged loudly whenever the
+        hashing genuinely runs: on a network volume it can cost seconds per
+        snapshot, and that log line is what makes the cost diagnosable.
+        """
         snapshot_id = snapshot_dir.name
         manifest_mtime = _manifest_mtime_ns(snapshot_dir)
+        cached = self._legacy_files_cache.get(snapshot_id)
+        if cached is not None and cached[0] == manifest_mtime:
+            return dict(cached[1])
+
+        started = time.perf_counter()
+        legacy_files = self._scan_snapshot_files_metadata(snapshot_dir)
+        self._legacy_files_cache[snapshot_id] = (manifest_mtime, legacy_files)
+        total_bytes = sum(item.size for item in legacy_files.values())
+        _LOGGER.warning(
+            "workspace_snapshot.legacy_manifest_rehash id=%s format=%s "
+            "files=%d bytes=%d elapsed_ms=%.0f",
+            snapshot_id,
+            payload.get("format"),
+            len(legacy_files),
+            total_bytes,
+            (time.perf_counter() - started) * 1000.0,
+        )
+        declared_file_count = _safe_nonnegative_int(payload.get("file_count"))
+        declared_total_bytes = _safe_nonnegative_int(payload.get("total_bytes"))
         if (
-            snapshot_id not in self._legacy_rehash_logged
-            or self._legacy_rehash_logged[snapshot_id] != manifest_mtime
+            declared_file_count is not None
+            and declared_file_count != len(legacy_files)
+        ) or (
+            declared_total_bytes is not None and declared_total_bytes != total_bytes
         ):
-            self._legacy_rehash_logged[snapshot_id] = manifest_mtime
+            # The header promised a snapshot the blobs no longer back. What is
+            # on disk is the truth a restore can deliver, so it is used — and
+            # reported, because it means the snapshot is incomplete.
             _LOGGER.warning(
-                "workspace_snapshot.legacy_manifest_rehash id=%s format=%s "
-                "files=%d bytes=%d elapsed_ms=%.0f",
+                "workspace_snapshot.legacy_manifest_counts_differ id=%s "
+                "manifest_files=%s manifest_bytes=%s files=%d bytes=%d",
                 snapshot_id,
-                payload.get("format"),
+                declared_file_count,
+                declared_total_bytes,
                 len(legacy_files),
-                sum(item.size for item in legacy_files.values()),
-                (time.perf_counter() - started) * 1000.0,
+                total_bytes,
             )
-        return legacy_files
+        return dict(legacy_files)
 
     def _scan_snapshot_files_metadata(
         self, snapshot_dir: Path

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -52,6 +52,40 @@ REQUEST_ID_HEADERS = ("X-Request-Id", "X-Trace-Id")
 ACCESS_LOG = None
 # Status reported for a client disconnect / cancelled handler (nginx idiom).
 CLIENT_CLOSED_REQUEST_STATUS = 499
+# Infrastructure probes: kubernetes liveness/readiness checks and the
+# Spring-actuator endpoints scanners walk. Measured on a production pod, 568 of
+# 587 access-log lines (96.8%) were these, against 4 lines for the actual chat
+# requests — the real traffic was unreadable. They are logged at DEBUG instead
+# of INFO rather than dropped, so raising the level recovers them unchanged.
+PROBE_PATHS = frozenset(
+    {
+        "/health",
+        "/healthz",
+        "/live",
+        "/livez",
+        "/ready",
+        "/readyz",
+    }
+)
+# Everything at or below these prefixes is a probe (``/actuator`` itself plus
+# ``/actuator/health``, ``/actuator/env``, ``/actuator/jolokia``, ...).
+PROBE_PATH_PREFIXES = ("/actuator",)
+
+
+def is_probe_path(path: str) -> bool:
+    """Whether ``path`` is infrastructure noise rather than real traffic.
+
+    Matching is on whole path segments so an application route that merely
+    contains a probe word (``/api/actuator-report``) stays at INFO.
+    """
+    normalized = (path or "").rstrip("/") or "/"
+    if normalized in PROBE_PATHS:
+        return True
+    return any(
+        normalized == prefix or normalized.startswith(f"{prefix}/")
+        for prefix in PROBE_PATH_PREFIXES
+    )
+
 
 # Upload sizing. EFP_MAX_UPLOAD_MB is the user-facing per-file cap the Portal
 # enforces and reports; the runtime allows that plus headroom for multipart /
@@ -97,6 +131,13 @@ async def access_log_middleware(request: Request, handler):
     The start line is emitted before awaiting the handler on purpose: a slow
     handler (e.g. a synchronous workspace snapshot) otherwise leaves no
     evidence in stdout that the request was even received.
+
+    Probe traffic keeps the same lines with the same fields, at DEBUG -- but
+    only while it succeeds. Probes fail by *returning* an error (readiness
+    replies 503 rather than raising), and aiohttp's own access log is disabled
+    because this middleware replaces it, so keying the level on the path alone
+    would make a pod stuck failing readiness emit nothing at INFO. The end
+    line is therefore re-levelled from the final status.
     """
     request_id = resolve_request_id(request)
     request["request_id"] = request_id
@@ -105,9 +146,12 @@ async def access_log_middleware(request: Request, handler):
     remote = request.remote or "-"
     started = time.perf_counter()
     status = 500
+    is_probe = is_probe_path(path)
+    level = logging.DEBUG if is_probe else logging.INFO
 
-    logger.info(
-        f"http.start method={method} path={path} remote={remote} request_id={request_id}"
+    logger.log(
+        level,
+        f"http.start method={method} path={path} remote={remote} request_id={request_id}",
     )
     try:
         response = await handler(request)
@@ -121,9 +165,15 @@ async def access_log_middleware(request: Request, handler):
         raise
     finally:
         duration_ms = (time.perf_counter() - started) * 1000
-        logger.info(
+        # A probe that failed is the most important line in the log, so only a
+        # successful probe stays quiet. Non-int statuses (e.g. the cancelled
+        # sentinel) are treated as not-success.
+        succeeded = isinstance(status, int) and status < 400
+        end_level = logging.DEBUG if (is_probe and succeeded) else logging.INFO
+        logger.log(
+            end_level,
             f"http.end method={method} path={path} status={status} "
-            f"duration_ms={duration_ms:.1f} request_id={request_id}"
+            f"duration_ms={duration_ms:.1f} request_id={request_id}",
         )
 
 

--- a/tests/runtime/test_session_revert_summary.py
+++ b/tests/runtime/test_session_revert_summary.py
@@ -723,6 +723,129 @@ async def test_revert_reports_paths_the_snapshot_could_not_capture(tmp_path: Pat
     assert not (tmp_path / "created.txt").exists()
 
 
+def _write_legacy_snapshot_on_disk(root: Path, snapshot_id: str) -> Path:
+    """A retained snapshot written by the pre-file-map code (format 1)."""
+    snapshot_dir = root / ".efp_runtime" / "workspace_snapshots" / snapshot_id
+    blob = snapshot_dir / "files" / "captured.txt"
+    blob.parent.mkdir(parents=True, exist_ok=True)
+    blob.write_bytes(b"captured\n")
+    (snapshot_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "snapshot_id": snapshot_id,
+                "workspace_root": str(root),
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "label": "legacy",
+                "metadata": {},
+                "file_count": 1,
+                "total_bytes": len(b"captured\n"),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return snapshot_dir
+
+
+class _SnapshotDirectoryWatch:
+    """Records reads of the workspace snapshot storage directory."""
+
+    def __init__(self, monkeypatch, root: Path) -> None:
+        from efp_runtime import workspace_snapshots
+
+        self.storage_root = (root / ".efp_runtime" / "workspace_snapshots").resolve()
+        self.listed: list[Path] = []
+        self.hashed: list[Path] = []
+
+        original_iterdir = Path.iterdir
+        original_stream_sha256 = workspace_snapshots._stream_sha256
+
+        def tracked_iterdir(directory: Path):
+            if Path(directory).resolve() == self.storage_root:
+                self.listed.append(Path(directory))
+            return original_iterdir(directory)
+
+        def tracked_stream_sha256(path: Path):
+            self.hashed.append(Path(path))
+            return original_stream_sha256(path)
+
+        monkeypatch.setattr(Path, "iterdir", tracked_iterdir)
+        monkeypatch.setattr(
+            workspace_snapshots, "_stream_sha256", tracked_stream_sha256
+        )
+
+
+@pytest.mark.asyncio
+async def test_disabled_revert_snapshots_never_read_the_snapshot_directory(
+    tmp_path: Path,
+    monkeypatch,
+):
+    """A runtime that will not snapshot must not pay to load the store.
+
+    ``AgentRuntime`` is constructed once per chat request and building the
+    store walks every retained snapshot on the workspace volume, re-hashing
+    legacy ones. With the feature off that is pure cost, so the store is only
+    built when something actually asks for it.
+    """
+    _write_legacy_snapshot_on_disk(tmp_path, "workspace_snapshot_1")
+    watch = _SnapshotDirectoryWatch(monkeypatch, tmp_path)
+
+    runtime = AgentRuntime(
+        provider=ScriptedLLMProvider([{"content": "done"}]),
+        config=RuntimeConfig(
+            enable_session_revert_snapshots=False,
+            workspace_root=tmp_path,
+            max_iterations=2,
+            model_aware_tool_selection=False,
+        ),
+    )
+    result = await runtime.run("hey", session_id="session-no-snapshots")
+
+    assert result.status == LoopStatus.COMPLETED
+    assert watch.listed == []
+    assert watch.hashed == []
+    assert runtime.get_session("session-no-snapshots").metadata["revert"][
+        "workspace_snapshot_id"
+    ] is None
+
+    # The store is still fully available to anything that does ask for it.
+    assert [
+        snapshot.snapshot_id for snapshot in runtime.list_workspace_snapshots()
+    ] == ["workspace_snapshot_1"]
+    assert watch.listed
+
+
+@pytest.mark.asyncio
+async def test_enabled_revert_snapshots_still_capture_and_restore(
+    tmp_path: Path,
+    monkeypatch,
+):
+    """With the feature on, the deferred store is built and the revert works."""
+    watch = _SnapshotDirectoryWatch(monkeypatch, tmp_path)
+    runtime = AgentRuntime(
+        provider=_writing_provider("call-write-lazy", "created.txt", "created\n"),
+        config=RuntimeConfig(
+            enable_session_revert_snapshots=True,
+            workspace_root=tmp_path,
+            max_iterations=2,
+            model_aware_tool_selection=False,
+            tool_permissions={"write": "allow"},
+        ),
+    )
+
+    await runtime.run("Create a file.", session_id="session-lazy-enabled")
+
+    assert (tmp_path / "created.txt").read_text(encoding="utf-8") == "created\n"
+    assert runtime.get_session("session-lazy-enabled").metadata["revert"][
+        "workspace_snapshot_id"
+    ]
+    assert watch.listed
+
+    reverted = runtime.revert_session("session-lazy-enabled")
+
+    assert not (tmp_path / "created.txt").exists()
+    assert reverted.metadata["revert"]["workspace_restore_status"] == "restored"
+
+
 @pytest.mark.asyncio
 async def test_complete_revert_reports_no_unrestored_paths(tmp_path: Path):
     runtime = AgentRuntime(

--- a/tests/runtime/test_workspace_snapshot_memory.py
+++ b/tests/runtime/test_workspace_snapshot_memory.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -355,6 +356,167 @@ def test_diff_treats_file_deleted_after_scan_as_deleted(
     assert diff.after_bytes is None
 
 
+def _write_legacy_snapshot(root: Path, snapshot_id: str, files: dict[str, str]) -> None:
+    """A snapshot as the pre-file-map code wrote it: no ``files`` map."""
+    snapshot_dir = _snapshot_dir(root, snapshot_id)
+    for relative_path, content in files.items():
+        _write_text(snapshot_dir / "files" / relative_path, content)
+    manifest = {
+        "snapshot_id": snapshot_id,
+        "workspace_root": str(root),
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "label": snapshot_id,
+        "metadata": {},
+        "file_count": len(files),
+        "total_bytes": sum(len(content.encode("utf-8")) for content in files.values()),
+    }
+    (snapshot_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+class _BlobHashWatch:
+    """Records which snapshot blobs get stream-hashed."""
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+        from src.efp_runtime import workspace_snapshots
+
+        self._storage_root = (root / ".efp_runtime" / "workspace_snapshots").resolve()
+        self.hashed: list[Path] = []
+        original = workspace_snapshots._stream_sha256
+
+        def tracked(path: Path):
+            resolved = Path(path).resolve()
+            if self._storage_root in resolved.parents:
+                self.hashed.append(resolved)
+            return original(path)
+
+        monkeypatch.setattr(workspace_snapshots, "_stream_sha256", tracked)
+
+    def snapshots_hashed(self) -> set[str]:
+        return {
+            path.relative_to(self._storage_root).parts[0] for path in self.hashed
+        }
+
+
+def _rehash_warnings(caplog) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("workspace_snapshot.legacy_manifest_rehash")
+    ]
+
+
+def test_loading_legacy_snapshots_reads_no_blobs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+):
+    """Construction must not re-hash what the manifests already describe.
+
+    A production pod re-hashed 577 MB across 27 retained legacy snapshots on
+    every store construction — and a store is built per chat request.
+    """
+    for index in range(1, 4):
+        _write_legacy_snapshot(
+            tmp_path,
+            f"workspace_snapshot_{index}",
+            {"keep.txt": f"captured {index}\n", "sub/other.txt": "other\n"},
+        )
+    watch = _BlobHashWatch(monkeypatch, tmp_path)
+    caplog.set_level(logging.WARNING)
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    listed = store.list_snapshots()
+
+    assert [item.snapshot_id for item in listed] == [
+        "workspace_snapshot_1",
+        "workspace_snapshot_2",
+        "workspace_snapshot_3",
+    ]
+    # The header describes the snapshot well enough to list it.
+    assert [item.file_count for item in listed] == [2, 2, 2]
+    assert [item.total_bytes for item in listed] == [
+        len(b"captured 1\n") + len(b"other\n"),
+        len(b"captured 2\n") + len(b"other\n"),
+        len(b"captured 3\n") + len(b"other\n"),
+    ]
+    assert watch.hashed == []
+    assert _rehash_warnings(caplog) == []
+
+
+def test_pruning_legacy_snapshots_reads_no_blobs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+):
+    """Retention runs several times a turn and must stay blob-free."""
+    for index in range(1, 4):
+        _write_legacy_snapshot(
+            tmp_path, f"workspace_snapshot_{index}", {"keep.txt": f"captured {index}\n"}
+        )
+    _write_text(tmp_path / "live.txt", "live\n")
+    watch = _BlobHashWatch(monkeypatch, tmp_path)
+    caplog.set_level(logging.WARNING)
+
+    store = WorkspaceSnapshotStore(tmp_path, max_retained_snapshots=2)
+    created = store.create_snapshot(label="fresh")
+
+    assert {item.snapshot_id for item in store.list_snapshots()} == {
+        "workspace_snapshot_3",
+        created.snapshot_id,
+    }
+    assert not _snapshot_dir(tmp_path, "workspace_snapshot_1").exists()
+    assert watch.hashed == []
+    assert _rehash_warnings(caplog) == []
+
+
+def test_diffing_one_legacy_snapshot_rehashes_only_that_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+):
+    for index in range(1, 4):
+        _write_legacy_snapshot(
+            tmp_path, f"workspace_snapshot_{index}", {"keep.txt": f"captured {index}\n"}
+        )
+    _write_text(tmp_path / "keep.txt", "current\n")
+    watch = _BlobHashWatch(monkeypatch, tmp_path)
+    caplog.set_level(logging.WARNING)
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    [diff] = store.diff_snapshot("workspace_snapshot_2")
+
+    assert diff.path == "keep.txt"
+    assert diff.status == "modified"
+    assert watch.snapshots_hashed() == {"workspace_snapshot_2"}
+    warnings = _rehash_warnings(caplog)
+    assert len(warnings) == 1
+    assert "id=workspace_snapshot_2" in warnings[0]
+
+
+def test_restoring_one_legacy_snapshot_rehashes_only_that_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+):
+    for index in range(1, 4):
+        _write_legacy_snapshot(
+            tmp_path, f"workspace_snapshot_{index}", {"keep.txt": f"captured {index}\n"}
+        )
+    _write_text(tmp_path / "keep.txt", "current\n")
+    _write_text(tmp_path / "added.txt", "added by the turn\n")
+    watch = _BlobHashWatch(monkeypatch, tmp_path)
+    caplog.set_level(logging.WARNING)
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    restored = store.restore_snapshot("workspace_snapshot_3")
+
+    assert (tmp_path / "keep.txt").read_bytes() == b"captured 3\n"
+    assert not (tmp_path / "added.txt").exists()
+    assert restored.file_count == 1
+    assert watch.snapshots_hashed() == {"workspace_snapshot_3"}
+    assert len(_rehash_warnings(caplog)) == 1
+
+
 def test_legacy_format1_manifest_still_loads_and_restores(tmp_path: Path):
     _write_text(tmp_path / "keep.txt", "current\n")
     legacy_dir = _snapshot_dir(tmp_path, "workspace_snapshot_1")
@@ -379,3 +541,43 @@ def test_legacy_format1_manifest_still_loads_and_restores(tmp_path: Path):
 
     store.restore_snapshot("workspace_snapshot_1")
     assert (tmp_path / "keep.txt").read_bytes() == b"captured\n"
+
+
+def test_incomplete_legacy_snapshot_refuses_instead_of_wiping_the_workspace(
+    tmp_path: Path,
+):
+    """A legacy snapshot that lost its blobs must not delete the workspace.
+
+    Header-only loading trusts the manifest's declared counts. If the blobs
+    later disagree (``shutil.rmtree(ignore_errors=True)`` in ``_remove_snapshot``
+    walks bottom-up, so a partial failure can remove ``files/`` while leaving
+    ``manifest.json``), reconciling the file map down to the surviving blobs
+    would make ``restore_snapshot(delete_added=True)`` protect nothing and
+    delete everything. It must raise instead.
+    """
+    from src.efp_runtime.workspace_snapshots import (
+        WorkspaceSnapshotIncompleteError,
+    )
+
+    _write_legacy_snapshot(
+        tmp_path, "workspace_snapshot_1", {"app.py": "orig\n", "README.md": "x\n"}
+    )
+    # Simulate the lost-blobs shape: manifest still declares 2 files, none remain.
+    blobs = _snapshot_dir(tmp_path, "workspace_snapshot_1") / "files"
+    for blob in list(blobs.rglob("*")):
+        if blob.is_file():
+            blob.unlink()
+
+    _write_text(tmp_path / "app.py", "current\n")
+    _write_text(tmp_path / "unrelated_new_work.py", "keep me\n")
+
+    store = WorkspaceSnapshotStore(tmp_path)
+    # Header still advertises the declared counts.
+    assert store.list_snapshots()[0].file_count == 2
+
+    with pytest.raises(WorkspaceSnapshotIncompleteError):
+        store.restore_snapshot("workspace_snapshot_1", delete_added=True)
+
+    # Nothing was touched: the workspace survives intact.
+    assert (tmp_path / "app.py").read_bytes() == b"current\n"
+    assert (tmp_path / "unrelated_new_work.py").read_bytes() == b"keep me\n"

--- a/tests/runtime/test_workspace_snapshot_memory.py
+++ b/tests/runtime/test_workspace_snapshot_memory.py
@@ -581,3 +581,13 @@ def test_incomplete_legacy_snapshot_refuses_instead_of_wiping_the_workspace(
     # Nothing was touched: the workspace survives intact.
     assert (tmp_path / "app.py").read_bytes() == b"current\n"
     assert (tmp_path / "unrelated_new_work.py").read_bytes() == b"keep me\n"
+
+    # Repairing the blobs without rewriting the manifest must recover in this
+    # same store. A failed derived map must not remain cached by manifest mtime.
+    _write_text(blobs / "app.py", "orig\n")
+    _write_text(blobs / "README.md", "x\n")
+
+    store.restore_snapshot("workspace_snapshot_1", delete_added=False)
+
+    assert (tmp_path / "app.py").read_bytes() == b"orig\n"
+    assert (tmp_path / "unrelated_new_work.py").read_bytes() == b"keep me\n"

--- a/tests/runtime/test_workspace_snapshots.py
+++ b/tests/runtime/test_workspace_snapshots.py
@@ -390,15 +390,26 @@ def test_legacy_manifest_rehash_is_logged_as_a_warning(tmp_path: Path, caplog):
     caplog.set_level(logging.WARNING)
     reloaded = WorkspaceSnapshotStore(tmp_path)
 
-    warnings = [
-        record.getMessage()
-        for record in caplog.records
-        if record.getMessage().startswith("workspace_snapshot.legacy_manifest_rehash")
-    ]
+    def rehash_warnings():
+        return [
+            record.getMessage()
+            for record in caplog.records
+            if record.getMessage().startswith(
+                "workspace_snapshot.legacy_manifest_rehash"
+            )
+        ]
 
+    # Loading and listing work from the manifest header alone: no blob is
+    # hashed, so nothing is reported.
     assert [item.snapshot_id for item in reloaded.list_snapshots()] == [
         snapshot.snapshot_id
     ]
+    assert rehash_warnings() == []
+
+    # Diffing needs the file map, so the rehash genuinely happens here.
+    reloaded.diff_snapshot(snapshot.snapshot_id)
+    warnings = rehash_warnings()
+
     assert len(warnings) >= 1
     assert f"id={snapshot.snapshot_id}" in warnings[0]
     assert "format=1" in warnings[0]

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -468,6 +468,108 @@ class TestGatewayAccessLogMiddleware:
         assert "path=/missing" in end_lines[1] and "status=404" in end_lines[1]
 
     @pytest.mark.asyncio
+    async def test_failing_probe_is_visible_at_info(self, caplog):
+        """A probe demoted to DEBUG must resurface at INFO when it FAILS.
+
+        /ready and /health report failure by returning 503, not by raising,
+        and this middleware replaces aiohttp's own access log — so keying the
+        level on the path alone would make a pod stuck failing readiness emit
+        nothing at INFO, the single most important line when a pod won't come
+        up.
+        """
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async def handler(request):
+            return web.json_response({"ready": False}, status=503)
+
+        caplog.set_level(logging.DEBUG, logger="src.gateway.server")
+        app = self._app_with(handler, path="/ready")
+        async with TestClient(TestServer(app)) as client:
+            assert (await client.get("/ready")).status == 503
+
+        # The start line may stay quiet, but the failing end line must be INFO+.
+        info_end = self._records(caplog, "http.end", logging.INFO)
+        assert len(info_end) == 1
+        assert "status=503" in info_end[0]
+        assert self._records(caplog, "http.end", logging.DEBUG) == []
+
+    @staticmethod
+    def _records(caplog, prefix, level):
+        return [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == level and record.getMessage().startswith(prefix)
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/ready",
+            "/readyz",
+            "/health",
+            "/healthz",
+            "/live",
+            "/actuator",
+            "/actuator/health",
+            "/actuator/threaddump",
+        ],
+    )
+    async def test_probe_traffic_is_logged_at_debug_instead_of_info(
+        self, caplog, path
+    ):
+        """k8s and actuator probes were 96.8% of production access-log lines."""
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async def handler(request):
+            return web.json_response({"ok": True})
+
+        caplog.set_level(logging.DEBUG, logger="src.gateway.server")
+        app = self._app_with(handler, path=path)
+        async with TestClient(TestServer(app)) as client:
+            assert (await client.get(path)).status == 200
+
+        assert self._records(caplog, "http.start", logging.INFO) == []
+        assert self._records(caplog, "http.end", logging.INFO) == []
+
+        # Still recoverable — the lines keep every field, only the level drops.
+        debug_start = self._records(caplog, "http.start", logging.DEBUG)
+        debug_end = self._records(caplog, "http.end", logging.DEBUG)
+        assert len(debug_start) == 1
+        assert f"path={path}" in debug_start[0]
+        assert len(debug_end) == 1
+        assert "status=200" in debug_end[0]
+        assert "duration_ms=" in debug_end[0]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "path",
+        ["/api/chat/stream", "/api/actuator-report", "/actuatorish"],
+    )
+    async def test_application_traffic_stays_at_info(self, caplog, path):
+        """Only whole-path probes are demoted; lookalike routes are real traffic."""
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async def handler(request):
+            return web.json_response({"ok": True})
+
+        caplog.set_level(logging.DEBUG, logger="src.gateway.server")
+        app = self._app_with(handler, path=path)
+        async with TestClient(TestServer(app)) as client:
+            assert (await client.get(path)).status == 200
+
+        info_start = self._records(caplog, "http.start", logging.INFO)
+        info_end = self._records(caplog, "http.end", logging.INFO)
+        assert len(info_start) == 1
+        assert f"path={path}" in info_start[0]
+        assert len(info_end) == 1
+        assert "status=200" in info_end[0]
+        assert self._records(caplog, "http.start", logging.DEBUG) == []
+
+    @pytest.mark.asyncio
     async def test_runner_disables_the_duplicate_aiohttp_access_log(self, monkeypatch):
         """One line pair per request: the middleware's, not aiohttp's too."""
         from src.gateway import server as gateway_server


### PR DESCRIPTION
## Why

Follow-up to the merged observability work, driven by a **real production log** where a "hey" still took **28,292 ms**. The new snapshot timing line pinpointed it: **26.4 s** was `workspace_snapshot.legacy_manifest_rehash` — the pod re-hashing **577 MB** of pre-#577 (`format=None`) snapshots off the EFS PVC, **twice per turn**, even though snapshot creation is disabled. The operator deleted the stale snapshot dir and the turn got much faster, confirming it.

## Root causes

**Store built per request, even when unused.** `AgentRuntime.__init__` constructed `WorkspaceSnapshotStore` whenever `workspace_root` was set, and the runtime is built per chat request — so `_load_existing_snapshots()` ran every turn. Now the store is a **lazy property**: a runtime that never takes or restores a snapshot never touches the PVC. The revert flow still materialises it (correctly, for an explicit revert), callbacks still wired.

**Legacy manifests re-hashed on every load.** A `format=1` manifest carries no file map, so it was stream-hashed (every blob) on every store construction, for every retained snapshot. Now the header loads without touching blobs; the per-file map is derived only when that specific snapshot is diffed/restored, cached per `(id, manifest mtime)`. Listing, pruning, retention and protection never trigger a rehash.

## Data-loss guard (caught in review)

Deferring the legacy map surfaced a hazard: a legacy snapshot whose blobs no longer match its declared counts — reachable via `_remove_snapshot`'s `shutil.rmtree(ignore_errors=True)`, which removes `files/` before `manifest.json` — must **not** reconcile down to the surviving blobs. `restore_snapshot(delete_added=True)` protects exactly `record.files | record.skipped`, so an empty map would delete the **entire workspace**. It now raises `WorkspaceSnapshotIncompleteError`, preserving the old load-time rejection. Regression test reproduces the lost-blobs shape and asserts the workspace survives.

## Probe log noise (with the error-visibility fix)

**568 of 587** access-log lines in the production log were k8s/actuator probes (`/ready` ×320, `/actuator/health` ×164). They now log at **DEBUG — but only while they succeed**. `/ready` and `/health` report failure by *returning* 503, not raising, and this middleware replaces aiohttp's own access log, so the end line is re-levelled from the status: **a failing probe stays at INFO** — the one line an operator needs when a pod won't come up.

## Testing

All new tests behaviour-level and **mutation-verified**. `tests/runtime` + gateway + logger + main_startup: **24 failed / 1026 passed** — failing set byte-identical to master's pre-existing Windows-only failures (verified by stashing + diffing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)