### PR TITLE
Bound the native runtime context by the model catalog, and classify the overflow 400

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -122,6 +122,36 @@ llm:
   # workspace. Edit it directly or through the Portal system prompt editor.
 
 # ============================================
+# Runtime Context Budget (OPTIONAL)
+# ============================================
+# These are TOP-LEVEL keys, not nested under `llm:`. They are the only
+# context-budget knobs the native (efp_runtime) request path reads: they are
+# lifted off the top level of the effective config by
+# src/gateway/runtime_chat.py:_runtime_config_profile_kwargs, filtered by
+# PORTAL_MANAGED_RUNTIME_FIELDS in src/config.py.
+#
+# Leave them unset and the budget is derived from the model catalog
+# (src/efp_runtime/llm/models.py): the model's declared context window minus a
+# safety margin, with the model's declared response reserve held back. That
+# default is what keeps a long conversation from growing past the model window
+# and returning `400 Bad Request / "Your input exceeds the context window"`.
+#
+# Set them only to override that default -- for example to pin a smaller
+# prompt budget, or to opt in to compaction of the STORED session history
+# (which the model-derived default deliberately does NOT do, because rewriting
+# stored history discards the user's transcript).
+#
+# max_context_tokens: 250000   # prompt budget in tokens; wins over the catalog
+# max_context_chars: 1000000   # same, in characters; wins over max_context_tokens
+# max_context_parts: 200       # cap on message parts, independent of the above
+# context_reserve_tokens: 128000  # response headroom withheld from the budget
+#
+# NOTE: the `llm.context_budget` and `llm.model_limits` blocks above are read
+# by the LEGACY progressive-context stack (src/runtime/progressive_context.py,
+# src/config.py:resolve_model_limits), NOT by the native request path. Changing
+# them will not resize a native runtime chat request.
+
+# ============================================
 # Session Configuration (OPTIONAL)
 # ============================================
 # Session persistence and caching settings

--- a/src/agents/compaction.py
+++ b/src/agents/compaction.py
@@ -812,6 +812,9 @@ def resolve_context_window_tokens(model: Optional[str] = None) -> int:
         "gpt-5.4": 400000,
         "gpt-5.4-mini": 400000,
         "gpt-5.5": 400000,
+        "gpt-5.6-luna": 328000,
+        "gpt-5.6-sol": 400000,
+        "gpt-5.6-terra": 400000,
         "gemini-2.5-pro": 128000,
         "gemini-3.5-flash": 128000,
     }

--- a/src/config.py
+++ b/src/config.py
@@ -837,6 +837,21 @@ DEFAULT_MODEL_LIMITS: Dict[str, Dict[str, int]] = {
         "max_prompt_tokens": 272000,
         "max_output_tokens": 128000,
     },
+    "gpt-5.6-luna": {
+        "max_context_window_tokens": 328000,
+        "max_prompt_tokens": 200000,
+        "max_output_tokens": 128000,
+    },
+    "gpt-5.6-sol": {
+        "max_context_window_tokens": 400000,
+        "max_prompt_tokens": 272000,
+        "max_output_tokens": 128000,
+    },
+    "gpt-5.6-terra": {
+        "max_context_window_tokens": 400000,
+        "max_prompt_tokens": 272000,
+        "max_output_tokens": 128000,
+    },
     "gemini-2.5-pro": {
         "max_context_window_tokens": 128_000,
         "max_prompt_tokens": 128_000,

--- a/src/efp_runtime/compaction/strategy.py
+++ b/src/efp_runtime/compaction/strategy.py
@@ -73,13 +73,23 @@ class _Block:
     refs: list[_PartRef]
     is_tool_pair: bool = False
 
+    def __post_init__(self) -> None:
+        # Sizes are read once per candidate selection inside the budget search
+        # loop, so compute them once instead of re-summing on every access.
+        object.__setattr__(self, "_part_count", len(self.refs))
+        object.__setattr__(
+            self,
+            "_char_count",
+            sum(_part_chars(ref.part) for ref in self.refs),
+        )
+
     @property
     def part_count(self) -> int:
-        return len(self.refs)
+        return self._part_count  # type: ignore[attr-defined]
 
     @property
     def char_count(self) -> int:
-        return sum(_part_chars(ref.part) for ref in self.refs)
+        return self._char_count  # type: ignore[attr-defined]
 
 
 @dataclass(frozen=True)
@@ -188,14 +198,32 @@ class BudgetCompactionStrategy:
         if latest_unprotected_index is not None:
             kept_indices.add(latest_unprotected_index)
 
+        # Running totals for the kept set plus a per-call memo for the summary
+        # renderer's relevant-file regex scan. Without both, each of the n loop
+        # iterations re-scanned every compacted message's text, making the search
+        # quadratic in total history size (minutes of blocking CPU on the
+        # multi-megabyte sessions this budget exists to bound).
+        kept_parts = sum(blocks[index].part_count for index in kept_indices)
+        kept_chars = sum(blocks[index].char_count for index in kept_indices)
+        path_candidate_cache: dict[int, tuple[Message, list[str]]] = {}
+
         for index in reversed(range(len(blocks))):
             if index in kept_indices:
                 continue
+            block = blocks[index]
             candidate_indices = {*kept_indices, index}
-            candidate_parts, candidate_chars = _selection_usage(blocks, candidate_indices)
+            candidate_parts, candidate_chars = _selection_usage(
+                blocks,
+                candidate_indices,
+                kept_parts=kept_parts + block.part_count,
+                kept_chars=kept_chars + block.char_count,
+                path_candidate_cache=path_candidate_cache,
+            )
             if not self._fits_budget(part_count=candidate_parts, char_count=candidate_chars):
                 continue
             kept_indices.add(index)
+            kept_parts += block.part_count
+            kept_chars += block.char_count
 
         return [blocks[index] for index in sorted(kept_indices)]
 
@@ -574,16 +602,32 @@ def _recent_char_block_indices(
     return selected
 
 
-def _selection_usage(blocks: list[_Block], kept_indices: set[int]) -> tuple[int, int]:
-    kept_blocks = [block for index, block in enumerate(blocks) if index in kept_indices]
+def _selection_usage(
+    blocks: list[_Block],
+    kept_indices: set[int],
+    *,
+    kept_parts: int,
+    kept_chars: int,
+    path_candidate_cache: dict[int, tuple[Message, list[str]]] | None = None,
+) -> tuple[int, int]:
+    """Return the (parts, chars) a selection would cost.
+
+    ``kept_parts``/``kept_chars`` are the caller's running totals for
+    ``kept_indices``; they are pure sums over the kept blocks and are passed in
+    so the budget search does not re-sum the whole selection per candidate.
+    """
+
     compacted_blocks = [
         block for index, block in enumerate(blocks) if index not in kept_indices
     ]
-    part_count = sum(block.part_count for block in kept_blocks)
-    char_count = sum(block.char_count for block in kept_blocks)
+    part_count = kept_parts
+    char_count = kept_chars
     if compacted_blocks:
         part_count += 1
-        char_count += _compaction_summary_chars(compacted_blocks)
+        char_count += _compaction_summary_chars(
+            compacted_blocks,
+            path_candidate_cache=path_candidate_cache,
+        )
     return part_count, char_count
 
 
@@ -593,6 +637,7 @@ def _build_compaction_message(
     previous_summary: str | None = None,
     tail_start_message_id: str | None = None,
     metadata: Mapping[str, Any] | None = None,
+    path_candidate_cache: dict[int, tuple[Message, list[str]]] | None = None,
 ) -> Message:
     part_count = sum(block.part_count for block in compacted_blocks)
     message_refs = {ref.message_index: ref.message for block in compacted_blocks for ref in block.refs}
@@ -610,6 +655,7 @@ def _build_compaction_message(
             "compacted_message_count": message_count,
             "compacted_tool_pair_count": tool_pair_count,
         },
+        path_candidate_cache=path_candidate_cache,
     )
     compaction_metadata = {
         "approx_compacted_chars": sum(block.char_count for block in compacted_blocks)
@@ -739,10 +785,21 @@ def _part_chars(part: MessagePart) -> int:
     return len(part.text or "")
 
 
-def _compaction_summary_chars(compacted_blocks: list[_Block]) -> int:
+def _compaction_summary_chars(
+    compacted_blocks: list[_Block],
+    *,
+    path_candidate_cache: dict[int, tuple[Message, list[str]]] | None = None,
+) -> int:
     if not compacted_blocks:
         return 0
-    return _messages_chars([_build_compaction_message(compacted_blocks)])
+    return _messages_chars(
+        [
+            _build_compaction_message(
+                compacted_blocks,
+                path_candidate_cache=path_candidate_cache,
+            )
+        ]
+    )
 
 
 def _json_chars(value: Mapping[str, Any]) -> int:

--- a/src/efp_runtime/compaction/summary.py
+++ b/src/efp_runtime/compaction/summary.py
@@ -117,8 +117,13 @@ def render_anchored_compaction_summary(
     kept_messages: Iterable[Message] = (),
     previous_summary: str | None = None,
     metadata: Mapping[str, Any] | None = None,
+    path_candidate_cache: dict[int, tuple[Message, list[str]]] | None = None,
 ) -> str:
-    """Render a conservative deterministic summary with stable anchors."""
+    """Render a conservative deterministic summary with stable anchors.
+
+    ``path_candidate_cache`` is an optional per-caller memo for the relevant-file
+    regex scan; see :func:`extract_relevant_files`.
+    """
 
     compacted = list(compacted_messages)
     kept = list(kept_messages)
@@ -131,7 +136,10 @@ def render_anchored_compaction_summary(
     )
     tool_pair_count = int(request_metadata.get("compacted_tool_pair_count") or 0)
     source_message_ids = _source_message_ids(compacted)
-    relevant_files = extract_relevant_files([*compacted, *kept])
+    relevant_files = extract_relevant_files(
+        [*compacted, *kept],
+        candidate_cache=path_candidate_cache,
+    )
     previous_context = _bounded_previous_summary(previous_summary)
     critical_items = [
         (
@@ -186,22 +194,58 @@ def latest_compaction_summary(messages: Iterable[Message]) -> str | None:
     return latest
 
 
-def extract_relevant_files(messages: Iterable[Message]) -> list[str]:
-    """Extract obvious workspace paths from message text and tool payloads."""
+def message_path_candidates(message: Message) -> list[str]:
+    """Return every path-shaped token in one message, in order, without dedup.
+
+    Split out of :func:`extract_relevant_files` so callers that re-extract over
+    overlapping message sets (the compaction budget search) can scan each
+    message's text with the regex exactly once. Dedup and the
+    ``RELEVANT_FILE_LIMIT`` cutoff stay in the caller because both are global
+    across the message sequence.
+    """
+
+    candidates: list[str] = []
+    for part in message.parts:
+        for text in _part_text_sources(part):
+            for match in _PATH_PATTERN.findall(text):
+                path = match.rstrip(".,;)]}'\"")
+                if "://" in path:
+                    continue
+                candidates.append(path)
+    return candidates
+
+
+def extract_relevant_files(
+    messages: Iterable[Message],
+    *,
+    candidate_cache: dict[int, tuple[Message, list[str]]] | None = None,
+) -> list[str]:
+    """Extract obvious workspace paths from message text and tool payloads.
+
+    ``candidate_cache`` memoizes the per-message regex scan. It is keyed by
+    ``id(message)`` and stores the message alongside its candidates so the
+    object stays alive and the id cannot be recycled while the cache lives.
+    """
 
     paths: list[str] = []
     seen: set[str] = set()
     for message in messages:
-        for part in message.parts:
-            for text in _part_text_sources(part):
-                for match in _PATH_PATTERN.findall(text):
-                    path = match.rstrip(".,;)]}'\"")
-                    if "://" in path or path in seen:
-                        continue
-                    seen.add(path)
-                    paths.append(path)
-                    if len(paths) >= RELEVANT_FILE_LIMIT:
-                        return paths
+        if candidate_cache is None:
+            candidates = message_path_candidates(message)
+        else:
+            cached = candidate_cache.get(id(message))
+            if cached is None:
+                candidates = message_path_candidates(message)
+                candidate_cache[id(message)] = (message, candidates)
+            else:
+                candidates = cached[1]
+        for path in candidates:
+            if path in seen:
+                continue
+            seen.add(path)
+            paths.append(path)
+            if len(paths) >= RELEVANT_FILE_LIMIT:
+                return paths
     return paths
 
 
@@ -409,5 +453,6 @@ __all__ = [
     "build_compaction_prompt",
     "extract_relevant_files",
     "latest_compaction_summary",
+    "message_path_candidates",
     "render_anchored_compaction_summary",
 ]

--- a/src/efp_runtime/llm/models.py
+++ b/src/efp_runtime/llm/models.py
@@ -11,6 +11,8 @@ DEFAULT_MODEL_ID = "gpt-5.6-terra"
 DEFAULT_CHARS_PER_TOKEN = 4
 MIN_PRESERVE_RECENT_TOKENS = 2_000
 MAX_PRESERVE_RECENT_TOKENS = 8_000
+DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS = 8_000
+CONTEXT_SAFETY_MARGIN_WINDOW_DIVISOR = 20
 SUPPORTED_COPILOT_MODEL_IDS = (
     "gpt-5.4",
     "gpt-5.5",
@@ -46,14 +48,21 @@ def resolve_model_context_profile(
     *,
     provider_id: Any = DEFAULT_PROVIDER_ID,
 ) -> ModelContextProfile:
-    """Resolve a Copilot model profile with a conservative Copilot fallback."""
+    """Resolve a model context profile with a conservative fallback.
 
-    requested_provider, requested_model = _split_model_id(model)
-    fallback_provider = _normalize_identifier(provider_id) or DEFAULT_PROVIDER_ID
-    provider = requested_provider or fallback_provider
+    The catalog is keyed by model id alone: a context window is a property of
+    the model, not of the gateway serving it. ``provider_id`` is accepted (and
+    a ``provider/model`` prefix is stripped from ``model``) so callers can pass
+    a qualified id, but it does not gate the lookup - ai_platform serves
+    ``gpt-5.4`` (see ``AI_PLATFORM_MODEL_IDS``) with the same 400k window as
+    Copilot, and this profile is the default source of the native runtime's
+    context budget, so falling back to the 64k profile purely because of a
+    provider id would compact those sessions roughly seven times too early.
+    """
+
+    del provider_id  # accepted for call-site compatibility; see docstring
+    _, requested_model = _split_model_id(model)
     model_id = requested_model or DEFAULT_MODEL_ID
-    if provider != DEFAULT_PROVIDER_ID:
-        return replace(_CONSERVATIVE_FALLBACK_PROFILE, model_id=model_id)
     return _COPILOT_PROFILES.get(
         model_id,
         replace(_CONSERVATIVE_FALLBACK_PROFILE, model_id=model_id),
@@ -91,6 +100,34 @@ def tokens_to_chars(
     _validate_non_negative_int(tokens, "tokens")
     _validate_positive_int(chars_per_token, "chars_per_token")
     return int(tokens) * int(chars_per_token)
+
+
+def context_safety_margin_tokens(profile: ModelContextProfile) -> int:
+    """Return the token margin held back from a model's declared window.
+
+    Mirrors the legacy safety-margin rule in ``src/runtime/progressive_context.py``
+    (``min(configured_safety, int(context_window * 0.05))`` with a configured
+    safety of 8000 tokens). Combined with ``default_reserve_tokens`` this
+    reproduces the legacy prompt budget ``context_window - reserved - safety``;
+    the legacy path additionally clamps by a configured ``max_prompt_tokens``,
+    which has no native-runtime equivalent, and has no table entry for the
+    ``gpt-5.6-*`` models at all.
+    """
+
+    return min(
+        DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
+        profile.context_window_tokens // CONTEXT_SAFETY_MARGIN_WINDOW_DIVISOR,
+    )
+
+
+def default_max_context_tokens(profile: ModelContextProfile) -> int:
+    """Return the catalog-derived prompt budget for a model, in tokens.
+
+    The model's response headroom (``default_reserve_tokens``) is NOT subtracted
+    here; callers subtract it separately via ``ContextBudget.reserve_chars``.
+    """
+
+    return max(1, profile.context_window_tokens - context_safety_margin_tokens(profile))
 
 
 def _profile(
@@ -212,7 +249,9 @@ def _validate_positive_int(value: Any, field_name: str) -> None:
 
 
 __all__ = [
+    "CONTEXT_SAFETY_MARGIN_WINDOW_DIVISOR",
     "DEFAULT_CHARS_PER_TOKEN",
+    "DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS",
     "DEFAULT_MODEL_ID",
     "DEFAULT_PROVIDER_ID",
     "MAX_PRESERVE_RECENT_TOKENS",
@@ -220,6 +259,8 @@ __all__ = [
     "ModelContextProfile",
     "SUPPORTED_COPILOT_MODEL_IDS",
     "canonicalize_copilot_model_id",
+    "context_safety_margin_tokens",
+    "default_max_context_tokens",
     "resolve_model_context_profile",
     "tokens_to_chars",
 ]

--- a/src/efp_runtime/llm/provider.py
+++ b/src/efp_runtime/llm/provider.py
@@ -23,6 +23,7 @@ from urllib import parse as urllib_parse
 from urllib import request as urllib_request
 
 from .adapter import DefaultLLMEventAdapter, LLMEventAdapter
+from .errors import ProviderContextOverflowError
 from .models import (
     DEFAULT_MODEL_ID,
     DEFAULT_PROVIDER_ID,
@@ -94,6 +95,21 @@ GITHUB_SOURCE_TOKEN_PREFIXES = (
     "github_pat_",
 )
 _PROXY_ENDPOINT_PATTERN = re.compile(r"(?:^|[;&,\s])proxy-ep=([^;&,\s]+)")
+# Substrings that identify a provider 400/413 as "the prompt is too big". The
+# message is the primary discriminator, never the generic error code: the
+# Copilot /responses endpoint returns "invalid_request_body" for tool-schema and
+# call-id rejections too (see _sanitize_copilot_responses_payload), so matching
+# on that code would classify a malformed-tool 400 as a context overflow and send
+# the runner into a pointless compacted retry. Only the unambiguous codes in
+# _CONTEXT_OVERFLOW_ERROR_CODES below classify on their own.
+_CONTEXT_OVERFLOW_MESSAGE_MARKERS = (
+    "exceeds the context window",
+    "context_length_exceeded",
+    "context length exceeded",
+    "maximum context length",
+)
+# Secondary allowlist of provider error codes that mean overflow on their own.
+_CONTEXT_OVERFLOW_ERROR_CODES = ("context_length_exceeded",)
 
 
 class GitHubCopilotHTTPTransport:
@@ -248,6 +264,13 @@ class GitHubCopilotHTTPTransport:
             )
             if model_unavailable_error is not None:
                 raise model_unavailable_error from None
+            overflow_error = _context_overflow_error_from_http_error(
+                exc,
+                response_text=response_text,
+                token=self._token,
+            )
+            if overflow_error is not None:
+                raise overflow_error from None
             message = _format_http_error(
                 exc,
                 self._token,
@@ -321,6 +344,13 @@ class GitHubCopilotHTTPTransport:
             )
             if model_unavailable_error is not None:
                 raise model_unavailable_error from None
+            overflow_error = _context_overflow_error_from_http_error(
+                exc,
+                response_text=response_text,
+                token=self._token,
+            )
+            if overflow_error is not None:
+                raise overflow_error from None
             message = _format_http_error(
                 exc,
                 self._token,
@@ -480,6 +510,12 @@ class OpenAICompatibleProvider:
             raw_output = self.transport.send(payload)
             if inspect.isawaitable(raw_output):
                 raw_output = await raw_output
+        except ProviderContextOverflowError:
+            # A context overflow is recoverable by the runner's compacted retry,
+            # which only sees it if it stays an exception. Absorbing it into an
+            # error mapping ends the run. Deliberately narrow: every other
+            # transport failure keeps mapping to a provider error response.
+            raise
         except Exception as exc:
             return self._transport_error_response(exc)
 
@@ -766,6 +802,14 @@ class AIPlatformHTTPTransport:
                     self._ensure_token(force=True)
                     continue
                 text = _read_http_error_body(exc)
+                overflow_error = _context_overflow_error_from_http_error(
+                    exc,
+                    response_text=text,
+                    token=self._token,
+                    provider_label="AI Platform",
+                )
+                if overflow_error is not None:
+                    raise overflow_error from None
                 raise ProviderTransportError(
                     "AI Platform HTTP transport failed ({0}): {1}".format(
                         exc.code, _redact_secret(text, self._token)
@@ -796,6 +840,14 @@ class AIPlatformHTTPTransport:
                     self._ensure_token(force=True)
                     continue
                 text = _read_http_error_body(exc)
+                overflow_error = _context_overflow_error_from_http_error(
+                    exc,
+                    response_text=text,
+                    token=self._token,
+                    provider_label="AI Platform",
+                )
+                if overflow_error is not None:
+                    raise overflow_error from None
                 raise ProviderTransportError(
                     "AI Platform HTTP transport failed ({0}): {1}".format(
                         exc.code, _redact_secret(text, self._token)
@@ -1487,12 +1539,60 @@ def _model_unavailable_error_from_http_error(
     )
 
 
-def _json_error_message(response_text: str) -> str | None:
+def _context_overflow_error_from_http_error(
+    exc: urllib_error.HTTPError,
+    *,
+    response_text: str,
+    token: str,
+    provider_label: str = "GitHub Copilot",
+) -> ProviderContextOverflowError | None:
+    status = getattr(exc, "code", None)
+    if status not in (400, 413):
+        return None
+    error_message = _json_error_message(response_text)
+    error_code = _json_error_code(response_text)
+    if error_message is None and _parse_json_object(response_text) is None:
+        # Non-JSON envelope (a proxy's HTML or bare text): the whole body is the
+        # only message there is. Deliberately NOT done for a JSON object that
+        # simply lacks a message key - such a body often echoes the rejected
+        # request back, and scanning it would classify a validation 400 as an
+        # overflow whenever the user's own prompt mentions a context window.
+        error_message = response_text.strip()
+    if status == 413:
+        # 413 Payload Too Large on a JSON prompt POST has exactly one meaning,
+        # and the ingress or proxy that emits it usually sends an empty or HTML
+        # body with no marker to match. Requiring a marker here would make 413
+        # unreachable: every 413 that carries one would already match as a 400.
+        error_message = error_message or "HTTP 413 Payload Too Large"
+    elif not _is_context_overflow_message(error_message or "") and (
+        error_code not in _CONTEXT_OVERFLOW_ERROR_CODES
+    ):
+        return None
+    safe_message = _redact_secret(
+        error_message or error_code or "HTTP {0}".format(status), token
+    )
+    return ProviderContextOverflowError(
+        "{0} rejected the request as larger than the model context window: {1}".format(
+            provider_label,
+            safe_message,
+        ),
+        metadata={"status_code": status, "provider_error_code": error_code},
+    )
+
+
+def _parse_json_object(response_text: str) -> Mapping[str, Any] | None:
+    """Return ``response_text`` decoded as a JSON object, or ``None``."""
+
     try:
         data = json.loads(response_text)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError, ValueError):
         return None
-    if not isinstance(data, Mapping):
+    return data if isinstance(data, Mapping) else None
+
+
+def _json_error_message(response_text: str) -> str | None:
+    data = _parse_json_object(response_text)
+    if data is None:
         return None
 
     error_value = data.get("error")
@@ -1508,6 +1608,29 @@ def _json_error_message(response_text: str) -> str | None:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return None
+
+
+def _json_error_code(response_text: str) -> str | None:
+    data = _parse_json_object(response_text)
+    if data is None:
+        return None
+
+    error_value = data.get("error")
+    if isinstance(error_value, Mapping):
+        for key in ("code", "type"):
+            value = error_value.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    for key in ("code", "type"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _is_context_overflow_message(message: str) -> bool:
+    text = message.lower()
+    return any(marker in text for marker in _CONTEXT_OVERFLOW_MESSAGE_MARKERS)
 
 
 def _is_model_unavailable_message(message: str) -> bool:

--- a/src/efp_runtime/loop/runner.py
+++ b/src/efp_runtime/loop/runner.py
@@ -31,6 +31,8 @@ from ..llm.models import (
     DEFAULT_MODEL_ID,
     DEFAULT_PROVIDER_ID,
     ModelContextProfile,
+    context_safety_margin_tokens,
+    default_max_context_tokens,
     resolve_model_context_profile,
 )
 from ..permissions import ASK, DENY, PermissionMetadata
@@ -57,6 +59,11 @@ from ..usage import (
 from .provider import LLMProvider, ProviderOutput, ProviderResult, RuntimeRequest
 from .stream_events import bridge_llm_stream_events
 
+
+# The context reserve is response headroom; it may never claim more than
+# 1/MAX_RESERVE_BUDGET_DIVISOR of the prompt budget. See
+# RuntimeLoopRunner._clamp_reserve_chars.
+MAX_RESERVE_BUDGET_DIVISOR = 2
 
 ContextMessageProvider = Callable[[Mapping[str, Any]], Iterable[Message]]
 
@@ -549,6 +556,13 @@ class RuntimeLoopRunner:
                 request,
                 compaction_outcome.replay,
             )
+            _append_request_compaction_event(
+                runtime_events,
+                request=request,
+                session_id=resolved_session_id,
+                run_id=run_id,
+                iteration=iteration,
+            )
             runtime_events.append(
                 RuntimeEvent(
                     type="iteration_start",
@@ -817,15 +831,52 @@ class RuntimeLoopRunner:
 
     def _context_budget(self, metadata: Mapping[str, Any] | None = None) -> ContextBudget:
         profile = self._model_context_profile(metadata)
+        max_chars = self._context_budget_max_chars(profile)
+        reserve_chars = self._clamp_reserve_chars(
+            self._context_budget_reserve_chars(profile),
+            max_chars=max_chars,
+        )
         return ContextBudget(
             max_parts=self.max_context_parts,
-            max_chars=self._context_budget_max_chars(profile),
-            reserve_chars=self._context_budget_reserve_chars(profile),
+            max_chars=max_chars,
+            reserve_chars=reserve_chars,
         )
+
+    @staticmethod
+    def _clamp_reserve_chars(reserve_chars: int, *, max_chars: int | None) -> int:
+        """Keep the reserve from swallowing the whole prompt budget.
+
+        ``ContextBudget.effective_max_chars`` is ``max_chars - reserve_chars``
+        clamped at 0, and nothing else checks the two against each other. Before
+        the catalog default, ``max_chars`` was ``None`` on an unconfigured
+        runtime so the reserve knobs were inert; now they are always live, and a
+        portal-managed ``context_reserve_tokens``/``compaction_reserved_chars``
+        larger than the window would silently reduce every request to the system
+        prompt plus the latest turn. The reserve is response headroom, so more
+        than half the budget is never meaningful.
+        """
+
+        if max_chars is None:
+            return reserve_chars
+        return min(reserve_chars, max_chars // MAX_RESERVE_BUDGET_DIVISOR)
 
     def _context_budget_enabled(self, budget: Optional[ContextBudget] = None) -> bool:
         resolved = budget or self._context_budget()
         return resolved.max_parts is not None or resolved.max_chars is not None
+
+    def _context_budget_explicitly_configured(self) -> bool:
+        """Report whether an operator configured a context budget explicitly.
+
+        The model-catalog default only sizes the in-memory provider request. The
+        stored-history compactor rewrites the session on disk (and therefore the
+        Portal transcript), so it stays opt-in.
+        """
+
+        return (
+            self.max_context_parts is not None
+            or self.max_context_chars is not None
+            or self.max_context_tokens is not None
+        )
 
     def _overflow_retry_budget(
         self,
@@ -837,8 +888,16 @@ class RuntimeLoopRunner:
         if max_parts is not None:
             max_parts = max(1, min(max_parts, 2))
         if max_chars is not None:
-            max_chars = max(1, max_chars // 2)
+            # Halve the *effective* budget, not the raw cap. Halving max_chars
+            # directly does nothing once the reserve is a large share of it (the
+            # retry would re-send an identically sized prompt), and can drive
+            # effective_max_chars to 0, which compacts the whole conversation
+            # away.
+            effective = current_budget.effective_max_chars or max_chars
+            max_chars = current_budget.reserve_chars + max(1, effective // 2)
         if max_parts is None and max_chars is None:
+            # Unreachable from _context_budget, which always derives max_chars
+            # from the model catalog; kept for hand-built budgets in tests.
             max_parts = 8
         return ContextBudget(
             max_parts=max_parts,
@@ -849,20 +908,16 @@ class RuntimeLoopRunner:
     def _context_budget_max_chars(self, profile: ModelContextProfile) -> int | None:
         if self.max_context_chars is not None:
             return self.max_context_chars
-        if self.max_context_tokens is None:
-            return None
-        return max(1, profile.tokens_to_chars(self.max_context_tokens))
+        if self.max_context_tokens is not None:
+            return max(1, profile.tokens_to_chars(self.max_context_tokens))
+        return max(1, profile.tokens_to_chars(default_max_context_tokens(profile)))
 
     def _context_budget_reserve_chars(self, profile: ModelContextProfile) -> int:
         if self.context_reserve_tokens is not None:
             return profile.tokens_to_chars(self.context_reserve_tokens)
         if self.compaction_reserved_chars is not None:
             return self.compaction_reserved_chars
-        if (
-            self.max_context_chars is None
-            and self.max_context_tokens is not None
-            and self.context_reserve_chars == 0
-        ):
+        if self.max_context_chars is None and self.context_reserve_chars == 0:
             return profile.tokens_to_chars(profile.default_reserve_tokens)
         return self.context_reserve_chars
 
@@ -888,7 +943,7 @@ class RuntimeLoopRunner:
             return profile.tokens_to_chars(self.compaction_preserve_recent_tokens)
         if self.compaction_preserve_recent_chars is not None:
             return self.compaction_preserve_recent_chars
-        if self.max_context_chars is None and self.max_context_tokens is not None:
+        if self.max_context_chars is None:
             return profile.tokens_to_chars(profile.default_preserve_recent_tokens)
         return None
 
@@ -900,12 +955,16 @@ class RuntimeLoopRunner:
     ) -> dict[str, Any]:
         profile = self._model_context_profile(metadata)
         resolved_budget = budget or self._context_budget(metadata)
+        resolved_max_context_tokens = self.max_context_tokens
+        safety_margin_tokens: int | None = None
+        if self.max_context_chars is None and self.max_context_tokens is None:
+            safety_margin_tokens = context_safety_margin_tokens(profile)
+            resolved_max_context_tokens = default_max_context_tokens(profile)
         preserve_recent_chars = self._compaction_preserve_recent_chars(profile)
         reserve_tokens = self.context_reserve_tokens
         if (
             reserve_tokens is None
             and self.max_context_chars is None
-            and self.max_context_tokens is not None
             and self.compaction_reserved_chars is None
             and self.context_reserve_chars == 0
         ):
@@ -916,7 +975,6 @@ class RuntimeLoopRunner:
             and preserve_recent_chars is not None
             and self.compaction_preserve_recent_chars is None
             and self.max_context_chars is None
-            and self.max_context_tokens is not None
         ):
             preserve_recent_tokens = profile.default_preserve_recent_tokens
         max_context_chars_source = (
@@ -924,7 +982,7 @@ class RuntimeLoopRunner:
             if self.max_context_chars is not None
             else "max_context_tokens"
             if self.max_context_tokens is not None
-            else None
+            else "profile_context_window_tokens"
         )
         reserve_chars_source = (
             "context_reserve_tokens"
@@ -934,7 +992,6 @@ class RuntimeLoopRunner:
             else "profile_default_reserve_tokens"
             if reserve_tokens == profile.default_reserve_tokens
             and self.max_context_chars is None
-            and self.max_context_tokens is not None
             else "context_reserve_chars"
         )
         preserve_recent_chars_source = (
@@ -945,14 +1002,14 @@ class RuntimeLoopRunner:
             else "profile_default_preserve_recent_tokens"
             if preserve_recent_tokens == profile.default_preserve_recent_tokens
             and self.max_context_chars is None
-            and self.max_context_tokens is not None
             else None
         )
         payload = {
             "provider_id": profile.provider_id,
             "model_id": profile.model_id,
             "context_window_tokens": profile.context_window_tokens,
-            "max_context_tokens": self.max_context_tokens,
+            "context_safety_margin_tokens": safety_margin_tokens,
+            "max_context_tokens": resolved_max_context_tokens,
             "context_reserve_tokens": reserve_tokens,
             "compaction_preserve_recent_tokens": preserve_recent_tokens,
             "chars_per_token": profile.chars_per_token,
@@ -989,6 +1046,12 @@ class RuntimeLoopRunner:
         if not self.compaction_auto:
             return _StoredCompactionOutcome(history=history)
         if not self._context_budget_enabled(budget):
+            return _StoredCompactionOutcome(history=history)
+        if not overflow_retry and not self._context_budget_explicitly_configured():
+            # The catalog-derived default budget drives the in-memory request only.
+            # Rewriting stored history discards the user's transcript, so it stays
+            # gated on explicit operator config (or the last-resort overflow retry,
+            # where the alternative is a failed run).
             return _StoredCompactionOutcome(history=history)
         if not history:
             return _StoredCompactionOutcome(history=history)
@@ -2956,6 +3019,45 @@ def _apply_compaction_replay_request_metadata(
         compaction_payload = {}
     compaction_payload.update(replay_metadata)
     metadata["compaction"] = compaction_payload
+
+
+def _append_request_compaction_event(
+    runtime_events: list[RuntimeEvent],
+    *,
+    request: RuntimeRequest,
+    session_id: str,
+    run_id: str,
+    iteration: int,
+) -> None:
+    """Report render-time compaction, which never touches stored history.
+
+    The stored-history compactor emits session_compaction_started/session_compacted,
+    but request rendering dropped messages silently. That was tolerable while a
+    budget only existed for operators who configured one; now the model catalog
+    supplies a budget on every run, so an unconfigured session can quietly lose
+    the older two thirds of its context while the Portal transcript still shows
+    it in full. ``stored`` distinguishes this from the destructive path.
+    """
+
+    prepared = request.prepared_request
+    if not prepared.compaction_applied:
+        return
+    runtime_events.append(
+        RuntimeEvent(
+            type="session_compacted",
+            message="Request context compacted to fit the model context budget.",
+            session_id=session_id,
+            payload={
+                "run_id": run_id,
+                "iteration": iteration,
+                "trigger": "context_budget",
+                "auto": True,
+                "stored": False,
+                "scope": "request",
+                **dict(prepared.compaction_metadata),
+            },
+        )
+    )
 
 
 def _apply_compaction_replay_metadata_to_request(

--- a/src/efp_runtime/loop/runner.py
+++ b/src/efp_runtime/loop/runner.py
@@ -2048,9 +2048,19 @@ async def _replay_async_stream(
     first: Any,
     iterator: AsyncIterator[Any],
 ) -> AsyncIterator[Any]:
-    yield first
-    async for event in iterator:
-        yield event
+    try:
+        yield first
+        async for event in iterator:
+            yield event
+    finally:
+        # `async for` never closes its iterator, and closing this wrapper does
+        # not cascade into `iterator` either, so forward the close by hand:
+        # otherwise abandoning the replay leaves the provider stream suspended
+        # at its own ``yield`` and its cleanup waits for GC finalization. A
+        # provider may hand back a plain async iterator with no ``aclose``.
+        aclose = getattr(iterator, "aclose", None)
+        if aclose is not None:
+            await aclose()
 
 
 def _last_assistant_message(messages: Iterable[Message]) -> Optional[Message]:

--- a/src/efp_runtime/loop/runner.py
+++ b/src/efp_runtime/loop/runner.py
@@ -1152,6 +1152,8 @@ class RuntimeLoopRunner:
                 payload={
                     **event_payload,
                     "stored_message_count": len(updated_history),
+                    "stored": True,
+                    "scope": "session",
                 },
             )
         )
@@ -3078,7 +3080,14 @@ def _append_request_compaction_event(
     budget only existed for operators who configured one; now the model catalog
     supplies a budget on every run, so an unconfigured session can quietly lose
     the older two thirds of its context while the Portal transcript still shows
-    it in full. ``stored`` distinguishes this from the destructive path.
+    it in full.
+
+    This deliberately uses its own ``request_compacted`` type rather than
+    reusing ``session_compacted``: that type means the stored session was
+    rewritten, and a consumer must be able to tell whether anything on disk
+    changed. Both project to the same ``session.next.compaction.ended`` UI
+    event, and the projection carries ``stored``/``scope`` through so the
+    distinction survives.
     """
 
     prepared = request.prepared_request
@@ -3086,7 +3095,7 @@ def _append_request_compaction_event(
         return
     runtime_events.append(
         RuntimeEvent(
-            type="session_compacted",
+            type="request_compacted",
             message="Request context compacted to fit the model context budget.",
             session_id=session_id,
             payload={

--- a/src/efp_runtime/loop/runner.py
+++ b/src/efp_runtime/loop/runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterable, Iterable, Mapping
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 import inspect
@@ -1047,11 +1047,13 @@ class RuntimeLoopRunner:
             return _StoredCompactionOutcome(history=history)
         if not self._context_budget_enabled(budget):
             return _StoredCompactionOutcome(history=history)
-        if not overflow_retry and not self._context_budget_explicitly_configured():
-            # The catalog-derived default budget drives the in-memory request only.
-            # Rewriting stored history discards the user's transcript, so it stays
-            # gated on explicit operator config (or the last-resort overflow retry,
-            # where the alternative is a failed run).
+        if not self._context_budget_explicitly_configured():
+            # The catalog-derived default budget drives the in-memory request
+            # only. Rewriting stored history discards the user's transcript, so
+            # it stays gated on explicit operator config - including on the
+            # provider-overflow retry, which does not need it: the retry sends
+            # its halved budget through _prepare_runtime_request, and
+            # prepare_history_for_request compacts at render time.
             return _StoredCompactionOutcome(history=history)
         if not history:
             return _StoredCompactionOutcome(history=history)
@@ -1270,7 +1272,14 @@ class RuntimeLoopRunner:
 
         if inspect.isawaitable(raw_result):
             raw_result = await raw_result
-        return raw_result
+        if isinstance(raw_result, Mapping) or not isinstance(raw_result, AsyncIterable):
+            return raw_result
+        # A streaming provider returns an *unstarted* async generator, and the
+        # HTTP request only runs once it is iterated - which happens well outside
+        # this retry loop. Pull the first chunk here so a context-overflow 400
+        # surfaces as an exception the retry handler can act on. Later chunks
+        # still stream lazily to the caller.
+        return await _prefetch_async_stream(raw_result)
 
     async def _invoke_provider_with_retries(
         self,
@@ -2007,6 +2016,39 @@ async def run_runtime_loop(
         structured_output_required=structured_output_required,
         structured_output_tool_id=structured_output_tool_id,
     )
+
+
+async def _prefetch_async_stream(
+    stream: AsyncIterable[Any],
+) -> AsyncIterable[Any]:
+    """Start ``stream`` and return an equivalent stream replaying its head.
+
+    This is deliberately a plain coroutine that *returns* an async generator
+    rather than an ``async def ... yield`` generator: an async generator would
+    defer the first ``__anext__`` right back to the caller and the prefetch
+    would be a no-op.
+    """
+
+    iterator = stream.__aiter__()
+    try:
+        first = await iterator.__anext__()
+    except StopAsyncIteration:
+        return _empty_async_stream()
+    return _replay_async_stream(first, iterator)
+
+
+async def _empty_async_stream() -> AsyncIterator[Any]:
+    return
+    yield  # pragma: no cover - unreachable, marks this an async generator
+
+
+async def _replay_async_stream(
+    first: Any,
+    iterator: AsyncIterator[Any],
+) -> AsyncIterator[Any]:
+    yield first
+    async for event in iterator:
+        yield event
 
 
 def _last_assistant_message(messages: Iterable[Message]) -> Optional[Message]:

--- a/src/gateway/runtime_event_projection.py
+++ b/src/gateway/runtime_event_projection.py
@@ -749,6 +749,15 @@ def _compaction_data(payload: Mapping[str, Any]) -> dict[str, Any]:
         # event whether anything on disk changed.
         "stored": payload.get("stored"),
         "scope": payload.get("scope"),
+        # Both emitters spread compaction/controller._compaction_metadata flat
+        # into the payload, while "compaction" above is the nested shape only
+        # the overflow-retry path sets. Without these the projected event
+        # reaches the UI carrying no numbers at all -- not how much was
+        # dropped, kept, or budgeted.
+        "max_chars": payload.get("max_chars"),
+        "compacted_message_count": payload.get("compacted_message_count"),
+        "compacted_chars": payload.get("compacted_chars"),
+        "kept_chars": payload.get("kept_chars"),
     }
 
 

--- a/src/gateway/runtime_event_projection.py
+++ b/src/gateway/runtime_event_projection.py
@@ -279,6 +279,10 @@ class RuntimeEventProjector:
             "session_compacted",
             "session_compaction_completed",
             "overflow_retry.compaction_applied",
+            # Render-time compaction. Same UI event as the stored path so the
+            # timeline keeps rendering it, but _compaction_data carries
+            # stored/scope so consumers can tell the two apart.
+            "request_compacted",
         }:
             outputs.append(
                 self._build(
@@ -740,6 +744,11 @@ def _compaction_data(payload: Mapping[str, Any]) -> dict[str, Any]:
         "summary_preview": _first_preview(payload, "summary", "compaction_summary"),
         "stored_message_count": payload.get("stored_message_count"),
         "overflow": payload.get("overflow"),
+        # Whether the stored session was rewritten, or only this request was
+        # trimmed. Without these a consumer cannot tell from the projected
+        # event whether anything on disk changed.
+        "stored": payload.get("stored"),
+        "scope": payload.get("scope"),
     }
 
 

--- a/src/hooks/file_context/retrieval.py
+++ b/src/hooks/file_context/retrieval.py
@@ -105,6 +105,9 @@ class RetrievalEngine:
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.5",
+            "gpt-5.6-luna",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
             "gemini-2.5-pro",
             "gemini-3.5-flash",
         )

--- a/tests/runtime/test_auto_session_compaction.py
+++ b/tests/runtime/test_auto_session_compaction.py
@@ -155,8 +155,12 @@ async def test_auto_compaction_persists_before_provider_and_request_includes_lat
         assert event.payload["auto"] is True
         assert event.payload["overflow"] is False
         assert event.payload["max_parts"] == 3
-        assert event.payload["max_chars"] is None
-        assert event.payload["reserve_chars"] == 0
+        # A parts-only config leaves the char budget unset, so it now comes from
+        # the model catalog (gpt-5.6-terra: 400k window - 8k safety margin, at 4
+        # chars/token) with the model's 128k reserve. max_parts stays the binding
+        # constraint here; before the catalog default these were None and 0.
+        assert event.payload["max_chars"] == 1_568_000
+        assert event.payload["reserve_chars"] == 512_000
         assert event.payload["compacted_part_count"] > 0
         assert event.payload["compacted_message_count"] > 0
     assert [event.type for event in bus.history("session-auto")[:2]] == [

--- a/tests/runtime/test_loop_runner.py
+++ b/tests/runtime/test_loop_runner.py
@@ -159,8 +159,12 @@ async def test_max_context_parts_compacts_provider_request_metadata():
     request = provider.requests[0]
     assert request.prepared_request.compaction_applied is True
     assert request.prepared_request.compaction_metadata["max_parts"] == 2
-    assert request.prepared_request.compaction_metadata["max_chars"] is None
-    assert request.prepared_request.compaction_metadata["reserve_chars"] == 0
+    # A parts-only config leaves the char budget unset, so it now comes from the
+    # model catalog (gpt-5.6-terra: 400k window - 8k safety margin, at 4
+    # chars/token) with the model's 128k reserve. max_parts stays the binding
+    # constraint here; before the catalog default these were None and 0.
+    assert request.prepared_request.compaction_metadata["max_chars"] == 1_568_000
+    assert request.prepared_request.compaction_metadata["reserve_chars"] == 512_000
     assert request.prepared_request.compaction_metadata["compacted_part_count"] == 2
     assert request.prepared_request.compaction_metadata["compacted_message_count"] == 2
     assert request.prepared_request.compaction_metadata["compacted_tool_pair_count"] == 0

--- a/tests/runtime/test_model_catalog_context_budget.py
+++ b/tests/runtime/test_model_catalog_context_budget.py
@@ -319,12 +319,19 @@ async def test_request_compaction_is_reported_as_a_runtime_event():
     result = await runner.run(session_id="session-event", user_text="latest request")
 
     events = [
-        event for event in result.runtime_events if event.type == "session_compacted"
+        event for event in result.runtime_events if event.type == "request_compacted"
     ]
     assert len(events) == 1
     assert events[0].payload["stored"] is False
     assert events[0].payload["scope"] == "request"
     assert events[0].payload["compacted_message_count"] > 0
+
+    # "session_compacted" means the stored session was rewritten. Render-time
+    # trimming must never claim that, or a consumer cannot tell whether
+    # anything on disk changed.
+    assert not [
+        event for event in result.runtime_events if event.type == "session_compacted"
+    ]
 
 
 @pytest.mark.asyncio
@@ -339,7 +346,9 @@ async def test_short_session_is_not_compacted_by_the_default_budget():
     assert result.status == LoopStatus.COMPLETED
     assert provider.requests[0].prepared_request.compaction_applied is False
     assert not [
-        event for event in result.runtime_events if event.type == "session_compacted"
+        event
+        for event in result.runtime_events
+        if event.type in {"session_compacted", "request_compacted"}
     ]
 
 

--- a/tests/runtime/test_model_catalog_context_budget.py
+++ b/tests/runtime/test_model_catalog_context_budget.py
@@ -1,0 +1,400 @@
+"""Regression tests for the model-catalog-derived default context budget.
+
+Before this behavior existed an unconfigured native runtime had
+``max_context_chars``/``max_context_tokens`` unset, so ``ContextBudget.max_chars``
+was ``None``, no compaction strategy was built at render time, and the full
+history went to the provider - which is how a long gpt-5.6-sol chat produced
+``400 Bad Request / "Your input exceeds the context window of this model."``.
+
+Every test here fails on that behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from efp_runtime.compaction import summary as summary_module
+from efp_runtime.compaction.strategy import BudgetCompactionStrategy, ContextBudget
+from efp_runtime.llm.models import (
+    context_safety_margin_tokens,
+    default_max_context_tokens,
+    resolve_model_context_profile,
+)
+from efp_runtime.loop import LoopStatus, RuntimeLoopRunner, ScriptedLLMProvider
+from efp_runtime.models import Message, MessagePart, MessagePartType, MessageRole
+from efp_runtime.session.store import InMemorySessionStore
+from efp_runtime.tools.registry import ToolRegistry
+from efp_runtime.tools.runtime import ToolRuntime
+
+
+SOL_WINDOW_TOKENS = 400_000
+SOL_SAFETY_TOKENS = 8_000
+SOL_MAX_CHARS = (SOL_WINDOW_TOKENS - SOL_SAFETY_TOKENS) * 4  # 1_568_000
+SOL_RESERVE_CHARS = 128_000 * 4  # 512_000
+
+
+def _runner(store, provider, **kwargs) -> RuntimeLoopRunner:
+    kwargs.setdefault("default_model", "gpt-5.6-sol")
+    return RuntimeLoopRunner(
+        store=store,
+        provider=provider,
+        tool_runtime=ToolRuntime(ToolRegistry()),
+        **kwargs,
+    )
+
+
+def _seed_large_history(store, session_id: str, *, messages: int, chars: int) -> None:
+    store.create_session(session_id=session_id)
+    per_message = chars // messages
+    for index in range(messages):
+        store.append_message(
+            session_id,
+            role=MessageRole.USER if index % 2 == 0 else MessageRole.ASSISTANT,
+            parts=[MessagePart.text_part("word " * (per_message // 5))],
+            message_id=f"msg-bulk-{index}",
+            status="complete",
+        )
+
+
+def _request_chars(provider_request) -> int:
+    return sum(len(message.text or "") for message in provider_request.messages)
+
+
+# --------------------------------------------------------------------------
+# The budget itself
+# --------------------------------------------------------------------------
+
+
+def test_unconfigured_runtime_derives_char_budget_from_model_catalog():
+    runner = _runner(InMemorySessionStore(), ScriptedLLMProvider([]))
+
+    budget = runner._context_budget()
+
+    assert budget.max_chars == SOL_MAX_CHARS
+    assert budget.reserve_chars == SOL_RESERVE_CHARS
+    assert budget.effective_max_chars == SOL_MAX_CHARS - SOL_RESERVE_CHARS
+    # The whole point: a stock config must not leave the request unbounded.
+    assert budget.max_chars is not None
+
+
+def test_default_budget_leaves_room_for_the_declared_response_reserve():
+    profile = resolve_model_context_profile("gpt-5.6-sol")
+
+    prompt_tokens = default_max_context_tokens(profile) - profile.default_reserve_tokens
+
+    assert context_safety_margin_tokens(profile) == SOL_SAFETY_TOKENS
+    assert (
+        prompt_tokens + profile.default_reserve_tokens + SOL_SAFETY_TOKENS
+        == profile.context_window_tokens
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_window"),
+    [
+        ("gpt-5.6-sol", 400_000),
+        ("gpt-5.6-terra", 400_000),
+        ("gpt-5.6-luna", 328_000),
+        ("gpt-5.4", 400_000),
+    ],
+)
+def test_catalog_models_all_produce_a_budget(model, expected_window):
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        default_model=model,
+    )
+
+    budget = runner._context_budget()
+    margin = min(8_000, expected_window // 20)
+
+    assert budget.max_chars == (expected_window - margin) * 4
+    assert budget.effective_max_chars > 0
+
+
+def test_catalog_lookup_is_by_model_id_not_provider_id():
+    """ai_platform serves gpt-5.4 with the same 400k window as Copilot.
+
+    Resolving by provider id sent those runtimes to the 64k conservative
+    profile, which now binds as a real budget and would compact them roughly
+    seven times too early.
+    """
+
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        default_provider_id="ai_platform",
+        default_model="gpt-5.4",
+    )
+
+    assert runner._context_budget().max_chars == SOL_MAX_CHARS
+
+
+def test_unknown_model_still_falls_back_to_the_conservative_profile():
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        default_model="some-unlisted-model",
+    )
+
+    budget = runner._context_budget()
+
+    assert budget.max_chars == (64_000 - 3_200) * 4
+    assert budget.effective_max_chars > 0
+
+
+# --------------------------------------------------------------------------
+# Explicit operator config keeps overriding
+# --------------------------------------------------------------------------
+
+
+def test_explicit_max_context_chars_overrides_the_catalog():
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_chars=100_000,
+    )
+
+    budget = runner._context_budget()
+
+    assert budget.max_chars == 100_000
+    assert budget.reserve_chars == 0
+
+
+def test_explicit_max_context_tokens_overrides_the_catalog():
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_tokens=50_000,
+    )
+
+    assert runner._context_budget().max_chars == 200_000
+
+
+def test_budget_metadata_reports_the_catalog_as_the_source():
+    runner = _runner(InMemorySessionStore(), ScriptedLLMProvider([]))
+
+    metadata = runner._model_context_budget_metadata()
+
+    assert metadata["context_budget"]["max_context_chars_source"] == (
+        "profile_context_window_tokens"
+    )
+    assert metadata["context_safety_margin_tokens"] == SOL_SAFETY_TOKENS
+    assert metadata["max_context_tokens"] == SOL_WINDOW_TOKENS - SOL_SAFETY_TOKENS
+
+
+def test_explicit_config_metadata_still_names_the_explicit_source():
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_tokens=50_000,
+    )
+
+    metadata = runner._model_context_budget_metadata()
+
+    assert metadata["context_budget"]["max_context_chars_source"] == "max_context_tokens"
+    assert metadata["context_safety_margin_tokens"] is None
+
+
+# --------------------------------------------------------------------------
+# The reserve may never swallow the budget
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"context_reserve_tokens": 400_000},
+        {"compaction_reserved_chars": 2_000_000},
+        {"context_reserve_chars": 4_000_000},
+    ],
+)
+def test_oversized_reserve_cannot_zero_the_prompt_budget(kwargs):
+    """Reserve knobs are portal-managed and were inert while max_chars was None.
+
+    Unclamped they drive effective_max_chars to 0, which compacts every request
+    down to system context plus the latest turn with no event and no error.
+    """
+
+    runner = _runner(InMemorySessionStore(), ScriptedLLMProvider([]), **kwargs)
+
+    budget = runner._context_budget()
+
+    assert budget.reserve_chars == SOL_MAX_CHARS // 2
+    assert budget.effective_max_chars == SOL_MAX_CHARS - SOL_MAX_CHARS // 2
+
+
+def test_small_explicit_budget_is_not_zeroed_by_the_catalog_reserve():
+    """max_context_tokens=50_000 gives 200_000 chars against a 512_000 reserve."""
+
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_tokens=50_000,
+    )
+
+    assert runner._context_budget().effective_max_chars == 100_000
+
+
+def test_reasonable_reserve_is_left_alone():
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        context_reserve_chars=1_000,
+    )
+
+    assert runner._context_budget().reserve_chars == 1_000
+
+
+def test_overflow_retry_halves_the_effective_budget():
+    runner = _runner(InMemorySessionStore(), ScriptedLLMProvider([]))
+    budget = runner._context_budget()
+
+    retry = runner._overflow_retry_budget()
+
+    assert retry.reserve_chars == budget.reserve_chars
+    assert retry.effective_max_chars == budget.effective_max_chars // 2
+    assert retry.effective_max_chars > 0
+
+
+# --------------------------------------------------------------------------
+# End-to-end: request bounded, stored history untouched
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_long_session_request_is_bounded_by_the_default_budget():
+    store = InMemorySessionStore()
+    _seed_large_history(store, "session-big", messages=40, chars=1_800_000)
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runner = _runner(store, provider)
+
+    result = await runner.run(session_id="session-big", user_text="latest request")
+
+    assert result.status == LoopStatus.COMPLETED
+    request = provider.requests[0]
+    assert request.prepared_request.compaction_applied is True
+    assert _request_chars(request.provider_request) < 1_800_000
+    assert (
+        request.prepared_request.compaction_metadata["kept_chars"]
+        <= runner._context_budget().effective_max_chars
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_budget_never_rewrites_stored_history():
+    """The catalog default sizes the in-memory request only.
+
+    Stored history is the Portal transcript; rewriting it on a default that no
+    operator opted into would destroy the user's conversation on disk.
+    """
+
+    store = InMemorySessionStore()
+    _seed_large_history(store, "session-keep", messages=40, chars=1_800_000)
+    before = len(store.read_history("session-keep"))
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runner = _runner(store, provider)
+
+    result = await runner.run(session_id="session-keep", user_text="latest request")
+
+    assert result.status == LoopStatus.COMPLETED
+    after = store.read_history("session-keep")
+    # Only the new user turn and the new assistant turn were appended.
+    assert len(after) == before + 2
+    assert not [
+        part
+        for message in after
+        for part in message.parts
+        if part.type is MessagePartType.COMPACTION
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_compaction_is_reported_as_a_runtime_event():
+    store = InMemorySessionStore()
+    _seed_large_history(store, "session-event", messages=40, chars=1_800_000)
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runner = _runner(store, provider)
+
+    result = await runner.run(session_id="session-event", user_text="latest request")
+
+    events = [
+        event for event in result.runtime_events if event.type == "session_compacted"
+    ]
+    assert len(events) == 1
+    assert events[0].payload["stored"] is False
+    assert events[0].payload["scope"] == "request"
+    assert events[0].payload["compacted_message_count"] > 0
+
+
+@pytest.mark.asyncio
+async def test_short_session_is_not_compacted_by_the_default_budget():
+    store = InMemorySessionStore()
+    _seed_large_history(store, "session-small", messages=4, chars=400)
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runner = _runner(store, provider)
+
+    result = await runner.run(session_id="session-small", user_text="latest request")
+
+    assert result.status == LoopStatus.COMPLETED
+    assert provider.requests[0].prepared_request.compaction_applied is False
+    assert not [
+        event for event in result.runtime_events if event.type == "session_compacted"
+    ]
+
+
+# --------------------------------------------------------------------------
+# The budget search must not block the event loop
+# --------------------------------------------------------------------------
+
+
+def test_budget_search_scans_each_message_once(monkeypatch):
+    """Guards the quadratic re-scan that made this default unusable.
+
+    The budget search re-derives the compaction summary for every candidate
+    selection, and rendering that summary scans every compacted message's text
+    with the relevant-file regex. Without a per-call memo that is O(blocks x
+    history chars): a 3 MB / 600 block history took ~170 s of synchronous,
+    event-loop-blocking CPU per LLM iteration - on the exact long conversations
+    this budget exists to bound.
+
+    Asserted structurally rather than by wall clock so the guard is
+    machine-independent and fails fast.
+    """
+
+    message_count = 600
+    # One scan per message, plus a small constant for the final summary build.
+    # The quadratic implementation made ~message_count scans per candidate.
+    scan_limit = 4 * message_count
+    calls = {"count": 0}
+    real_pattern = summary_module._PATH_PATTERN
+
+    class _CountingPattern:
+        def findall(self, text):
+            calls["count"] += 1
+            # Trip immediately rather than letting the quadratic version grind
+            # through several minutes of CPU before the assertion below.
+            assert calls["count"] <= scan_limit, (
+                f"relevant-file regex ran {calls['count']} times for "
+                f"{message_count} messages: the budget search is re-scanning "
+                "history per candidate selection"
+            )
+            return real_pattern.findall(text)
+
+    monkeypatch.setattr(summary_module, "_PATH_PATTERN", _CountingPattern())
+
+    messages = [
+        Message(
+            role=MessageRole.USER if index % 2 == 0 else MessageRole.ASSISTANT,
+            parts=[MessagePart.text_part("word " * 1_000)],
+        )
+        for index in range(message_count)
+    ]
+    strategy = BudgetCompactionStrategy(
+        budget=ContextBudget(max_chars=SOL_MAX_CHARS, reserve_chars=SOL_RESERVE_CHARS)
+    )
+
+    result = strategy.compact(messages)
+
+    assert result.compacted is True
+    assert calls["count"] <= scan_limit

--- a/tests/runtime/test_provider_retry_overflow.py
+++ b/tests/runtime/test_provider_retry_overflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import inspect
 import json
 import os
 import subprocess
@@ -479,6 +480,67 @@ async def test_prefetch_replays_the_consumed_head_chunk():
 
     empty = await _prefetch_async_stream(no_chunks())
     assert [chunk async for chunk in empty] == []
+
+
+@pytest.mark.asyncio
+async def test_closing_the_replay_wrapper_closes_the_provider_stream():
+    # `async for` does not close the iterator it drives, and closing an async
+    # generator does not cascade into the generator it was iterating. Without an
+    # explicit forward, abandoning the replay wrapper mid-stream leaves the
+    # provider stream suspended at its `yield`, so the transport's `finally`
+    # (which cancels the worker task feeding the queue) never runs until GC.
+    closed = False
+
+    async def source():
+        nonlocal closed
+        try:
+            yield "head"
+            yield "middle"
+            yield "tail"
+        finally:
+            closed = True
+
+    stream = source()  # held explicitly so refcount finalization cannot mask it
+    replayed = await _prefetch_async_stream(stream)
+
+    seen = []
+    async for chunk in replayed:
+        seen.append(chunk)
+        if len(seen) == 2:
+            break  # abandon mid-stream
+
+    assert seen == ["head", "middle"]
+    assert inspect.getasyncgenstate(stream) == "AGEN_SUSPENDED"
+
+    await replayed.aclose()
+
+    assert closed, "closing the replay wrapper must close the provider stream"
+    assert inspect.getasyncgenstate(stream) == "AGEN_CLOSED"
+
+
+@pytest.mark.asyncio
+async def test_replay_wrapper_tolerates_a_provider_iterator_without_aclose():
+    # A provider may hand back a plain class-based async iterator (`__aiter__`
+    # returning self) which has no `aclose`. Forwarding closure must not turn
+    # that into an AttributeError raised out of the wrapper's cleanup.
+    class PlainAsyncIterator:
+        def __init__(self, chunks):
+            self._chunks = list(chunks)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._chunks:
+                raise StopAsyncIteration
+            return self._chunks.pop(0)
+
+    replayed = await _prefetch_async_stream(PlainAsyncIterator(["head", "tail"]))
+    assert [chunk async for chunk in replayed] == ["head", "tail"]
+
+    replayed = await _prefetch_async_stream(PlainAsyncIterator(["head", "tail"]))
+    assert await replayed.__anext__() == "head"
+    await replayed.aclose()  # must not raise AttributeError
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_provider_retry_overflow.py
+++ b/tests/runtime/test_provider_retry_overflow.py
@@ -15,7 +15,9 @@ from efp_runtime.llm.errors import (
     ProviderFatalError,
     ProviderTransientError,
 )
+from efp_runtime.llm.events import LLMEvent, LLMEventType
 from efp_runtime.loop import LoopStatus, RuntimeLoopRunner, RuntimeRequest
+from efp_runtime.loop.runner import _prefetch_async_stream
 from efp_runtime.models import Message, MessagePart, ToolCall
 from efp_runtime.session.models import Session
 from efp_runtime.session.store import InMemorySessionStore
@@ -51,6 +53,38 @@ class SequenceProvider:
         return step
 
 
+class StreamSequenceProvider:
+    """Provider whose invoke() returns an *unstarted* async generator per call.
+
+    This is the shape every streaming provider has (OpenAICompatibleProvider
+    returns ``adapter.normalize_stream(...)``), so a failure raised before the
+    first yield only reaches the runner if the runner starts the stream itself.
+    """
+
+    def __init__(self, steps):
+        self.steps = list(steps)
+        self.requests: list[RuntimeRequest] = []
+        self.message_snapshots: list[list[tuple[str, str]]] = []
+
+    def invoke(self, request: RuntimeRequest):
+        self.requests.append(request)
+        self.message_snapshots.append(
+            [
+                (message.role, message.text)
+                for message in request.provider_request.messages
+            ]
+        )
+        if not self.steps:
+            raise AssertionError("StreamSequenceProvider has no step left")
+        return self._stream(self.steps.pop(0))
+
+    async def _stream(self, step):
+        if isinstance(step, BaseException):
+            raise step
+        for event in step:
+            yield event
+
+
 def _runner(provider, **kwargs) -> RuntimeLoopRunner:
     return RuntimeLoopRunner(
         store=InMemorySessionStore(),
@@ -72,6 +106,14 @@ def _old_session(*texts: str) -> Session:
 
 def _events(result, event_type: str):
     return [event for event in result.runtime_events if event.type == event_type]
+
+
+def _stored_fingerprint(message) -> tuple:
+    return (
+        message.message_id,
+        message.role,
+        tuple(part.text for part in message.parts),
+    )
 
 
 @pytest.mark.asyncio
@@ -361,6 +403,183 @@ async def test_context_overflow_retry_preserves_pending_tool_call():
     ]
     assert calls == ["call-pending"]
     assert provider.message_snapshots[1][-1] == ("user", "latest request")
+
+
+@pytest.mark.asyncio
+async def test_stream_overflow_before_first_chunk_triggers_compacted_retry():
+    provider = StreamSequenceProvider(
+        [
+            ProviderContextOverflowError("context too long"),
+            [
+                LLMEvent(LLMEventType.STEP_START),
+                LLMEvent(LLMEventType.TEXT_DELTA, part_id="text_0", delta="Recovered."),
+                LLMEvent(LLMEventType.STEP_FINISH),
+            ],
+        ]
+    )
+    runner = _runner(provider, max_context_parts=5)
+
+    result = await runner.run(
+        session=_old_session("old 1", "old 2", "old 3", "old 4"),
+        user_text="latest request",
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    assert len(provider.requests) == 2
+    assert len(_events(result, "provider.context_overflow_retry")) == 1
+    assert provider.requests[1].metadata["overflow_retry"] is True
+    assert provider.message_snapshots[1][-1] == ("user", "latest request")
+    assert result.final_assistant_message is not None
+    assert result.final_assistant_message.parts[0].text == "Recovered."
+
+
+@pytest.mark.asyncio
+async def test_stream_overflow_retry_emits_llm_events_only_for_the_served_attempt():
+    provider = StreamSequenceProvider(
+        [
+            ProviderContextOverflowError("context too long"),
+            [
+                LLMEvent(LLMEventType.STEP_START),
+                LLMEvent(LLMEventType.TEXT_DELTA, part_id="text_0", delta="Recovered."),
+                LLMEvent(LLMEventType.STEP_FINISH),
+            ],
+        ]
+    )
+    runner = _runner(provider, max_context_parts=5)
+
+    result = await runner.run(
+        session=_old_session("old 1", "old 2", "old 3", "old 4"),
+        user_text="latest request",
+    )
+
+    # The discarded first attempt must not leak llm.* events; prefetching the
+    # first chunk happens before the stream-event bridge runs.
+    assert [event.payload["delta"] for event in _events(result, "llm.text_delta")] == [
+        "Recovered."
+    ]
+    assert len(_events(result, "llm.step_finish")) == 1
+
+
+@pytest.mark.asyncio
+async def test_prefetch_replays_the_consumed_head_chunk():
+    # _prefetch_async_stream pulls the first chunk off the provider stream to
+    # surface a pre-first-yield failure. That chunk is already consumed, so the
+    # replay wrapper has to hand it back or every stream silently loses its head.
+    async def three_chunks():
+        yield "head"
+        yield "middle"
+        yield "tail"
+
+    replayed = await _prefetch_async_stream(three_chunks())
+    assert [chunk async for chunk in replayed] == ["head", "middle", "tail"]
+
+    async def no_chunks():
+        return
+        yield  # pragma: no cover - marks this an async generator
+
+    empty = await _prefetch_async_stream(no_chunks())
+    assert [chunk async for chunk in empty] == []
+
+
+@pytest.mark.asyncio
+async def test_stream_first_text_delta_survives_the_prefetch():
+    # End-to-end guard for the same head chunk: the first *normalized* event of
+    # a stream is often already a TEXT_DELTA, and dropping it would silently
+    # truncate the assistant's answer rather than fail loudly.
+    provider = StreamSequenceProvider(
+        [
+            [
+                LLMEvent(LLMEventType.TEXT_DELTA, part_id="text_0", delta="HEAD-"),
+                LLMEvent(LLMEventType.TEXT_DELTA, part_id="text_0", delta="TAIL"),
+                LLMEvent(LLMEventType.STEP_FINISH),
+            ]
+        ]
+    )
+    runner = _runner(provider)
+
+    result = await runner.run(session_id="session-stream-head", user_text="hi")
+
+    assert result.status == LoopStatus.COMPLETED
+    assert result.final_assistant_message is not None
+    assert result.final_assistant_message.parts[0].text == "HEAD-TAIL"
+
+
+@pytest.mark.asyncio
+async def test_stream_transient_error_before_first_chunk_is_retried():
+    # Scope note, pinned deliberately: prefetching the first chunk makes *every*
+    # retryable provider error raised before the first yield reachable by the
+    # retry loop, not only ProviderContextOverflowError. Nothing was yielded, so
+    # no partial assistant message and no tool call can have escaped.
+    provider = StreamSequenceProvider(
+        [
+            ProviderTransientError("stream connect failed"),
+            [
+                LLMEvent(LLMEventType.STEP_START),
+                LLMEvent(LLMEventType.TEXT_DELTA, part_id="text_0", delta="Recovered."),
+                LLMEvent(LLMEventType.STEP_FINISH),
+            ],
+        ]
+    )
+    runner = _runner(provider, provider_retry_backoff_seconds=0)
+
+    result = await runner.run(session_id="session-stream-transient", user_text="hi")
+
+    assert result.status == LoopStatus.COMPLETED
+    assert len(provider.requests) == 2
+    assert len(_events(result, "provider.retry")) == 1
+    assert not _events(result, "provider.context_overflow_retry")
+    assert result.final_assistant_message is not None
+    assert result.final_assistant_message.parts[0].text == "Recovered."
+
+
+_STOCK_BUDGET_TURN_TEXTS = tuple(
+    # The catalog default for the stock model leaves ~1.05M prompt chars, halved
+    # to ~528k on the overflow retry. The transcript has to exceed the halved
+    # budget or "the retry sends less" would be vacuously false.
+    "bulk turn {0} ".format(index) * 6000
+    for index in range(10)
+)
+
+
+@pytest.mark.asyncio
+async def test_overflow_retry_shrinks_request_without_rewriting_stored_history():
+    provider = SequenceProvider(
+        [
+            ProviderContextOverflowError("context too long"),
+            {"content": "Recovered without rewriting the transcript."},
+        ]
+    )
+    store = InMemorySessionStore()
+    # Stock runner: no max_context_parts/chars/tokens. The catalog-derived budget
+    # sizes the in-memory request only, so the overflow retry must compact at
+    # render time and leave the stored transcript alone.
+    runner = RuntimeLoopRunner(
+        store=store,
+        provider=provider,
+        tool_runtime=ToolRuntime(ToolRegistry()),
+    )
+    seeded = _old_session(*_STOCK_BUDGET_TURN_TEXTS)
+    seeded_messages = [_stored_fingerprint(message) for message in seeded.messages]
+
+    result = await runner.run(session=seeded, user_text="latest request")
+
+    assert result.status == LoopStatus.COMPLETED
+    assert len(provider.requests) == 2
+    assert len(_events(result, "provider.context_overflow_retry")) == 1
+
+    # The stored transcript is untouched: same ids, same text, still leading.
+    stored = store.read_history("session-provider-retry")
+    assert [
+        _stored_fingerprint(message) for message in stored[: len(seeded_messages)]
+    ] == seeded_messages
+    assert _events(result, "session_compacted") == []
+    assert _events(result, "session_compaction_started") == []
+
+    # ...and the retry still sent strictly less than the first attempt.
+    first_chars = sum(len(text) for _role, text in provider.message_snapshots[0])
+    retry_chars = sum(len(text) for _role, text in provider.message_snapshots[1])
+    assert retry_chars < first_chars
+    assert provider.requests[1].prepared_request.compaction_applied is True
 
 
 def test_provider_retry_error_import_boundary():

--- a/tests/runtime/test_provider_transport.py
+++ b/tests/runtime/test_provider_transport.py
@@ -5,13 +5,16 @@ import json
 import os
 import subprocess
 import sys
+from copy import deepcopy
 from pathlib import Path
 from urllib import error as urllib_error
 
 import pytest
 
 import efp_runtime.llm.provider as provider_module
+from efp_runtime.llm.errors import ProviderContextOverflowError
 from efp_runtime.llm.provider import (
+    AIPlatformHTTPTransport,
     DEFAULT_COPILOT_REASONING_EFFORT,
     DEFAULT_GITHUB_COPILOT_TIMEOUT_SECONDS,
     GitHubCopilotHTTPTransport,
@@ -35,7 +38,8 @@ from efp_runtime.llm.request import (
     RequestToolSchema,
 )
 from efp_runtime.loop import LoopStatus, RuntimeLoopRunner, RuntimeRequest
-from efp_runtime.session.models import MessagePartType, MessageRole
+from efp_runtime.models import Message
+from efp_runtime.session.models import MessagePartType, MessageRole, Session
 from efp_runtime.session.store import InMemorySessionStore
 from efp_runtime.tools.definition import ToolDef
 from efp_runtime.tools.registry import ToolRegistry
@@ -592,8 +596,21 @@ async def test_github_copilot_model_unavailable_does_not_fallback_to_gpt_5_5():
 
 
 @pytest.mark.asyncio
-async def test_github_copilot_regular_http_400_does_not_fallback():
-    transport = RecordingTransport([ProviderTransportError("HTTP 400 bad request")])
+async def test_github_copilot_regular_http_400_does_not_fallback_or_retry():
+    # Runner-level pin only: the transport hands the runner an already-built
+    # ProviderTransportError, so a payload-shape 400 must end the run instead of
+    # buying a compacted retry. The classifier itself is not exercised here - see
+    # test_github_copilot_http_transport_invalid_request_body_is_not_overflow.
+    transport = RecordingTransport(
+        [
+            ProviderTransportError(
+                "GitHub Copilot HTTP transport failed with status 400 (Bad Request) "
+                "response: "
+                '{"error":{"message":"Invalid value for tools[0].function.name",'
+                '"code":"invalid_request_body"}}'
+            )
+        ]
+    )
     provider = GitHubCopilotProvider(transport=transport, model="gpt-5.4")
     runner = RuntimeLoopRunner(
         store=InMemorySessionStore(),
@@ -609,6 +626,11 @@ async def test_github_copilot_regular_http_400_does_not_fallback():
     assert result.status == LoopStatus.ERROR
     assert len(transport.payloads) == 1
     assert transport.payloads[0]["model"] == "gpt-5.4"
+    assert not [
+        event
+        for event in result.runtime_events
+        if event.type == "provider.context_overflow_retry"
+    ]
     _assert_strict_copilot_responses_payload(transport.payloads[0])
 
 
@@ -1121,6 +1143,356 @@ async def test_github_copilot_http_transport_regular_400_is_transport_error(
     assert "invalid request" in str(exc_info.value)
 
 
+_CONTEXT_OVERFLOW_400_BODY = (
+    b'{"error":{"message":"Your input exceeds the context window of this model. '
+    b'Reduce the input for integrator secret-token and try again.",'
+    b'"code":"invalid_request_body"}}'
+)
+
+
+def _copilot_payload(*, stream: bool) -> dict:
+    return {
+        "model": "gpt-5.4",
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "Say ok"}]}
+        ],
+        "reasoning": {"effort": "high"},
+        "stream": stream,
+    }
+
+
+@pytest.mark.asyncio
+async def test_github_copilot_http_transport_raises_context_overflow(monkeypatch):
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(_CONTEXT_OVERFLOW_400_BODY),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = GitHubCopilotHTTPTransport(token="secret-token")
+    with pytest.raises(ProviderContextOverflowError) as exc_info:
+        await transport.send(_copilot_payload(stream=False))
+
+    error = exc_info.value
+    assert not isinstance(error, ProviderModelUnavailableError)
+    assert error.code == "context_overflow"
+    assert error.retryable is True
+    assert error.metadata["status_code"] == 400
+    assert "exceeds the context window" in str(error)
+    assert "[redacted]" in str(error)
+    assert "secret-token" not in str(error)
+
+
+@pytest.mark.asyncio
+async def test_github_copilot_http_transport_stream_raises_context_overflow(
+    monkeypatch,
+):
+    # The gateway builds Copilot providers with stream=True, so the streaming
+    # branch is the one production actually hits.
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(_CONTEXT_OVERFLOW_400_BODY),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = GitHubCopilotHTTPTransport(token="secret-token")
+    stream = await transport.send(_copilot_payload(stream=True))
+    with pytest.raises(ProviderContextOverflowError) as exc_info:
+        [chunk async for chunk in stream]
+
+    assert exc_info.value.metadata["status_code"] == 400
+    assert "secret-token" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_github_copilot_http_transport_invalid_request_body_is_not_overflow(
+    monkeypatch,
+):
+    # "invalid_request_body" is the generic /responses payload rejection code; a
+    # tool-schema 400 must not be classified as a context overflow.
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(
+                b'{"error":{"message":"Invalid value for tools[0].function.name",'
+                b'"code":"invalid_request_body"}}'
+            ),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = GitHubCopilotHTTPTransport(token="secret-token")
+    with pytest.raises(ProviderTransportError) as exc_info:
+        await transport.send(_copilot_payload(stream=False))
+
+    assert not isinstance(exc_info.value, ProviderContextOverflowError)
+    assert "tools[0].function.name" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_github_copilot_http_transport_model_unavailable_wins_over_overflow(
+    monkeypatch,
+):
+    # Both classifiers match this body; the model-unavailable check runs first
+    # because retrying a smaller prompt cannot fix an unavailable model.
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(
+                b'{"error":{"message":"The requested model is not available; its '
+                b'maximum context length is 128000 tokens. Available models: '
+                b'[gpt-5.5]","code":"context_length_exceeded"}}'
+            ),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = GitHubCopilotHTTPTransport(token="secret-token")
+    with pytest.raises(ProviderModelUnavailableError) as exc_info:
+        await transport.send(_copilot_payload(stream=False))
+
+    assert not isinstance(exc_info.value, ProviderContextOverflowError)
+    assert exc_info.value.available_models_text == "[gpt-5.5]"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Your input exceeds the context window of this model.",
+        "Rejected: context_length_exceeded",
+        "Context length exceeded for this request",
+        "This model's maximum context length is 128000 tokens",
+    ],
+)
+@pytest.mark.asyncio
+async def test_github_copilot_http_transport_each_overflow_marker_classifies(
+    monkeypatch, message
+):
+    # Every marker carries the classification on its own: the bodies below all
+    # ship the generic /responses code, so no other signal can stand in for one.
+    body = json.dumps(
+        {"error": {"message": message, "code": "invalid_request_body"}}
+    ).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url, 400, "Bad Request", hdrs=None, fp=io.BytesIO(body)
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = GitHubCopilotHTTPTransport(token="secret-token")
+    with pytest.raises(ProviderContextOverflowError):
+        await transport.send(_copilot_payload(stream=False))
+
+
+@pytest.mark.asyncio
+async def test_github_copilot_http_transport_overflow_code_alone_classifies(
+    monkeypatch,
+):
+    # Mirror image of the marker test: no marker anywhere in the message, so the
+    # allowlisted error code is the only thing that can classify this body.
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(
+                b'{"error":{"message":"Request too large","code":'
+                b'"context_length_exceeded"}}'
+            ),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = GitHubCopilotHTTPTransport(token="secret-token")
+    with pytest.raises(ProviderContextOverflowError) as exc_info:
+        await transport.send(_copilot_payload(stream=False))
+
+    assert exc_info.value.metadata["provider_error_code"] == "context_length_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_github_copilot_http_transport_413_without_a_marker_is_overflow(
+    monkeypatch,
+):
+    # A proxy in front of the endpoint answers an oversized POST with a bare 413
+    # and no JSON envelope. 413 on a prompt POST has no other meaning, so it must
+    # still buy the compacted retry.
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            413,
+            "Request Entity Too Large",
+            hdrs=None,
+            fp=io.BytesIO(b"<html><body>413 Request Entity Too Large</body></html>"),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = GitHubCopilotHTTPTransport(token="secret-token")
+    with pytest.raises(ProviderContextOverflowError) as exc_info:
+        await transport.send(_copilot_payload(stream=False))
+
+    assert exc_info.value.metadata["status_code"] == 413
+
+
+@pytest.mark.asyncio
+async def test_github_copilot_http_transport_non_json_body_marker_is_overflow(
+    monkeypatch,
+):
+    # A gateway that answers in plain text still has to be understood, so the
+    # whole body is scanned when it is not a JSON object.
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(b"Bad Request: input exceeds the context window"),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = GitHubCopilotHTTPTransport(token="secret-token")
+    with pytest.raises(ProviderContextOverflowError):
+        await transport.send(_copilot_payload(stream=False))
+
+
+@pytest.mark.asyncio
+async def test_github_copilot_http_transport_echoed_request_is_not_overflow(
+    monkeypatch,
+):
+    # A JSON envelope without a message key must NOT be scanned as raw text: the
+    # body echoes the rejected request, and the user's own prompt mentioning a
+    # context window would otherwise turn a validation 400 into an "overflow" -
+    # which, with an explicitly configured budget, rewrites the stored transcript.
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(
+                b'{"error":{"code":"invalid_request_body","param":"input[3].content"},'
+                b'"request":{"input":[{"text":"explain the maximum context length '
+                b'of gpt-5"}]}}'
+            ),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = GitHubCopilotHTTPTransport(token="secret-token")
+    with pytest.raises(ProviderTransportError) as exc_info:
+        await transport.send(_copilot_payload(stream=False))
+
+    assert not isinstance(exc_info.value, ProviderContextOverflowError)
+    assert "input[3].content" in str(exc_info.value)
+
+
+def _ai_platform_transport() -> AIPlatformHTTPTransport:
+    return AIPlatformHTTPTransport(
+        chat_endpoint="https://chat.test/v1/api/v1/chat/completions",
+        token="ap-secret-token",
+        trust_token_header="X-Trust",
+        tracking_prefix="EFP",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ai_platform_http_transport_raises_context_overflow(monkeypatch):
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(
+                b'{"error":{"message":"This model\'s maximum context length is '
+                b'128000 tokens","code":"context_length_exceeded"}}'
+            ),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = _ai_platform_transport()
+    with pytest.raises(ProviderContextOverflowError) as exc_info:
+        await transport.send({"model": "gpt-5.4", "messages": [], "stream": False})
+
+    error = exc_info.value
+    assert error.code == "context_overflow"
+    assert error.metadata["status_code"] == 400
+    assert error.metadata["provider_error_code"] == "context_length_exceeded"
+    assert "AI Platform" in str(error)
+
+
+@pytest.mark.asyncio
+async def test_ai_platform_http_transport_stream_raises_context_overflow(monkeypatch):
+    # The AI Platform streaming branch is a separate error path from the
+    # non-streaming one, and streaming is what the gateway builds.
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(
+                b'{"error":{"message":"This model\'s maximum context length is '
+                b'128000 tokens","code":"context_length_exceeded"}}'
+            ),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = _ai_platform_transport()
+    stream = await transport.send(
+        {"model": "gpt-5.4", "messages": [], "stream": True}
+    )
+    with pytest.raises(ProviderContextOverflowError) as exc_info:
+        [chunk async for chunk in stream]
+
+    assert exc_info.value.metadata["status_code"] == 400
+    assert "AI Platform" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ai_platform_http_transport_unrelated_400_is_transport_error(monkeypatch):
+    def fake_urlopen(request, timeout):
+        raise urllib_error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(b'{"error":{"message":"usercase is required"}}'),
+        )
+
+    monkeypatch.setattr(provider_module.urllib_request, "urlopen", fake_urlopen)
+
+    transport = _ai_platform_transport()
+    with pytest.raises(ProviderTransportError) as exc_info:
+        await transport.send({"model": "gpt-5.4", "messages": [], "stream": False})
+
+    assert not isinstance(exc_info.value, ProviderContextOverflowError)
+    assert "usercase is required" in str(exc_info.value)
+
+
 def test_github_copilot_provider_from_env_reads_token_and_base_url():
     provider = github_copilot_provider_from_env(
         env={
@@ -1398,6 +1770,142 @@ async def test_transport_send_error_maps_to_loop_error_status():
     assert "OpenAI-compatible transport failed" in error_part.text
     assert "network disabled" in error_part.text
     assert any(event.type == "llm.provider_error" for event in result.runtime_events)
+
+
+class _StreamingSequenceTransport:
+    """Transport whose send() returns an *unstarted* async generator per call.
+
+    Mirrors GitHubCopilotHTTPTransport._send_stream: send() resolves without
+    touching the network, and the HTTP failure only surfaces on the first
+    __anext__.
+    """
+
+    def __init__(self, steps):
+        self._steps = list(steps)
+        self.payloads: list[dict] = []
+
+    async def send(self, payload):
+        self.payloads.append(deepcopy(payload))
+        if not self._steps:
+            raise AssertionError("_StreamingSequenceTransport has no step left")
+        return self._stream(self._steps.pop(0))
+
+    async def _stream(self, step):
+        if isinstance(step, BaseException):
+            raise step
+        for chunk in step:
+            yield chunk
+
+
+def _overflow_session(session_id: str, *texts: str) -> Session:
+    return Session(
+        session_id=session_id,
+        messages=[
+            Message.from_text("user", text, message_id="msg-{0}".format(index))
+            for index, text in enumerate(texts)
+        ],
+    )
+
+
+# Long enough that dropping the old turns for a compaction summary is a net
+# reduction; a handful of short turns would be replaced by boilerplate larger
+# than the text it summarises and the anti-theatre assertion below would be
+# measuring the summary header instead of a real shrink.
+_OVERFLOW_HISTORY_TEXTS = tuple(
+    "old turn {0} ".format(index) * 400 for index in range(1, 5)
+)
+
+
+@pytest.mark.asyncio
+async def test_stream_context_overflow_reaches_runner_retry():
+    transport = _StreamingSequenceTransport(
+        [
+            ProviderContextOverflowError(
+                "GitHub Copilot rejected the request as larger than the model "
+                "context window: Your input exceeds the context window."
+            ),
+            [
+                {"choices": [{"delta": {"content": "Recovered."}}]},
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            ],
+        ]
+    )
+    provider = GitHubCopilotProvider(
+        transport=transport,
+        model="gpt-5.4",
+        stream=True,
+    )
+    runner = RuntimeLoopRunner(
+        store=InMemorySessionStore(),
+        provider=provider,
+        tool_runtime=ToolRuntime(ToolRegistry()),
+        max_context_parts=5,
+    )
+
+    result = await runner.run(
+        session=_overflow_session(
+            "session-stream-overflow",
+            *_OVERFLOW_HISTORY_TEXTS,
+        ),
+        user_text="latest request must survive",
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    assert len(transport.payloads) == 2
+    overflow_events = [
+        event
+        for event in result.runtime_events
+        if event.type == "provider.context_overflow_retry"
+    ]
+    assert len(overflow_events) == 1
+    assert transport.payloads[1]["input"][-1]["content"][0]["text"] == (
+        "latest request must survive"
+    )
+    # Anti-theatre: the retry must actually send less, not resend the same bytes.
+    assert len(json.dumps(transport.payloads[1]["input"])) < len(
+        json.dumps(transport.payloads[0]["input"])
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_stream_context_overflow_reaches_runner_retry():
+    transport = RecordingTransport(
+        [
+            ProviderContextOverflowError(
+                "GitHub Copilot rejected the request as larger than the model "
+                "context window: Your input exceeds the context window."
+            ),
+            _responses_response("Recovered."),
+        ]
+    )
+    provider = GitHubCopilotProvider(transport=transport, model="gpt-5.4")
+    runner = RuntimeLoopRunner(
+        store=InMemorySessionStore(),
+        provider=provider,
+        tool_runtime=ToolRuntime(ToolRegistry()),
+        max_context_parts=5,
+    )
+
+    result = await runner.run(
+        session=_overflow_session(
+            "session-non-stream-overflow",
+            *_OVERFLOW_HISTORY_TEXTS,
+        ),
+        user_text="latest request must survive",
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    assert len(transport.payloads) == 2
+    assert (
+        len(
+            [
+                event
+                for event in result.runtime_events
+                if event.type == "provider.context_overflow_retry"
+            ]
+        )
+        == 1
+    )
 
 
 def test_provider_transport_imports_standalone_with_pythonpath_src():

--- a/tests/test_runtime_event_projection.py
+++ b/tests/test_runtime_event_projection.py
@@ -204,6 +204,10 @@ def test_projector_distinguishes_request_compaction_from_stored_rewrites():
                 "trigger": "context_budget",
                 "stored": False,
                 "scope": "request",
+                "max_chars": 1_568_000,
+                "compacted_message_count": 9,
+                "compacted_chars": 840_000,
+                "kept_chars": 1_050_000,
             },
         )
     )
@@ -229,6 +233,13 @@ def test_projector_distinguishes_request_compaction_from_stored_rewrites():
     # ...but the on-disk distinction survives projection.
     assert request_only[0]["data"]["stored"] is False
     assert request_only[0]["data"]["scope"] == "request"
+    # Both emitters spread the compaction counters flat, so the projection has
+    # to read them flat too -- otherwise the card reaches the UI with no
+    # numbers and the user cannot tell how much context was dropped.
+    assert request_only[0]["data"]["max_chars"] == 1_568_000
+    assert request_only[0]["data"]["compacted_message_count"] == 9
+    assert request_only[0]["data"]["compacted_chars"] == 840_000
+    assert request_only[0]["data"]["kept_chars"] == 1_050_000
     assert stored[0]["data"]["stored"] is True
     assert stored[0]["data"]["scope"] == "session"
     assert stored[0]["data"]["stored_message_count"] == 7

--- a/tests/test_runtime_event_projection.py
+++ b/tests/test_runtime_event_projection.py
@@ -180,3 +180,55 @@ def test_projector_maps_new_llm_error_and_finish_events():
         )
     )
     assert finish == []
+
+
+def test_projector_distinguishes_request_compaction_from_stored_rewrites():
+    """Both compaction kinds render the same, but must stay tellable apart.
+
+    ``session_compacted`` means the stored session was rewritten on disk;
+    ``request_compacted`` means only the outgoing request was trimmed. They
+    share a UI event so the timeline keeps rendering both, so the projected
+    ``stored``/``scope`` fields are the only signal a consumer has for whether
+    anything on disk changed.
+    """
+
+    projector = RuntimeEventProjector(request_id="req-1", model="gpt-5.6-sol")
+
+    request_only = projector.project(
+        RuntimeEvent(
+            type="request_compacted",
+            session_id="s-1",
+            payload={
+                "run_id": "run-1",
+                "iteration": 3,
+                "trigger": "context_budget",
+                "stored": False,
+                "scope": "request",
+            },
+        )
+    )
+    stored = projector.project(
+        RuntimeEvent(
+            type="session_compacted",
+            session_id="s-1",
+            payload={
+                "run_id": "run-1",
+                "trigger": "context_budget",
+                "stored": True,
+                "scope": "session",
+                "stored_message_count": 7,
+            },
+        )
+    )
+
+    assert len(request_only) == 1
+    assert len(stored) == 1
+    # Same UI event, so the Portal timeline needs no change...
+    assert request_only[0]["type"] == "session.next.compaction.ended"
+    assert stored[0]["type"] == "session.next.compaction.ended"
+    # ...but the on-disk distinction survives projection.
+    assert request_only[0]["data"]["stored"] is False
+    assert request_only[0]["data"]["scope"] == "request"
+    assert stored[0]["data"]["stored"] is True
+    assert stored[0]["data"]["scope"] == "session"
+    assert stored[0]["data"]["stored_message_count"] == 7


### PR DESCRIPTION
## The bug

A Portal chat against a native-runtime agent on `gpt-5.6-sol` fails after a long conversation:

```
completion_state: error
incomplete_reason: GitHub Copilot HTTP transport failed with status 400 (Bad Request)
{"error":{"message":"Your input exceeds the context window of this model.","code":"invalid_request_body"}}
```

## Root cause

The native runtime had **no context bound at all** under stock configuration.

`_context_budget_max_chars` returned `None` whenever neither `max_context_chars` nor `max_context_tokens` was set. That made `_context_budget_enabled` false, which skipped both the render-time and the stored-history compactor, so the entire session history was resent every turn until Copilot rejected it. No `config.yaml` ships those knobs, so this was every deployed pod.

The model already declared its window — `gpt-5.6-sol: 400k, reserve 128k` — but that number was only ever emitted as telemetry. `_context_budget_max_chars` never consulted it.

The model is **not** a variable here: `gpt-5.6-sol` and `gpt-5.6-terra` are byte-identical profiles.

## What changed

### 1. The catalog becomes the default budget source

Prompt budget = declared window − safety margin (`min(8000, window/20)`, mirroring the legacy progressive-context rule), with the model's declared response reserve held back. For sol: 392k tokens prompt, 128k reserve, ~264k effective.

Explicit `max_context_chars` / `max_context_tokens` still win, so configured deployments are unchanged.

**The derived default sizes the in-memory request only.** The stored-history compactor rewrites the session on disk — and therefore the Portal transcript — so it stays gated on explicit operator config. Pinned by `test_default_budget_never_rewrites_stored_history`.

### 2. Three latent defects that only became reachable once compaction was on

- **`BudgetCompactionStrategy` was O(n²).** The budget search re-ran the relevant-file path regex over every compacted message for each candidate. Measured **166 s (600 msgs) / 344 s (1200 msgs)** of synchronous, event-loop-blocking CPU per iteration — worse than the bug being fixed. Memoizing the per-message scan for one selection pass: **166 s → 1.59 s, 344 s → 3.64 s**, with byte-identical `kept_chars` at every size.
- **A reserve larger than the budget** silently reduced every request to system context plus the latest turn. The reserve is response headroom, so it is clamped to half the budget. This also fixes the pre-existing `max_context_tokens=50_000` → effective 0 case.
- **`_overflow_retry_budget` was cosmetic**: it returned the budget unchanged when `reserve >= max_chars/2`, making the retry identical to the attempt that just failed. It now halves the *effective* budget.

### 3. The overflow 400 is classified, and the retry is reachable

The retry handler and `enable_context_overflow_retry=True` have been there all along, but the path was dead three times over: nothing raised `ProviderContextOverflowError`, `OpenAICompatibleProvider.invoke` absorbed every transport exception into an error mapping, and the streaming generator was consumed outside the retry's `try`.

All three fixed. Classification matches on the error **message**; `invalid_request_body` is deliberately **not** a discriminator — it is the generic payload-rejection code on `/responses`, which also 400s for tool-schema and call-id reasons, so matching it would classify a malformed tool definition as an overflow. For the same reason the raw body is only scanned when it is not a JSON object, or a validation 400 that echoes the request back would classify as overflow the moment the user's own prompt said "maximum context length".

`_prefetch_async_stream` is a plain coroutine **returning** an async generator — if it were an async generator itself the await would be deferred and the fix would be a no-op.

### 4. Stale model tables

Three tables had no `gpt-5.6-*` entries. The live one is `hooks/file_context/retrieval.py`, on the Portal attachment path: its substring gate missed every 5.6 model, zeroing `prompt_budget` and falling back to the emergency 1000/4000/8000 thresholds.

| | before | after |
|---|---|---|
| `agents/compaction.py` window (sol) | **4096** | 400000 |
| `resolve_model_limits` (sol) | generic 200k/128k | 400k/272k/128k |
| retrieval thresholds (sol) | **emergency 1000/4000/8000** | 13600/… |

## Behaviour changes worth a second opinion

- **Parts-only configs.** A pod with only `max_context_parts` set now also picks up the catalog char budget and reserve — because a parts-only pod with no char budget is exactly a pod that still 400s. The two tests pinning the old `None`/`0` metadata are updated with that reasoning recorded.
- **`_clamp_reserve_chars` applies to explicit configs too.** This is the one place the change goes beyond "explicitly configured deployments behave exactly as before". Intentional: it turns `max_context_tokens=50_000` from "compact everything away" into something usable.
- **Prefetch widens retry eligibility.** Any exception before a stream's first chunk is now retried, including `ProviderTransientError`. Safe — nothing was yielded, so no partial assistant message escaped — and pinned by `test_stream_transient_error_before_first_chunk_is_retried`.
- **Bare HTTP 413** short-circuits to overflow with no marker required.
- `resolve_model_context_profile` no longer short-circuits on provider id, so ai_platform `gpt-5.4` gets its declared 400k instead of the 64k unknown-model fallback.

## Not in scope

The uncompactable system-context floor (unbounded `SKILL.md` bodies + 20k system prompt + 20k `AGENTS.md`) is protected from compaction and never checked against the budget. If it alone exceeds the budget, compaction returns an over-budget payload and the request still 400s. Pre-existing, not introduced here, worth a follow-up.

Token accounting is also wrong in both directions (reasoning parts are charged but never sent; `TOOL_CALL` arguments dicts and error-only `TOOL_RESULT`s are charged at ~0; data-URI attachments are excluded by design). Also pre-existing.

## Testing

Full suite: **33 failed / 2506 passed / 5 skipped**, failure set byte-identical to master. The 33 are pre-existing Windows environment failures (CRLF / `PermissionError`); none are in provider, transport, compaction or context tests.

Mutation-verified rather than assumed:

| reverted | tests that go red |
|---|---|
| `_context_budget_max_chars` catalog fall-through | 13 |
| the stream prefetch | 4 |
| `except ProviderContextOverflowError: raise` in `invoke` | 1 |
| the stored-history guard | 3 |
| each individual message marker / the code allowlist | ≥1 each |

🤖 Generated with [Claude Code](https://claude.com/claude-code)