### PR TITLE
Correct the context budget example: tokens and chars are not the same knob

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -141,10 +141,23 @@ llm:
 # (which the model-derived default deliberately does NOT do, because rewriting
 # stored history discards the user's transcript).
 #
-# max_context_tokens: 250000   # prompt budget in tokens; wins over the catalog
-# max_context_chars: 1000000   # same, in characters; wins over max_context_tokens
+# These two are NOT the same knob and do not produce the same budget:
+#
+# max_context_tokens: 250000   # CONTEXT WINDOW, not prompt budget. The model's
+#                              # declared response reserve is then subtracted
+#                              # (clamped to half), so on a 400k/128k model this
+#                              # yields ~125000 tokens of actual prompt.
+# max_context_chars: 1000000   # PROMPT BUDGET directly. No model reserve is
+#                              # subtracted -- only context_reserve_chars, which
+#                              # defaults to 0. Wins over max_context_tokens.
+#                              # 1000000 chars is ~250000 tokens at 4 chars/token.
 # max_context_parts: 200       # cap on message parts, independent of the above
-# context_reserve_tokens: 128000  # response headroom withheld from the budget
+# context_reserve_tokens: 128000  # response headroom; overrides the model's own
+#                              # reserve for BOTH of the above
+#
+# Setting ANY of the three caps above also opts this deployment into rewriting
+# STORED session history on disk when it exceeds the budget -- the catalog
+# default deliberately does not do that. Leave them unset unless you want that.
 #
 # NOTE: the `llm.context_budget` and `llm.model_limits` blocks above are read
 # by the LEGACY progressive-context stack (src/runtime/progressive_context.py,


### PR DESCRIPTION
Follow-up to #582, which shipped an operator-facing comment in `config.yaml.example` claiming `max_context_tokens` and `max_context_chars` are the same setting in different units ("same, in characters").

Measured on `gpt-5.6-sol` (window 400k, reserve 128k):

| config | effective chars | ≈ tokens |
|---|---|---|
| `max_context_tokens: 250000` | 500 000 | **125 000** |
| `max_context_chars: 1000000` | 1 000 000 | **250 000** |

`_context_budget_reserve_chars` branches on `max_context_chars is None`, so the token route has the model's declared 128k response reserve subtracted (then clamped to half by `_clamp_reserve_chars`), while the char route subtracts only `context_reserve_chars`, which defaults to 0. An operator following the old comment and asking for 250k tokens got half that.

**The asymmetry itself predates #582** — the same branch is in `0efc5aa`. This PR corrects the documentation to describe what the code actually does; it does not change behaviour. Making the two routes consistent is a real change with real blast radius on explicitly-configured deployments and belongs in its own PR.

Also states a consequence the old block omitted: setting any of the three caps opts the deployment into rewriting **stored** session history on disk, because `_context_budget_explicitly_configured()` gates that compactor. The catalog default deliberately does not, and an operator reaching for "make my prompt smaller" is not obviously asking for "rewrite my transcripts".

Docs only. Full suite unchanged: 33 failed / 2509 passed / 5 skipped, failure set byte-identical to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)