### PR TITLE
Harden the context budget: reject zero, clamp over-window, decouple stored-history rewriting

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -137,9 +137,36 @@ llm:
 # and returning `400 Bad Request / "Your input exceeds the context window"`.
 #
 # Set them only to override that default -- for example to pin a smaller
-# prompt budget, or to opt in to compaction of the STORED session history
-# (which the model-derived default deliberately does NOT do, because rewriting
-# stored history discards the user's transcript).
+# prompt budget. They size the in-memory provider request ONLY; none of them
+# touches the stored session. See `compaction_rewrite_stored_history` below.
+#
+# All three caps must be >= 1. `0` is rejected (the chat returns 400 naming the
+# field) rather than silently meaning "unlimited" or "disabled" -- it used to
+# produce a one-character budget, i.e. every request cut down to system context
+# plus the latest turn. To turn a cap off, omit the key and inherit the
+# model-catalog default.
+#
+# A value larger than the catalog PROMPT CEILING is clamped down to it. The
+# ceiling is the declared window minus the safety margin -- 392000 tokens /
+# 1568000 chars on a 400k model -- i.e. the same cap the unset path uses, NOT
+# the declared window itself. So `max_context_tokens: 400000` on a 400k model
+# is clamped to 392000 (a ~2% reduction): the margin absorbs the error in the
+# 4-chars-per-token estimate, and without it a nominally exact value still
+# reproduces the provider `400 / input exceeds the context window` this whole
+# default exists to prevent. The clamp is reported in run metadata under
+# `context_budget` as max_context_chars_clamped / _requested / _limit, so a
+# clamp of that size is visible rather than silent.
+#
+# The clamp does NOT apply to a model id absent from
+# src/efp_runtime/llm/models.py: an uncatalogued model falls back to a
+# conservative 64k guess, and an override is the only way to correct that
+# guess, so there the operator's value is honoured verbatim (_limit is null).
+#
+# Note the clamp bounds the CAP, not the final prompt: the two routes subtract
+# different reserves (see below), so a clamped `max_context_tokens` lands on the
+# same effective budget as leaving it unset, while a clamped `max_context_chars`
+# keeps its zero reserve and so allows a larger prompt -- still inside the
+# window, because the safety margin is what the ceiling holds back.
 #
 # These two are NOT the same knob and do not produce the same budget:
 #
@@ -155,9 +182,22 @@ llm:
 # context_reserve_tokens: 128000  # response headroom; overrides the model's own
 #                              # reserve for BOTH of the above
 #
-# Setting ANY of the three caps above also opts this deployment into rewriting
-# STORED session history on disk when it exceeds the budget -- the catalog
-# default deliberately does not do that. Leave them unset unless you want that.
+# compaction_rewrite_stored_history: true
+#   Rewrites the STORED session on disk -- the transcript the user reads in the
+#   Portal -- whenever it exceeds the budget above. IRREVERSIBLE: the replaced
+#   messages are gone. Off by default and NOT implied by any of the caps above;
+#   setting a cap only shrinks the request that goes to the model, which is
+#   already enough to stay inside the budget. Turn this on only if you also want
+#   old turns removed from the stored conversation. (Manual /compact is
+#   unaffected either way.) The state in force is reported in run metadata as
+#   `context_budget.stored_history_rewrite`.
+#
+#   OPERATIONAL WARNING: with this off (the default), long-lived sessions grow
+#   without bound on disk. Requests stay bounded -- the render-time compactor
+#   handles that -- but nothing trims the stored session, and the file store
+#   rewrites and re-parses the whole session file per turn, so turn latency
+#   grows with session length. If you previously relied on a size cap to keep
+#   stored sessions small, set this to `true` to keep that behaviour.
 #
 # NOTE: the `llm.context_budget` and `llm.model_limits` blocks above are read
 # by the LEGACY progressive-context stack (src/runtime/progressive_context.py,

--- a/src/config.py
+++ b/src/config.py
@@ -45,6 +45,7 @@ PORTAL_MANAGED_RUNTIME_FIELDS = frozenset(
         "context_reserve_chars",
         "context_reserve_tokens",
         "compaction_auto",
+        "compaction_rewrite_stored_history",
         "compaction_prune",
         "compaction_tail_turns",
         "compaction_preserve_recent_chars",

--- a/src/efp_runtime/agents/task_runner.py
+++ b/src/efp_runtime/agents/task_runner.py
@@ -376,6 +376,11 @@ def _child_config(
         compaction_auto=(
             True if base_config is None else base_config.compaction_auto
         ),
+        compaction_rewrite_stored_history=(
+            False
+            if base_config is None
+            else base_config.compaction_rewrite_stored_history
+        ),
         compaction_prune=(
             True if base_config is None else base_config.compaction_prune
         ),

--- a/src/efp_runtime/config_loader.py
+++ b/src/efp_runtime/config_loader.py
@@ -84,6 +84,7 @@ _RUNTIME_CONFIG_KEYS = {
     "model_aware_tool_selection",
     "compaction",
     "compaction_auto",
+    "compaction_rewrite_stored_history",
     "compaction_prune",
     "compaction_tail_turns",
     "compaction_preserve_recent_chars",
@@ -729,6 +730,8 @@ def _model_aware_tool_selection(raw: Mapping[str, Any]) -> Any:
 
 _COMPACTION_NESTED_ALIASES = {
     "auto": "compaction_auto",
+    "rewrite_stored_history": "compaction_rewrite_stored_history",
+    "rewriteStoredHistory": "compaction_rewrite_stored_history",
     "prune": "compaction_prune",
     "tail_turns": "compaction_tail_turns",
     "tailTurns": "compaction_tail_turns",
@@ -747,6 +750,7 @@ _COMPACTION_NESTED_ALIASES = {
 
 _COMPACTION_TOP_LEVEL_FIELDS = {
     "compaction_auto",
+    "compaction_rewrite_stored_history",
     "compaction_prune",
     "compaction_tail_turns",
     "compaction_preserve_recent_chars",

--- a/src/efp_runtime/llm/models.py
+++ b/src/efp_runtime/llm/models.py
@@ -130,6 +130,24 @@ def default_max_context_tokens(profile: ModelContextProfile) -> int:
     return max(1, profile.context_window_tokens - context_safety_margin_tokens(profile))
 
 
+def is_catalog_model_context_profile(profile: ModelContextProfile) -> bool:
+    """Report whether ``profile`` came from the catalog rather than the fallback.
+
+    ``resolve_model_context_profile`` returns
+    ``replace(_CONSERVATIVE_FALLBACK_PROFILE, model_id=model_id)`` on a miss, so
+    ``profile.model_id`` alone cannot tell a real catalog entry from a guess -
+    an uncatalogued model reports its own id next to a 64k window it never
+    declared.
+
+    Callers must not narrow an operator's explicit context budget on a profile
+    this returns ``False`` for: a newly released or gateway-only model needs an
+    override precisely because the conservative fallback is wrong about it, and
+    clamping to 64k would defeat the only purpose the override has.
+    """
+
+    return _COPILOT_PROFILES.get(profile.model_id) == profile
+
+
 def _profile(
     model_id: str,
     *,
@@ -261,6 +279,7 @@ __all__ = [
     "canonicalize_copilot_model_id",
     "context_safety_margin_tokens",
     "default_max_context_tokens",
+    "is_catalog_model_context_profile",
     "resolve_model_context_profile",
     "tokens_to_chars",
 ]

--- a/src/efp_runtime/loop/runner.py
+++ b/src/efp_runtime/loop/runner.py
@@ -33,6 +33,7 @@ from ..llm.models import (
     ModelContextProfile,
     context_safety_margin_tokens,
     default_max_context_tokens,
+    is_catalog_model_context_profile,
     resolve_model_context_profile,
 )
 from ..permissions import ASK, DENY, PermissionMetadata
@@ -208,6 +209,7 @@ class RuntimeLoopRunner:
         tool_selection: Optional[ToolSelection] = None,
         compaction_summarizer: Optional[CompactionSummarizer] = None,
         compaction_auto: bool = True,
+        compaction_rewrite_stored_history: bool = False,
         compaction_tail_turns: int = 2,
         compaction_preserve_recent_chars: int | None = None,
         compaction_preserve_recent_tokens: int | None = None,
@@ -224,10 +226,16 @@ class RuntimeLoopRunner:
             raise ValueError("max_iterations must be at least 1")
         if doom_loop_threshold is not None and doom_loop_threshold < 2:
             raise ValueError("doom_loop_threshold must be at least 2 or None")
-        if max_context_parts is not None and max_context_parts < 1:
-            raise ValueError("max_context_parts must be at least 1")
-        if max_context_chars is not None and max_context_chars < 1:
-            raise ValueError("max_context_chars must be at least 1")
+        # Must stay acceptance-identical to RuntimeConfig.__post_init__: this is
+        # the second, hand-written entry point for the same knobs.
+        _validate_optional_positive_int(
+            max_context_parts,
+            field_name="max_context_parts",
+        )
+        _validate_optional_positive_int(
+            max_context_chars,
+            field_name="max_context_chars",
+        )
         default_provider_id = _validate_non_empty_string(
             default_provider_id,
             field_name="default_provider_id",
@@ -236,12 +244,16 @@ class RuntimeLoopRunner:
             default_model,
             field_name="default_model",
         )
-        _validate_optional_non_negative_int(
+        # Zero is rejected here too; see RuntimeConfig.__post_init__ for why it
+        # is not coerced to None.
+        _validate_optional_positive_int(
             max_context_tokens,
             field_name="max_context_tokens",
         )
-        if context_reserve_chars < 0:
-            raise ValueError("context_reserve_chars must be at least 0")
+        _validate_non_negative_int(
+            context_reserve_chars,
+            field_name="context_reserve_chars",
+        )
         _validate_optional_non_negative_int(
             context_reserve_tokens,
             field_name="context_reserve_tokens",
@@ -290,6 +302,7 @@ class RuntimeLoopRunner:
         self.tool_selection = _copy_tool_selection(tool_selection)
         self.compaction_summarizer = compaction_summarizer
         self.compaction_auto = bool(compaction_auto)
+        self.compaction_rewrite_stored_history = bool(compaction_rewrite_stored_history)
         self.compaction_tail_turns = compaction_tail_turns
         self.compaction_preserve_recent_chars = compaction_preserve_recent_chars
         self.compaction_preserve_recent_tokens = compaction_preserve_recent_tokens
@@ -864,20 +877,6 @@ class RuntimeLoopRunner:
         resolved = budget or self._context_budget()
         return resolved.max_parts is not None or resolved.max_chars is not None
 
-    def _context_budget_explicitly_configured(self) -> bool:
-        """Report whether an operator configured a context budget explicitly.
-
-        The model-catalog default only sizes the in-memory provider request. The
-        stored-history compactor rewrites the session on disk (and therefore the
-        Portal transcript), so it stays opt-in.
-        """
-
-        return (
-            self.max_context_parts is not None
-            or self.max_context_chars is not None
-            or self.max_context_tokens is not None
-        )
-
     def _overflow_retry_budget(
         self,
         metadata: Mapping[str, Any] | None = None,
@@ -905,12 +904,57 @@ class RuntimeLoopRunner:
             reserve_chars=current_budget.reserve_chars,
         )
 
-    def _context_budget_max_chars(self, profile: ModelContextProfile) -> int | None:
+    def _explicit_context_budget_max_chars(
+        self,
+        profile: ModelContextProfile,
+    ) -> int | None:
+        """Return the operator's char budget before clamping, or None if unset."""
+
         if self.max_context_chars is not None:
             return self.max_context_chars
         if self.max_context_tokens is not None:
             return max(1, profile.tokens_to_chars(self.max_context_tokens))
+        return None
+
+    @staticmethod
+    def _context_budget_max_chars_limit(profile: ModelContextProfile) -> int | None:
+        """Return the largest char budget this model can be asked to accept.
+
+        ``None`` means "no trustworthy ceiling exists, do not clamp". That is the
+        case for every model that missed the catalog: ``resolve_model_context_profile``
+        hands back the 64k conservative fallback, and a newly released or
+        gateway-only model needs an operator override precisely because that
+        guess is wrong about it. Clamping such an override to 64k would defeat
+        the only purpose an override has.
+
+        For a real catalog entry the ceiling is the same CAP the unset path
+        produces (declared window minus the safety margin), rather than a novel
+        third number. Clamping to the raw window instead would authorise a
+        prompt sized at 100% of it, leaving nothing for the chars/4 estimate
+        error the safety margin exists to absorb.
+
+        Note this bounds ``max_chars``, not ``effective_max_chars``: the two
+        routes subtract different reserves (see
+        ``_context_budget_reserve_chars`` and the asymmetry pinned by
+        ``test_tokens_and_chars_routes_keep_their_asymmetric_reserves``), so a
+        clamped ``max_context_tokens`` ends up on the unset path's effective
+        budget while a clamped ``max_context_chars`` keeps its zero reserve and
+        so authorises a larger prompt - still under the declared window, since
+        the safety margin is what the ceiling holds back.
+        """
+
+        if not is_catalog_model_context_profile(profile):
+            return None
         return max(1, profile.tokens_to_chars(default_max_context_tokens(profile)))
+
+    def _context_budget_max_chars(self, profile: ModelContextProfile) -> int | None:
+        explicit = self._explicit_context_budget_max_chars(profile)
+        if explicit is None:
+            return max(1, profile.tokens_to_chars(default_max_context_tokens(profile)))
+        limit = self._context_budget_max_chars_limit(profile)
+        if limit is None:
+            return explicit
+        return min(explicit, limit)
 
     def _context_budget_reserve_chars(self, profile: ModelContextProfile) -> int:
         if self.context_reserve_tokens is not None:
@@ -955,9 +999,26 @@ class RuntimeLoopRunner:
     ) -> dict[str, Any]:
         profile = self._model_context_profile(metadata)
         resolved_budget = budget or self._context_budget(metadata)
+        requested_max_chars = self._explicit_context_budget_max_chars(profile)
+        max_chars_limit = (
+            self._context_budget_max_chars_limit(profile)
+            if requested_max_chars is not None
+            else None
+        )
+        max_chars_clamped = (
+            max_chars_limit is not None and requested_max_chars > max_chars_limit
+        )
         resolved_max_context_tokens = self.max_context_tokens
         safety_margin_tokens: int | None = None
         if self.max_context_chars is None and self.max_context_tokens is None:
+            safety_margin_tokens = context_safety_margin_tokens(profile)
+            resolved_max_context_tokens = default_max_context_tokens(profile)
+        elif max_chars_clamped:
+            # Once the clamp fires, the catalog ceiling IS the budget. Reporting
+            # the operator's rejected number as ``max_context_tokens`` next to a
+            # clamped ``max_context_chars`` would have the two disagree by the
+            # whole overshoot; the original stays visible as
+            # ``max_context_chars_requested``.
             safety_margin_tokens = context_safety_margin_tokens(profile)
             resolved_max_context_tokens = default_max_context_tokens(profile)
         preserve_recent_chars = self._compaction_preserve_recent_chars(profile)
@@ -1020,6 +1081,16 @@ class RuntimeLoopRunner:
         payload["context_budget"] = {
             **payload,
             "max_context_chars_source": max_context_chars_source,
+            "max_context_chars_requested": requested_max_chars,
+            "max_context_chars_limit": max_chars_limit,
+            "max_context_chars_clamped": max_chars_clamped,
+            # Whether exceeding this budget also rewrites the STORED session.
+            # Without it the only signal for the gate is the ABSENCE of
+            # session_compaction_started/session_compacted, which is only
+            # legible to someone who already knew to look - and the deployment
+            # this flag changes most (a size knob set, stored rewriting now off,
+            # session files growing) is exactly the one that would not know.
+            "stored_history_rewrite": self.compaction_rewrite_stored_history,
             "context_reserve_chars_source": reserve_chars_source,
             "compaction_preserve_recent_chars_source": preserve_recent_chars_source,
             "max_parts": resolved_budget.max_parts,
@@ -1047,12 +1118,14 @@ class RuntimeLoopRunner:
             return _StoredCompactionOutcome(history=history)
         if not self._context_budget_enabled(budget):
             return _StoredCompactionOutcome(history=history)
-        if not self._context_budget_explicitly_configured():
-            # The catalog-derived default budget drives the in-memory request
-            # only. Rewriting stored history discards the user's transcript, so
-            # it stays gated on explicit operator config - including on the
-            # provider-overflow retry, which does not need it: the retry sends
-            # its halved budget through _prepare_runtime_request, and
+        if not self.compaction_rewrite_stored_history:
+            # Sizing the request and rewriting the transcript are separate
+            # decisions, so they are separate knobs: a context budget - whether
+            # catalog-derived or set by an operator - drives the in-memory
+            # request only. Rewriting stored history discards the user's
+            # transcript irreversibly, so it needs its own opt-in, including on
+            # the provider-overflow retry, which does not need it: the retry
+            # sends its halved budget through _prepare_runtime_request, and
             # prepare_history_for_request compacts at render time.
             return _StoredCompactionOutcome(history=history)
         if not history:
@@ -1962,6 +2035,7 @@ async def run_runtime_loop(
     structured_output_tool_id: str = "StructuredOutput",
     compaction_summarizer: Optional[CompactionSummarizer] = None,
     compaction_auto: bool = True,
+    compaction_rewrite_stored_history: bool = False,
     compaction_tail_turns: int = 2,
     compaction_preserve_recent_chars: int | None = None,
     compaction_preserve_recent_tokens: int | None = None,
@@ -1993,6 +2067,7 @@ async def run_runtime_loop(
         tool_selection=tool_selection,
         compaction_summarizer=compaction_summarizer,
         compaction_auto=compaction_auto,
+        compaction_rewrite_stored_history=compaction_rewrite_stored_history,
         compaction_tail_turns=compaction_tail_turns,
         compaction_preserve_recent_chars=compaction_preserve_recent_chars,
         compaction_preserve_recent_tokens=compaction_preserve_recent_tokens,
@@ -2148,6 +2223,17 @@ def _validate_optional_non_negative_int(value: Any, *, field_name: str) -> None:
     if value is None:
         return
     _validate_non_negative_int(value, field_name=field_name)
+
+
+def _validate_positive_int(value: Any, *, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field_name} must be a positive integer")
+
+
+def _validate_optional_positive_int(value: Any, *, field_name: str) -> None:
+    if value is None:
+        return
+    _validate_positive_int(value, field_name=field_name)
 
 
 def _validate_non_empty_string(value: Any, *, field_name: str) -> str:

--- a/src/efp_runtime/loop/runner.py
+++ b/src/efp_runtime/loop/runner.py
@@ -302,7 +302,12 @@ class RuntimeLoopRunner:
         self.tool_selection = _copy_tool_selection(tool_selection)
         self.compaction_summarizer = compaction_summarizer
         self.compaction_auto = bool(compaction_auto)
-        self.compaction_rewrite_stored_history = bool(compaction_rewrite_stored_history)
+        # Not bool(): this flag alone authorises rewriting the stored session,
+        # and bool() fails open -- the string "false" is truthy. See the same
+        # guard in RuntimeConfig.
+        if not isinstance(compaction_rewrite_stored_history, bool):
+            raise ValueError("compaction_rewrite_stored_history must be a boolean")
+        self.compaction_rewrite_stored_history = compaction_rewrite_stored_history
         self.compaction_tail_turns = compaction_tail_turns
         self.compaction_preserve_recent_chars = compaction_preserve_recent_chars
         self.compaction_preserve_recent_tokens = compaction_preserve_recent_tokens

--- a/src/efp_runtime/runtime/agent.py
+++ b/src/efp_runtime/runtime/agent.py
@@ -161,6 +161,7 @@ class AgentRuntime:
         context_reserve_chars: int | None = None,
         context_reserve_tokens: int | None = None,
         compaction_auto: bool | None = None,
+        compaction_rewrite_stored_history: bool | None = None,
         compaction_tail_turns: int | None = None,
         compaction_preserve_recent_chars: int | None = None,
         compaction_preserve_recent_tokens: int | None = None,
@@ -194,6 +195,7 @@ class AgentRuntime:
             context_reserve_chars=context_reserve_chars,
             context_reserve_tokens=context_reserve_tokens,
             compaction_auto=compaction_auto,
+            compaction_rewrite_stored_history=compaction_rewrite_stored_history,
             compaction_tail_turns=compaction_tail_turns,
             compaction_preserve_recent_chars=compaction_preserve_recent_chars,
             compaction_preserve_recent_tokens=compaction_preserve_recent_tokens,
@@ -673,6 +675,9 @@ class AgentRuntime:
                     else None
                 ),
                 compaction_auto=self.config.compaction_auto,
+                compaction_rewrite_stored_history=(
+                    self.config.compaction_rewrite_stored_history
+                ),
                 compaction_tail_turns=self.config.compaction_tail_turns,
                 compaction_preserve_recent_chars=(
                     self.config.compaction_preserve_recent_chars
@@ -901,6 +906,9 @@ class AgentRuntime:
                     else None
                 ),
                 compaction_auto=self.config.compaction_auto,
+                compaction_rewrite_stored_history=(
+                    self.config.compaction_rewrite_stored_history
+                ),
                 compaction_tail_turns=self.config.compaction_tail_turns,
                 compaction_preserve_recent_chars=(
                     self.config.compaction_preserve_recent_chars
@@ -2684,6 +2692,7 @@ def _resolve_config(
     context_reserve_tokens: int | None = None,
     metadata: Mapping[str, Any] | None,
     compaction_auto: bool | None = None,
+    compaction_rewrite_stored_history: bool | None = None,
     compaction_tail_turns: int | None = None,
     compaction_preserve_recent_chars: int | None = None,
     compaction_preserve_recent_tokens: int | None = None,
@@ -2702,6 +2711,11 @@ def _resolve_config(
             ),
             context_reserve_tokens=context_reserve_tokens,
             compaction_auto=True if compaction_auto is None else compaction_auto,
+            compaction_rewrite_stored_history=(
+                False
+                if compaction_rewrite_stored_history is None
+                else compaction_rewrite_stored_history
+            ),
             compaction_tail_turns=(
                 2 if compaction_tail_turns is None else compaction_tail_turns
             ),
@@ -2743,6 +2757,11 @@ def _resolve_config(
         enable_compaction_summarizer=config.enable_compaction_summarizer,
         compaction_auto=(
             compaction_auto if compaction_auto is not None else config.compaction_auto
+        ),
+        compaction_rewrite_stored_history=(
+            compaction_rewrite_stored_history
+            if compaction_rewrite_stored_history is not None
+            else config.compaction_rewrite_stored_history
         ),
         compaction_prune=config.compaction_prune,
         compaction_tail_turns=(

--- a/src/efp_runtime/runtime/config.py
+++ b/src/efp_runtime/runtime/config.py
@@ -27,6 +27,15 @@ class RuntimeConfig:
     context_reserve_chars: int = 0
     context_reserve_tokens: int | None = None
     compaction_auto: bool = True
+    # Off by default, and deliberately NOT implied by the context-budget size
+    # knobs above. A context budget sizes the in-memory provider request; the
+    # render-time compactor (context/render.py:prepare_history_for_request)
+    # keeps every request inside it on its own, with no persistence. This flag
+    # additionally rewrites the STORED session through
+    # SessionStore.replace_history - irreversibly, discarding the transcript the
+    # user reads in the Portal. "I want a smaller prompt" and "please rewrite my
+    # transcripts" are different requests, so they get different knobs.
+    compaction_rewrite_stored_history: bool = False
     compaction_prune: bool = True
     compaction_tail_turns: int = 2
     compaction_preserve_recent_chars: int | None = None
@@ -99,10 +108,17 @@ class RuntimeConfig:
             raise ValueError("max_iterations must be at least 1")
         if self.doom_loop_threshold is not None and self.doom_loop_threshold < 2:
             raise ValueError("doom_loop_threshold must be at least 2 or None")
-        if self.max_context_parts is not None and self.max_context_parts < 1:
-            raise ValueError("max_context_parts must be at least 1")
-        if self.max_context_chars is not None and self.max_context_chars < 1:
-            raise ValueError("max_context_chars must be at least 1")
+        # The three size caps are strictly positive. A bare ``< 1`` comparison
+        # let ``True`` through as a 1-part/1-char budget and raised a fieldless
+        # TypeError on a string; the shared validator names the field either way.
+        self.max_context_parts = _validate_optional_positive_int(
+            self.max_context_parts,
+            "max_context_parts",
+        )
+        self.max_context_chars = _validate_optional_positive_int(
+            self.max_context_chars,
+            "max_context_chars",
+        )
         self.default_provider_id = _validate_non_empty_string(
             self.default_provider_id,
             "default_provider_id",
@@ -111,12 +127,30 @@ class RuntimeConfig:
             self.default_model,
             "default_model",
         )
-        self.max_context_tokens = _validate_optional_non_negative_int(
+        # Zero is rejected, not coerced to None. ``max_context_chars`` already
+        # rejects it and the two knobs are interchangeable expressions of the
+        # same budget, so accepting ``max_context_tokens: 0`` - which yields a
+        # 1-character budget, i.e. every request reduced to system context plus
+        # the latest turn - would be indefensible. Coercing to None instead
+        # would need a second representation of "unset" (``max_context_chars is
+        # None`` is load-bearing in the reserve, preserve-recent and metadata
+        # branches) and would leave the config file saying 0 while the runtime
+        # silently ran the catalog default. To turn the knob off, omit the key.
+        self.max_context_tokens = _validate_optional_positive_int(
             self.max_context_tokens,
             "max_context_tokens",
         )
-        if self.context_reserve_chars < 0:
-            raise ValueError("context_reserve_chars must be at least 0")
+        # Reserves stay non-negative: 0 is meaningful and distinct from unset
+        # ("no response headroom", versus "use the model's declared reserve").
+        # The shared validator does tighten the TYPE here - a bare ``< 0`` let
+        # ``True`` and ``1000.0`` through, where the sibling
+        # ``context_reserve_tokens`` below has always rejected both. Deliberate:
+        # the two knobs feed the same arithmetic and should not disagree about
+        # what a reserve is.
+        self.context_reserve_chars = _validate_non_negative_int(
+            self.context_reserve_chars,
+            "context_reserve_chars",
+        )
         self.context_reserve_tokens = _validate_optional_non_negative_int(
             self.context_reserve_tokens,
             "context_reserve_tokens",
@@ -181,6 +215,9 @@ class RuntimeConfig:
             None if self.enabled_tools is None else list(self.enabled_tools)
         )
         self.compaction_auto = bool(self.compaction_auto)
+        self.compaction_rewrite_stored_history = bool(
+            self.compaction_rewrite_stored_history
+        )
         self.compaction_prune = bool(self.compaction_prune)
         self.enable_compaction_summarizer = bool(self.enable_compaction_summarizer)
         self.enable_context_overflow_retry = bool(self.enable_context_overflow_retry)
@@ -237,6 +274,18 @@ def _validate_optional_non_negative_int(value: Any, field_name: str) -> int | No
     if value is None:
         return None
     return _validate_non_negative_int(value, field_name)
+
+
+def _validate_positive_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field_name} must be a positive integer")
+    return int(value)
+
+
+def _validate_optional_positive_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    return _validate_positive_int(value, field_name)
 
 
 def _validate_non_empty_string(value: Any, field_name: str) -> str:

--- a/src/efp_runtime/runtime/config.py
+++ b/src/efp_runtime/runtime/config.py
@@ -215,8 +215,16 @@ class RuntimeConfig:
             None if self.enabled_tools is None else list(self.enabled_tools)
         )
         self.compaction_auto = bool(self.compaction_auto)
-        self.compaction_rewrite_stored_history = bool(
-            self.compaction_rewrite_stored_history
+        # Deliberately stricter than its neighbours, which all coerce with
+        # bool(). This flag alone authorises rewriting the stored session, and
+        # bool() fails OPEN: the string "false" is truthy, so a value that
+        # stringified anywhere on the way in would silently start destroying
+        # transcripts. The size caps in this same class reject rather than
+        # coerce for the weaker reason that coercion ignores what the operator
+        # wrote; that argument is strictly stronger here.
+        self.compaction_rewrite_stored_history = _validate_bool(
+            self.compaction_rewrite_stored_history,
+            "compaction_rewrite_stored_history",
         )
         self.compaction_prune = bool(self.compaction_prune)
         self.enable_compaction_summarizer = bool(self.enable_compaction_summarizer)
@@ -286,6 +294,12 @@ def _validate_optional_positive_int(value: Any, field_name: str) -> int | None:
     if value is None:
         return None
     return _validate_positive_int(value, field_name)
+
+
+def _validate_bool(value: Any, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a boolean")
+    return value
 
 
 def _validate_non_empty_string(value: Any, field_name: str) -> str:

--- a/tests/runtime/test_auto_session_compaction.py
+++ b/tests/runtime/test_auto_session_compaction.py
@@ -107,6 +107,89 @@ def test_runtime_config_validates_auto_compaction_integers(kwargs):
 
 
 @pytest.mark.asyncio
+async def test_size_knob_alone_does_not_rewrite_stored_history():
+    """A context budget sizes the request; it must not rewrite the transcript.
+
+    Before ``compaction_rewrite_stored_history`` existed, setting any of
+    max_context_parts/chars/tokens silently also opted the deployment into
+    ``SessionStore.replace_history`` - so "I want a smaller prompt" and "please
+    rewrite my transcripts" were the same statement. The request still has to
+    come out bounded, which is the render-time compactor's job, not the stored
+    one's.
+    """
+
+    store = InMemorySessionStore()
+    _seed_history(store, "session-size-only")
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runner = _runner(
+        store,
+        provider,
+        max_context_parts=3,
+        compaction_tail_turns=1,
+    )
+
+    result = await runner.run(
+        session_id="session-size-only",
+        user_text="latest request",
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    # The transcript is intact: every seeded message is still there.
+    stored = store.read_history("session-size-only")
+    assert [message.message_id for message in stored[:4]] == [
+        "msg-old-0",
+        "msg-old-1",
+        "msg-old-2",
+        "msg-old-3",
+    ]
+    assert _compaction_parts(stored) == []
+    assert _replay_messages(stored) == []
+    assert _events(result, "session_compaction_started") == []
+    assert _events(result, "session_compacted") == []
+    # ...and the request was still bounded by the knob the operator set.
+    assert provider.requests[0].prepared_request.compaction_applied is True
+    assert provider.requests[0].provider_request.messages[-1].text == "latest request"
+
+
+@pytest.mark.asyncio
+async def test_rewrite_flag_alone_without_a_size_knob_rewrites_stored_history():
+    """The opt-in is sufficient on its own; it does not need a size knob too.
+
+    Requiring a second knob would make the flag silently do nothing, which is
+    the same class of surprise this separation removes. With no cap set the
+    budget is the catalog-derived one, so the history has to exceed that.
+    """
+
+    store = InMemorySessionStore()
+    store.create_session(session_id="session-flag-only")
+    for index in range(40):
+        store.append_message(
+            "session-flag-only",
+            role=MessageRole.USER if index % 2 == 0 else MessageRole.ASSISTANT,
+            parts=[MessagePart.text_part("word " * 9_000)],
+            message_id=f"msg-bulk-{index}",
+            status="complete",
+        )
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runner = _runner(
+        store,
+        provider,
+        compaction_rewrite_stored_history=True,
+        compaction_tail_turns=1,
+    )
+
+    result = await runner.run(
+        session_id="session-flag-only",
+        user_text="latest request",
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    stored = store.read_history("session-flag-only")
+    assert _compaction_parts(stored)
+    assert len(_events(result, "session_compacted")) == 1
+
+
+@pytest.mark.asyncio
 async def test_auto_compaction_persists_before_provider_and_request_includes_latest():
     store = InMemorySessionStore()
     _seed_history(store, "session-auto")
@@ -116,6 +199,7 @@ async def test_auto_compaction_persists_before_provider_and_request_includes_lat
         store,
         provider,
         max_context_parts=3,
+        compaction_rewrite_stored_history=True,
         compaction_tail_turns=1,
         event_bus=bus,
     )
@@ -180,6 +264,7 @@ async def test_token_budget_converts_to_char_budget_for_auto_compaction():
         max_context_tokens=20,
         context_reserve_tokens=5,
         compaction_preserve_recent_tokens=20,
+        compaction_rewrite_stored_history=True,
         compaction_tail_turns=1,
     )
 
@@ -255,6 +340,7 @@ async def test_max_context_chars_takes_priority_over_token_budget():
         max_context_tokens=10,
         context_reserve_tokens=5,
         compaction_preserve_recent_tokens=20,
+        compaction_rewrite_stored_history=True,
         compaction_tail_turns=1,
     )
 
@@ -286,6 +372,7 @@ async def test_auto_compaction_tail_zero_synthetic_replays_active_user():
         store,
         provider,
         max_context_parts=1,
+        compaction_rewrite_stored_history=True,
         compaction_tail_turns=0,
     )
 
@@ -329,6 +416,9 @@ async def test_compaction_auto_false_leaves_stored_session_unchanged():
         store,
         provider,
         max_context_parts=3,
+        # Opted in to stored rewriting, so compaction_auto is provably the thing
+        # suppressing it - not the rewrite gate one check earlier.
+        compaction_rewrite_stored_history=True,
         compaction_auto=False,
     )
 
@@ -359,6 +449,9 @@ async def test_provider_only_context_messages_are_not_persisted():
         store,
         provider,
         max_context_parts=3,
+        # The claim under test is that a stored REWRITE never pulls provider-only
+        # context into the transcript, so the rewrite has to actually happen.
+        compaction_rewrite_stored_history=True,
         compaction_tail_turns=1,
     )
     provider_only = Message.from_text(
@@ -400,6 +493,7 @@ async def test_overflow_retry_persists_overflow_compaction_and_retries_once():
         store,
         provider,
         max_context_parts=10,
+        compaction_rewrite_stored_history=True,
         compaction_tail_turns=1,
     )
 
@@ -443,6 +537,7 @@ async def test_overflow_retry_request_contains_replayed_active_user():
         store,
         provider,
         max_context_parts=1,
+        compaction_rewrite_stored_history=True,
         compaction_tail_turns=0,
     )
 
@@ -479,6 +574,7 @@ async def test_compaction_replay_replaces_attachment_with_placeholder_text():
         store,
         provider,
         max_context_parts=1,
+        compaction_rewrite_stored_history=True,
         compaction_tail_turns=0,
     )
     attachment = Attachment(
@@ -526,6 +622,7 @@ async def test_resume_path_uses_auto_session_compaction():
         config=RuntimeConfig(
             max_iterations=2,
             max_context_parts=3,
+            compaction_rewrite_stored_history=True,
             compaction_tail_turns=1,
             include_default_system_prompt=False,
             include_runtime_reminders=False,
@@ -542,3 +639,59 @@ async def test_resume_path_uses_auto_session_compaction():
     stored_compactions = _compaction_parts(store.read_history("session-resume"))
     assert len(stored_compactions) == 1
     assert stored_compactions[0].compaction.metadata["trigger"] == "context_budget"
+
+
+@pytest.mark.parametrize("rewrite_stored_history", [True, False])
+@pytest.mark.asyncio
+async def test_run_path_plumbs_stored_history_rewrite_flag(rewrite_stored_history):
+    """AgentRuntime.run must hand the opt-in to the runner it builds.
+
+    ``run`` - not ``resume`` - is the only route the Portal opt-in travels in
+    production (runtime profile -> PORTAL_MANAGED_RUNTIME_FIELDS ->
+    RuntimeConfig -> AgentRuntime.run -> RuntimeLoopRunner), and sub-agents
+    reach the runner the same way. Asserting on the RuntimeConfig object is not
+    enough: dropping the kwarg from the ``run`` construction site leaves the
+    config correct and the flag dead, which is precisely the silent no-op this
+    knob exists to prevent.
+    """
+
+    session_id = f"session-run-plumbing-{rewrite_stored_history}"
+    store = InMemorySessionStore()
+    _seed_history(store, session_id)
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runtime = AgentRuntime(
+        provider=provider,
+        store=store,
+        config=RuntimeConfig(
+            max_iterations=2,
+            max_context_parts=3,
+            compaction_rewrite_stored_history=rewrite_stored_history,
+            compaction_tail_turns=1,
+            include_default_system_prompt=False,
+            include_runtime_reminders=False,
+        ),
+    )
+
+    result = await runtime.run("latest request", session_id=session_id)
+
+    assert result.status == LoopStatus.COMPLETED
+    stored = store.read_history(session_id)
+    stored_compactions = _compaction_parts(stored)
+    if rewrite_stored_history:
+        assert len(stored_compactions) == 1
+        assert stored_compactions[0].compaction.metadata["trigger"] == "context_budget"
+        assert _events(result, "session_compacted")
+    else:
+        assert stored_compactions == []
+        assert _events(result, "session_compacted") == []
+        # The transcript survives untouched even though the size knob is set...
+        assert [message.message_id for message in stored[:4]] == [
+            "msg-old-0",
+            "msg-old-1",
+            "msg-old-2",
+            "msg-old-3",
+        ]
+        # ...and the request is still bounded, by the render-time compactor.
+        assert provider.requests[0].prepared_request.compaction_applied is True
+    # Either way the model saw the latest turn last.
+    assert provider.requests[0].provider_request.messages[-1].text == "latest request"

--- a/tests/runtime/test_config_loader.py
+++ b/tests/runtime/test_config_loader.py
@@ -564,6 +564,10 @@ def test_model_context_budget_snake_case_aliases_are_consumed(tmp_path: Path):
         {"provider_id": " "},
         {"defaultModel": ""},
         {"max_context_tokens": -1},
+        # 0 is the plausible "disable it" typo, and it used to be accepted here.
+        {"max_context_tokens": 0},
+        {"maxContextTokens": 0},
+        {"maxContextTokens": True},
         {"contextReserveTokens": -1},
         {"compaction": {"preserve_recent_tokens": -1}},
     ],

--- a/tests/runtime/test_context_compaction_policy.py
+++ b/tests/runtime/test_context_compaction_policy.py
@@ -119,6 +119,48 @@ def test_runtime_config_rejects_bool_and_non_int_context_ints(field: str, value)
         RuntimeConfig(**{field: value})
 
 
+@pytest.mark.parametrize("value", ["false", "true", 1, 0, None, "", 1.0])
+def test_runtime_config_rejects_non_bool_stored_history_rewrite(value):
+    """This flag is validated strictly while its neighbours use ``bool()``.
+
+    ``bool()`` fails OPEN here: ``bool("false")`` is ``True``, so a value that
+    stringified anywhere on the way in -- an HTML form, a Portal profile that
+    stores booleans as text -- would silently authorise rewriting the user's
+    stored transcript. Every other ``compaction_*`` flag is non-destructive on
+    its own, which is why only this one is strict.
+    """
+
+    with pytest.raises(ValueError, match="compaction_rewrite_stored_history"):
+        RuntimeConfig(compaction_rewrite_stored_history=value)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_runtime_config_accepts_real_bool_stored_history_rewrite(value):
+    assert (
+        RuntimeConfig(compaction_rewrite_stored_history=value)
+        .compaction_rewrite_stored_history
+        is value
+    )
+
+
+@pytest.mark.parametrize("value", ["false", 1, None])
+def test_runner_rejects_non_bool_stored_history_rewrite(value):
+    """The runner takes the flag directly, so it needs its own guard."""
+
+    from efp_runtime.loop.runner import RuntimeLoopRunner
+    from efp_runtime.session.store import InMemorySessionStore
+    from efp_runtime.tools.registry import ToolRegistry
+    from efp_runtime.tools.runtime import ToolRuntime
+
+    with pytest.raises(ValueError, match="compaction_rewrite_stored_history"):
+        RuntimeLoopRunner(
+            store=InMemorySessionStore(),
+            provider=None,
+            tool_runtime=ToolRuntime(ToolRegistry()),
+            compaction_rewrite_stored_history=value,
+        )
+
+
 @pytest.mark.parametrize("field", ["default_provider_id", "default_model"])
 def test_runtime_config_rejects_blank_model_context_strings(field: str):
     with pytest.raises(ValueError, match=field):

--- a/tests/runtime/test_context_compaction_policy.py
+++ b/tests/runtime/test_context_compaction_policy.py
@@ -56,6 +56,69 @@ def test_runtime_config_rejects_negative_compaction_policy_ints(field: str):
         RuntimeConfig(**{field: -1})
 
 
+@pytest.mark.parametrize(
+    "field",
+    ["max_context_parts", "max_context_chars", "max_context_tokens"],
+)
+def test_runtime_config_rejects_zero_context_size_caps(field: str):
+    """Zero is a typo, not a way to disable a cap.
+
+    ``max_context_tokens: 0`` used to be accepted and produced a one-character
+    budget - every request cut to system context plus the latest turn - while
+    also flipping the deployment into rewriting stored history at that budget.
+    It is rejected rather than coerced to None so the config file can never say
+    ``0`` while the runtime silently runs the catalog default; the way to turn a
+    cap off is to omit the key.
+    """
+
+    with pytest.raises(ValueError, match=field):
+        RuntimeConfig(**{field: 0})
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "context_reserve_chars",
+        "context_reserve_tokens",
+        "compaction_reserved_chars",
+        "compaction_preserve_recent_chars",
+        "compaction_preserve_recent_tokens",
+    ],
+)
+def test_runtime_config_keeps_zero_reserve_knobs(field: str):
+    """Zero is meaningful for a reserve and must stay legal.
+
+    "No response headroom, spend the whole budget on prompt" is distinct from
+    unset ("use the model's declared reserve"), and a zero reserve cannot shrink
+    the prompt budget. Only the three size caps are strictly positive; pinned so
+    a later consistency cleanup cannot sweep these up with them.
+    """
+
+    assert getattr(RuntimeConfig(**{field: 0}), field) == 0
+
+
+@pytest.mark.parametrize("value", [True, False, "5", 2.5])
+@pytest.mark.parametrize(
+    "field",
+    [
+        "max_context_parts",
+        "max_context_chars",
+        "max_context_tokens",
+        "context_reserve_chars",
+    ],
+)
+def test_runtime_config_rejects_bool_and_non_int_context_ints(field: str, value):
+    """These four were validated by a bare ``<`` comparison.
+
+    ``True`` therefore passed as a 1-unit budget (``True < 1`` is False) and a
+    string raised a fieldless TypeError from the comparison itself rather than a
+    ValueError naming the field.
+    """
+
+    with pytest.raises(ValueError, match=field):
+        RuntimeConfig(**{field: value})
+
+
 @pytest.mark.parametrize("field", ["default_provider_id", "default_model"])
 def test_runtime_config_rejects_blank_model_context_strings(field: str):
     with pytest.raises(ValueError, match=field):
@@ -156,6 +219,43 @@ def test_config_loader_maps_top_level_compaction_policy_fields(tmp_path: Path):
     assert result.config.compaction_reserved_chars == 8000
     assert result.config.compaction_tool_output_max_chars == 1900
     assert result.metadata["unconsumed_config"] == {}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"compaction": {"rewrite_stored_history": True}},
+        {"compaction": {"rewriteStoredHistory": True}},
+        {"compaction_rewrite_stored_history": True},
+    ],
+)
+def test_config_loader_maps_the_stored_history_rewrite_opt_in(
+    tmp_path: Path,
+    payload: dict[str, object],
+):
+    """A config file can set only max_context_tokens of the size knobs.
+
+    Without this alias, an efp.json deployment that used to get stored-history
+    rewriting implied by that one knob would have no way to ask for it back.
+    """
+
+    _write_json(tmp_path / "policy.json", payload)
+
+    result = load_runtime_config(
+        tmp_path,
+        paths=["policy.json"],
+        include_defaults=False,
+    )
+
+    assert result.config.compaction_rewrite_stored_history is True
+    assert result.metadata["unconsumed_config"] == {}
+
+
+def test_runtime_config_defaults_to_not_rewriting_stored_history():
+    assert RuntimeConfig().compaction_rewrite_stored_history is False
+    assert RuntimeConfig(max_context_tokens=1000).compaction_rewrite_stored_history is (
+        False
+    )
 
 
 def test_tail_turn_strategy_keeps_last_two_user_turns_and_marks_tail_start():

--- a/tests/runtime/test_model_catalog_context_budget.py
+++ b/tests/runtime/test_model_catalog_context_budget.py
@@ -196,6 +196,303 @@ def test_explicit_config_metadata_still_names_the_explicit_source():
     assert metadata["context_safety_margin_tokens"] is None
 
 
+def test_runner_rejects_zero_and_bool_context_size_caps():
+    """The runner constructor is a second, hand-written copy of these guards.
+
+    RuntimeConfig and RuntimeLoopRunner validate the same knobs in separate
+    code; without a mirror test here they can drift apart again.
+    """
+
+    for field in ["max_context_tokens", "max_context_chars", "max_context_parts"]:
+        for value in [0, -1, True, "5"]:
+            with pytest.raises(ValueError, match=field):
+                _runner(
+                    InMemorySessionStore(),
+                    ScriptedLLMProvider([]),
+                    **{field: value},
+                )
+
+
+# --------------------------------------------------------------------------
+# ...but an explicit budget larger than the model can take is clamped
+# --------------------------------------------------------------------------
+
+
+def test_over_window_max_context_tokens_is_clamped_to_the_catalog_ceiling():
+    """10M tokens on a 400k model reproduces the exact 400 the default prevents.
+
+    Nothing compared the explicit value against the model window, so an
+    over-window override sailed straight through to the provider.
+    """
+
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_tokens=10_000_000,
+    )
+
+    budget = runner._context_budget()
+
+    assert budget.max_chars == SOL_MAX_CHARS  # was 40_000_000
+    assert budget.reserve_chars == SOL_RESERVE_CHARS
+    assert budget.effective_max_chars == SOL_MAX_CHARS - SOL_RESERVE_CHARS
+    # Clamping lands on the same budget as no override at all, not a third value.
+    assert budget.max_chars == _runner(
+        InMemorySessionStore(), ScriptedLLMProvider([])
+    )._context_budget().max_chars
+
+
+def test_over_window_max_context_chars_is_clamped_too():
+    """The chars route is unbounded in exactly the same way.
+
+    But the clamp bounds the CAP, not the final prompt, and the two routes hold
+    back different reserves (see
+    test_tokens_and_chars_routes_keep_their_asymmetric_reserves). So a clamped
+    max_context_chars does NOT land on the unset path's effective budget the way
+    a clamped max_context_tokens does - it keeps its zero reserve and authorises
+    the whole ceiling. That is in-spec (the ceiling already excludes the safety
+    margin, so it is still inside the declared window) but it is not parity, and
+    it is pinned here so it cannot change unnoticed.
+    """
+
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_chars=10_000_000,
+    )
+
+    budget = runner._context_budget()
+
+    assert budget.max_chars == SOL_MAX_CHARS  # was 10_000_000
+    assert budget.reserve_chars == 0
+    assert budget.effective_max_chars == SOL_MAX_CHARS
+    # ~392_000 tokens: below the 400_000 window, above the 264_000 that the
+    # unset path and a clamped max_context_tokens both produce.
+    assert budget.effective_max_chars // 4 == SOL_WINDOW_TOKENS - SOL_SAFETY_TOKENS
+    assert budget.effective_max_chars > (SOL_MAX_CHARS - SOL_RESERVE_CHARS)
+
+
+def test_clamped_chars_route_metadata_reports_the_in_force_token_numbers():
+    """The clamp fills in two token fields the chars route otherwise leaves None.
+
+    A consumer reading ``max_context_tokens`` off a chars-configured runtime
+    gets ``None`` normally and an int once the clamp fires, because the catalog
+    ceiling - which is token-denominated - has become the budget. Pinned so the
+    type change is a decision rather than a surprise.
+    """
+
+    unclamped = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_chars=1_000_000,
+    )._model_context_budget_metadata()
+    clamped = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_chars=10_000_000,
+    )._model_context_budget_metadata()
+
+    assert unclamped["context_safety_margin_tokens"] is None
+    assert unclamped["max_context_tokens"] is None
+    assert unclamped["context_budget"]["max_context_chars_clamped"] is False
+
+    assert clamped["context_safety_margin_tokens"] == SOL_SAFETY_TOKENS
+    assert clamped["max_context_tokens"] == SOL_WINDOW_TOKENS - SOL_SAFETY_TOKENS
+    assert clamped["context_budget"]["max_context_chars_clamped"] is True
+    # The source still names the knob the operator actually set.
+    assert clamped["context_budget"]["max_context_chars_source"] == "max_context_chars"
+    assert clamped["context_budget"]["max_context_chars_requested"] == 10_000_000
+
+
+def test_a_budget_exactly_at_the_ceiling_is_not_clamped():
+    """Pins the comparison as ``>``, not ``>=``.
+
+    Otherwise the largest legal budget would report itself as clamped and drag
+    the token metadata fields along with it.
+    """
+
+    at_ceiling = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_chars=SOL_MAX_CHARS,
+    )._model_context_budget_metadata()
+
+    assert at_ceiling["context_budget"]["max_context_chars_clamped"] is False
+    assert at_ceiling["context_budget"]["max_chars"] == SOL_MAX_CHARS
+    assert at_ceiling["max_context_tokens"] is None
+
+    one_over = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_chars=SOL_MAX_CHARS + 1,
+    )._model_context_budget_metadata()
+
+    assert one_over["context_budget"]["max_context_chars_clamped"] is True
+    assert one_over["context_budget"]["max_chars"] == SOL_MAX_CHARS
+
+
+def test_clamp_uses_each_models_own_window():
+    """The ceiling is per-profile, resolved per request, not a constant."""
+
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        default_model="gpt-5.6-luna",
+        max_context_tokens=10_000_000,
+    )
+
+    assert runner._context_budget().max_chars == (328_000 - 8_000) * 4
+
+
+def test_unknown_model_override_is_never_clamped():
+    """The required design: the fallback profile is exempt.
+
+    A newly released or gateway-only model resolves to the 64k conservative
+    fallback, and an operator override is the only way to correct that guess.
+    Clamping it to the fallback ceiling would defeat the override's only
+    purpose, so an uncatalogued model's explicit budget is honoured verbatim.
+    """
+
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        default_model="some-unlisted-model",
+        max_context_tokens=1_000_000,
+    )
+
+    budget = runner._context_budget()
+
+    # The fallback ceiling would have been (64_000 - 3_200) * 4 == 243_200.
+    assert budget.max_chars == 4_000_000
+    assert budget.effective_max_chars == 4_000_000 - 4_000 * 4
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_max_chars"),
+    [
+        ({"max_context_tokens": 250_000}, 1_000_000),
+        ({"max_context_chars": 1_000_000}, 1_000_000),
+        ({"max_context_tokens": 50_000}, 200_000),
+        ({"max_context_chars": 100_000}, 100_000),
+    ],
+)
+def test_sub_window_explicit_budgets_are_untouched_by_the_clamp(
+    kwargs, expected_max_chars
+):
+    runner = _runner(InMemorySessionStore(), ScriptedLLMProvider([]), **kwargs)
+
+    assert runner._context_budget().max_chars == expected_max_chars
+
+
+def test_clamped_budget_metadata_records_the_clamp():
+    """A clamp must never be silent - the operator's number stops being used."""
+
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_tokens=10_000_000,
+    )
+
+    metadata = runner._model_context_budget_metadata()
+    context_budget = metadata["context_budget"]
+
+    assert context_budget["max_context_chars_source"] == "max_context_tokens"
+    assert context_budget["max_context_chars_requested"] == 40_000_000
+    assert context_budget["max_context_chars_limit"] == SOL_MAX_CHARS
+    assert context_budget["max_context_chars_clamped"] is True
+    assert context_budget["max_chars"] == SOL_MAX_CHARS
+    # The token-denominated fields describe the budget actually in force, not
+    # the rejected request; the original stays visible as ..._requested.
+    assert metadata["context_safety_margin_tokens"] == SOL_SAFETY_TOKENS
+    assert metadata["max_context_tokens"] == SOL_WINDOW_TOKENS - SOL_SAFETY_TOKENS
+
+
+def test_unclamped_budget_metadata_reports_no_clamp():
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_tokens=250_000,
+    )
+
+    context_budget = runner._model_context_budget_metadata()["context_budget"]
+
+    assert context_budget["max_context_chars_requested"] == 1_000_000
+    assert context_budget["max_context_chars_limit"] == SOL_MAX_CHARS
+    assert context_budget["max_context_chars_clamped"] is False
+    assert runner._model_context_budget_metadata()["max_context_tokens"] == 250_000
+
+
+def test_fallback_profile_metadata_reports_no_ceiling_at_all():
+    """An uncatalogued model advertises that no ceiling was applicable.
+
+    ``max_context_chars_limit is None`` alone does not distinguish this from
+    "nothing configured" - the unset case reports None too (see
+    test_unset_budget_metadata_has_nothing_to_clamp). The pair does: a non-null
+    ``_requested`` next to a null ``_limit`` means "an override was set and
+    deliberately not clamped", which is the state an operator debugging an
+    uncatalogued model needs to see.
+    """
+
+    runner = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        default_model="some-unlisted-model",
+        max_context_tokens=1_000_000,
+    )
+
+    context_budget = runner._model_context_budget_metadata()["context_budget"]
+
+    assert context_budget["max_context_chars_source"] == "max_context_tokens"
+    assert context_budget["max_context_chars_requested"] == 4_000_000
+    assert context_budget["max_context_chars_limit"] is None
+    assert context_budget["max_context_chars_clamped"] is False
+
+
+def test_unset_budget_metadata_has_nothing_to_clamp():
+    context_budget = _runner(
+        InMemorySessionStore(), ScriptedLLMProvider([])
+    )._model_context_budget_metadata()["context_budget"]
+
+    assert context_budget["max_context_chars_requested"] is None
+    assert context_budget["max_context_chars_limit"] is None
+    assert context_budget["max_context_chars_clamped"] is False
+
+
+def test_tokens_and_chars_routes_keep_their_asymmetric_reserves():
+    """Pins a deliberate asymmetry. Do NOT "fix" this test by equalising them.
+
+    ``max_context_tokens`` is read as a context WINDOW and has the model's
+    declared response reserve subtracted; ``max_context_chars`` is read as a
+    prompt BUDGET and has nothing subtracted. So the same nominal size yields a
+    2x different prompt. This predates the model-catalog default (it arrived
+    with the Runtime v2 baseline, #521) and both directions of changing it are
+    behaviour changes to explicitly-configured deployments, so #583 documented
+    the real numbers in config.yaml.example instead of altering them. This test
+    exists so the asymmetry cannot drift silently in either direction.
+    """
+
+    tokens_budget = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_tokens=250_000,
+    )._context_budget()
+    chars_budget = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_chars=1_000_000,
+    )._context_budget()
+
+    assert tokens_budget.max_chars == 1_000_000
+    assert tokens_budget.reserve_chars == 500_000  # 512_000 reserve, clamped to half
+    assert tokens_budget.effective_max_chars == 500_000  # ~125_000 tokens
+
+    assert chars_budget.max_chars == 1_000_000
+    assert chars_budget.reserve_chars == 0
+    assert chars_budget.effective_max_chars == 1_000_000  # ~250_000 tokens
+
+    assert chars_budget.effective_max_chars == 2 * tokens_budget.effective_max_chars
+
+
 # --------------------------------------------------------------------------
 # The reserve may never swallow the budget
 # --------------------------------------------------------------------------
@@ -332,6 +629,71 @@ async def test_request_compaction_is_reported_as_a_runtime_event():
     assert not [
         event for event in result.runtime_events if event.type == "session_compacted"
     ]
+
+
+@pytest.mark.asyncio
+async def test_over_window_override_produces_a_bounded_request_end_to_end():
+    """The clamp has to bind a real provider request, not just a private method.
+
+    Every other clamp test pokes ``_context_budget()``. This one proves the
+    clamped ceiling actually reaches ``prepare_history_for_request``: without
+    the clamp a 10M-token override sends the whole 1.8M-char history verbatim,
+    which is the provider 400 the catalog default exists to prevent.
+    """
+
+    store = InMemorySessionStore()
+    _seed_large_history(store, "session-over-window", messages=40, chars=1_800_000)
+    provider = ScriptedLLMProvider([{"content": "Done."}])
+    runner = _runner(store, provider, max_context_tokens=10_000_000)
+
+    result = await runner.run(
+        session_id="session-over-window",
+        user_text="latest request",
+    )
+
+    assert result.status == LoopStatus.COMPLETED
+    request = provider.requests[0]
+    assert request.prepared_request.compaction_applied is True
+    assert _request_chars(request.provider_request) < SOL_MAX_CHARS
+    assert (
+        request.prepared_request.compaction_metadata["kept_chars"]
+        <= SOL_MAX_CHARS - SOL_RESERVE_CHARS
+    )
+    # ...and the clamp is legible on the event the compaction emits.
+    events = [
+        event for event in result.runtime_events if event.type == "request_compacted"
+    ]
+    assert events[0].payload["context_budget"]["max_context_chars_clamped"] is True
+    assert events[0].payload["context_budget"]["max_context_chars_requested"] == (
+        40_000_000
+    )
+    # The size knob alone still does not touch the transcript.
+    assert not [
+        event for event in result.runtime_events if event.type == "session_compacted"
+    ]
+
+
+@pytest.mark.parametrize("rewrite_stored_history", [True, False])
+def test_budget_metadata_reports_whether_stored_history_gets_rewritten(
+    rewrite_stored_history,
+):
+    """The rewrite gate must be readable, not inferable from missing events.
+
+    Its only other signal is the ABSENCE of session_compaction_started /
+    session_compacted, which tells an operator nothing unless they already knew
+    the flag existed - and the deployment it changes most (a size knob set,
+    stored rewriting now off, session files growing) is exactly the one that
+    would not.
+    """
+
+    context_budget = _runner(
+        InMemorySessionStore(),
+        ScriptedLLMProvider([]),
+        max_context_tokens=50_000,
+        compaction_rewrite_stored_history=rewrite_stored_history,
+    )._model_context_budget_metadata()["context_budget"]
+
+    assert context_budget["stored_history_rewrite"] is rewrite_stored_history
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_model_context_profiles.py
+++ b/tests/runtime/test_model_context_profiles.py
@@ -8,6 +8,7 @@ from efp_runtime.llm.models import (
     ModelContextProfile,
     SUPPORTED_COPILOT_MODEL_IDS,
     canonicalize_copilot_model_id,
+    is_catalog_model_context_profile,
     resolve_model_context_profile,
     tokens_to_chars,
 )
@@ -78,6 +79,30 @@ def test_non_copilot_qualified_model_still_uses_copilot_fallback():
     assert profile.provider_id == DEFAULT_PROVIDER_ID
     assert profile.model_id == "custom-model"
     assert profile.context_window_tokens == 64_000
+
+
+@pytest.mark.parametrize(
+    "model",
+    [*SUPPORTED_COPILOT_MODEL_IDS, "github-copilot/gpt-5.6-sol", "gpt-5.6 sol"],
+)
+def test_catalog_hit_is_distinguishable_from_the_conservative_fallback(model: str):
+    assert is_catalog_model_context_profile(resolve_model_context_profile(model)) is True
+
+
+@pytest.mark.parametrize("model", ["some-new-model", "other-provider/custom-model"])
+def test_fallback_profile_is_not_reported_as_a_catalog_hit(model: str):
+    """``model_id`` alone cannot tell the two apart, and callers depend on this.
+
+    ``resolve_model_context_profile`` stamps the requested id onto a copy of the
+    conservative fallback, so a miss reports its own id next to a 64k window it
+    never declared. The context-budget clamp must not narrow an operator's
+    override on one of these.
+    """
+
+    profile = resolve_model_context_profile(model)
+
+    assert profile.context_window_tokens == 64_000
+    assert is_catalog_model_context_profile(profile) is False
 
 
 def test_tokens_to_chars_is_deterministic_and_validated():

--- a/tests/runtime/test_permission_config.py
+++ b/tests/runtime/test_permission_config.py
@@ -593,6 +593,46 @@ def test_resolve_config_and_child_config_preserve_tool_permissions(tmp_path: Pat
     assert child.metadata["child"] is True
 
 
+@pytest.mark.parametrize("enabled", [True, False])
+def test_resolve_config_and_child_config_preserve_stored_history_rewrite(
+    tmp_path: Path,
+    enabled: bool,
+):
+    """Both builders re-materialise RuntimeConfig from hand-written field lists.
+
+    ``_resolve_config`` runs on every ``AgentRuntime(config=...)`` and
+    ``_child_config`` on every sub-agent. A field missing from either list is
+    dropped back to its default with no error - so an opt-in set by an operator
+    would silently not apply, which is exactly the class of surprise this flag
+    exists to remove. Sub-agent sessions land in the same store and are equally
+    Portal-visible, so the parent's choice has to reach them.
+    """
+
+    base = RuntimeConfig(
+        workspace_root=tmp_path,
+        compaction_rewrite_stored_history=enabled,
+    )
+
+    resolved = _resolve_config(
+        base,
+        workspace_root=None,
+        max_iterations=None,
+        max_context_parts=None,
+        max_context_chars=None,
+        context_reserve_chars=None,
+        metadata=None,
+    )
+    child = _child_config(
+        profile=AgentProfile(name="general"),
+        base_config=base,
+        workspace_root=None,
+        metadata={},
+    )
+
+    assert resolved.compaction_rewrite_stored_history is enabled
+    assert child.compaction_rewrite_stored_history is enabled
+
+
 @pytest.mark.asyncio
 async def test_permission_config_does_not_control_tool_schema_visibility(
     tmp_path: Path,

--- a/tests/runtime/test_provider_retry_overflow.py
+++ b/tests/runtime/test_provider_retry_overflow.py
@@ -644,6 +644,52 @@ async def test_overflow_retry_shrinks_request_without_rewriting_stored_history()
     assert provider.requests[1].prepared_request.compaction_applied is True
 
 
+@pytest.mark.asyncio
+async def test_overflow_retry_shrinks_request_with_a_size_knob_and_no_stored_rewrite():
+    """The sibling of the stock-runner test, but with a size cap configured.
+
+    A configured cap used to imply stored-history rewriting, which pre-shrank
+    attempt #1. Now it does not, so attempt #1 is larger than it used to be -
+    but the retry still lands on the same halved render-time budget and still
+    recovers, with the transcript intact. That is the whole argument for
+    decoupling: the size knob keeps doing its job without the disk rewrite.
+    """
+
+    provider = SequenceProvider(
+        [
+            ProviderContextOverflowError("context too long"),
+            {"content": "Recovered without rewriting the transcript."},
+        ]
+    )
+    store = InMemorySessionStore()
+    runner = RuntimeLoopRunner(
+        store=store,
+        provider=provider,
+        tool_runtime=ToolRuntime(ToolRegistry()),
+        max_context_parts=5,
+    )
+    seeded = _old_session(*_STOCK_BUDGET_TURN_TEXTS)
+    seeded_messages = [_stored_fingerprint(message) for message in seeded.messages]
+
+    result = await runner.run(session=seeded, user_text="latest request")
+
+    assert result.status == LoopStatus.COMPLETED
+    assert len(provider.requests) == 2
+    assert len(_events(result, "provider.context_overflow_retry")) == 1
+
+    stored = store.read_history("session-provider-retry")
+    assert [
+        _stored_fingerprint(message) for message in stored[: len(seeded_messages)]
+    ] == seeded_messages
+    assert _events(result, "session_compacted") == []
+    assert _events(result, "session_compaction_started") == []
+
+    first_chars = sum(len(text) for _role, text in provider.message_snapshots[0])
+    retry_chars = sum(len(text) for _role, text in provider.message_snapshots[1])
+    assert retry_chars < first_chars
+    assert provider.message_snapshots[1][-1] == ("user", "latest request")
+
+
 def test_provider_retry_error_import_boundary():
     code = """
 import json

--- a/tests/runtime/test_runtime_chat_gateway.py
+++ b/tests/runtime/test_runtime_chat_gateway.py
@@ -357,6 +357,7 @@ async def test_runtime_chat_applies_trusted_portal_runtime_profile_config(monkey
         "active_skills": ["review"],
         "command_directories": ["/workspace/.efp/commands"],
         "compaction_auto": False,
+        "compaction_rewrite_stored_history": True,
         "max_context_tokens": 64000,
         "system_prompt_texts": ["system"],
         "instruction_texts": ["instruction"],
@@ -397,6 +398,9 @@ async def test_runtime_chat_applies_trusted_portal_runtime_profile_config(monkey
     assert runtime_config.active_skills == ["review"]
     assert runtime_config.command_directories == ["/workspace/.efp/commands"]
     assert runtime_config.compaction_auto is False
+    # Portal is the only route that can turn this on in production: without the
+    # allowlist entry the opt-in is unreachable and stored compaction is dead.
+    assert runtime_config.compaction_rewrite_stored_history is True
     assert runtime_config.max_context_tokens == 64000
     assert runtime_config.system_prompt_texts == ["system"]
     assert runtime_config.instruction_texts == ["instruction"]
@@ -430,6 +434,47 @@ def test_runtime_chat_ignores_untrusted_runtime_profile_metadata(monkeypatch):
 
     assert runtime_config.enabled_tools is None
     assert runtime_config.track_usage is True
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["max_context_tokens", "max_context_chars", "max_context_parts"],
+)
+def test_runtime_chat_rejects_a_zero_context_size_cap_with_a_400(monkeypatch, field):
+    """Rejecting 0 is only defensible if the operator is told which key is bad.
+
+    A stored runtime profile carrying `max_context_tokens: 0` used to produce a
+    one-character budget - every request cut down to system context plus the
+    latest turn. It now fails the chat instead, and this pins the translation
+    from RuntimeConfig's ValueError to a 400 naming the field, which is the
+    justification for rejecting rather than silently coercing.
+    """
+
+    class _FakeConfig:
+        @property
+        def session(self):
+            return {"max_iterations": 2}
+
+        def get_effective_config(self):
+            return {}
+
+    monkeypatch.setattr(runtime_chat, "config", _FakeConfig())
+
+    with pytest.raises(runtime_chat.RuntimeChatError) as exc_info:
+        runtime_chat._runtime_config(
+            "request-model",
+            track_usage=True,
+            execution_metadata={
+                "runtime_profile": {
+                    "source": "portal.runtime_profile",
+                    "config": {field: 0},
+                }
+            },
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.error_type == "invalid_runtime_config"
+    assert field in str(exc_info.value)
 
 
 def test_runtime_chat_uses_persisted_runtime_config_fields(monkeypatch):


### PR DESCRIPTION
Three defects that predate #582 but became reachable now that every pod has a budget from the model catalog. They land together deliberately — see [Why (2) and (3) ship together](#why-2-and-3-ship-together).

## (1) Zero was accepted, and it was maximally destructive

`max_context_chars` was validated `>= 1`, but `max_context_tokens` went through a non-negative validator. So `max_context_tokens: 0` — a plausible operator spelling of "disable this" — produced a **one character** budget, reducing every request to system context plus the latest turn, *and* flipped the predicate that enabled destructive stored-history rewriting.

All three size caps now require a positive int and reject bools (`isinstance(True, int)` is `True` in Python). Rejection surfaces as a 400 from the chat gateway naming the field. That is loud, and it is the right trade: silently coercing `0 → None` would ignore what the operator actually wrote.

## (2) Over-window values were honoured verbatim

10M tokens on a 400k model yielded a 39.5M character budget and silently reproduced the exact 400 that #582 fixed.

Explicit values are now clamped to the same ceiling the unset path uses (window − safety margin) — **but only when the model resolved to a real catalog entry.**

| model | requested | result |
|---|---|---|
| `gpt-5.6-sol` (catalog) | 10M tokens | clamped to 1 568 000 chars |
| unknown model (64k fallback) | 10M tokens | **not clamped**, 40 000 000 chars |

A model that fell back to the conservative 64k profile is precisely the case where an override is legitimate — a newly released or gateway-only model that `models.py` doesn't know yet. Clamping it to a wrong catalog guess would defeat the only purpose an override has.

The clamp is recorded, not silent: `max_context_chars_requested` / `_limit` / `_clamped`. An unknown model reports `limit=None, clamped=False`.

## (3) A size knob meant "rewrite my transcripts"

The predicate gating the stored-history compactor returned `True` whenever *any* size cap was set, and that compactor calls `store.replace_history` — an irreversible rewrite of the session the Portal displays.

"I want a smaller prompt" and "please rewrite my stored history" are different statements. Stored rewriting now has its own opt-in, `compaction_rewrite_stored_history`, defaulting `False`, plumbed through `RuntimeConfig`, `AgentRuntime._resolve_config`, the run and resume paths, `PORTAL_MANAGED_RUNTIME_FIELDS`, the `efp.json` loader aliases, and sub-agent config. The old predicate is deleted rather than left with zero callers.

`_resolve_config` re-materialises `RuntimeConfig` field-by-field from a hand-written list, so a field missing from it is **silently dropped** — that was the highest-risk part of this change and it is pinned by a test on both the run and resume paths.

Decoupling does not weaken the size knob: render-time compaction is gated only on the budget existing, and the overflow retry still produces a strictly smaller second request with the flag off. Measured, not argued.

## Why (2) and (3) ship together

Today an over-window override yields a budget stored history never reaches, so the rewrite never fires. Clamping makes it reachable. **Shipping (2) alone would newly begin destroying transcripts for exactly the deployments the clamp is meant to rescue.**

## Not changed

The tokens-vs-chars reserve asymmetry: `max_context_tokens: 250000` delivers 125 000 tokens while `max_context_chars: 1000000` delivers 250 000. It arrived with the Runtime v2 baseline (#521) with no justifying commit message, and both directions of "fixing" it change behaviour for explicitly-configured deployments. #583 documented it; this adds a test pinning both routes' numbers so it cannot drift silently.

## Before merging — someone with Portal access should check

The repo sets none of these knobs anywhere (`config.yaml.example` has them commented out), but all three are Portal-managed, so a runtime profile stored in the Portal DB can set one invisibly from here. Please query stored profiles for `max_context_tokens` / `max_context_chars` / `max_context_parts`:

- a stored `0` now returns 400 on the next chat for that profile;
- any profile that relied on the implied stored-history rewriting needs `compaction_rewrite_stored_history: true` added.

Also filed rather than fixed: a deployment that stops rewriting stored history will grow session files without bound, and per-turn latency grows with them (measured 0.4 s → 59.3 s at 60 turns). A compensating trimmer is a fourth fix, not this one. `config.yaml.example` carries an operational warning.

## Testing

Full suite: **33 failed / 2578 passed / 5 skipped**, failure set byte-identical to master (33 pre-existing Windows environment failures).

Mutation-verified independently of the implementation's own claims: forcing the rewrite gate open turns 8 tests red, removing the clamp 8, re-accepting zero 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)